### PR TITLE
Make proxy port binding failures fatal with actionable errors

### DIFF
--- a/docs/discovery/shared-proxy-across-projects.md
+++ b/docs/discovery/shared-proxy-across-projects.md
@@ -1,0 +1,99 @@
+# Shared Proxy Across Projects
+
+## Problem Statement
+
+A common usage pattern for prox is running the proxy on well-known ports (443 for HTTPS, 80 for HTTP). Users often have multiple projects on the same machine that each define their own `prox.yaml`, and ideally each project's domains would be served through the same proxy port.
+
+For example:
+- **Project A** (`~/projects/auth-service/prox.yaml`): `auth.local.stridelabs.ai` on port 443
+- **Project B** (`~/projects/audit-service/prox.yaml`): `audit.local.stridelabs.ai` on port 443
+
+Today, each `prox up` invocation starts its own independent proxy listener. If Project A already owns port 443, Project B's proxy silently fails to bind (see Issue 1: port conflict detection), and its domains are unreachable.
+
+## Current Architecture
+
+- All state is **per-project scoped**: `.prox/prox.state`, `.prox/prox.pid`, and `.prox/prox.log` live in each project's working directory.
+- Each `prox up` creates its own `proxy.Service` that binds its own HTTP/HTTPS ports.
+- There is no awareness of other prox instances running on the machine.
+- The proxy routes requests by extracting the subdomain from the Host header and looking it up in a static `services` map built from the project's config at startup.
+
+## Use Cases
+
+1. **Multiple microservices in development**: Different repos/projects each define a service that should be reachable via its own subdomain, all on the same port.
+2. **Shared base domain**: All services share a base domain (e.g., `*.local.stridelabs.ai`) but are developed in separate project directories.
+3. **Independent lifecycle**: Each project should be able to `prox up` and `prox down` independently without affecting the other projects' routes.
+
+## Options Explored
+
+### Option A: Central Proxy Daemon at `~/.prox/`
+
+A standalone, long-lived proxy process that multiple projects register with.
+
+- `prox proxy start` starts a background proxy daemon that owns port 443/80, stores state in `~/.prox/`.
+- `prox up` in a project detects the running proxy daemon, registers its domains/services via API, deregisters on shutdown.
+- The proxy daemon has its own route table that projects dynamically add to and remove from.
+
+**Pros:**
+- Clean ownership model -- the proxy lifecycle is independent of any single project.
+- Multiple projects can come and go freely.
+- No "first project owns the port" ambiguity.
+
+**Cons:**
+- Extra thing to manage -- user needs to run `prox proxy start` (or it auto-starts).
+- Requires a registration API/protocol between project instances and the daemon.
+- Daemon needs its own logging, status, and management commands.
+
+### Option B: First-Come-First-Served with Registration
+
+The first `prox up` that wants a given port starts the proxy. Subsequent projects detect the existing proxy and register their routes with it via the existing API.
+
+- No separate daemon -- the proxy lives inside whichever `prox up` process started first.
+- Other projects register routes via the first instance's API.
+
+**Pros:**
+- Simpler, no extra command or process.
+- Feels natural for the single-project case.
+
+**Cons:**
+- Fragile -- when the "owner" project does `prox down`, all other projects' routes die.
+- Transferring proxy ownership between processes is complex and error-prone.
+- The owner project's process manager and the shared proxy are coupled.
+
+### Option C: Hybrid -- Auto-Start Daemon on Demand
+
+Like Option A, but the daemon auto-starts when the first `prox up` needs a proxy port and no daemon is running. Subsequent `prox up` calls detect it and register.
+
+- `prox up` checks `~/.prox/proxy.state` -- if no proxy daemon is running, it forks one off as a separate background process.
+- The proxy daemon has its own PID, independent of any project.
+- `prox proxy stop` (or stopping all registered projects) brings it down.
+- `prox proxy start` also available for explicit control.
+
+**Pros:**
+- No extra manual step for users -- seamless experience.
+- Proxy daemon is independent of any project's lifecycle.
+- Supports both implicit and explicit management.
+
+**Cons:**
+- "Magic" background process that users might not realize is running.
+- Need clear status/stop commands (`prox proxy status`, `prox proxy stop`).
+- Auto-start logic adds complexity.
+
+## Open Design Questions
+
+1. **Opt-in vs default**: Should port sharing be the default behavior, or should projects explicitly opt in (e.g., `proxy: shared: true` in `prox.yaml`)? The default behavior change could surprise existing users.
+
+2. **Domain conflicts**: What happens if two projects both try to register the same domain (e.g., both claim `api.local.stridelabs.ai`)? Options: first-come-first-served, error on the second, or last-write-wins.
+
+3. **Certificate management**: The shared proxy needs certs for all registered domains. Currently certs are per-project. A shared proxy would likely need wildcard certs or dynamic cert generation as routes are added.
+
+4. **Stale route cleanup**: If a project crashes without deregistering, the proxy has a stale route pointing at a dead backend. Options: heartbeat-based expiry, health checking registered backends, or relying on the project's PID liveness.
+
+5. **Visibility and debugging**: How does the user inspect the shared proxy's state? Something like `prox proxy routes` to list all registered domains and which project owns them.
+
+6. **Registration protocol**: Should project instances communicate with the proxy daemon via HTTP API, Unix socket, or filesystem-based coordination (e.g., writing route files to `~/.prox/routes.d/`)?
+
+## Current Recommendation
+
+Option C (auto-start daemon) likely provides the best user experience, but Option A (explicit daemon) is simpler and more predictable. Option B should be avoided due to the fragile ownership model.
+
+Before designing this in detail, Issue 1 (port conflict detection) should be resolved first, as it is a prerequisite -- clear error messages when ports conflict will be needed regardless of which shared-proxy approach is chosen.

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -317,6 +317,48 @@ func runUp(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	// Start proxy server first if configured — fail fast on port conflicts
+	// before spawning child processes.
+	var proxyService *proxy.Service
+	if !noProxy && cfg.Proxy != nil && cfg.Proxy.Enabled {
+		level := slog.LevelInfo
+		if verbose {
+			level = slog.LevelDebug
+		}
+		logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level}))
+		var err error
+		proxyService, err = proxy.NewService(cfg.Proxy, cfg.Services, cfg.Certs, logger, cwd)
+		if err != nil {
+			return fmt.Errorf("failed to create proxy: %w", err)
+		}
+		if err := proxyService.Start(ctx); err != nil {
+			return proxyStartError(err)
+		}
+		// Ensure proxy is cleaned up on any subsequent error (e.g., supervisor
+		// fails to start). The normal shutdown path also calls Shutdown, but
+		// a double-call is safe since stopServers nil-checks server pointers.
+		defer func() {
+			if proxyService != nil {
+				sCtx, sCancel := context.WithTimeout(context.Background(), shutdownTimeout)
+				defer sCancel()
+				_ = proxyService.Shutdown(sCtx)
+			}
+		}()
+
+		var proxyAddrs []string
+		if cfg.Proxy.HTTPPort > 0 {
+			proxyAddrs = append(proxyAddrs, fmt.Sprintf("http://*.%s:%d", cfg.Proxy.Domain, cfg.Proxy.HTTPPort))
+		}
+		if cfg.Proxy.HTTPSPort > 0 {
+			proxyAddrs = append(proxyAddrs, fmt.Sprintf("https://*.%s:%d", cfg.Proxy.Domain, cfg.Proxy.HTTPSPort))
+		}
+		if len(proxyAddrs) > 0 {
+			fmt.Printf("Proxy server: %s\n", strings.Join(proxyAddrs, ", "))
+		}
+		handlers.SetRequestManager(proxyService.RequestManager())
+		handlers.SetCaptureManager(proxyService.CaptureManager())
+	}
+
 	// Start supervisor
 	fmt.Printf("Starting prox with config: %s\n", configPath)
 	if isLocalhost(cfg.API.Host) {
@@ -368,41 +410,6 @@ func runUp(cmd *cobra.Command, args []string) error {
 			}
 		}
 	}()
