### PR TITLE
Add HTTP proxy support for dual-stack proxying

### DIFF
--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -85,18 +85,18 @@ This document describes the internal design of prox for contributors.
 - Mark healthy after one success
 - Health state exposed via API and TUI
 
-## HTTPS Reverse Proxy
+## HTTP/HTTPS Reverse Proxy
 
-The optional HTTPS reverse proxy provides subdomain-based routing to local services.
+The optional reverse proxy provides subdomain-based routing to local services over HTTP and/or HTTPS.
 
 ### Proxy Architecture
 
 ```
 ┌──────────────────────────────────────────────────────────────────┐
-│                    HTTPS Reverse Proxy                            │
+│                   HTTP/HTTPS Reverse Proxy                        │
 │                                                                    │
 │  Browser Request                                                   │
-│  https://app.local.dev:6789/api/users                             │
+│  http(s)://app.local.dev:port/api/users                           │
 │         │                                                          │
 │         ▼                                                          │
 │  ┌─────────────────────┐                                          │
@@ -133,12 +133,13 @@ internal/proxy/
 
 ### Request Flow
 
-1. Incoming HTTPS request to `*.domain:port`
+1. Incoming HTTP or HTTPS request to `*.domain:port`
 2. Extract subdomain from Host header
 3. Look up service in route table
 4. Forward request via `httputil.ReverseProxy`
-5. Record request in RequestManager
-6. Return response to client
+5. Set `X-Forwarded-Proto` based on connection type (HTTP or HTTPS)
+6. Record request in RequestManager
+7. Return response to client
 
 ## Technologies
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -120,13 +120,31 @@ Background mode features:
 - CLI commands auto-discover the running daemon
 - Daemon logs are written to `.prox/prox.log`
 
-## HTTPS Proxy (Optional)
+## Proxy (Optional)
 
-prox can provide friendly HTTPS URLs for your services via subdomain routing.
+prox can provide friendly subdomain URLs for your services via HTTP and/or HTTPS reverse proxying.
 
-### Prerequisites
+### HTTP Proxy (simplest)
 
-Install mkcert for local certificate generation:
+No certificate setup required:
+
+```yaml
+processes:
+  frontend: npm run dev
+  backend: go run ./cmd/server
+
+proxy:
+  http_port: 6788
+  domain: local.myapp.dev
+
+services:
+  app: 3000
+  api: 8000
+```
+
+### HTTPS Proxy
+
+For locally-trusted HTTPS, install mkcert first:
 
 ```bash
 # macOS
@@ -136,9 +154,7 @@ brew install mkcert
 mkcert -install
 ```
 
-### Configuration
-
-Add proxy settings to your `prox.yaml`:
+Then configure HTTPS:
 
 ```yaml
 processes:
@@ -146,7 +162,6 @@ processes:
   backend: go run ./cmd/server
 
 proxy:
-  enabled: true
   https_port: 6789
   domain: local.myapp.dev
 
@@ -173,10 +188,10 @@ prox up
 
 Access your services:
 
-- `https://app.local.myapp.dev:6789` → `http://localhost:3000`
-- `https://api.local.myapp.dev:6789` → `http://localhost:8000`
+- `http://app.local.myapp.dev:6788` → `http://localhost:3000` (HTTP mode)
+- `https://app.local.myapp.dev:6789` → `http://localhost:3000` (HTTPS mode)
 
