### PR TITLE
Add HTTPS reverse proxy with subdomain routing

### DIFF
--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -120,6 +120,64 @@ Background mode features:
 - CLI commands auto-discover the running daemon
 - Daemon logs are written to `.prox/prox.log`
 
+## HTTPS Proxy (Optional)
+
+prox can provide friendly HTTPS URLs for your services via subdomain routing.
+
+### Prerequisites
+
+Install mkcert for local certificate generation:
+
+```bash
+# macOS
+brew install mkcert
+
+# Install the CA (run once)
+mkcert -install
+```
+
+### Configuration
+
+Add proxy settings to your `prox.yaml`:
+
+```yaml
+processes:
+  frontend: npm run dev
+  backend: go run ./cmd/server
+
+proxy:
+  enabled: true
+  https_port: 6789
+  domain: local.myapp.dev
+
+services:
+  app: 3000
+  api: 8000
+```
+
+### DNS Setup
+
+Add entries to `/etc/hosts`:
+
+```bash
+prox hosts --add
+```
+
+### Usage
+
+Start prox:
+
+```bash
+prox up
+```
+
+Access your services:
+
+- `https://app.local.myapp.dev:6789` → `http://localhost:3000`
+- `https://api.local.myapp.dev:6789` → `http://localhost:8000`
+
+See the [Configuration Reference](../reference/configuration.md#https-proxy-configuration) for full details.
+
 ## HTTP API
 
 The API runs at `http://127.0.0.1:5555/api/v1` by default.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,7 @@ A modern process manager for development with an API-first design, enabling both
 - **Simple by default** - Procfile-like experience with minimal YAML configuration
 - **API-first** - Full process control and log access via HTTP, always available
 - **Interactive TUI** - Real-time log viewing with filtering and search
+- **HTTPS Proxy** - Subdomain routing with locally-trusted certificates
 - **Health checks** - Optional health monitoring for processes
 - **LLM-friendly** - Structured output and filtering to support AI-assisted debugging
 
@@ -31,7 +32,6 @@ prox up
 
 prox is designed for local development. It intentionally does not include:
 
-- Daemon mode (runs in foreground only)
 - Log persistence to disk
 - Process dependencies or startup ordering
 - Distributed or multi-machine operation

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -29,6 +29,7 @@ prox up [processes...]
 | `--detach, -d` | Run in background (daemon mode) |
 | `--tui` | Enable interactive TUI mode (foreground only, mutually exclusive with `--detach`) |
 | `--port, -p` | Override API port (otherwise dynamic) |
+| `--no-proxy` | Disable HTTPS proxy even if configured |
 
 **Examples:**
 
@@ -187,6 +188,55 @@ Show version information.
 
 ```bash
 prox version
+```
+
+### certs
+
+Manage HTTPS certificates for the proxy.
+
+```bash
+prox certs [options]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--regenerate` | Force regenerate certificates |
+
+**Examples:**
+
+```bash
+# Show certificate status
+prox certs
+
+# Regenerate certificates
+prox certs --regenerate
+```
+
+### hosts
+
+Manage /etc/hosts entries for proxy subdomains.
+
+```bash
+prox hosts [options]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--show` | Show entries that would be added (default) |
+| `--add` | Add entries to /etc/hosts (requires sudo) |
+| `--remove` | Remove entries from /etc/hosts (requires sudo) |
+
+**Examples:**
+
+```bash
+# Show required entries
+prox hosts --show
+
+# Add entries (requires sudo)
+prox hosts --add
+
+# Remove entries
+prox hosts --remove
 ```
 
 ### help

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -134,6 +134,97 @@ The `.prox/` directory is project-local, so add it to your `.gitignore`:
 .prox/
 ```
 
+## HTTPS Proxy Configuration
+
+prox can act as an HTTPS reverse proxy, providing friendly subdomain URLs for your services.
+
+### Proxy Example
+
+```yaml
+processes:
+  frontend: npm run dev
+  backend: go run ./cmd/server
+
+proxy:
+  enabled: true
+  https_port: 6789
+  domain: local.myapp.dev
+
+services:
+  app: 3000                    # Simple: subdomain → port
+  api:                         # Expanded: with options
+    port: 8000
+    host: localhost
+
+certs:
+  dir: ~/.prox/certs
+  auto_generate: true
+```
+
+With this configuration:
+- `https://app.local.myapp.dev:6789` → `http://localhost:3000`
+- `https://api.local.myapp.dev:6789` → `http://localhost:8000`
+
+### Proxy Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `proxy.enabled` | bool | `false` | Enable HTTPS reverse proxy |
+| `proxy.https_port` | int | `6789` | Port for the HTTPS proxy server |
+| `proxy.domain` | string | required | Base domain for subdomain routing |
+
+### Service Fields
+
+Services can be defined in simple form (port only) or expanded form (object).
+
+#### Simple Form
+
+```yaml
+services:
+  app: 3000
+```
+
+#### Expanded Form
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `port` | int | required | Target port to proxy to |
+| `host` | string | `localhost` | Target host to proxy to |
+
+### Certificate Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `certs.dir` | string | `~/.prox/certs` | Directory for storing certificates |
+| `certs.auto_generate` | bool | `true` | Automatically generate certificates using mkcert |
+
+### Prerequisites
+
+The proxy requires [mkcert](https://github.com/FiloSottile/mkcert) for certificate generation:
+
+```bash
+# macOS
+brew install mkcert
+
+# Linux
+# See https://github.com/FiloSottile/mkcert#installation
+
+# Install the CA (run once)
+mkcert -install
+```
+
+### DNS Setup
+
+Add entries to `/etc/hosts` for your subdomains:
+
+```bash
+# View required entries
+prox hosts --show
+
+# Add entries (requires sudo)
+prox hosts --add
+```
+
 ## Security Note
 
 Commands in `prox.yaml` are executed via shell. Only use configuration files from trusted sources, similar to Makefiles or Procfiles.

--- a/docs/reference/tui.md
+++ b/docs/reference/tui.md
@@ -1,6 +1,6 @@
 # TUI Reference
 
-The interactive terminal UI provides real-time log viewing with filtering and search.
+The interactive terminal UI provides real-time log viewing with filtering and search, plus a proxy request viewer when the proxy is enabled.
 
 ## Starting the TUI
 
@@ -14,9 +14,16 @@ Or start specific processes:
 prox up --tui web api
 ```
 
-## Layout
+## Views
 
-```
+The TUI has two views you can switch between with `Tab`:
+
+- **Logs View** - Real-time process logs with filtering
+- **Requests View** - Real-time HTTP proxy requests (when proxy is enabled)
+
+## Logs View Layout
+
+```text
 ┌─ processes ──────────────────────────────────────────────┐
 │ [1] ● web     running   [2] ● api    running             │
 │ [3] ● worker  starting  [4] ○ cron   stopped             │
@@ -28,33 +35,66 @@ prox up --tui web api
 │ 10:32:03 api    │ WARN: connection pool running low      │
 │ ...                                                      │
 ├──────────────────────────────────────────────────────────┤
-│ [f]ilter [/]search [s]tring filter [r]estart [?]help [q] │
+│ Tab: switch view | ? for help  [Logs] [FOLLOW] 45 lines  │
 └──────────────────────────────────────────────────────────┘
 ```
 
+## Requests View Layout
+
+```text
+┌─ processes ──────────────────────────────────────────────┐
+│ ● web     running   ● api    running                     │
+├─ requests ───────────────────────────────────────────────┤
+│ 15:04:05  api        GET  200   45ms  /api/v1/users      │
+│ 15:04:05  app        POST 201  120ms  /api/v1/posts      │
+│ 15:04:06  api        GET  404   12ms  /api/v1/missing    │
+│ 15:04:07  web        GET  200   23ms  /assets/main.js    │
+│ ...                                                      │
+├──────────────────────────────────────────────────────────┤
+│ Tab: switch view | ? for help  [Requests] [FOLLOW] 12    │
+└──────────────────────────────────────────────────────────┘
+```
+
+Status codes are color-coded: green (2xx), cyan (3xx), yellow (4xx), red (5xx), gray (0/unknown).
+
 ## Keybindings
 
+### General
+
 | Key | Action |
-|-----|--------|
-| `↑` / `↓` / `j` / `k` | Scroll logs |
+| --- | ------ |
+| `Tab` | Switch between Logs and Requests views |
+| `↑` / `↓` / `j` / `k` | Scroll |
 | `PgUp` / `PgDn` | Scroll page |
-| `scroll wheel` | Scroll logs |
+| `scroll wheel` | Scroll |
 | `Home` / `End` / `g` / `G` | Jump to start/end |
+| `F` | Toggle auto-follow mode |
+| `Esc` | Clear filter/search, exit mode |
+| `?` | Show help overlay |
+| `q` | Quit |
+
+### Logs View
+
+| Key | Action |
+| --- | ------ |
 | `1-9` | Solo process (press again for all) |
 | `f` | Open process filter (multi-select) |
 | `/` | Search (highlight matches) |
 | `n` / `N` | Next/previous search match |
 | `s` | String filter (hide non-matching) |
-| `Esc` | Clear filter/search, exit mode |
 | `r` | Restart highlighted process |
-| `?` | Show help overlay |
-| `q` | Quit |
+
+### Requests View
+
+| Key | Action |
+| --- | ------ |
+| `s` | String filter (on URL/method/subdomain) |
 
 ## Process Filter Mode
 
 Press `f` to open the multi-select process filter:
 
-```
+```text
 ┌─ filter processes ───────────────────┐
 │ [x] web                              │
 │ [x] api                              │
@@ -67,7 +107,7 @@ Press `f` to open the multi-select process filter:
 ```
 
 | Key | Action |
-|-----|--------|
+| --- | ------ |
 | `↑` / `↓` | Navigate list |
 | `Space` | Toggle selection |
 | `a` | Select all |

--- a/internal/api/responses.go
+++ b/internal/api/responses.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/charliek/prox/internal/domain"
+	"github.com/charliek/prox/internal/proxy"
 )
 
 // sensitiveEnvPatterns contains patterns that indicate sensitive environment variables
@@ -167,5 +168,36 @@ func ToLogEntryResponse(entry domain.LogEntry) LogEntryResponse {
 		Process:   entry.Process,
 		Stream:    string(entry.Stream),
 		Line:      entry.Line,
+	}
+}
+
+// ProxyRequestResponse represents a single proxy request
+type ProxyRequestResponse struct {
+	Timestamp  string `json:"timestamp"`
+	Method     string `json:"method"`
+	URL        string `json:"url"`
+	Subdomain  string `json:"subdomain"`
+	StatusCode int    `json:"status_code"`
+	DurationMs int64  `json:"duration_ms"`
+	RemoteAddr string `json:"remote_addr"`
+}
+
+// ProxyRequestsResponse represents the response for GET /proxy/requests
+type ProxyRequestsResponse struct {
+	Requests      []ProxyRequestResponse `json:"requests"`
+	FilteredCount int                    `json:"filtered_count"`
+	TotalCount    int                    `json:"total_count"`
+}
+
+// ToProxyRequestResponse converts proxy.RequestRecord to ProxyRequestResponse
+func ToProxyRequestResponse(req proxy.RequestRecord) ProxyRequestResponse {
+	return ProxyRequestResponse{
+		Timestamp:  req.Timestamp.Format(time.RFC3339Nano),
+		Method:     req.Method,
+		URL:        req.URL,
+		Subdomain:  req.Subdomain,
+		StatusCode: req.StatusCode,
+		DurationMs: req.Duration.Milliseconds(),
+		RemoteAddr: req.RemoteAddr,
 	}
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -174,6 +174,10 @@ func (s *Server) registerRoutes() {
 		r.Get("/logs", s.handlers.GetLogs)
 		r.Get("/logs/stream", s.handlers.StreamLogs)
 
+		// Proxy requests
+		r.Get("/proxy/requests", s.handlers.GetProxyRequests)
+		r.Get("/proxy/requests/stream", s.handlers.StreamProxyRequests)
+
 		// Shutdown
 		r.Post("/shutdown", s.handlers.Shutdown)
 	})

--- a/internal/cli/proxy.go
+++ b/internal/cli/proxy.go
@@ -1,0 +1,257 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"text/tabwriter"
+
+	"github.com/charliek/prox/internal/config"
+	"github.com/charliek/prox/internal/proxy/certs"
+	"github.com/charliek/prox/internal/proxy/hosts"
+)
+
+// cmdCerts handles the 'certs' command
+func (a *App) cmdCerts(args []string) int {
+	regenerate := false
+	for _, arg := range args {
+		switch arg {
+		case "-h", "--help", "help":
+			fmt.Print(`prox certs - Manage HTTPS certificates
+
+Usage: prox certs [options]
+
+Options:
+  --regenerate    Force regenerate certificates
+  -h, --help      Show this help
+
+Examples:
+  prox certs              # Show certificate status
+  prox certs --regenerate # Regenerate certificates
+`)
+			return 0
+		case "--regenerate":
+			regenerate = true
+		}
+	}
+
+	// Load config
+	cfg, err := config.Load(a.configPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 1
+	}
+
+	// Check if proxy is configured
+	if cfg.Proxy == nil || !cfg.Proxy.Enabled {
+		fmt.Println("Proxy is not configured or not enabled.")
+		fmt.Println("Add a 'proxy' section to your prox.yaml to enable HTTPS proxy.")
+		return 0
+	}
+
+	if cfg.Certs == nil {
+		fmt.Fprintf(os.Stderr, "Error: certs configuration missing\n")
+		return 1
+	}
+
+	// Create cert manager
+	certMgr := certs.NewManager(cfg.Certs.Dir, cfg.Proxy.Domain)
+
+	// Check mkcert installation
+	if err := certMgr.CheckMkcert(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		fmt.Println("\nTo install mkcert:")
+		fmt.Println("  macOS:   brew install mkcert")
+		fmt.Println("  Linux:   See https://github.com/FiloSottile/mkcert#installation")
+		fmt.Println("  Windows: choco install mkcert")
+		return 1
+	}
+
+	// Check CA installation
+	caInstalled, err := certMgr.CheckCAInstalled()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not check CA status: %v\n", err)
+	}
+
+	// Print status
+	fmt.Printf("Domain: %s\n", cfg.Proxy.Domain)
+	fmt.Printf("Certs directory: %s\n", cfg.Certs.Dir)
+	fmt.Println()
+
+	if !caInstalled {
+		fmt.Println("CA Status: Not installed")
+		fmt.Println("Run 'mkcert -install' to install the CA (requires sudo)")
+		return 0
+	}
+	fmt.Println("CA Status: Installed")
+
+	paths := certMgr.GetCertPaths()
+	fmt.Printf("Certificate: %s\n", paths.CertFile)
+	fmt.Printf("Key: %s\n", paths.KeyFile)
+	fmt.Println()
+
+	if regenerate {
+		fmt.Println("Regenerating certificates...")
+		_, err := certMgr.RegenerateCerts()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			return 1
+		}
+		fmt.Println("Certificates regenerated successfully.")
+		return 0
+	}
+
+	// Check if certs exist
+	certPaths, err := certMgr.EnsureCerts()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error ensuring certificates: %v\n", err)
+		return 1
+	}
+
+	// Verify files exist
+	if _, err := os.Stat(certPaths.CertFile); err == nil {
+		fmt.Println("Status: Certificates exist and are ready")
+	} else {
+		fmt.Println("Status: Certificates will be generated on first use")
+	}
+
+	return 0
+}
+
+// cmdHosts handles the 'hosts' command
+func (a *App) cmdHosts(args []string) int {
+	add := false
+	remove := false
+	show := false
+
+	for _, arg := range args {
+		switch arg {
+		case "-h", "--help", "help":
+			fmt.Print(`prox hosts - Manage /etc/hosts entries
+
+Usage: prox hosts [options]
+
+Options:
+  --add       Add entries to /etc/hosts (requires sudo)
+  --remove    Remove entries from /etc/hosts (requires sudo)
+  --show      Show entries that would be added
+  -h, --help  Show this help
+
+Examples:
+  prox hosts          # Show current status and entries
+  prox hosts --add    # Add proxy hosts to /etc/hosts
+  prox hosts --remove # Remove proxy hosts from /etc/hosts
+`)
+			return 0
+		case "--add":
+			add = true
+		case "--remove":
+			remove = true
+		case "--show":
+			show = true
+		}
+	}
+
+	// Load config
+	cfg, err := config.Load(a.configPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 1
+	}
+
+	// Check if proxy is configured
+	if cfg.Proxy == nil || !cfg.Proxy.Enabled {
+		fmt.Println("Proxy is not configured or not enabled.")
+		fmt.Println("Add a 'proxy' section to your prox.yaml to enable HTTPS proxy.")
+		return 0
+	}
+
+	// Get service names
+	serviceNames := make([]string, 0, len(cfg.Services))
+	for name := range cfg.Services {
+		serviceNames = append(serviceNames, name)
+	}
+	sort.Strings(serviceNames)
+
+	if len(serviceNames) == 0 {
+		fmt.Println("No services configured.")
+		fmt.Println("Add a 'services' section to your prox.yaml to define service routing.")
+		return 0
+	}
+
+	// Create hosts manager
+	hostsMgr := hosts.NewManager(cfg.Proxy.Domain, serviceNames)
+
+	if show || (!add && !remove) {
+		// Show current status and entries
+		exists, upToDate, err := hostsMgr.Check()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: could not check hosts file: %v\n", err)
+		}
+
+		fmt.Printf("Domain: %s\n", cfg.Proxy.Domain)
+		fmt.Println()
+
+		// Show entries table
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "SERVICE\tHOSTNAME")
+		fmt.Fprintln(w, "-------\t--------")
+		fmt.Fprintf(w, "(base)\t%s\n", cfg.Proxy.Domain)
+		for _, name := range serviceNames {
+			fmt.Fprintf(w, "%s\t%s.%s\n", name, name, cfg.Proxy.Domain)
+		}
+		w.Flush()
+		fmt.Println()
+
+		if exists {
+			if upToDate {
+				fmt.Println("Status: Entries are up to date in /etc/hosts")
+			} else {
+				fmt.Println("Status: Entries exist but need updating")
+				fmt.Println("Run 'prox hosts --add' to update")
+			}
+		} else {
+			fmt.Println("Status: Entries not in /etc/hosts")
+			fmt.Println("Run 'prox hosts --add' to add entries (requires sudo)")
+		}
+
+		return 0
+	}
+
+	if add {
+		fmt.Println("Adding entries to /etc/hosts...")
+		fmt.Println()
+		fmt.Println("This will add the following block:")
+		fmt.Println(hostsMgr.PrintEntries())
+
+		if err := hostsMgr.Add(); err != nil {
+			// Likely permission error - print sudo instructions
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			fmt.Println()
+			fmt.Println("You need elevated privileges to modify /etc/hosts.")
+			fmt.Println("Run the following command manually:")
+			fmt.Println()
+			fmt.Println("  " + hostsMgr.GenerateAddCommand())
+			return 1
+		}
+		fmt.Println("Entries added successfully.")
+		return 0
+	}
+
+	if remove {
+		fmt.Println("Removing entries from /etc/hosts...")
+		if err := hostsMgr.Remove(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			fmt.Println()
+			fmt.Println("You need elevated privileges to modify /etc/hosts.")
+			fmt.Println("Run the following command manually:")
+			fmt.Println()
+			fmt.Println("  " + hostsMgr.GenerateRemoveCommand())
+			return 1
+		}
+		fmt.Println("Entries removed successfully.")
+		return 0
+	}
+
+	return 0
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -73,6 +73,10 @@ func (a *App) Run(args []string) int {
 		return a.cmdAttach(cmdArgs)
 	case "restart":
 		return a.cmdRestart(cmdArgs)
+	case "certs":
+		return a.cmdCerts(cmdArgs)
+	case "hosts":
+		return a.cmdHosts(cmdArgs)
 	case "version":
 		return a.cmdVersion(cmdArgs)
 	case "help", "-h", "--help":
@@ -146,6 +150,8 @@ Commands:
   stop                 Stop running instance (via API)
   down                 Alias for stop
   restart <process>    Restart a process (via API)
+  certs                Manage HTTPS certificates
+  hosts                Manage /etc/hosts entries
   version              Show version
   help                 Show this help
 
@@ -157,6 +163,7 @@ Global Options:
 Up Options:
   --tui                Enable interactive TUI mode (mutually exclusive with --detach)
   --port PORT          Override API port (otherwise dynamic)
+  --no-proxy           Disable HTTPS proxy even if configured
 
 Logs Options:
   -f, --follow         Stream logs continuously
@@ -169,9 +176,18 @@ Logs Options:
 Status Options:
   --json               Output as JSON
 
+Certs Options:
+  --regenerate         Force regenerate certificates
+
+Hosts Options:
+  --add                Add entries to /etc/hosts (requires sudo)
+  --remove             Remove entries from /etc/hosts (requires sudo)
+  --show               Show entries that would be added
+
 Examples:
   prox up                     # Start all processes (foreground)
   prox up -d                  # Start in background (daemon mode)
+  prox up --no-proxy          # Start without HTTPS proxy
   prox attach                 # Attach TUI to running daemon
   prox up --tui               # Start with TUI (foreground)
   prox up web api             # Start specific processes
@@ -179,6 +195,8 @@ Examples:
   prox logs -f                # Stream all logs
   prox restart worker         # Restart worker process
   prox down                   # Stop the daemon
+  prox certs                  # Show certificate status
+  prox hosts --add            # Add proxy hosts to /etc/hosts
 `)
 }
 

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -106,5 +107,363 @@ func TestValidateProcessName(t *testing.T) {
 		err := ValidateProcessName("my/service")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "path")
