### PR TITLE
Upgrade deploy-pages to v5 for Node.js 24 support

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,4 +41,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary
- Upgrades `actions/deploy-pages` from v4 to v5 to resolve the Node.js 20 deprecation warning in the docs workflow
- The remaining `upload-pages-artifact` Node 20 warning is waiting on an upstream fix ([actions/upload-pages-artifact#139](https://github.com/actions/upload-pages-artifact/pull/139))

## Test plan
- [ ] Verify the docs workflow runs successfully
- [ ] Confirm the `deploy-pages` Node 20 deprecation warning is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation deployment infrastructure to the latest version for improved reliability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->