-See the [Configuration Reference](../reference/configuration.md#https-proxy-configuration) for full details.
+See the [Configuration Reference](../reference/configuration.md#proxy-configuration) for full details.
 
 ## HTTP API
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ A modern process manager for development with an API-first design, enabling both
 - **Simple by default** - Procfile-like experience with minimal YAML configuration
 - **API-first** - Full process control and log access via HTTP, always available
 - **Interactive TUI** - Real-time log viewing with filtering and search
-- **HTTPS Proxy** - Subdomain routing with locally-trusted certificates
+- **HTTP/HTTPS Proxy** - Subdomain routing with optional locally-trusted certificates
 - **Health checks** - Optional health monitoring for processes
 - **LLM-friendly** - Structured output and filtering to support AI-assisted debugging
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -28,8 +28,10 @@ prox up [processes...]
 |------|-------------|
 | `--detach, -d` | Run in background (daemon mode) |
 | `--tui` | Enable interactive TUI mode (foreground only, mutually exclusive with `--detach`) |
-| `--port, -p` | Override API port (otherwise dynamic) |
-| `--no-proxy` | Disable HTTPS proxy even if configured |
+| `--api-port, -p` | Override API server port (otherwise dynamic) |
+| `--http-port` | Override proxy HTTP port |
+| `--https-port` | Override proxy HTTPS port |
+| `--no-proxy` | Disable proxy even if configured |
 
 **Examples:**
 
@@ -50,15 +52,21 @@ prox up --tui
 prox up --tui web api
 
 # Override API port
-prox up --port 6000
+prox up --api-port 6000
 
 # Daemon mode with specific port
-prox up -d --port 6000
+prox up -d --api-port 6000
+
+# Start with HTTP proxy only
+prox up --http-port 6788
+
+# Start with dual-stack proxy
+prox up --http-port 6788 --https-port 6789
 ```
 
 **Dynamic Port Allocation:**
 
-When no port is specified (via `--port` or `api.port` in config), prox automatically finds an available port. The port is stored in `.prox/prox.state` and auto-discovered by CLI commands.
+When no port is specified (via `--api-port` or `api.port` in config), prox automatically finds an available port. The port is stored in `.prox/prox.state` and auto-discovered by CLI commands.
 
 ### status
 

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -254,12 +254,20 @@ func TestCleanupStaleFiles(t *testing.T) {
 func TestSetupLogging(t *testing.T) {
 	t.Run("creates log file", func(t *testing.T) {
 		tmpDir := t.TempDir()
+		originalStdout := os.Stdout
+		originalStderr := os.Stderr
 
 		logFile, err := SetupLogging(tmpDir)
 		if err != nil {
 			t.Fatalf("SetupLogging failed: %v", err)
 		}
-		defer logFile.Close()
+		t.Cleanup(func() {
+			_ = logFile.Close()
+		})
+		t.Cleanup(func() {
+			os.Stdout = originalStdout
+			os.Stderr = originalStderr
+		})
 
 		// Check log file exists
 		logPath := LogPath(tmpDir)

--- a/testdata/configs/dual_stack.yaml
+++ b/testdata/configs/dual_stack.yaml
@@ -1,0 +1,14 @@
+api:
+  port: 5555
+  host: 127.0.0.1
+
+processes:
+  web: npm run dev
+
+proxy:
+  http_port: 6788
+  https_port: 6789
+  domain: local.test.dev
+
+services:
+  app: 3000

--- a/testdata/configs/http_only.yaml
+++ b/testdata/configs/http_only.yaml
@@ -1,0 +1,13 @@
+api:
+  port: 5555
+  host: 127.0.0.1
+
+processes:
+  web: npm run dev
+
+proxy:
+  http_port: 6788
+  domain: local.test.dev
+
+services:
+  app: 3000


### PR DESCRIPTION
## Summary

- Add HTTP-only proxy mode (no certificate setup required) alongside existing HTTPS support
- Enable dual-stack (HTTP+HTTPS) proxying with independent port configuration
- Add `http_port` config field and `--http-port`/`--https-port` CLI flags
- Auto-enable proxy when ports are set without explicit `enabled: true`
- Atomic startup with rollback if HTTPS fails after HTTP starts
- Validate negative port CLI flags and warn when port flags are set without proxy config
- Set `X-Forwarded-Proto` dynamically based on connection type
- Update all documentation for HTTP/HTTPS proxy support

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] Lint clean (`golangci-lint run ./...`)
- [x] Build succeeds (`go build ./...`)
- [x] New tests for X-Forwarded-Proto header (HTTP vs HTTPS)
- [x] New tests for HTTP-only and dual-stack config parsing
- [x] New tests for validation of HTTP port, negative ports, HTTPS requires certs
- [x] New test for startup rollback when HTTPS fails after HTTP starts
- [x] Proxy package coverage improved from 33% to 43%

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HTTP-only proxy mode (no certs required) and dual-stack (HTTP+HTTPS) support
  * Granular CLI port controls (--api-port, --http-port, --https-port)
  * Automatic proxy enablement and certificate generation when HTTPS is requested

* **Bug Fixes / Reliability**
  * Improved startup/shutdown with atomic rollback if HTTPS setup fails
  * Correct X-Forwarded-Proto handling for HTTP vs HTTPS

* **Documentation**
  * Updated docs and examples to cover HTTP, HTTPS, and dual-stack usage
<!-- end of auto-generated comment: release notes by coderabbit.ai -->