+	})
+}
+
+func TestValidateProxy(t *testing.T) {
+	baseConfig := func() *Config {
+		return &Config{
+			API: APIConfig{Port: 5555, Host: "127.0.0.1"},
+			Processes: map[string]ProcessConfig{
+				"web": {Cmd: "npm run dev"},
+			},
+		}
+	}
+
+	t.Run("valid proxy config passes", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Proxy = &ProxyConfig{
+			Enabled:   true,
+			HTTPSPort: 6789,
+			Domain:    "local.myapp.dev",
+		}
+		cfg.Services = map[string]ServiceConfig{
+			"app": {Port: 3000, Host: "localhost"},
+		}
+		err := Validate(cfg)
+		assert.NoError(t, err)
+	})
+
+	t.Run("proxy enabled without domain fails", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Proxy = &ProxyConfig{
+			Enabled:   true,
+			HTTPSPort: 6789,
+		}
+		err := Validate(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "proxy.domain")
+	})
+
+	t.Run("proxy disabled without domain passes", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Proxy = &ProxyConfig{
+			Enabled:   false,
+			HTTPSPort: 6789,
+		}
+		err := Validate(cfg)
+		assert.NoError(t, err)
+	})
+
+	t.Run("invalid proxy port fails", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Proxy = &ProxyConfig{
+			Enabled:   true,
+			HTTPSPort: 99999,
+			Domain:    "local.myapp.dev",
+		}
+		err := Validate(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "proxy.https_port")
+	})
+
+	t.Run("proxy port 0 fails", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Proxy = &ProxyConfig{
+			Enabled:   true,
+			HTTPSPort: 0,
+			Domain:    "local.myapp.dev",
+		}
+		cfg.Services = map[string]ServiceConfig{
+			"app": {Port: 3000, Host: "localhost"},
+		}
+		err := Validate(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "proxy.https_port")
+	})
+
+	t.Run("proxy port -1 fails", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Proxy = &ProxyConfig{
+			Enabled:   true,
+			HTTPSPort: -1,
+			Domain:    "local.myapp.dev",
+		}
+		cfg.Services = map[string]ServiceConfig{
+			"app": {Port: 3000, Host: "localhost"},
+		}
+		err := Validate(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "proxy.https_port")
+	})
+
+	t.Run("proxy port 65536 fails", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Proxy = &ProxyConfig{
+			Enabled:   true,
+			HTTPSPort: 65536,
+			Domain:    "local.myapp.dev",
+		}
+		cfg.Services = map[string]ServiceConfig{
+			"app": {Port: 3000, Host: "localhost"},
+		}
+		err := Validate(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "proxy.https_port")
+	})
+
+	t.Run("services without proxy fails", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Services = map[string]ServiceConfig{
+			"app": {Port: 3000, Host: "localhost"},
+		}
+		err := Validate(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "proxy must be enabled")
+	})
+
+	t.Run("invalid service port fails", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Proxy = &ProxyConfig{
+			Enabled: true,
+			Domain:  "local.myapp.dev",
+		}
+		cfg.Services = map[string]ServiceConfig{
+			"app": {Port: 0, Host: "localhost"},
+		}
+		err := Validate(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "services.app.port")
+	})
+
+	t.Run("service port 65536 fails", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Proxy = &ProxyConfig{
+			Enabled: true,
+			Domain:  "local.myapp.dev",
+		}
+		cfg.Services = map[string]ServiceConfig{
+			"app": {Port: 65536, Host: "localhost"},
+		}
+		err := Validate(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "services.app.port")
+	})
+
+	t.Run("service port 65535 passes", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Proxy = &ProxyConfig{
+			Enabled:   true,
+			HTTPSPort: 6789,
+			Domain:    "local.myapp.dev",
+		}
+		cfg.Services = map[string]ServiceConfig{
+			"app": {Port: 65535, Host: "localhost"},
+		}
+		err := Validate(cfg)
+		assert.NoError(t, err)
+	})
+}
+
+func TestValidateServiceName(t *testing.T) {
+	t.Run("valid service names", func(t *testing.T) {
+		validNames := []string{"app", "api", "my-service", "web123", "a1b2c3"}
+		for _, name := range validNames {
+			err := validateServiceName(name)
+			assert.NoError(t, err, "name %q should be valid", name)
+		}
+	})
+
+	t.Run("empty name fails", func(t *testing.T) {
+		err := validateServiceName("")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "empty")
+	})
+
+	t.Run("name with uppercase fails", func(t *testing.T) {
+		err := validateServiceName("MyService")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "lowercase")
+	})
+
+	t.Run("name starting with hyphen fails", func(t *testing.T) {
+		err := validateServiceName("-app")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "hyphen")
+	})
+
+	t.Run("name ending with hyphen fails", func(t *testing.T) {
+		err := validateServiceName("app-")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "hyphen")
+	})
+
+	t.Run("name too long fails", func(t *testing.T) {
+		longName := strings.Repeat("a", 64)
+		err := validateServiceName(longName)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "too long")
+	})
+
+	t.Run("name with underscore fails", func(t *testing.T) {
+		err := validateServiceName("my_service")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "lowercase letters, numbers, and hyphens")
+	})
+}
+
+func TestValidateHost(t *testing.T) {
+	t.Run("valid hosts", func(t *testing.T) {
+		validHosts := []string{"localhost", "127.0.0.1", "192.168.1.1", "example.com", "my-server.local"}
+		for _, host := range validHosts {
+			err := validateHost(host)
+			assert.NoError(t, err, "host %q should be valid", host)
+		}
+	})
+
+	t.Run("empty host fails", func(t *testing.T) {
+		err := validateHost("")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "empty")
+	})
+
+	t.Run("invalid host format fails", func(t *testing.T) {
+		invalidHosts := []string{"host:8080", "http://localhost", "my_server", "host name"}
+		for _, host := range invalidHosts {
+			err := validateHost(host)
+			require.Error(t, err, "host %q should be invalid", host)
+			assert.Contains(t, err.Error(), "invalid host format")
+		}
+	})
+}
+
+func TestValidateDomain(t *testing.T) {
+	baseConfig := func() *Config {
+		return &Config{
+			API: APIConfig{Port: 5555, Host: "127.0.0.1"},
+			Processes: map[string]ProcessConfig{
+				"web": {Cmd: "npm run dev"},
+			},
+		}
+	}
+
+	t.Run("valid domain formats pass", func(t *testing.T) {
+		validDomains := []string{"local.dev", "my-app.local.dev", "example.com", "sub.domain.co.uk"}
+		for _, domain := range validDomains {
+			cfg := baseConfig()
+			cfg.Proxy = &ProxyConfig{
+				Enabled:   true,
+				HTTPSPort: 6789,
+				Domain:    domain,
+			}
+			cfg.Services = map[string]ServiceConfig{
+				"app": {Port: 3000, Host: "localhost"},
+			}
+			err := Validate(cfg)
+			assert.NoError(t, err, "domain %q should be valid", domain)
+		}
+	})
+
+	t.Run("invalid domain format fails", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Proxy = &ProxyConfig{
+			Enabled:   true,
+			HTTPSPort: 6789,
+			Domain:    "invalid domain with spaces",
+		}
+		cfg.Services = map[string]ServiceConfig{
+			"app": {Port: 3000, Host: "localhost"},
+		}
+		err := Validate(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid domain format")
+	})
+
+	t.Run("domain starting with hyphen fails", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Proxy = &ProxyConfig{
+			Enabled:   true,
+			HTTPSPort: 6789,
+			Domain:    "-invalid.dev",
+		}
+		cfg.Services = map[string]ServiceConfig{
+			"app": {Port: 3000, Host: "localhost"},
+		}
+		err := Validate(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid domain format")
+	})
+}
+
+func TestValidateCertsConfig(t *testing.T) {
+	baseConfig := func() *Config {
+		return &Config{
+			API: APIConfig{Port: 5555, Host: "127.0.0.1"},
+			Processes: map[string]ProcessConfig{
+				"web": {Cmd: "npm run dev"},
+			},
+		}
+	}
+
+	t.Run("valid certs config passes", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Certs = &CertsConfig{
+			Dir:          "/path/to/certs",
+			AutoGenerate: true,
+		}
+		err := Validate(cfg)
+		assert.NoError(t, err)
+	})
+
+	t.Run("empty certs dir fails", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Certs = &CertsConfig{
+			Dir:          "",
+			AutoGenerate: true,
+		}
+		err := Validate(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "certs.dir")
+	})
+}
+
+func TestValidateServiceHost(t *testing.T) {
+	baseConfig := func() *Config {
+		return &Config{
+			API: APIConfig{Port: 5555, Host: "127.0.0.1"},
+			Processes: map[string]ProcessConfig{
+				"web": {Cmd: "npm run dev"},
+			},
+		}
+	}
+
+	t.Run("empty service host fails", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Proxy = &ProxyConfig{
+			Enabled:   true,
+			HTTPSPort: 6789,
+			Domain:    "local.dev",
+		}
+		cfg.Services = map[string]ServiceConfig{
+			"app": {Port: 3000, Host: ""},
+		}
+		err := Validate(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "services.app.host")
+	})
+
+	t.Run("invalid service host format fails", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.Proxy = &ProxyConfig{
+			Enabled:   true,
+			HTTPSPort: 6789,
+			Domain:    "local.dev",
+		}
+		cfg.Services = map[string]ServiceConfig{
+			"app": {Port: 3000, Host: "http://localhost"},
+		}
+		err := Validate(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "services.app.host")
 	})
 }

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -16,6 +16,12 @@ const (
 
 	// DefaultAPIAddress is the default API address for client connections
 	DefaultAPIAddress = "http://127.0.0.1:5555"
+
+	// DefaultProxyPort is the default port for the HTTPS reverse proxy
+	DefaultProxyPort = 6789
+
+	// DefaultCertsDir is the default directory for storing certificates
+	DefaultCertsDir = "~/.prox/certs"
 )
 
 // Timeout and duration defaults