-
-	// Start proxy server if configured and not disabled
-	var proxyService *proxy.Service
-	if !noProxy && cfg.Proxy != nil && cfg.Proxy.Enabled {
-		level := slog.LevelInfo
-		if verbose {
-			level = slog.LevelDebug
-		}
-		logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level}))
-		var err error
-		proxyService, err = proxy.NewService(cfg.Proxy, cfg.Services, cfg.Certs, logger, cwd)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error creating proxy service: %v\n", err)
-			// Continue without proxy - this is not fatal
-		} else if err := proxyService.Start(ctx); err != nil {
-			fmt.Fprintf(os.Stderr, "Error starting proxy: %v\n", err)
-			proxyService = nil
-			// Continue without proxy - this is not fatal
-		} else {
-			// Build proxy server display message
-			var proxyAddrs []string
-			if cfg.Proxy.HTTPPort > 0 {
-				proxyAddrs = append(proxyAddrs, fmt.Sprintf("http://*.%s:%d", cfg.Proxy.Domain, cfg.Proxy.HTTPPort))
-			}
-			if cfg.Proxy.HTTPSPort > 0 {
-				proxyAddrs = append(proxyAddrs, fmt.Sprintf("https://*.%s:%d", cfg.Proxy.Domain, cfg.Proxy.HTTPSPort))
-			}
-			if len(proxyAddrs) > 0 {
-				fmt.Printf("Proxy server: %s\n", strings.Join(proxyAddrs, ", "))
-			}
-			// Wire up request manager and capture manager to API handlers
-			handlers.SetRequestManager(proxyService.RequestManager())
-			handlers.SetCaptureManager(proxyService.CaptureManager())
-		}
-	}
 
 	// Handle TUI vs terminal output
 	if useTUI {
@@ -537,6 +544,16 @@ func ensureNotAlreadyRunning(cwd string) error {
 	}
 
 	return nil
+}
+
+// proxyStartError formats an actionable error message for proxy startup failures.
+// For port conflicts it includes the port number and a hint to identify the process.
+func proxyStartError(err error) error {
+	var portErr *proxy.PortConflictError
+	if errors.As(err, &portErr) {
+		return fmt.Errorf("%w\n\nAnother process is listening on this port. To identify it:\n  lsof -i :%d\n\nTo start without the proxy:\n  prox up --no-proxy", portErr, portErr.Port)
+	}
+	return fmt.Errorf("proxy failed to start: %w", err)
 }
 
 // printLogs subscribes to logs and prints them to terminal

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -443,11 +443,12 @@ func runUp(cmd *cobra.Command, args []string) error {
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), shutdownTimeout)
 	defer shutdownCancel()
 
