### PR TITLE
Upgrade GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.24'
       - run: go test -v ./...
@@ -19,10 +19,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.24'
-      - uses: golangci/golangci-lint-action@v7
+      - uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,12 +23,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v4
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
       - run: uv python install 3.13
       - run: uv sync --group docs
       - run: uv run mkdocs build
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v4
         with:
           path: site-build
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,12 +15,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -29,12 +29,12 @@ jobs:
         run: go test ./...
 
       - name: Run Linter
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           version: latest
           args: release --clean


### PR DESCRIPTION
## Summary

- Upgrade all GitHub Actions to latest major versions to resolve Node.js 20 deprecation warning
- Node.js 20 will be forced to Node.js 24 on June 2, 2026
- Updates across all 3 workflow files (ci.yml, release.yaml, docs.yml)

| Action | Before | After |
|--------|--------|-------|
| actions/checkout | v4 | v6 |
| actions/setup-go | v5 | v6 |
| golangci/golangci-lint-action | v7 | v9 |
| goreleaser/goreleaser-action | v6 | v7 |
| astral-sh/setup-uv | v4 | v7 |
| actions/upload-pages-artifact | v3 | v4 |

## Test plan

- [ ] CI workflow (test + lint) passes
- [ ] Docs workflow triggers and passes (docs.yml is in its own path filter)
- [ ] Release workflow validated on next tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions dependencies across continuous integration, documentation, and release workflows to newer major versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->