@@ -37,6 +43,16 @@ const (
 	MaxLogLines = 10000
 )
 
+// Proxy request configuration
+const (
+	// DefaultProxyRequestLimit is the default number of proxy requests to return
+	DefaultProxyRequestLimit = 100
+
+	// MaxProxyRequests is the maximum number of proxy requests that can be requested
+	// to prevent memory exhaustion (DoS protection)
+	MaxProxyRequests = 1000
+)
+
 // Buffer sizes
 const (
 	// DefaultLogBufferSize is the default size for log buffers
@@ -50,6 +66,48 @@ const (
 
 	// ScannerMaxBufferSize is the maximum buffer size for log line scanning
 	ScannerMaxBufferSize = 1024 * 1024 // 1MB
+
+	// DefaultProxyRequestBufferSize is the default number of proxy requests to keep in memory
+	DefaultProxyRequestBufferSize = 1000
+)
+
+// Proxy timeouts
+const (
+	// DefaultProxyBackendTimeout is the timeout for backend connections
+	DefaultProxyBackendTimeout = 30 * time.Second
+
+	// DefaultProxyReadTimeout is the timeout for reading the entire request
+	DefaultProxyReadTimeout = 30 * time.Second
+
+	// DefaultProxyWriteTimeout is the timeout for writing the response
+	DefaultProxyWriteTimeout = 30 * time.Second
+
+	// DefaultProxyIdleTimeout is the timeout for idle connections
+	DefaultProxyIdleTimeout = 120 * time.Second
+
+	// DefaultProxyDialTimeout is the timeout for dialing backend connections
+	DefaultProxyDialTimeout = 30 * time.Second
+
+	// DefaultProxyKeepAlive is the keep-alive duration for backend connections
+	DefaultProxyKeepAlive = 30 * time.Second
+
+	// DefaultProxyIdleConnTimeout is the timeout for idle connections in the transport
+	DefaultProxyIdleConnTimeout = 90 * time.Second
+
+	// DefaultProxyMaxIdleConns is the maximum number of idle connections
+	DefaultProxyMaxIdleConns = 100
+)
+
+// File permissions
+const (
+	// FilePermissionDefault is the default permission for regular files (0644)
+	FilePermissionDefault = 0644
+
+	// DirPermissionPrivate is the permission for private directories (0700)
+	DirPermissionPrivate = 0700
+
+	// FilePermissionPrivate is the permission for sensitive files like tokens and keys (0600)
+	FilePermissionPrivate = 0600
 )
 
 // ANSI color codes for terminal output

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -20,6 +20,11 @@ const (
 	ErrCodeProcessNotRunning     = "PROCESS_NOT_RUNNING"
 	ErrCodeInvalidPattern        = "INVALID_PATTERN"
 	ErrCodeShutdownInProgress    = "SHUTDOWN_IN_PROGRESS"
+
+	// Proxy-related error codes (API-only, no sentinel errors as they
+	// are only used for HTTP response formatting in the API layer)
+	ErrCodeProxyNotEnabled       = "PROXY_NOT_ENABLED"
+	ErrCodeStreamingNotSupported = "STREAMING_NOT_SUPPORTED"
 )
 
 // ErrorCode returns the API error code for a domain error

--- a/internal/proxy/certs/certs.go
+++ b/internal/proxy/certs/certs.go
@@ -1,0 +1,186 @@
+// Package certs provides certificate management for the HTTPS reverse proxy.
+// It integrates with mkcert to generate locally-trusted development certificates.
+package certs
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/charliek/prox/internal/constants"
+)
+
+// Manager handles certificate generation and management using mkcert.
+type Manager struct {
+	certsDir string
+	domain   string
+}
+
+// CertPaths contains the paths to the certificate and key files.
+type CertPaths struct {
+	CertFile string
+	KeyFile  string
+}
+
+// NewManager creates a new certificate manager.
+func NewManager(certsDir, domain string) *Manager {
+	return &Manager{
+		certsDir: expandPath(certsDir),
+		domain:   domain,
+	}
+}
+
+// CheckMkcert verifies that mkcert is installed and accessible.
+func (m *Manager) CheckMkcert() error {
+	_, err := exec.LookPath("mkcert")
+	if err != nil {
+		return fmt.Errorf("mkcert not found in PATH (install from https://github.com/FiloSottile/mkcert): %w", err)
+	}
+	return nil
+}
+
+// CheckCAInstalled verifies that the mkcert CA is installed in the system trust store.
+func (m *Manager) CheckCAInstalled() (bool, error) {
+	if err := m.CheckMkcert(); err != nil {
+		return false, err
+	}
+
+	// mkcert -check returns 0 if CA is installed, non-zero otherwise
+	// However, mkcert doesn't have a -check flag, so we use CAROOT to check
+	cmd := exec.Command("mkcert", "-CAROOT")
+	output, err := cmd.Output()
+	if err != nil {
+		return false, fmt.Errorf("checking mkcert CAROOT: %w", err)
+	}
+
+	caRoot := strings.TrimSpace(string(output))
+	if caRoot == "" {
+		return false, nil
+	}
+
+	// Check if the CA files exist
+	rootCA := filepath.Join(caRoot, "rootCA.pem")
+	if _, err := os.Stat(rootCA); os.IsNotExist(err) {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// InstallCA installs the mkcert CA into the system trust store.
+// This typically requires elevated privileges (sudo).
+func (m *Manager) InstallCA() error {
+	if err := m.CheckMkcert(); err != nil {
+		return err
+	}
+
+	cmd := exec.Command("mkcert", "-install")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("installing mkcert CA: %w", err)
+	}
+	return nil
+}
+
+// EnsureCerts ensures that valid certificates exist for the configured domain.
+// If certificates don't exist, they will be generated.
+// Returns the paths to the certificate and key files.
+func (m *Manager) EnsureCerts() (*CertPaths, error) {
+	paths := m.getCertPaths()
+
+	// Check if certificates already exist
+	if m.certsExist(paths) {
+		return paths, nil
+	}
+
+	// Generate new certificates
+	if err := m.generateCerts(paths); err != nil {
+		return nil, err
+	}
+
+	return paths, nil
+}
+
+// GetCertPaths returns the expected paths for certificate files.
+func (m *Manager) GetCertPaths() *CertPaths {
+	return m.getCertPaths()
+}
+
+// RegenerateCerts forces regeneration of certificates even if they exist.
+func (m *Manager) RegenerateCerts() (*CertPaths, error) {
+	paths := m.getCertPaths()
+
+	// Remove existing certificates
+	_ = os.Remove(paths.CertFile)
+	_ = os.Remove(paths.KeyFile)
+
+	// Generate new certificates
+	if err := m.generateCerts(paths); err != nil {
+		return nil, err
+	}
+
+	return paths, nil
+}
+
+func (m *Manager) getCertPaths() *CertPaths {
+	// Sanitize domain for filename (replace dots with underscores)
+	safeDomain := strings.ReplaceAll(m.domain, ".", "_")
+	return &CertPaths{
+		CertFile: filepath.Join(m.certsDir, fmt.Sprintf("%s.pem", safeDomain)),
+		KeyFile:  filepath.Join(m.certsDir, fmt.Sprintf("%s-key.pem", safeDomain)),
+	}
+}
+
+func (m *Manager) certsExist(paths *CertPaths) bool {
+	if _, err := os.Stat(paths.CertFile); err != nil {
+		return false
+	}
+	if _, err := os.Stat(paths.KeyFile); err != nil {
+		return false
+	}
+	return true
+}
+
+func (m *Manager) generateCerts(paths *CertPaths) error {
+	if err := m.CheckMkcert(); err != nil {
+		return err
+	}
+
+	// Ensure the certs directory exists
+	if err := os.MkdirAll(m.certsDir, constants.DirPermissionPrivate); err != nil {
+		return fmt.Errorf("creating certs directory: %w", err)
+	}
+
+	// Generate wildcard certificate for the domain
+	// mkcert -cert-file <cert> -key-file <key> "*.domain" "domain"
+	wildcardDomain := fmt.Sprintf("*.%s", m.domain)
+	cmd := exec.Command("mkcert",
+		"-cert-file", paths.CertFile,
+		"-key-file", paths.KeyFile,
+		wildcardDomain,
+		m.domain,
+	)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("generating certificates for %s: %w", m.domain, err)
+	}
+
+	return nil
+}
+
+// expandPath expands ~ to the user's home directory
+func expandPath(path string) string {
+	if strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return path
+		}
+		return filepath.Join(home, path[2:])
+	}
+	return path
+}