-	// Stop proxy server
+	// Stop proxy server and disarm the deferred shutdown
 	if proxyService != nil {
 		if err := proxyService.Shutdown(shutdownCtx); err != nil {
 			fmt.Fprintf(os.Stderr, "Error stopping proxy: %v\n", err)
 		}
+		proxyService = nil
 	}
 
 	// Stop API server

--- a/internal/proxy/errors.go
+++ b/internal/proxy/errors.go
@@ -1,0 +1,34 @@
+package proxy
+
+import (
+	"errors"
+	"fmt"
+	"syscall"
+)
+
+// ErrPortInUse is returned when a proxy port is already bound by another process.
+var ErrPortInUse = errors.New("port already in use")
+
+// PortConflictError carries metadata about which port and protocol conflicted.
+// It wraps both the ErrPortInUse sentinel and the original OS error so that
+// errors.Is works for either (Go 1.20+ multi-unwrap).
+type PortConflictError struct {
+	Port     int
+	Protocol string // "HTTP" or "HTTPS"
+	Cause    error  // original net.Listen error
+}
+
+func (e *PortConflictError) Error() string {
+	return fmt.Sprintf("%s proxy port %d already in use", e.Protocol, e.Port)
+}
+
+func (e *PortConflictError) Unwrap() []error {
+	return []error{ErrPortInUse, e.Cause}
+}
+
+// isAddrInUse checks whether an error from net.Listen is caused by the address
+// already being in use (EADDRINUSE). On Go 1.13+ the net and os packages
+// implement Unwrap(), so errors.Is traverses the chain correctly.
+func isAddrInUse(err error) bool {
+	return err != nil && errors.Is(err, syscall.EADDRINUSE)
+}

