### PR TITLE
Add proxy requests command and individual process control

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "plugin-dev@claude-plugins-official": true
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,9 @@ coverage.out
 
 # MkDocs build output
 site-build/
+
+# Prox runtime data
+.prox/
+
+# Claude Code local settings (user-specific)
+.claude/settings.local.json

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -82,3 +82,25 @@ Track running prox instances and dynamically assign API ports.
 - Graceful shutdown updates state before exit
 
 **Inspiration**: codelens project's ServerStateRepository pattern
+
+## Request Details & Body Inspection
+
+View detailed request/response information including bodies.
+
+**CLI:**
+- `prox requests <id>` - Show request details by short hash
+- `prox requests <id> --body` - Include request/response body
+
+**API:**
+- `GET /proxy/requests/{id}` - Get single request details
+- `GET /proxy/requests/{id}?include=body` - Include body content
+
+**Storage enhancements:**
+- Store request/response bodies (configurable max size)
+- Persist requests to disk for post-mortem debugging
+- Configurable retention policy
+
+**Use cases:**
+- Debug API payloads without external tools
+- Replay requests for testing
+- Post-mortem analysis of failed requests

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -227,6 +227,7 @@ Retrieve recent proxy requests (requires proxy to be enabled).
 {
   "requests": [
     {
+      "id": "a1b2c3d",
       "timestamp": "2025-01-19T10:32:01.123Z",
       "method": "GET",
       "url": "/api/users",
@@ -266,7 +267,7 @@ Stream proxy requests via Server-Sent Events (SSE).
 event: connected
 data: {}
 
-data: {"timestamp":"2025-01-19T10:32:01.123Z","method":"GET","url":"/api/users","subdomain":"api","status_code":200,"duration_ms":45,"remote_addr":"127.0.0.1"}
+data: {"id":"a1b2c3d","timestamp":"2025-01-19T10:32:01.123Z","method":"GET","url":"/api/users","subdomain":"api","status_code":200,"duration_ms":45,"remote_addr":"127.0.0.1"}
 ```
 
 **Example:**

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -124,19 +124,46 @@ prox logs --pattern "GET|POST" --regex
 prox logs -f --json | jq .
 ```
 
-### stop
+### start
 
-Stop the running prox instance.
+Start a stopped process.
 
 ```bash
-prox stop
+prox start <process>
 ```
 
-Sends a shutdown signal via the API. All processes receive SIGTERM, then SIGKILL after a timeout.
+**Examples:**
+
+```bash
+prox start api
+prox start worker
+```
+
+### stop
+
+Stop the running prox instance or a specific process.
+
+```bash
+prox stop [process]
+```
+
+Without arguments, sends a shutdown signal to the daemon. All processes receive SIGTERM, then SIGKILL after a timeout.
+
+With a process name, stops only that process while keeping prox and other processes running.
+
+**Examples:**
+
+```bash
+# Stop entire prox instance
+prox stop
+
+# Stop only the api process
+prox stop api
+```
 
 ### down
 
-Alias for `stop`. Provides symmetry with `prox up --detach`.
+Alias for `stop` (without arguments). Provides symmetry with `prox up --detach`.
 
 ```bash
 prox down
@@ -181,6 +208,49 @@ prox restart <process>
 prox restart api
 prox restart worker
 ```
+
+### requests
+
+Show or stream proxy requests.
+
+```bash
+prox requests [options]
+```
+
+| Flag | Description |
+|------|-------------|
+| `-f, --follow` | Stream requests continuously |
+| `-n, --limit` | Number of requests to show (default: 100) |
+| `--subdomain` | Filter by subdomain |
+| `--method` | Filter by HTTP method (GET, POST, etc.) |
+| `--min-status` | Filter by minimum status code (e.g., 400 for errors) |
+| `--json` | Output as JSON |
+
+**Examples:**
+
+```bash
+# Show recent requests
+prox requests
+
+# Stream requests in real-time
+prox requests -f
+
+# Filter by subdomain
+prox requests --subdomain api
+
+# Filter by HTTP method
+prox requests --method GET
+
+# Show only errors (4xx and 5xx)
+prox requests --min-status 400
+
+# JSON output for piping
+prox requests --json | jq .
+```
+
+**Request IDs:**
+
+Each request is assigned a short hash ID (7 characters, git-style). These IDs are displayed in the output and can be used to reference specific requests.
 
 ### version
 

--- a/internal/api/responses.go
+++ b/internal/api/responses.go
@@ -173,6 +173,7 @@ func ToLogEntryResponse(entry domain.LogEntry) LogEntryResponse {
 
 // ProxyRequestResponse represents a single proxy request
 type ProxyRequestResponse struct {
+	ID         string `json:"id"`
 	Timestamp  string `json:"timestamp"`
 	Method     string `json:"method"`
 	URL        string `json:"url"`
@@ -192,6 +193,7 @@ type ProxyRequestsResponse struct {
 // ToProxyRequestResponse converts proxy.RequestRecord to ProxyRequestResponse
 func ToProxyRequestResponse(req proxy.RequestRecord) ProxyRequestResponse {
 	return ProxyRequestResponse{
+		ID:         req.ID,
 		Timestamp:  req.Timestamp.Format(time.RFC3339Nano),
 		Method:     req.Method,
 		URL:        req.URL,

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -127,4 +127,10 @@ var (
 
 	// ColorBrightRed is used for stderr output
 	ColorBrightRed = "\033[91m"
+
+	// HTTP status code colors
+	ColorStatusSuccess  = "\033[32m" // green (2xx)
+	ColorStatusRedirect = "\033[36m" // cyan (3xx)
+	ColorStatusClient   = "\033[33m" // yellow (4xx)
+	ColorStatusServer   = "\033[31m" // red (5xx)
 )

--- a/internal/domain/log_params.go
+++ b/internal/domain/log_params.go
@@ -15,3 +15,20 @@ type LogParams struct {
 	Pattern string
 	Regex   bool
 }
+
+// ProxyRequestParams holds parameters for proxy request retrieval and streaming.
+// This type is shared between the TUI and CLI packages.
+//
+// Fields:
+//   - Subdomain: Filter to requests for a specific subdomain. Empty string means all.
+//   - Method: Filter to requests with a specific HTTP method. Empty string means all.
+//   - MinStatus: Filter to requests with status code >= this value. 0 means no minimum.
+//   - MaxStatus: Filter to requests with status code <= this value. 0 means no maximum.
+//   - Limit: Maximum number of requests to return. 0 means use server default.
+type ProxyRequestParams struct {
+	Subdomain string
+	Method    string
+	MinStatus int
+	MaxStatus int
+	Limit     int
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -96,7 +96,7 @@ type TUIClient interface {
 	GetProcesses() (*api.ProcessListResponse, error)
 	RestartProcess(name string) error
 	StreamLogsChannel(params domain.LogParams) (<-chan api.LogEntryResponse, error)
-	StreamProxyRequestsChannel() (<-chan api.ProxyRequestResponse, error)
+	StreamProxyRequestsChannel(params domain.ProxyRequestParams) (<-chan api.ProxyRequestResponse, error)
 }
 
 // RunClient starts the TUI application in client mode (connected via API)
@@ -174,7 +174,7 @@ func forwardClientLogs(ctx context.Context, p *tea.Program, client TUIClient) {
 // forwardClientProxyRequests streams proxy requests from the API and sends them to the TUI program.
 // It exits when the context is cancelled or the channel is closed.
 func forwardClientProxyRequests(ctx context.Context, p *tea.Program, client TUIClient) {
-	ch, err := client.StreamProxyRequestsChannel()
+	ch, err := client.StreamProxyRequestsChannel(domain.ProxyRequestParams{})
 	if err != nil {
 		// Proxy may not be enabled - this is not an error, just silently return
 		return
@@ -202,6 +202,7 @@ func forwardClientProxyRequests(ctx context.Context, p *tea.Program, client TUIC
 				}))
 			}
 			record := proxy.RequestRecord{
+				ID:         req.ID,
 				Timestamp:  ts,
 				Method:     req.Method,
 				URL:        req.URL,


### PR DESCRIPTION
## Summary
- Add `prox requests` command to view and stream proxy HTTP requests with filtering
- Add `prox start <process>` and `prox stop <process>` commands for individual process control
- Add corresponding API endpoints for requests and process management
- Improve CLI with TTY detection for clean piped output and HTTP status color constants

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Manual: `prox logs -f | head` should not show ANSI codes
- [ ] Manual: `prox requests --method get` should work (case-insensitive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `prox start <process>` command to restart stopped processes
  * Added `prox requests` command to view and stream proxy requests with filtering by subdomain, method, and status code
  * Added unique request IDs (7-character identifiers) to all proxy requests
  * Enhanced `prox stop` to support stopping individual processes or the entire daemon
  * Added color-coded HTTP status codes in terminal output
  * Added optional JSON output format for requests command

* **Documentation**
  * Updated CLI reference with new commands and available options
  * Updated API reference to include request ID field

<!-- end of auto-generated comment: release notes by coderabbit.ai -->