--- a/internal/proxy/certs/certs_test.go
+++ b/internal/proxy/certs/certs_test.go
@@ -1,0 +1,90 @@
+package certs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewManager(t *testing.T) {
+	m := NewManager("~/.prox/certs", "local.myapp.dev")
+	assert.NotNil(t, m)
+	assert.Contains(t, m.certsDir, ".prox/certs")
+	assert.Equal(t, "local.myapp.dev", m.domain)
+}
+
+func TestExpandPath(t *testing.T) {
+	t.Run("expands tilde", func(t *testing.T) {
+		home, _ := os.UserHomeDir()
+		result := expandPath("~/foo/bar")
+		assert.Equal(t, filepath.Join(home, "foo/bar"), result)
+	})
+
+	t.Run("leaves absolute path unchanged", func(t *testing.T) {
+		result := expandPath("/absolute/path")
+		assert.Equal(t, "/absolute/path", result)
+	})
+
+	t.Run("leaves relative path unchanged", func(t *testing.T) {
+		result := expandPath("relative/path")
+		assert.Equal(t, "relative/path", result)
+	})
+}
+
+func TestGetCertPaths(t *testing.T) {
+	m := NewManager("/tmp/certs", "local.myapp.dev")
+	paths := m.GetCertPaths()
+
+	assert.Equal(t, "/tmp/certs/local_myapp_dev.pem", paths.CertFile)
+	assert.Equal(t, "/tmp/certs/local_myapp_dev-key.pem", paths.KeyFile)
+}
+
+func TestCertsExist(t *testing.T) {
+	// Create a temp directory for test certs
+	tmpDir, err := os.MkdirTemp("", "certs-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	m := NewManager(tmpDir, "test.dev")
+	paths := m.getCertPaths()
+
+	t.Run("returns false when no certs exist", func(t *testing.T) {
+		assert.False(t, m.certsExist(paths))
+	})
+
+	t.Run("returns false when only cert exists", func(t *testing.T) {
+		err := os.WriteFile(paths.CertFile, []byte("cert"), 0600)
+		require.NoError(t, err)
+		assert.False(t, m.certsExist(paths))
+		os.Remove(paths.CertFile)
+	})
+
+	t.Run("returns false when only key exists", func(t *testing.T) {
+		err := os.WriteFile(paths.KeyFile, []byte("key"), 0600)
+		require.NoError(t, err)
+		assert.False(t, m.certsExist(paths))
+		os.Remove(paths.KeyFile)
+	})
+
+	t.Run("returns true when both exist", func(t *testing.T) {
+		err := os.WriteFile(paths.CertFile, []byte("cert"), 0600)
+		require.NoError(t, err)
+		err = os.WriteFile(paths.KeyFile, []byte("key"), 0600)
+		require.NoError(t, err)
+		assert.True(t, m.certsExist(paths))
+	})
+}
+
+func TestCheckMkcert(t *testing.T) {
+	m := NewManager("/tmp/certs", "test.dev")
+
+	// This test depends on whether mkcert is installed
+	// We just verify the function doesn't panic
+	err := m.CheckMkcert()
+	if err != nil {
+		assert.Contains(t, err.Error(), "mkcert")
+	}
+}

--- a/internal/proxy/hosts/hosts.go
+++ b/internal/proxy/hosts/hosts.go
@@ -1,0 +1,236 @@
+// Package hosts provides management of /etc/hosts entries for the proxy.
+// It uses a managed block pattern to safely add and remove entries.
+package hosts
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+)
+
+const (
+	// BlockBegin marks the start of prox-managed entries
+	BlockBegin = "# BEGIN prox managed block"
+	// BlockEnd marks the end of prox-managed entries
+	BlockEnd = "# END prox managed block"
+)
+
+// Manager handles hosts file management.
+type Manager struct {
+	hostsPath string
+	domain    string
+	services  []string
+}
+
+// NewManager creates a new hosts file manager.
+func NewManager(domain string, services []string) *Manager {
+	return &Manager{
+		hostsPath: getHostsPath(),
+		domain:    domain,
+		services:  services,
+	}
+}
+
+// NewManagerWithPath creates a manager with a custom hosts file path (for testing).
+func NewManagerWithPath(path, domain string, services []string) *Manager {
+	return &Manager{
+		hostsPath: path,
+		domain:    domain,
+		services:  services,
+	}
+}
+
+// Check returns the current state of hosts entries.
+// Returns (entriesExist, entriesUpToDate, error).
+func (m *Manager) Check() (bool, bool, error) {
+	content, err := os.ReadFile(m.hostsPath)
+	if err != nil {
+		return false, false, fmt.Errorf("reading hosts file: %w", err)
+	}
+
+	block := m.extractManagedBlock(string(content))
+	if block == "" {
+		return false, false, nil
+	}
+
+	expected := m.generateBlock()
+	upToDate := strings.TrimSpace(block) == strings.TrimSpace(expected)
+
+	return true, upToDate, nil
+}
+
+// GetEntries returns the hostnames that would be added to /etc/hosts.
+func (m *Manager) GetEntries() []string {
+	entries := make([]string, 0, len(m.services)+1)
+	// Add base domain
+	entries = append(entries, m.domain)
+	// Add service subdomains
+	for _, svc := range m.services {
+		entries = append(entries, fmt.Sprintf("%s.%s", svc, m.domain))
+	}
+	return entries
+}
+
+// Add adds or updates the prox managed block in the hosts file.
+// This requires elevated privileges (sudo).
+func (m *Manager) Add() error {
+	// Get original file permissions before reading
+	info, err := os.Stat(m.hostsPath)
+	if err != nil {
+		return fmt.Errorf("stat hosts file: %w", err)
+	}
+	perm := info.Mode().Perm()
+
+	content, err := os.ReadFile(m.hostsPath)
+	if err != nil {
+		return fmt.Errorf("reading hosts file: %w", err)
+	}
+
+	// Remove existing block if present
+	newContent := m.removeManagedBlock(string(content))
+
+	// Add new block
+	block := m.generateBlock()
+	newContent = strings.TrimRight(newContent, "\n") + "\n\n" + block + "\n"
+
+	// Write back with original permissions
+	if err := os.WriteFile(m.hostsPath, []byte(newContent), perm); err != nil {
+		return fmt.Errorf("writing hosts file: %w", err)
+	}
+
+	return nil
+}
+
+// Remove removes the prox managed block from the hosts file.
+// This requires elevated privileges (sudo).
+func (m *Manager) Remove() error {
+	// Get original file permissions before reading
+	info, err := os.Stat(m.hostsPath)
+	if err != nil {
+		return fmt.Errorf("stat hosts file: %w", err)
+	}
+	perm := info.Mode().Perm()
+
+	content, err := os.ReadFile(m.hostsPath)
+	if err != nil {
+		return fmt.Errorf("reading hosts file: %w", err)
+	}
+
+	newContent := m.removeManagedBlock(string(content))
+
+	// Clean up any extra newlines at the end
+	newContent = strings.TrimRight(newContent, "\n") + "\n"
+
+	// Write back with original permissions
+	if err := os.WriteFile(m.hostsPath, []byte(newContent), perm); err != nil {
+		return fmt.Errorf("writing hosts file: %w", err)
+	}
+
+	return nil
+}
+
+// generateBlock creates the managed block content.
+func (m *Manager) generateBlock() string {
+	entries := m.GetEntries()
+	hostLine := "127.0.0.1 " + strings.Join(entries, " ")
+
+	return fmt.Sprintf("%s\n%s\n%s", BlockBegin, hostLine, BlockEnd)
+}
+
+// extractManagedBlock returns the content of the managed block, or empty string if not found.
+func (m *Manager) extractManagedBlock(content string) string {
+	startIdx := strings.Index(content, BlockBegin)
+	if startIdx == -1 {
+		return ""
+	}
+
+	endIdx := strings.Index(content[startIdx:], BlockEnd)
+	if endIdx == -1 {
+		return ""
+	}
+
+	return content[startIdx : startIdx+endIdx+len(BlockEnd)]
+}
+
+// removeManagedBlock removes the managed block from the content.
+func (m *Manager) removeManagedBlock(content string) string {
+	startIdx := strings.Index(content, BlockBegin)
+	if startIdx == -1 {
+		return content
+	}
+
+	endIdx := strings.Index(content[startIdx:], BlockEnd)
+	if endIdx == -1 {
+		return content
+	}
+
+	// Include the newline after BlockEnd if present
+	blockEnd := startIdx + endIdx + len(BlockEnd)
+	if blockEnd < len(content) && content[blockEnd] == '\n' {
+		blockEnd++
+	}
+
+	// Also remove the empty line before the block if present
+	if startIdx > 0 && content[startIdx-1] == '\n' {
+		startIdx--
+	}
+
+	return content[:startIdx] + content[blockEnd:]
+}
+
+// GenerateAddCommand returns a shell command that can be used to add hosts entries.
+// This is useful when the user needs to run the command with sudo.
+// The command removes any existing block first, then adds the new one.
+func (m *Manager) GenerateAddCommand() string {
+	entries := m.GetEntries()
+	hostLine := "127.0.0.1 " + strings.Join(entries, " ")
+
+	// Generate a command that removes existing block first, then adds new one
+	removeCmd := m.GenerateRemoveCommand()
+	addCmd := fmt.Sprintf(`sudo sh -c 'echo "" >> %s; echo "%s" >> %s; echo "%s" >> %s; echo "%s" >> %s'`,
+		m.hostsPath,
+		BlockBegin,
+		m.hostsPath,
+		hostLine,
+		m.hostsPath,
+		BlockEnd,
+		m.hostsPath,
+	)
+	return removeCmd + " 2>/dev/null; " + addCmd
+}
+
+// GenerateRemoveCommand returns a shell command that can be used to remove hosts entries.
+// The command syntax differs between macOS and Linux due to sed differences.
+func (m *Manager) GenerateRemoveCommand() string {
+	escapedBegin := strings.ReplaceAll(BlockBegin, " ", "\\ ")
+	escapedEnd := strings.ReplaceAll(BlockEnd, " ", "\\ ")
+
+	// macOS sed requires -i '' (empty string for in-place with no backup)
+	// Linux sed uses -i.bak (backup extension)
+	if runtime.GOOS == "darwin" {
+		return fmt.Sprintf(`sudo sed -i '' '/%s/,/%s/d' %s`,
+			escapedBegin,
+			escapedEnd,
+			m.hostsPath,
+		)
+	}
+	return fmt.Sprintf(`sudo sed -i.bak '/%s/,/%s/d' %s`,
+		escapedBegin,
+		escapedEnd,
+		m.hostsPath,
+	)
+}
+
+// PrintEntries prints the entries that would be added to stdout.
+func (m *Manager) PrintEntries() string {
+	return m.generateBlock() + "\n"
+}
+
+// getHostsPath returns the path to the hosts file for the current OS.
+func getHostsPath() string {
+	if runtime.GOOS == "windows" {
+		return `C:\Windows\System32\drivers\etc\hosts`
+	}
+	return "/etc/hosts"
+}