--- a/internal/proxy/errors.go
+++ b/internal/proxy/errors.go
@@ -23,7 +23,10 @@ func (e *PortConflictError) Error() string {
 }
 
 func (e *PortConflictError) Unwrap() []error {
-	return []error{ErrPortInUse, e.Cause}
+	if e.Cause != nil {
+		return []error{ErrPortInUse, e.Cause}
+	}
+	return []error{ErrPortInUse}
 }
 
 // isAddrInUse checks whether an error from net.Listen is caused by the address

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -143,6 +143,9 @@ func (s *Service) startHTTP(router http.Handler) error {
 
 	listener, err := net.Listen("tcp", addr)
 	if err != nil {
+		if isAddrInUse(err) {
+			return &PortConflictError{Port: s.cfg.HTTPPort, Protocol: "HTTP", Cause: err}
+		}
 		return fmt.Errorf("listening on %s: %w", addr, err)
 	}
 
@@ -202,6 +205,9 @@ func (s *Service) startHTTPS(router http.Handler) error {
 
 	listener, err := net.Listen("tcp", addr)
 	if err != nil {
+		if isAddrInUse(err) {
+			return &PortConflictError{Port: s.cfg.HTTPSPort, Protocol: "HTTPS", Cause: err}
+		}
 		return fmt.Errorf("listening on %s: %w", addr, err)
 	}
 

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -7,11 +7,11 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
-	"syscall"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -3,9 +3,11 @@ package proxy
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
+	"syscall"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -270,4 +272,97 @@ func TestCreateRouter_XForwardedProto(t *testing.T) {
 
 		assert.Equal(t, "https", receivedProto.Load())
 	})
+}
+
+func TestPortConflictError_ErrorMessage(t *testing.T) {
+	tests := []struct {
+		port     int
+		protocol string
+		expected string
+	}{
+		{443, "HTTPS", "HTTPS proxy port 443 already in use"},
+		{80, "HTTP", "HTTP proxy port 80 already in use"},
+		{8080, "HTTP", "HTTP proxy port 8080 already in use"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			err := &PortConflictError{Port: tt.port, Protocol: tt.protocol}
+			assert.Equal(t, tt.expected, err.Error())
+		})
+	}
+}
+
+func TestPortConflictError_Unwrap(t *testing.T) {
+	cause := fmt.Errorf("listen tcp :443: bind: address already in use")
+	err := &PortConflictError{Port: 443, Protocol: "HTTPS", Cause: cause}
+
+	// Sentinel is reachable via multi-unwrap
+	assert.True(t, errors.Is(err, ErrPortInUse))
+	// Original cause is also reachable
+	assert.True(t, errors.Is(err, cause))
+	assert.False(t, errors.Is(err, errors.New("something else")))
+}
+
+func TestPortConflictError_Unwrap_NilCause(t *testing.T) {
+	err := &PortConflictError{Port: 80, Protocol: "HTTP"}
+	assert.True(t, errors.Is(err, ErrPortInUse))
+}
+
+func TestIsAddrInUse(t *testing.T) {
+	t.Run("returns true for EADDRINUSE", func(t *testing.T) {
+		// Bind a port and try to bind it again
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		defer listener.Close()
+
+		addr := listener.Addr().String()
+		_, err = net.Listen("tcp", addr)
+		require.Error(t, err)
+		assert.True(t, isAddrInUse(err))
+	})
+
+	t.Run("returns false for nil", func(t *testing.T) {
+		assert.False(t, isAddrInUse(nil))
+	})
+
+	t.Run("returns false for other errors", func(t *testing.T) {
+		assert.False(t, isAddrInUse(errors.New("something else")))
+	})
+}
+
+func TestStart_PortConflict_HTTP(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	workDir := t.TempDir()
+
+	// Hold a port open on all interfaces to match how the proxy binds (":port")
+	listener, err := net.Listen("tcp", ":0")
+	require.NoError(t, err)
+	defer listener.Close()
+	port := listener.Addr().(*net.TCPAddr).Port
+
+	cfg := &config.ProxyConfig{
+		Enabled:  true,
+		HTTPPort: port,
+		Domain:   "local.myapp.dev",
+	}
+	services := map[string]config.ServiceConfig{
+		"app": {Port: 3000, Host: "localhost"},
+	}
+
+	svc, err := NewService(cfg, services, nil, logger, workDir)
+	require.NoError(t, err)
+
+	err = svc.Start(context.Background())
+	require.Error(t, err)
+
+	// Verify it's a PortConflictError with correct metadata
+	assert.True(t, errors.Is(err, ErrPortInUse))
+
+	var portErr *PortConflictError
+	require.True(t, errors.As(err, &portErr))
+	assert.Equal(t, port, portErr.Port)
+	assert.Equal(t, "HTTP", portErr.Protocol)
+	// Original OS error is preserved via multi-unwrap
+	assert.NotNil(t, portErr.Cause)
+	assert.True(t, errors.Is(err, syscall.EADDRINUSE))
 }


### PR DESCRIPTION
## Summary

- Previously, when a configured proxy port was already in use, prox silently continued without the proxy — leading to confusing "domain not found" behavior
- Proxy startup failures are now fatal with clear, actionable error messages that include the port number, a `lsof` hint, and the `--no-proxy` workaround
- Proxy startup is moved before the supervisor/API server so port conflicts fail fast before spawning child processes
- Adds `PortConflictError` type with Go 1.20+ multi-unwrap to preserve both the `ErrPortInUse` sentinel and the original OS error
- Includes a design doc for future multi-project shared proxy work (`docs/discovery/`)

## Test plan

- [x] `go test ./internal/proxy/ -run "PortConflict|IsAddrInUse"` — new unit tests pass
- [x] `go test ./internal/...` — full unit test suite passes
- [ ] Manual: `nc -l 8080 &` then `prox up` with `http_port: 8080` — should see actionable error and exit non-zero
- [ ] Manual: `prox up --no-proxy` with blocked port — should succeed (processes start, no proxy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Port conflict errors now show the conflicting port and actionable diagnostic hints; proxy startup failures now halt immediately with clear messages.
* **Documentation**
  * New guide describing shared-proxy options and design considerations for managing proxy ports across local projects.
* **Tests**
  * Added unit and integration tests to validate port-conflict detection and error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->