--- a/internal/proxy/hosts/hosts_test.go
+++ b/internal/proxy/hosts/hosts_test.go
@@ -1,0 +1,178 @@
+package hosts
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewManager(t *testing.T) {
+	m := NewManager("local.myapp.dev", []string{"app", "api"})
+	assert.Equal(t, "local.myapp.dev", m.domain)
+	assert.Equal(t, []string{"app", "api"}, m.services)
+}
+
+func TestGetEntries(t *testing.T) {
+	m := NewManager("local.myapp.dev", []string{"app", "api"})
+	entries := m.GetEntries()
+
+	assert.Len(t, entries, 3)
+	assert.Contains(t, entries, "local.myapp.dev")
+	assert.Contains(t, entries, "app.local.myapp.dev")
+	assert.Contains(t, entries, "api.local.myapp.dev")
+}
+
+func TestGenerateBlock(t *testing.T) {
+	m := NewManager("local.myapp.dev", []string{"app", "api"})
+	block := m.generateBlock()
+
+	assert.Contains(t, block, BlockBegin)
+	assert.Contains(t, block, BlockEnd)
+	assert.Contains(t, block, "127.0.0.1")
+	assert.Contains(t, block, "local.myapp.dev")
+	assert.Contains(t, block, "app.local.myapp.dev")
+	assert.Contains(t, block, "api.local.myapp.dev")
+}
+
+func TestExtractManagedBlock(t *testing.T) {
+	m := NewManager("local.myapp.dev", []string{"app"})
+
+	t.Run("extracts existing block", func(t *testing.T) {
+		content := `127.0.0.1 localhost
+# BEGIN prox managed block
+127.0.0.1 local.myapp.dev app.local.myapp.dev
+# END prox managed block
+`
+		block := m.extractManagedBlock(content)
+		assert.Contains(t, block, BlockBegin)
+		assert.Contains(t, block, BlockEnd)
+		assert.Contains(t, block, "app.local.myapp.dev")
+	})
+
+	t.Run("returns empty for no block", func(t *testing.T) {
+		content := "127.0.0.1 localhost\n"
+		block := m.extractManagedBlock(content)
+		assert.Empty(t, block)
+	})
+
+	t.Run("returns empty for incomplete block", func(t *testing.T) {
+		content := `127.0.0.1 localhost
+# BEGIN prox managed block
+127.0.0.1 app.local.myapp.dev
+`
+		block := m.extractManagedBlock(content)
+		assert.Empty(t, block)
+	})
+}
+
+func TestRemoveManagedBlock(t *testing.T) {
+	m := NewManager("local.myapp.dev", []string{"app"})
+
+	t.Run("removes existing block", func(t *testing.T) {
+		content := `127.0.0.1 localhost
+
+# BEGIN prox managed block
+127.0.0.1 local.myapp.dev app.local.myapp.dev
+# END prox managed block
+`
+		result := m.removeManagedBlock(content)
+		assert.NotContains(t, result, BlockBegin)
+		assert.NotContains(t, result, BlockEnd)
+		assert.Contains(t, result, "127.0.0.1 localhost")
+	})
+
+	t.Run("leaves content unchanged if no block", func(t *testing.T) {
+		content := "127.0.0.1 localhost\n"
+		result := m.removeManagedBlock(content)
+		assert.Equal(t, content, result)
+	})
+}
+
+func TestAddAndRemove(t *testing.T) {
+	// Create a temp hosts file
+	tmpDir, err := os.MkdirTemp("", "hosts-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	hostsPath := filepath.Join(tmpDir, "hosts")
+	initial := "127.0.0.1 localhost\n::1 localhost\n"
+	err = os.WriteFile(hostsPath, []byte(initial), 0644)
+	require.NoError(t, err)
+
+	m := NewManagerWithPath(hostsPath, "local.myapp.dev", []string{"app", "api"})
+
+	t.Run("Check shows no entries initially", func(t *testing.T) {
+		exists, upToDate, err := m.Check()
+		require.NoError(t, err)
+		assert.False(t, exists)
+		assert.False(t, upToDate)
+	})
+
+	t.Run("Add creates managed block", func(t *testing.T) {
+		err := m.Add()
+		require.NoError(t, err)
+
+		content, err := os.ReadFile(hostsPath)
+		require.NoError(t, err)
+
+		assert.Contains(t, string(content), BlockBegin)
+		assert.Contains(t, string(content), BlockEnd)
+		assert.Contains(t, string(content), "app.local.myapp.dev")
+		assert.Contains(t, string(content), "api.local.myapp.dev")
+	})
+
+	t.Run("Check shows entries exist and are up to date", func(t *testing.T) {
+		exists, upToDate, err := m.Check()
+		require.NoError(t, err)
+		assert.True(t, exists)
+		assert.True(t, upToDate)
+	})
+
+	t.Run("Add updates existing block", func(t *testing.T) {
+		// Change services
+		m.services = []string{"app", "api", "admin"}
+		err := m.Add()
+		require.NoError(t, err)
+
+		content, err := os.ReadFile(hostsPath)
+		require.NoError(t, err)
+
+		assert.Contains(t, string(content), "admin.local.myapp.dev")
+		// Should only have one block
+		assert.Equal(t, 1, strings.Count(string(content), BlockBegin))
+	})
+
+	t.Run("Remove cleans up block", func(t *testing.T) {
+		err := m.Remove()
+		require.NoError(t, err)
+
+		content, err := os.ReadFile(hostsPath)
+		require.NoError(t, err)
+
+		assert.NotContains(t, string(content), BlockBegin)
+		assert.NotContains(t, string(content), BlockEnd)
+		// Original content should still be there
+		assert.Contains(t, string(content), "127.0.0.1 localhost")
+	})
+}
+
+func TestGenerateAddCommand(t *testing.T) {
+	m := NewManager("local.myapp.dev", []string{"app"})
+	cmd := m.GenerateAddCommand()
+
+	assert.Contains(t, cmd, "sudo")
+	assert.Contains(t, cmd, BlockBegin)
+	assert.Contains(t, cmd, "app.local.myapp.dev")
+}
+
+func TestGenerateRemoveCommand(t *testing.T) {
+	m := NewManager("local.myapp.dev", []string{"app"})
+	cmd := m.GenerateRemoveCommand()
+
+	assert.Contains(t, cmd, "sudo")
+	assert.Contains(t, cmd, "sed")
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1,0 +1,331 @@
+// Package proxy provides an HTTPS reverse proxy with subdomain-based routing.
+// It allows mapping subdomains to local ports (e.g., app.local.dev:6789 → localhost:3000).
+package proxy
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/charliek/prox/internal/config"
+	"github.com/charliek/prox/internal/constants"
+	"github.com/charliek/prox/internal/proxy/certs"
+)
+
+// Service manages the HTTPS reverse proxy server.
+type Service struct {
+	cfg      *config.ProxyConfig
+	services map[string]config.ServiceConfig
+	certs    *certs.Manager
+	logger   *slog.Logger
+
+	server    *http.Server
+	transport *http.Transport
+	mu        sync.RWMutex
+
+	// Request tracking
+	requestManager *RequestManager
+}
+
+// NewService creates a new proxy service.
+// Returns an error if cfg is nil when proxy is expected to be enabled.
+func NewService(cfg *config.ProxyConfig, services map[string]config.ServiceConfig, certsCfg *config.CertsConfig, logger *slog.Logger) (*Service, error) {
+	// Allow nil cfg only if proxy won't be started
+	if cfg != nil && cfg.Enabled && cfg.Domain == "" {
+		return nil, fmt.Errorf("proxy config requires domain when enabled")
+	}
+
+	var certsMgr *certs.Manager
+	if certsCfg != nil && cfg != nil {
+		certsMgr = certs.NewManager(certsCfg.Dir, cfg.Domain)
+	}
+
+	// Create shared transport for connection pooling
+	transport := &http.Transport{
+		DialContext: (&net.Dialer{
+			Timeout:   constants.DefaultProxyDialTimeout,
+			KeepAlive: constants.DefaultProxyKeepAlive,
+		}).DialContext,
+		ResponseHeaderTimeout: constants.DefaultProxyBackendTimeout,
+		MaxIdleConns:          constants.DefaultProxyMaxIdleConns,
+		IdleConnTimeout:       constants.DefaultProxyIdleConnTimeout,
+	}
+
+	return &Service{
+		cfg:            cfg,
+		services:       services,
+		certs:          certsMgr,
+		logger:         logger,
+		transport:      transport,
+		requestManager: NewRequestManager(constants.DefaultProxyRequestBufferSize),
+	}, nil
+}
+
+// Start starts the HTTPS reverse proxy server.
+func (s *Service) Start(ctx context.Context) error {
+	if s.cfg == nil || !s.cfg.Enabled {
+		return nil
+	}
+
+	// Check that certs manager is configured
+	if s.certs == nil {
+		return fmt.Errorf("certificates not configured for proxy")
+	}
+
+	// Ensure certificates exist
+	certPaths, err := s.certs.EnsureCerts()
+	if err != nil {
+		return fmt.Errorf("ensuring certificates: %w", err)
+	}
+
+	// Load TLS certificate
+	cert, err := tls.LoadX509KeyPair(certPaths.CertFile, certPaths.KeyFile)
+	if err != nil {
+		return fmt.Errorf("loading TLS certificate: %w", err)
+	}
+
+	// Create TLS config
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS12,
+	}
+
+	// Create the router
+	router := s.createRouter()
+
+	// Create HTTP server
+	addr := fmt.Sprintf(":%d", s.cfg.HTTPSPort)
+	server := &http.Server{
+		Addr:         addr,
+		Handler:      router,
+		TLSConfig:    tlsConfig,
+		ReadTimeout:  constants.DefaultProxyReadTimeout,
+		WriteTimeout: constants.DefaultProxyWriteTimeout,
+		IdleTimeout:  constants.DefaultProxyIdleTimeout,
+	}
+
+	// Assign server with lock to avoid race condition with Shutdown
+	s.mu.Lock()
+	s.server = server
+	s.mu.Unlock()
+
+	// Start listening
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("listening on %s: %w", addr, err)
+	}
+
+	tlsListener := tls.NewListener(listener, tlsConfig)
+
+	s.logger.Info("proxy server started",
+		"addr", addr,
+		"domain", s.cfg.Domain,
+		"services", len(s.services),
+	)
+
+	// Start server in goroutine
+	go func() {
+		if err := s.server.Serve(tlsListener); err != nil && err != http.ErrServerClosed {
+			s.logger.Error("proxy server error", "error", err)
+		}
+	}()
+
+	return nil
+}
+
+// Shutdown gracefully stops the proxy server.
+func (s *Service) Shutdown(ctx context.Context) error {
+	s.mu.Lock()
+	server := s.server
+	s.mu.Unlock()
+
+	if server == nil {
+		return nil
+	}
+
+	s.logger.Info("shutting down proxy server")
+
+	// Close the request manager to clean up subscriptions
+	s.requestManager.Close()
+
+	return server.Shutdown(ctx)
+}
+
+// RequestManager returns the request manager for tracking proxy requests.
+func (s *Service) RequestManager() *RequestManager {
+	return s.requestManager
+}
+
+// createRouter creates the HTTP handler that routes requests based on subdomain.
+func (s *Service) createRouter() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		startTime := time.Now()
+
+		// Extract subdomain from host
+		subdomain := s.extractSubdomain(r.Host)
+		if subdomain == "" {
+			s.recordRequest(r, subdomain, http.StatusNotFound, startTime)
+			http.Error(w, "No subdomain specified", http.StatusNotFound)
+			return
+		}
+
+		// Look up service
+		svc, ok := s.services[subdomain]
+		if !ok {
+			s.recordRequest(r, subdomain, http.StatusNotFound, startTime)
+			http.Error(w, fmt.Sprintf("Unknown service: %s", subdomain), http.StatusNotFound)
+			return
+		}
+
+		// Create reverse proxy
+		target := &url.URL{
+			Scheme: "http",
+			Host:   fmt.Sprintf("%s:%d", svc.Host, svc.Port),
+		}
+
+		proxy := httputil.NewSingleHostReverseProxy(target)
+
+		// Use shared transport for connection pooling
+		proxy.Transport = s.transport
+
+		// Customize the director to preserve the original request info
+		originalDirector := proxy.Director
+		proxy.Director = func(req *http.Request) {
+			originalDirector(req)
+			// Preserve the original host header for applications that need it
+			req.Header.Set("X-Forwarded-Host", r.Host)
+			req.Header.Set("X-Forwarded-Proto", "https")
+			req.Header.Set("X-Real-IP", getClientIP(r))
+		}
+
+		// Wrap response writer to capture status code (before ErrorHandler so it can set status)
+		rw := &responseWriter{ResponseWriter: w, statusCode: http.StatusOK}
+
+		// Custom error handler - log detailed error but return generic message to client
+		// Note: We set rw.statusCode here instead of calling recordRequest to avoid double-recording
+		proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
+			s.logger.Error("proxy error",
+				"subdomain", subdomain,
+				"target", target.String(),
+				"error", err,
+			)
+			rw.statusCode = http.StatusBadGateway
+			http.Error(w, "Backend unavailable", http.StatusBadGateway)
+		}
+
+		// Serve the request
+		proxy.ServeHTTP(rw, r)
+
+		// Record the request (single recording point for all cases)
+		s.recordRequest(r, subdomain, rw.statusCode, startTime)
+	})
+}
+
+// extractSubdomain extracts the subdomain from the host header.
+// For example, "app.local.myapp.dev:6789" with domain "local.myapp.dev" returns "app".
+func (s *Service) extractSubdomain(host string) string {
+	// Remove port if present
+	if colonIdx := strings.LastIndex(host, ":"); colonIdx != -1 {
+		host = host[:colonIdx]
+	}
+
+	// Check if host ends with our domain with a proper label boundary (dot)
+	// This prevents "evilocal.myapp.dev" from matching domain "local.myapp.dev"
+	suffix := "." + s.cfg.Domain
+	if !strings.HasSuffix(host, suffix) {
+		return ""
+	}
+
+	// Remove the domain and the dot before it
+	subdomain := strings.TrimSuffix(host, suffix)
+
+	// Handle nested subdomains - take only the first part
+	if dotIdx := strings.Index(subdomain, "."); dotIdx != -1 {
+		subdomain = subdomain[:dotIdx]
+	}
+
+	return subdomain
+}
+
+// recordRequest records a request in the request manager.
+func (s *Service) recordRequest(r *http.Request, subdomain string, statusCode int, startTime time.Time) {
+	record := RequestRecord{
+		Timestamp:  startTime,
+		Method:     r.Method,
+		URL:        r.URL.String(),
+		Subdomain:  subdomain,
+		StatusCode: statusCode,
+		Duration:   time.Since(startTime),
+		RemoteAddr: getClientIP(r),
+	}
+	s.requestManager.Record(record)
+}
+
+// getClientIP extracts the client IP from the request.
+func getClientIP(r *http.Request) string {
+	// Check X-Forwarded-For header
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		if idx := strings.Index(xff, ","); idx != -1 {
+			return strings.TrimSpace(xff[:idx])
+		}
+		return strings.TrimSpace(xff)
+	}
+
+	// Check X-Real-IP header
+	if xri := r.Header.Get("X-Real-IP"); xri != "" {
+		return xri
+	}
+
+	// Fall back to RemoteAddr
+	ip, _, _ := net.SplitHostPort(r.RemoteAddr)
+	return ip
+}
+
+// responseWriter wraps http.ResponseWriter to capture the status code.
+type responseWriter struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func (rw *responseWriter) WriteHeader(code int) {
+	rw.statusCode = code
+	rw.ResponseWriter.WriteHeader(code)
+}
+
+// Flush implements http.Flusher for streaming responses (SSE).
+func (rw *responseWriter) Flush() {
+	if f, ok := rw.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// Hijack implements http.Hijacker for WebSocket support.
+func (rw *responseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if h, ok := rw.ResponseWriter.(http.Hijacker); ok {
+		return h.Hijack()
+	}
+	return nil, nil, errors.New("hijacking not supported")
+}
+
+// Push implements http.Pusher for HTTP/2 server push.
+func (rw *responseWriter) Push(target string, opts *http.PushOptions) error {
+	if p, ok := rw.ResponseWriter.(http.Pusher); ok {
+		return p.Push(target, opts)
+	}
+	return http.ErrNotSupported
+}
+
+// Unwrap returns the underlying ResponseWriter for Go 1.20+ http.ResponseController compatibility.
+func (rw *responseWriter) Unwrap() http.ResponseWriter {
+	return rw.ResponseWriter
+}

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1,0 +1,133 @@
+package proxy
+
+import (
+	"log/slog"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/charliek/prox/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractSubdomain(t *testing.T) {
+	cfg := &config.ProxyConfig{
+		Domain: "local.myapp.dev",
+	}
+	s := &Service{cfg: cfg}
+
+	tests := []struct {
+		name     string
+		host     string
+		expected string
+	}{
+		{"simple subdomain", "app.local.myapp.dev", "app"},
+		{"subdomain with port", "app.local.myapp.dev:6789", "app"},
+		{"nested subdomain", "foo.bar.local.myapp.dev", "foo"},
+		{"api subdomain", "api.local.myapp.dev:6789", "api"},
+		{"no subdomain", "local.myapp.dev", ""},
+		{"no subdomain with port", "local.myapp.dev:6789", ""},
+		{"wrong domain", "app.other.dev", ""},
+		{"empty host", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := s.extractSubdomain(tt.host)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetClientIP(t *testing.T) {
+	tests := []struct {
+		name       string
+		remoteAddr string
+		xff        string
+		xri        string
+		expected   string
+	}{
+		{"from RemoteAddr", "192.168.1.1:1234", "", "", "192.168.1.1"},
+		{"from X-Forwarded-For", "192.168.1.1:1234", "10.0.0.1", "", "10.0.0.1"},
+		{"from X-Forwarded-For multiple", "192.168.1.1:1234", "10.0.0.1, 10.0.0.2", "", "10.0.0.1"},
+		{"from X-Real-IP", "192.168.1.1:1234", "", "172.16.0.1", "172.16.0.1"},
+		{"X-Forwarded-For takes precedence", "192.168.1.1:1234", "10.0.0.1", "172.16.0.1", "10.0.0.1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/test", nil)
+			req.RemoteAddr = tt.remoteAddr
+			if tt.xff != "" {
+				req.Header.Set("X-Forwarded-For", tt.xff)
+			}
+			if tt.xri != "" {
+				req.Header.Set("X-Real-IP", tt.xri)
+			}
+
+			result := getClientIP(req)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestNewService(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	t.Run("nil config is allowed", func(t *testing.T) {
+		svc, err := NewService(nil, nil, nil, logger)
+		require.NoError(t, err)
+		assert.NotNil(t, svc)
+	})
+
+	t.Run("disabled proxy with no domain is allowed", func(t *testing.T) {
+		cfg := &config.ProxyConfig{
+			Enabled: false,
+		}
+		svc, err := NewService(cfg, nil, nil, logger)
+		require.NoError(t, err)
+		assert.NotNil(t, svc)
+	})
+
+	t.Run("enabled proxy without domain fails", func(t *testing.T) {
+		cfg := &config.ProxyConfig{
+			Enabled:   true,
+			HTTPSPort: 6789,
+		}
+		svc, err := NewService(cfg, nil, nil, logger)
+		require.Error(t, err)
+		assert.Nil(t, svc)
+		assert.Contains(t, err.Error(), "domain")
+	})
+
+	t.Run("enabled proxy with domain succeeds", func(t *testing.T) {
+		cfg := &config.ProxyConfig{
+			Enabled:   true,
+			HTTPSPort: 6789,
+			Domain:    "local.myapp.dev",
+		}
+		services := map[string]config.ServiceConfig{
+			"app": {Port: 3000, Host: "localhost"},
+		}
+		svc, err := NewService(cfg, services, nil, logger)
+		require.NoError(t, err)
+		assert.NotNil(t, svc)
+	})
+}
+
+func TestRequestManagerSubscriptionID(t *testing.T) {
+	rm := NewRequestManager(10)
+
+	t.Run("subscription IDs are formatted correctly", func(t *testing.T) {
+		sub1 := rm.Subscribe(RequestFilter{})
+		defer rm.Unsubscribe(sub1.ID)
+
+		assert.Equal(t, "sub-1", sub1.ID)
+
+		sub2 := rm.Subscribe(RequestFilter{})
+		defer rm.Unsubscribe(sub2.ID)
+
+		assert.Equal(t, "sub-2", sub2.ID)
+	})
+}

--- a/internal/proxy/requests.go
+++ b/internal/proxy/requests.go
@@ -1,0 +1,178 @@
+package proxy
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// RequestRecord represents a single proxied request.
+type RequestRecord struct {
+	Timestamp  time.Time     `json:"timestamp"`
+	Method     string        `json:"method"`
+	URL        string        `json:"url"`
+	Subdomain  string        `json:"subdomain"`
+	StatusCode int           `json:"status_code"`
+	Duration   time.Duration `json:"duration"`
+	RemoteAddr string        `json:"remote_addr"`
+}
+
+// RequestFilter specifies criteria for filtering requests.
+type RequestFilter struct {
+	Subdomain string
+	Method    string
+	MinStatus int
+	MaxStatus int
+	Since     time.Time
+	Limit     int
+}
+
+// RequestSubscription represents a subscription to request updates.
+type RequestSubscription struct {
+	ID     string
+	Filter RequestFilter
+	Ch     chan RequestRecord
+}
+
+// RequestManager tracks proxied requests in a ring buffer and supports subscriptions.
+type RequestManager struct {
+	mu       sync.RWMutex
+	buffer   []RequestRecord
+	head     int
+	count    int
+	capacity int
+
+	subMu  sync.RWMutex
+	subs   map[string]*RequestSubscription
+	nextID int
+}
+
+// NewRequestManager creates a new request manager with the specified buffer capacity.
+func NewRequestManager(capacity int) *RequestManager {
+	if capacity <= 0 {
+		capacity = 1
+	}
+	return &RequestManager{
+		buffer:   make([]RequestRecord, capacity),
+		capacity: capacity,
+		subs:     make(map[string]*RequestSubscription),
+	}
+}
+
+// Record adds a new request record to the buffer and notifies subscribers.
+func (m *RequestManager) Record(record RequestRecord) {
+	m.mu.Lock()
+	m.buffer[m.head] = record
+	m.head = (m.head + 1) % m.capacity
+	if m.count < m.capacity {
+		m.count++
+	}
+	m.mu.Unlock()
+
+	// Notify subscribers
+	m.notifySubscribers(record)
+}
+
+// Recent returns the most recent requests matching the filter.
+func (m *RequestManager) Recent(filter RequestFilter) []RequestRecord {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	limit := filter.Limit
+	if limit <= 0 || limit > m.count {
+		limit = m.count
+	}
+
+	result := make([]RequestRecord, 0, limit)
+
+	// Iterate from newest to oldest
+	for i := 0; i < m.count && len(result) < limit; i++ {
+		idx := (m.head - 1 - i + m.capacity) % m.capacity
+		record := m.buffer[idx]
+
+		if m.matchesFilter(record, filter) {
+			result = append(result, record)
+		}
+	}
+
+	return result
+}
+
+// Subscribe creates a subscription for real-time request updates.
+func (m *RequestManager) Subscribe(filter RequestFilter) *RequestSubscription {
+	m.subMu.Lock()
+	defer m.subMu.Unlock()
+
+	m.nextID++
+	sub := &RequestSubscription{
+		ID:     fmt.Sprintf("sub-%d", m.nextID),
+		Filter: filter,
+		Ch:     make(chan RequestRecord, 100),
+	}
+	m.subs[sub.ID] = sub
+
+	return sub
+}
+
+// Unsubscribe removes a subscription.
+func (m *RequestManager) Unsubscribe(id string) {
+	m.subMu.Lock()
+	defer m.subMu.Unlock()
+
+	if sub, ok := m.subs[id]; ok {
+		close(sub.Ch)
+		delete(m.subs, id)
+	}
+}
+
+// Count returns the number of requests currently in the buffer.
+func (m *RequestManager) Count() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.count
+}
+
+// Close closes all subscription channels and cleans up resources.
+func (m *RequestManager) Close() {
+	m.subMu.Lock()
+	defer m.subMu.Unlock()
+
+	for id, sub := range m.subs {
+		close(sub.Ch)
+		delete(m.subs, id)
+	}
+}
+
+func (m *RequestManager) notifySubscribers(record RequestRecord) {
+	m.subMu.RLock()
+	defer m.subMu.RUnlock()
+
+	for _, sub := range m.subs {
+		if m.matchesFilter(record, sub.Filter) {
+			select {
+			case sub.Ch <- record:
+			default:
+				// Channel full, drop the message
+			}
+		}
+	}
+}
+
+func (m *RequestManager) matchesFilter(record RequestRecord, filter RequestFilter) bool {
+	if filter.Subdomain != "" && record.Subdomain != filter.Subdomain {
+		return false
+	}
+	if filter.Method != "" && record.Method != filter.Method {
+		return false
+	}
+	if filter.MinStatus > 0 && record.StatusCode < filter.MinStatus {
+		return false
+	}
+	if filter.MaxStatus > 0 && record.StatusCode > filter.MaxStatus {
+		return false
+	}
+	if !filter.Since.IsZero() && record.Timestamp.Before(filter.Since) {
+		return false
+	}
+	return true
+}

--- a/internal/proxy/requests_test.go
+++ b/internal/proxy/requests_test.go
@@ -1,0 +1,154 @@
+package proxy
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequestManager_Record(t *testing.T) {
+	m := NewRequestManager(10)
+
+	record := RequestRecord{
+		Timestamp:  time.Now(),
+		Method:     "GET",
+		URL:        "/api/users",
+		Subdomain:  "api",
+		StatusCode: 200,
+		Duration:   100 * time.Millisecond,
+		RemoteAddr: "127.0.0.1",
+	}
+
+	m.Record(record)
+	assert.Equal(t, 1, m.Count())
+}
+
+func TestRequestManager_Recent(t *testing.T) {
+	m := NewRequestManager(10)
+
+	// Add some records
+	for i := 0; i < 5; i++ {
+		m.Record(RequestRecord{
+			Timestamp:  time.Now().Add(time.Duration(i) * time.Second),
+			Method:     "GET",
+			URL:        "/api/users",
+			Subdomain:  "api",
+			StatusCode: 200,
+			Duration:   100 * time.Millisecond,
+		})
+	}
+
+	t.Run("returns all records", func(t *testing.T) {
+		records := m.Recent(RequestFilter{})
+		assert.Len(t, records, 5)
+	})
+
+	t.Run("respects limit", func(t *testing.T) {
+		records := m.Recent(RequestFilter{Limit: 3})
+		assert.Len(t, records, 3)
+	})
+
+	t.Run("returns newest first", func(t *testing.T) {
+		records := m.Recent(RequestFilter{})
+		for i := 1; i < len(records); i++ {
+			assert.True(t, records[i-1].Timestamp.After(records[i].Timestamp) ||
+				records[i-1].Timestamp.Equal(records[i].Timestamp))
+		}
+	})
+}
+
+func TestRequestManager_Filter(t *testing.T) {
+	m := NewRequestManager(100)
+
+	// Add mixed records
+	m.Record(RequestRecord{Subdomain: "api", Method: "GET", StatusCode: 200})
+	m.Record(RequestRecord{Subdomain: "api", Method: "POST", StatusCode: 201})
+	m.Record(RequestRecord{Subdomain: "app", Method: "GET", StatusCode: 200})
+	m.Record(RequestRecord{Subdomain: "api", Method: "GET", StatusCode: 500})
+
+	t.Run("filter by subdomain", func(t *testing.T) {
+		records := m.Recent(RequestFilter{Subdomain: "api"})
+		assert.Len(t, records, 3)
+	})
+
+	t.Run("filter by method", func(t *testing.T) {
+		records := m.Recent(RequestFilter{Method: "GET"})
+		assert.Len(t, records, 3)
+	})
+
+	t.Run("filter by status range", func(t *testing.T) {
+		records := m.Recent(RequestFilter{MinStatus: 200, MaxStatus: 299})
+		assert.Len(t, records, 3)
+	})
+
+	t.Run("combined filters", func(t *testing.T) {
+		records := m.Recent(RequestFilter{Subdomain: "api", Method: "GET"})
+		assert.Len(t, records, 2)
+	})
+}
+
+func TestRequestManager_RingBuffer(t *testing.T) {
+	m := NewRequestManager(5)
+
+	// Add more records than capacity
+	for i := 0; i < 10; i++ {
+		m.Record(RequestRecord{
+			StatusCode: i,
+		})
+	}
+
+	assert.Equal(t, 5, m.Count())
+
+	records := m.Recent(RequestFilter{})
+	assert.Len(t, records, 5)
+
+	// Should have the newest records (5-9)
+	for i, r := range records {
+		expected := 9 - i
+		assert.Equal(t, expected, r.StatusCode)
+	}
+}
+
+func TestRequestManager_Subscribe(t *testing.T) {
+	m := NewRequestManager(10)
+
+	sub := m.Subscribe(RequestFilter{Subdomain: "api"})
+	require.NotNil(t, sub)
+
+	// Record a matching request
+	go func() {
+		m.Record(RequestRecord{Subdomain: "api", Method: "GET"})
+	}()
+
+	select {
+	case record := <-sub.Ch:
+		assert.Equal(t, "api", record.Subdomain)
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for record")
+	}
+
+	// Record a non-matching request
+	m.Record(RequestRecord{Subdomain: "app", Method: "GET"})
+
+	select {
+	case <-sub.Ch:
+		t.Fatal("should not receive non-matching record")
+	case <-time.After(100 * time.Millisecond):
+		// Expected
+	}
+
+	m.Unsubscribe(sub.ID)
+}
+
+func TestRequestManager_Unsubscribe(t *testing.T) {
+	m := NewRequestManager(10)
+
+	sub := m.Subscribe(RequestFilter{})
+	m.Unsubscribe(sub.ID)
+
+	// Channel should be closed
+	_, ok := <-sub.Ch
+	assert.False(t, ok)
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -9,11 +9,12 @@ import (
 	"github.com/charliek/prox/internal/api"
 	"github.com/charliek/prox/internal/domain"
 	"github.com/charliek/prox/internal/logs"
+	"github.com/charliek/prox/internal/proxy"
 	"github.com/charliek/prox/internal/supervisor"
 )
 
 // Run starts the TUI application
-func Run(sup *supervisor.Supervisor, logMgr *logs.Manager) error {
+func Run(sup *supervisor.Supervisor, logMgr *logs.Manager, reqMgr *proxy.RequestManager) error {
 	model := NewModel(sup, logMgr)
 	p := tea.NewProgram(model, tea.WithAltScreen())
 
@@ -22,8 +23,8 @@ func Run(sup *supervisor.Supervisor, logMgr *logs.Manager) error {
 	// Subscribe to logs before starting the forwarder
 	subID, ch, err := logMgr.Subscribe(domain.LogFilter{})
 	if err != nil {
-		cancel()
 		// Send error as a system log entry so user sees feedback
+		// Don't cancel context here - proxy request forwarding should still work
 		p.Send(LogEntryMsg(domain.LogEntry{
 			Timestamp: time.Now(),
 			Process:   "system",
@@ -35,12 +36,23 @@ func Run(sup *supervisor.Supervisor, logMgr *logs.Manager) error {
 		go forwardLogs(ctx, p, ch)
 	}
 
+	// Subscribe to proxy requests if available
+	var reqSubID string
+	if reqMgr != nil {
+		sub := reqMgr.Subscribe(proxy.RequestFilter{})
+		reqSubID = sub.ID
+		go forwardProxyRequests(ctx, p, sub.Ch)
+	}
+
 	_, runErr := p.Run()
 
 	// Cleanup: cancel context and unsubscribe
 	cancel()
 	if subID != "" {
 		logMgr.Unsubscribe(subID)
+	}
+	if reqSubID != "" && reqMgr != nil {
+		reqMgr.Unsubscribe(reqSubID)
 	}
 
 	return runErr
@@ -62,12 +74,29 @@ func forwardLogs(ctx context.Context, p *tea.Program, ch <-chan domain.LogEntry)
 	}
 }
 
+// forwardProxyRequests forwards proxy requests from the subscription channel to the TUI program.
+// It exits when the context is cancelled or the channel is closed.
+func forwardProxyRequests(ctx context.Context, p *tea.Program, ch <-chan proxy.RequestRecord) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case req, ok := <-ch:
+			if !ok {
+				return
+			}
+			p.Send(ProxyRequestMsg(req))
+		}
+	}
+}
+
 // TUIClient is the interface for TUI client mode API interactions.
 // It consolidates all API operations needed by the TUI client.
 type TUIClient interface {
 	GetProcesses() (*api.ProcessListResponse, error)
 	RestartProcess(name string) error
 	StreamLogsChannel(params domain.LogParams) (<-chan api.LogEntryResponse, error)
+	StreamProxyRequestsChannel() (<-chan api.ProxyRequestResponse, error)
 }
 
 // RunClient starts the TUI application in client mode (connected via API)
@@ -77,12 +106,13 @@ func RunClient(client TUIClient) error {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	// Start a goroutine to stream logs from the API
+	// Start goroutines to stream logs and proxy requests from the API
 	go forwardClientLogs(ctx, p, client)
+	go forwardClientProxyRequests(ctx, p, client)
 
 	_, err := p.Run()
 
-	// Cleanup: cancel context to stop the forwarder goroutine
+	// Cleanup: cancel context to stop the forwarder goroutines
 	cancel()
 
 	return err
@@ -122,6 +152,13 @@ func forwardClientLogs(ctx context.Context, p *tea.Program, client TUIClient) {
 			ts, parseErr := time.Parse(time.RFC3339Nano, entry.Timestamp)
 			if parseErr != nil {
 				ts = time.Now() // Fallback for malformed timestamps
+				// Log warning so server-side timestamp bugs are visible
+				p.Send(LogEntryMsg(domain.LogEntry{
+					Timestamp: ts,
+					Process:   "system",
+					Stream:    domain.StreamStderr,
+					Line:      "Warning: failed to parse log timestamp: " + parseErr.Error(),
+				}))
 			}
 			logEntry := domain.LogEntry{
 				Timestamp: ts,
@@ -130,6 +167,50 @@ func forwardClientLogs(ctx context.Context, p *tea.Program, client TUIClient) {
 				Line:      entry.Line,
 			}
 			p.Send(LogEntryMsg(logEntry))
+		}
+	}
+}
+
+// forwardClientProxyRequests streams proxy requests from the API and sends them to the TUI program.
+// It exits when the context is cancelled or the channel is closed.
+func forwardClientProxyRequests(ctx context.Context, p *tea.Program, client TUIClient) {
+	ch, err := client.StreamProxyRequestsChannel()
+	if err != nil {
+		// Proxy may not be enabled - this is not an error, just silently return
+		return
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case req, ok := <-ch:
+			if !ok {
+				// Channel closed - connection lost
+				return
+			}
+			// Convert API response to RequestRecord
+			ts, parseErr := time.Parse(time.RFC3339Nano, req.Timestamp)
+			if parseErr != nil {
+				ts = time.Now() // Fallback for malformed timestamps
+				// Log warning so server-side timestamp bugs are visible
+				p.Send(LogEntryMsg(domain.LogEntry{
+					Timestamp: ts,
+					Process:   "system",
+					Stream:    domain.StreamStderr,
+					Line:      "Warning: failed to parse proxy request timestamp: " + parseErr.Error(),
+				}))
+			}
+			record := proxy.RequestRecord{
+				Timestamp:  ts,
+				Method:     req.Method,
+				URL:        req.URL,
+				Subdomain:  req.Subdomain,
+				StatusCode: req.StatusCode,
+				Duration:   time.Duration(req.DurationMs) * time.Millisecond,
+				RemoteAddr: req.RemoteAddr,
+			}
+			p.Send(ProxyRequestMsg(record))
 		}
 	}
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/charliek/prox/internal/domain"
 	"github.com/charliek/prox/internal/logs"
+	"github.com/charliek/prox/internal/proxy"
 	"github.com/charliek/prox/internal/supervisor"
 )
 
@@ -19,6 +20,14 @@ const (
 	ModeSearch
 	ModeStringFilter
 	ModeHelp
+)
+
+// ViewMode represents which content is being displayed
+type ViewMode int
+
+const (
+	ViewModeLogs ViewMode = iota
+	ViewModeRequests
 )
 
 // Model is the bubbletea model for the TUI
@@ -35,7 +44,10 @@ type Model struct {
 
 // NewModel creates a new TUI model
 func NewModel(sup *supervisor.Supervisor, logMgr *logs.Manager) Model {
-	base := newBaseModel()
+	base := newBaseModel(HelpConfig{
+		TitleSuffix: "",
+		QuitMessage: "Quit",
+	})
 
 	// Initialize filter to show all processes
 	for _, p := range sup.Processes() {
@@ -61,6 +73,9 @@ func (m Model) Init() tea.Cmd {
 
 // LogEntryMsg is sent when a new log entry arrives
 type LogEntryMsg domain.LogEntry
+
+// ProxyRequestMsg is sent when a new proxy request is recorded
+type ProxyRequestMsg proxy.RequestRecord
 
 // ProcessesMsg is sent when processes should be refreshed
 type ProcessesMsg []domain.ProcessInfo

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -9,14 +9,20 @@ import (
 
 	"github.com/charliek/prox/internal/domain"
 	"github.com/charliek/prox/internal/logs"
+	"github.com/charliek/prox/internal/proxy"
 	"github.com/charliek/prox/internal/supervisor"
 )
 
-func TestNewModel(t *testing.T) {
+// newTestModel creates a Model with default test dependencies.
+// This reduces boilerplate in tests that need a basic model.
+func newTestModel() Model {
 	logMgr := logs.NewManager(logs.DefaultManagerConfig())
 	sup := supervisor.New(nil, logMgr, nil, supervisor.DefaultSupervisorConfig())
+	return NewModel(sup, logMgr)
+}
 
-	model := NewModel(sup, logMgr)
+func TestNewModel(t *testing.T) {
+	model := newTestModel()
 
 	assert.Equal(t, ModeNormal, model.mode)
 	assert.False(t, model.ready)
@@ -24,10 +30,7 @@ func TestNewModel(t *testing.T) {
 }
 
 func TestModel_HandleKey_Quit(t *testing.T) {
-	logMgr := logs.NewManager(logs.DefaultManagerConfig())
-	sup := supervisor.New(nil, logMgr, nil, supervisor.DefaultSupervisorConfig())
-
-	model := NewModel(sup, logMgr)
+	model := newTestModel()
 
 	// Test quit with 'q'
 	newModel, cmd := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
@@ -36,10 +39,7 @@ func TestModel_HandleKey_Quit(t *testing.T) {
 }
 
 func TestModel_HandleKey_ModeSwitch(t *testing.T) {
-	logMgr := logs.NewManager(logs.DefaultManagerConfig())
-	sup := supervisor.New(nil, logMgr, nil, supervisor.DefaultSupervisorConfig())
-
-	model := NewModel(sup, logMgr)
+	model := newTestModel()
 
 	// Test switching to help mode
 	newModel, _ := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'?'}})
@@ -47,29 +47,26 @@ func TestModel_HandleKey_ModeSwitch(t *testing.T) {
 	assert.Equal(t, ModeHelp, m.mode)
 
 	// Test switching to filter mode
-	model = NewModel(sup, logMgr)
+	model = newTestModel()
 	newModel, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
 	m = newModel.(Model)
 	assert.Equal(t, ModeFilter, m.mode)
 
 	// Test switching to search mode
-	model = NewModel(sup, logMgr)
+	model = newTestModel()
 	newModel, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
 	m = newModel.(Model)
 	assert.Equal(t, ModeSearch, m.mode)
 
 	// Test switching to string filter mode
-	model = NewModel(sup, logMgr)
+	model = newTestModel()
 	newModel, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
 	m = newModel.(Model)
 	assert.Equal(t, ModeStringFilter, m.mode)
 }
 
 func TestModel_HandleKey_EscClearsFilters(t *testing.T) {
-	logMgr := logs.NewManager(logs.DefaultManagerConfig())
-	sup := supervisor.New(nil, logMgr, nil, supervisor.DefaultSupervisorConfig())
-
-	model := NewModel(sup, logMgr)
+	model := newTestModel()
 	model.soloProcess = "test"
 	model.searchPattern = "pattern"
 
@@ -81,10 +78,7 @@ func TestModel_HandleKey_EscClearsFilters(t *testing.T) {
 }
 
 func TestModel_LogEntryMsg(t *testing.T) {
-	logMgr := logs.NewManager(logs.DefaultManagerConfig())
-	sup := supervisor.New(nil, logMgr, nil, supervisor.DefaultSupervisorConfig())
-
-	model := NewModel(sup, logMgr)
+	model := newTestModel()
 	model.ready = true // Set ready to avoid viewport issues
 
 	entry := domain.LogEntry{
@@ -103,10 +97,7 @@ func TestModel_LogEntryMsg(t *testing.T) {
 }
 
 func TestModel_LogEntryLimit(t *testing.T) {
-	logMgr := logs.NewManager(logs.DefaultManagerConfig())
-	sup := supervisor.New(nil, logMgr, nil, supervisor.DefaultSupervisorConfig())
-
-	model := NewModel(sup, logMgr)
+	model := newTestModel()
 	model.ready = true
 
 	// Add more than 1000 entries
@@ -126,10 +117,7 @@ func TestModel_LogEntryLimit(t *testing.T) {
 }
 
 func TestFilteredEntries(t *testing.T) {
-	logMgr := logs.NewManager(logs.DefaultManagerConfig())
-	sup := supervisor.New(nil, logMgr, nil, supervisor.DefaultSupervisorConfig())
-
-	model := NewModel(sup, logMgr)
+	model := newTestModel()
 
 	// Add some log entries
 	model.logEntries = []domain.LogEntry{
@@ -183,10 +171,7 @@ func TestContainsIgnoreCase(t *testing.T) {
 }
 
 func TestUpdateSearchMatches(t *testing.T) {
-	logMgr := logs.NewManager(logs.DefaultManagerConfig())
-	sup := supervisor.New(nil, logMgr, nil, supervisor.DefaultSupervisorConfig())
-
-	model := NewModel(sup, logMgr)
+	model := newTestModel()
 
 	model.logEntries = []domain.LogEntry{
 		{Line: "error: something failed"},
@@ -204,19 +189,13 @@ func TestUpdateSearchMatches(t *testing.T) {
 }
 
 func TestFollowModeDefaults(t *testing.T) {
-	logMgr := logs.NewManager(logs.DefaultManagerConfig())
-	sup := supervisor.New(nil, logMgr, nil, supervisor.DefaultSupervisorConfig())
-
-	model := NewModel(sup, logMgr)
+	model := newTestModel()
 
 	// followMode should default to true
 	assert.True(t, model.followMode)
 }
 
 func TestFollowModeDisabledOnScrollUp(t *testing.T) {
-	logMgr := logs.NewManager(logs.DefaultManagerConfig())
-	sup := supervisor.New(nil, logMgr, nil, supervisor.DefaultSupervisorConfig())
-
 	tests := []struct {
 		name string
 		key  tea.KeyMsg
@@ -230,7 +209,7 @@ func TestFollowModeDisabledOnScrollUp(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			model := NewModel(sup, logMgr)
+			model := newTestModel()
 			assert.True(t, model.followMode) // starts true
 
 			newModel, _ := model.Update(tt.key)
@@ -242,9 +221,6 @@ func TestFollowModeDisabledOnScrollUp(t *testing.T) {
 }
 
 func TestFollowModeEnabledOnGoToBottom(t *testing.T) {
-	logMgr := logs.NewManager(logs.DefaultManagerConfig())
-	sup := supervisor.New(nil, logMgr, nil, supervisor.DefaultSupervisorConfig())
-
 	tests := []struct {
 		name string
 		key  tea.KeyMsg
@@ -255,7 +231,7 @@ func TestFollowModeEnabledOnGoToBottom(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			model := NewModel(sup, logMgr)
+			model := newTestModel()
 			model.followMode = false // start with followMode disabled
 
 			newModel, _ := model.Update(tt.key)
@@ -267,10 +243,7 @@ func TestFollowModeEnabledOnGoToBottom(t *testing.T) {
 }
 
 func TestFollowModeToggle(t *testing.T) {
-	logMgr := logs.NewManager(logs.DefaultManagerConfig())
-	sup := supervisor.New(nil, logMgr, nil, supervisor.DefaultSupervisorConfig())
-
-	model := NewModel(sup, logMgr)
+	model := newTestModel()
 	assert.True(t, model.followMode) // starts true
 
 	// First toggle - should disable
@@ -282,4 +255,271 @@ func TestFollowModeToggle(t *testing.T) {
 	newModel, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'F'}})
 	m = newModel.(Model)
 	assert.True(t, m.followMode)
+}
+
+func TestFilteredProxyRequests(t *testing.T) {
+	model := newTestModel()
+
+	// Add some proxy requests
+	model.proxyRequests = []proxy.RequestRecord{
+		{Subdomain: "api", Method: "GET", URL: "/users"},
+		{Subdomain: "web", Method: "POST", URL: "/login"},
+		{Subdomain: "api", Method: "GET", URL: "/posts"},
+		{Subdomain: "admin", Method: "DELETE", URL: "/users/1"},
+	}
+
+	// No filter - should return all
+	requests := model.filteredProxyRequests()
+	assert.Len(t, requests, 4)
+
+	// String filter on URL
+	model.searchPattern = "users"
+	requests = model.filteredProxyRequests()
+	assert.Len(t, requests, 2)
+
+	// String filter on method
+	model.searchPattern = "GET"
+	requests = model.filteredProxyRequests()
+	assert.Len(t, requests, 2)
+	for _, r := range requests {
+		assert.Equal(t, "GET", r.Method)
+	}
+
+	// String filter on subdomain
+	model.searchPattern = "api"
+	requests = model.filteredProxyRequests()
+	assert.Len(t, requests, 2)
+	for _, r := range requests {
+		assert.Equal(t, "api", r.Subdomain)
+	}
+
+	// Case-insensitive filter
+	model.searchPattern = "API"
+	requests = model.filteredProxyRequests()
+	assert.Len(t, requests, 2)
+}
+
+func TestProxyRequestBufferLimit(t *testing.T) {
+	model := newTestModel()
+	model.ready = true
+
+	// Add more than maxProxyRequests (1000) entries
+	for i := 0; i < 1005; i++ {
+		req := proxy.RequestRecord{
+			Timestamp: time.Now(),
+			Subdomain: "api",
+			Method:    "GET",
+			URL:       "/test",
+		}
+		newModel, _ := model.Update(ProxyRequestMsg(req))
+		model = newModel.(Model)
+	}
+
+	// Should be capped at 1000
+	assert.Len(t, model.proxyRequests, 1000)
+}
+
+func TestModel_ProxyRequestMsg(t *testing.T) {
+	model := newTestModel()
+	model.ready = true
+
+	// Send a proxy request through Update()
+	req := proxy.RequestRecord{
+		Timestamp:  time.Now(),
+		Subdomain:  "web",
+		Method:     "POST",
+		URL:        "/api/users",
+		StatusCode: 201,
+		Duration:   50 * time.Millisecond,
+		RemoteAddr: "192.168.1.1:54321",
+	}
+
+	newModel, _ := model.Update(ProxyRequestMsg(req))
+	m := newModel.(Model)
+
+	// Verify request was added
+	assert.Len(t, m.proxyRequests, 1)
+	assert.Equal(t, "web", m.proxyRequests[0].Subdomain)
+	assert.Equal(t, "POST", m.proxyRequests[0].Method)
+	assert.Equal(t, "/api/users", m.proxyRequests[0].URL)
+	assert.Equal(t, 201, m.proxyRequests[0].StatusCode)
+	assert.Equal(t, 50*time.Millisecond, m.proxyRequests[0].Duration)
+
+	// Verify request is accessible via filteredProxyRequests
+	filtered := m.filteredProxyRequests()
+	assert.Len(t, filtered, 1)
+	assert.Equal(t, "/api/users", filtered[0].URL)
+
+	// Add another request and verify both are present
+	req2 := proxy.RequestRecord{
+		Timestamp:  time.Now(),
+		Subdomain:  "api",
+		Method:     "GET",
+		URL:        "/health",
+		StatusCode: 200,
+		Duration:   5 * time.Millisecond,
+	}
+
+	newModel, _ = m.Update(ProxyRequestMsg(req2))
+	m = newModel.(Model)
+
+	assert.Len(t, m.proxyRequests, 2)
+	filtered = m.filteredProxyRequests()
+	assert.Len(t, filtered, 2)
+
+	// Test filtering
+	m.searchPattern = "users"
+	filtered = m.filteredProxyRequests()
+	assert.Len(t, filtered, 1)
+	assert.Equal(t, "/api/users", filtered[0].URL)
+}
+
+func TestViewModeSwitch(t *testing.T) {
+	model := newTestModel()
+
+	// Default view mode is Logs
+	assert.Equal(t, ViewModeLogs, model.viewMode)
+
+	// Tab key switches to Requests view
+	newModel, _ := model.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m := newModel.(Model)
+	assert.Equal(t, ViewModeRequests, m.viewMode)
+
+	// Tab again switches back to Logs view
+	newModel, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = newModel.(Model)
+	assert.Equal(t, ViewModeLogs, m.viewMode)
+}
+
+func TestFormatProxyRequest_StatusCode0(t *testing.T) {
+	model := newTestModel()
+
+	// Status code 0 indicates connection error or timeout
+	req := proxy.RequestRecord{
+		Timestamp:  time.Now(),
+		Subdomain:  "api",
+		Method:     "GET",
+		URL:        "/test",
+		StatusCode: 0,
+		Duration:   100 * time.Millisecond,
+	}
+
+	formatted := model.formatProxyRequest(req)
+
+	// Status 0 should be formatted (verify it doesn't panic and contains expected fields)
+	assert.Contains(t, formatted, "api")
+	assert.Contains(t, formatted, "GET")
+	assert.Contains(t, formatted, "/test")
+	assert.Contains(t, formatted, "  0") // Status code 0 with 3-char right-aligned padding
+
+	// Verify exact padding for subdomain (10 chars left-aligned)
+	// "api" should be followed by 7 spaces to make 10 chars total
+	assert.Contains(t, formatted, "api       ") // 10 chars total
+
+	// Verify exact padding for method (7 chars left-aligned)
+	// "GET" should be followed by 4 spaces to make 7 chars total
+	assert.Contains(t, formatted, "GET    ") // 7 chars total
+
+	// Verify duration is 5 chars right-aligned (100ms = "  100")
+	assert.Contains(t, formatted, "  100")
+}
+
+func TestFormatProxyRequest_DurationOverflow(t *testing.T) {
+	model := newTestModel()
+
+	// Duration exceeding 9999ms should show "9999+"
+	req := proxy.RequestRecord{
+		Timestamp:  time.Now(),
+		Subdomain:  "api",
+		Method:     "POST",
+		URL:        "/slow-endpoint",
+		StatusCode: 200,
+		Duration:   15 * time.Second, // 15000ms > 9999ms
+	}
+
+	formatted := model.formatProxyRequest(req)
+
+	// Should contain "9999+" for overflow duration (5 chars total)
+	assert.Contains(t, formatted, "9999+")
+	assert.Contains(t, formatted, "api")
+	assert.Contains(t, formatted, "POST")
+
+	// Verify exact padding for subdomain (10 chars left-aligned)
+	assert.Contains(t, formatted, "api       ") // 10 chars total
+
+	// Verify exact padding for method (7 chars left-aligned)
+	// "POST" should be followed by 3 spaces to make 7 chars total
+	assert.Contains(t, formatted, "POST   ") // 7 chars total
+
+	// Verify status code is 3 chars right-aligned
+	assert.Contains(t, formatted, "200")
+}
+
+func TestFormatProxyRequest_Padding(t *testing.T) {
+	model := newTestModel()
+
+	tests := []struct {
+		name       string
+		subdomain  string
+		method     string
+		statusCode int
+		durationMs int64
+		wantSub    string // Expected subdomain with padding (10 chars)
+		wantMethod string // Expected method with padding (7 chars)
+		wantStatus string // Expected status with padding (3 chars)
+		wantDur    string // Expected duration with padding (5 chars)
+	}{
+		{
+			name:       "short fields",
+			subdomain:  "a",
+			method:     "GET",
+			statusCode: 200,
+			durationMs: 1,
+			wantSub:    "a         ", // 1 + 9 spaces
+			wantMethod: "GET    ",    // 3 + 4 spaces
+			wantStatus: "200",        // already 3 chars
+			wantDur:    "    1",      // 4 spaces + 1
+		},
+		{
+			name:       "max length subdomain",
+			subdomain:  "webservice",
+			method:     "DELETE",
+			statusCode: 404,
+			durationMs: 9999,
+			wantSub:    "webservice", // exactly 10 chars
+			wantMethod: "DELETE ",    // 6 + 1 space
+			wantStatus: "404",
+			wantDur:    " 9999", // 1 space + 4 digits
+		},
+		{
+			name:       "single digit status",
+			subdomain:  "api",
+			method:     "OPTIONS",
+			statusCode: 0,
+			durationMs: 50,
+			wantSub:    "api       ",
+			wantMethod: "OPTIONS", // exactly 7 chars
+			wantStatus: "  0",     // 2 spaces + 0
+			wantDur:    "   50",   // 3 spaces + 50
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := proxy.RequestRecord{
+				Timestamp:  time.Now(),
+				Subdomain:  tt.subdomain,
+				Method:     tt.method,
+				StatusCode: tt.statusCode,
+				Duration:   time.Duration(tt.durationMs) * time.Millisecond,
+			}
+
+			formatted := model.formatProxyRequest(req)
+
+			assert.Contains(t, formatted, tt.wantSub, "subdomain padding")
+			assert.Contains(t, formatted, tt.wantMethod, "method padding")
+			assert.Contains(t, formatted, tt.wantStatus, "status padding")
+			assert.Contains(t, formatted, tt.wantDur, "duration padding")
+		})
+	}
 }

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -18,6 +18,12 @@ var (
 	errorColor = lipgloss.Color("9")
 	dimColor   = lipgloss.Color("8")
 
+	// HTTP status colors
+	successColor  = lipgloss.Color("10") // Green for 2xx
+	redirectColor = lipgloss.Color("14") // Cyan for 3xx
+	warningColor  = lipgloss.Color("11") // Yellow for 4xx
+	// errorColor already defined above for 5xx
+
 	// Process name colors (for log lines)
 	processColorList = []lipgloss.Color{
 		lipgloss.Color("14"),  // Cyan
@@ -81,6 +87,19 @@ var (
 	// Dim style for timestamps
 	dimStyle = lipgloss.NewStyle().
 			Foreground(dimColor)
+
+	// HTTP status styles
+	httpSuccessStyle = lipgloss.NewStyle().
+				Foreground(successColor)
+
+	httpRedirectStyle = lipgloss.NewStyle().
+				Foreground(redirectColor)
+
+	httpWarningStyle = lipgloss.NewStyle().
+				Foreground(warningColor)
+
+	httpErrorStyle = lipgloss.NewStyle().
+			Foreground(errorColor)
 
 	// Process colors for log lines
 	processColors []lipgloss.Style

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -7,6 +7,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/charliek/prox/internal/domain"
+	"github.com/charliek/prox/internal/proxy"
 )
 
 // restartTimeout is the maximum time to wait for a restart operation
@@ -27,6 +28,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case LogEntryMsg:
 		m.handleLogEntry(domain.LogEntry(msg))
+
+	case ProxyRequestMsg:
+		m.handleProxyRequest(proxy.RequestRecord(msg))
 
 	case ProcessesMsg:
 		m.processes = m.supervisor.Processes()

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -14,7 +14,7 @@ func (m Model) View() string {
 
 	switch m.mode {
 	case ModeHelp:
-		return m.helpView()
+		return m.BaseModel.helpView()
 	default:
 		statusInfo := ""
 		if m.lastRestartProcess != "" {
@@ -26,36 +26,6 @@ func (m Model) View() string {
 		}
 		return m.BaseModel.mainView(statusInfo)
 	}
-}
-
-// helpView renders the help overlay
-func (m Model) helpView() string {
-	help := `
-Prox - Process Manager
-
-Navigation:
-  j/↓        Scroll down
-  k/↑        Scroll up (pauses auto-follow)
-  g/Home     Go to top (pauses auto-follow)
-  G/End      Go to bottom (resumes auto-follow)
-  PgUp/PgDn  Page up/down
-  F          Toggle auto-follow mode
-
-Filtering:
-  1-9        Solo process (toggle)
-  f          Filter mode (process selection)
-  /          Pattern filter (regex)
-  s          String filter (substring)
-  ESC        Clear filters
-
-Other:
-  r          Restart selected process (1-9 to select)
-  ?          Toggle help
-  q/Ctrl+C   Quit
-
-Press any key to close help...
-`
-	return helpStyle.Render(help)
 }
 
 // getProcessStyle returns the style for a process name


### PR DESCRIPTION
## Summary

- Add HTTPS reverse proxy that routes requests to processes based on subdomain (e.g., `api.localhost` → api process)
- Auto-generate self-signed TLS certificates with configurable trust installation
- Add real-time proxy requests view in TUI with Tab-based view switching
- Stream proxy requests via SSE API for client mode

## Features

### Proxy Server
- Subdomain-based routing to configured processes
- Automatic TLS certificate generation (stored in `~/.prox/certs/`)
- Optional system trust installation (`--proxy-trust-cert`)
- `/etc/hosts` management for subdomain resolution (`--proxy-manage-hosts`)
- Request logging with method, status, duration, and URL

### TUI Requests View
- New view accessible via Tab key showing real-time HTTP requests
- Color-coded status codes (green 2xx, cyan 3xx, yellow 4xx, red 5xx)
- String filtering on URL, method, and subdomain
- Works in both local and client (API) modes

### Configuration
```yaml
proxy:
  enabled: true
  domain: localhost
  port: 8443
```

## Test plan

- [ ] Run `prox up --proxy` and verify proxy starts on port 8443
- [ ] Verify subdomain routing (e.g., `curl -k https://api.localhost:8443/`)
- [ ] Test TUI proxy requests view with Tab key
- [ ] Verify `--proxy-trust-cert` installs certificate in system trust
- [ ] Verify `--proxy-manage-hosts` updates /etc/hosts
- [ ] Run `go test ./...` to verify all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HTTPS reverse proxy with subdomain routing and locally‑trusted certificates.
  * CLI: certs (manage/regenerate certificates), hosts (show/add/remove host entries), and up --no-proxy.
  * API: list proxy requests and SSE streaming endpoint.
  * TUI: Requests view with live streaming, filtering, and status‑based coloring.

* **Documentation**
  * Added proxy architecture, quick‑start, configuration, CLI, TUI, and API docs.

* **Other**
  * Updated token path to ~/.prox/token.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->