### PR TITLE
Add shared proxy daemon for multi-project port sharing

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,7 +20,7 @@ builds:
       - arm64
     ldflags:
       - -s -w
-      - -X github.com/charliek/prox/internal/cli.Version={{.Version}}
+      - -X github.com/charliek/prox/internal/version.Version={{.Version}}
 
 archives:
   - id: default

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -49,6 +49,11 @@ func (h *Handlers) SetRequestManager(rm *proxy.RequestManager) {
 	h.requestManager = rm
 }
 
+// GetRequestManager returns the proxy request manager, or nil if not set.
+func (h *Handlers) GetRequestManager() *proxy.RequestManager {
+	return h.requestManager
+}
+
 // SetCaptureManager sets the capture manager for loading captured body data.
 func (h *Handlers) SetCaptureManager(cm *proxy.CaptureManager) {
 	h.captureManager = cm

--- a/internal/cli/proxy_cmd.go
+++ b/internal/cli/proxy_cmd.go
@@ -1,0 +1,167 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/charliek/prox/internal/proxyd"
+	"github.com/spf13/cobra"
+)
+
+// Proxy command flags
+var (
+	proxyJSON  bool
+	proxyForce bool
+)
+
+// proxyCmd is the parent command for shared proxy daemon management.
+var proxyCmd = &cobra.Command{
+	Use:   "proxy",
+	Short: "Manage the shared proxy daemon (advanced)",
+	Long: `Manage the shared proxy daemon that handles port sharing between projects.
+
+The proxy daemon is normally started and stopped automatically by 'prox up'
+and 'prox down'. These subcommands are for debugging and advanced usage.
+
+Examples:
+  prox proxy status    # Show daemon status
+  prox proxy routes    # List registered routes
+  prox proxy stop      # Stop the daemon`,
+}
+
+// proxyStatusCmd shows daemon status.
+var proxyStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show proxy daemon status",
+	RunE:  runProxyStatus,
+}
+
+func runProxyStatus(cmd *cobra.Command, args []string) error {
+	client, err := connectDaemon()
+	if err != nil {
+		return err
+	}
+
+	status, err := client.Status()
+	if err != nil {
+		return fmt.Errorf("failed to get daemon status: %w", err)
+	}
+
+	if proxyJSON {
+		return json.NewEncoder(os.Stdout).Encode(status)
+	}
+
+	fmt.Printf("Proxy Daemon\n")
+	fmt.Printf("  Version:    %s\n", status.Version)
+	fmt.Printf("  PID:        %d\n", status.PID)
+	fmt.Printf("  Uptime:     %s\n", status.Uptime)
+	fmt.Printf("  Projects:   %d\n", status.ProjectCount)
+	fmt.Printf("  Routes:     %d\n", status.RouteCount)
+	if len(status.ListenerPorts) > 0 {
+		fmt.Printf("  Ports:      %v\n", status.ListenerPorts)
+	}
+
+	if len(status.Routes) > 0 {
+		fmt.Println()
+		printRoutesTable(status.Routes)
+	}
+	return nil
+}
+
+// proxyRoutesCmd lists all registered routes.
+var proxyRoutesCmd = &cobra.Command{
+	Use:   "routes",
+	Short: "List registered proxy routes",
+	RunE:  runProxyRoutes,
+}
+
+func runProxyRoutes(cmd *cobra.Command, args []string) error {
+	client, err := connectDaemon()
+	if err != nil {
+		return err
+	}
+
+	routes, err := client.Routes()
+	if err != nil {
+		return fmt.Errorf("failed to get routes: %w", err)
+	}
+
+	if proxyJSON {
+		return json.NewEncoder(os.Stdout).Encode(map[string]any{"routes": routes})
+	}
+
+	if len(routes) == 0 {
+		fmt.Println("No routes registered")
+		return nil
+	}
+
+	printRoutesTable(routes)
+	return nil
+}
+
+// proxyStopCmd stops the proxy daemon.
+var proxyStopCmd = &cobra.Command{
+	Use:   "stop",
+	Short: "Stop the proxy daemon",
+	Long: `Stop the shared proxy daemon.
+
+By default, this fails if any projects have active routes registered.
+Use --force to stop the daemon regardless, which will disconnect all projects.`,
+	RunE: runProxyStop,
+}
+
+func runProxyStop(cmd *cobra.Command, args []string) error {
+	client, err := connectDaemon()
+	if err != nil {
+		return err
+	}
+
+	if err := client.Shutdown(proxyForce); err != nil {
+		return fmt.Errorf("%w", err)
+	}
+
+	fmt.Println("Proxy daemon shutdown initiated")
+	return nil
+}
+
+// connectDaemon connects to the running proxy daemon.
+func connectDaemon() (*proxyd.Client, error) {
+	socketPath := proxyd.SocketPath()
+	client := proxyd.NewClient(socketPath)
+
+	// Quick health check
+	if _, err := client.Health(); err != nil {
+		return nil, fmt.Errorf("proxy daemon is not running\nIt starts automatically when you run 'prox up' with proxy configured")
+	}
+	return client, nil
+}
+
+// printRoutesTable prints routes in a tabwriter table.
+func printRoutesTable(routes []proxyd.RouteInfo) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "HOSTNAME\tPORT\tPROTOCOL\tTARGET\tPROJECT\tPID")
+	fmt.Fprintln(w, "--------\t----\t--------\t------\t-------\t---")
+
+	for _, r := range routes {
+		fmt.Fprintf(w, "%s\t%d\t%s\t%s:%d\t%s\t%d\n",
+			r.Hostname, r.Port, r.Protocol,
+			r.Target.Host, r.Target.Port,
+			r.ProjectDir, r.PID)
+	}
+	w.Flush()
+}
+
+func init() {
+	rootCmd.AddCommand(proxyCmd)
+
+	proxyCmd.AddCommand(proxyStatusCmd)
+	proxyCmd.AddCommand(proxyRoutesCmd)
+	proxyCmd.AddCommand(proxyStopCmd)
+
+	// Shared flags
+	proxyStatusCmd.Flags().BoolVar(&proxyJSON, "json", false, "Output as JSON")
+	proxyRoutesCmd.Flags().BoolVar(&proxyJSON, "json", false, "Output as JSON")
+	proxyStopCmd.Flags().BoolVar(&proxyForce, "force", false, "Force stop even with active routes")
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1,17 +1,17 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"os"
 
 	"github.com/charliek/prox/internal/config"
 	"github.com/charliek/prox/internal/constants"
 	"github.com/charliek/prox/internal/daemon"
+	"github.com/charliek/prox/internal/proxyd"
+	"github.com/charliek/prox/internal/version"
 	"github.com/spf13/cobra"
 )
-
-// Version is set during build
-var Version = "dev"
 
 // Global flags
 var (
@@ -33,7 +33,7 @@ processes for local development. It supports:
   - HTTPS reverse proxy with subdomain routing
   - Interactive TUI for monitoring
   - Background daemon mode`,
-	Version:       Version,
+	Version:       version.Version,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
@@ -57,8 +57,18 @@ processes for local development. It supports:
 	},
 }
 
-// Execute runs the root command
+// Execute runs the root command.
+// If the process is the proxy daemon child, it runs the daemon instead of
+// normal CLI dispatch.
 func Execute() {
+	if proxyd.IsDaemonProcess() {
+		if err := proxyd.RunDaemon(context.Background()); err != nil {
+			fmt.Fprintf(os.Stderr, "Proxy daemon error: %v\n", err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
@@ -70,7 +80,7 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Show version",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("prox version %s\n", Version)
+		fmt.Printf("prox version %s\n", version.Version)
 	},
 }
 
@@ -102,7 +112,7 @@ func loadAPIAddrFromConfig() string {
 	}
 	port := cfg.API.Port
 	if port == 0 {
-		port = constants.DefaultAPIPort
+		return "" // Port is dynamic, must discover from state file
 	}
 
 	return fmt.Sprintf("http://%s:%d", host, port)

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -34,7 +34,7 @@ processes:
 		}
 	})
 
-	t.Run("returns address with default port when not specified", func(t *testing.T) {
+	t.Run("returns empty when port not specified (dynamic)", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		testConfigPath := filepath.Join(tmpDir, "prox.yaml")
 		err := os.WriteFile(testConfigPath, []byte(`
@@ -48,8 +48,8 @@ processes:
 		configPath = testConfigPath
 		addr := loadAPIAddrFromConfig()
 
-		if addr != "http://127.0.0.1:5555" {
-			t.Errorf("expected http://127.0.0.1:5555, got %s", addr)
+		if addr != "" {
+			t.Errorf("expected empty string for dynamic port, got %s", addr)
 		}
 	})
 

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -323,7 +323,11 @@ func runUp(cmd *cobra.Command, args []string) error {
 	var proxyService *proxy.Service
 	var daemonClient *proxyd.Client
 	if !noProxy && cfg.Proxy != nil && cfg.Proxy.Enabled {
-		daemonClient, proxyService = startProxy(cfg, cwd, ctx, handlers)
+		var proxyErr error
+		daemonClient, proxyService, proxyErr = startProxy(cfg, cwd, ctx, handlers)
+		if proxyErr != nil {
+			return proxyErr
+		}
 	}
 	// Ensure standalone proxy is cleaned up on any subsequent error
 	if proxyService != nil {
@@ -543,38 +547,37 @@ func proxyStartError(err error) error {
 // cannot be reached (e.g., sandboxed environment), it falls back to starting a
 // standalone proxy. Returns the daemon client (if using daemon) and/or the
 // standalone proxy service (if using fallback).
-func startProxy(cfg *config.Config, cwd string, ctx context.Context, handlers *api.Handlers) (*proxyd.Client, *proxy.Service) {
+func startProxy(cfg *config.Config, cwd string, ctx context.Context, handlers *api.Handlers) (*proxyd.Client, *proxy.Service, error) {
 	// Try shared daemon first
-	client, ok, fatal := tryDaemonProxy(cfg, cwd, ctx, handlers)
+	client, ok, fatalErr := tryDaemonProxy(cfg, cwd, ctx, handlers)
 	if ok {
-		return client, nil
+		return client, nil, nil
 	}
-	if fatal {
+	if fatalErr != nil {
 		// Daemon is running but registration failed (conflict, version mismatch, etc.)
-		// Don't fall back to standalone — it would just fail on port binding too.
-		return nil, nil
+		return nil, nil, fatalErr
 	}
 
 	// Fallback to standalone proxy (daemon unavailable or sandboxed)
-	return nil, startStandaloneProxy(cfg, cwd, ctx, handlers)
+	return nil, startStandaloneProxy(cfg, cwd, ctx, handlers), nil
 }
 
 // tryDaemonProxy attempts to register with the shared proxy daemon.
-// Returns (client, true, false) on success, (nil, false, false) when daemon is
-// unavailable (fall back to standalone), (nil, false, true) when daemon is running
-// but registration failed (don't fall back).
-func tryDaemonProxy(cfg *config.Config, cwd string, ctx context.Context, handlers *api.Handlers) (*proxyd.Client, bool, bool) {
+// Returns (client, true, nil) on success, (nil, false, nil) when daemon is
+// unavailable (fall back to standalone), (nil, false, error) when daemon is
+// running but registration failed (don't fall back, fail the command).
+func tryDaemonProxy(cfg *config.Config, cwd string, ctx context.Context, handlers *api.Handlers) (*proxyd.Client, bool, error) {
 	// Check if we can access the daemon directory
 	if err := proxyd.EnsureDaemonDir(); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: %v — running proxy in standalone mode\n", err)
-		return nil, false, false
+		return nil, false, nil
 	}
 
 	// Ensure daemon is running
 	client, err := proxyd.EnsureRunning()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: proxy daemon unavailable: %v — running proxy in standalone mode\n", err)
-		return nil, false, false
+		return nil, false, nil
 	}
 
 	// Build registration request
@@ -596,8 +599,7 @@ func tryDaemonProxy(cfg *config.Config, cwd string, ctx context.Context, handler
 
 	resp, err := client.Register(req)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		return nil, false, true // fatal — daemon running but registration failed
+		return nil, false, fmt.Errorf("failed to register with proxy daemon: %w", err)
 	}
 
 	// Print registered routes
@@ -621,7 +623,7 @@ func tryDaemonProxy(cfg *config.Config, cwd string, ctx context.Context, handler
 	handlers.SetRequestManager(localRM)
 	go proxyd.ForwardRequests(ctx, proxyd.SocketPath(), resp.Registered, localRM)
 
-	return client, true, false
+	return client, true, nil
 }
 
 // startStandaloneProxy creates and starts a standalone proxy (current behavior).

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -22,8 +22,10 @@ import (
 	"github.com/charliek/prox/internal/domain"
 	"github.com/charliek/prox/internal/logs"
 	"github.com/charliek/prox/internal/proxy"
+	"github.com/charliek/prox/internal/proxyd"
 	"github.com/charliek/prox/internal/supervisor"
 	"github.com/charliek/prox/internal/tui"
+	"github.com/charliek/prox/internal/version"
 	"github.com/spf13/cobra"
 )
 
@@ -317,26 +319,14 @@ func runUp(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Start proxy server first if configured — fail fast on port conflicts
-	// before spawning child processes.
+	// Start proxy — either via shared daemon or standalone fallback.
 	var proxyService *proxy.Service
+	var daemonClient *proxyd.Client
 	if !noProxy && cfg.Proxy != nil && cfg.Proxy.Enabled {
-		level := slog.LevelInfo
-		if verbose {
-			level = slog.LevelDebug
-		}
-		logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level}))
-		var err error
-		proxyService, err = proxy.NewService(cfg.Proxy, cfg.Services, cfg.Certs, logger, cwd)
-		if err != nil {
-			return fmt.Errorf("failed to create proxy: %w", err)
-		}
-		if err := proxyService.Start(ctx); err != nil {
-			return proxyStartError(err)
-		}
-		// Ensure proxy is cleaned up on any subsequent error (e.g., supervisor
-		// fails to start). The normal shutdown path also calls Shutdown, but
-		// a double-call is safe since stopServers nil-checks server pointers.
+		daemonClient, proxyService = startProxy(cfg, cwd, ctx, handlers)
+	}
+	// Ensure standalone proxy is cleaned up on any subsequent error
+	if proxyService != nil {
 		defer func() {
 			if proxyService != nil {
 				sCtx, sCancel := context.WithTimeout(context.Background(), shutdownTimeout)
@@ -344,19 +334,6 @@ func runUp(cmd *cobra.Command, args []string) error {
 				_ = proxyService.Shutdown(sCtx)
 			}
 		}()
-
-		var proxyAddrs []string
-		if cfg.Proxy.HTTPPort > 0 {
-			proxyAddrs = append(proxyAddrs, fmt.Sprintf("http://*.%s:%d", cfg.Proxy.Domain, cfg.Proxy.HTTPPort))
-		}
-		if cfg.Proxy.HTTPSPort > 0 {
-			proxyAddrs = append(proxyAddrs, fmt.Sprintf("https://*.%s:%d", cfg.Proxy.Domain, cfg.Proxy.HTTPSPort))
-		}
-		if len(proxyAddrs) > 0 {
-			fmt.Printf("Proxy server: %s\n", strings.Join(proxyAddrs, ", "))
-		}
-		handlers.SetRequestManager(proxyService.RequestManager())
-		handlers.SetCaptureManager(proxyService.CaptureManager())
 	}
 
 	// Start supervisor
@@ -414,10 +391,7 @@ func runUp(cmd *cobra.Command, args []string) error {
 	// Handle TUI vs terminal output
 	if useTUI {
 		// Run TUI - it blocks until quit
-		var reqMgr *proxy.RequestManager
-		if proxyService != nil {
-			reqMgr = proxyService.RequestManager()
-		}
+		reqMgr := localRequestManager(proxyService, handlers)
 		if err := tui.Run(sup, logMgr, reqMgr); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		}
@@ -443,7 +417,15 @@ func runUp(cmd *cobra.Command, args []string) error {
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), shutdownTimeout)
 	defer shutdownCancel()
 
-	// Stop proxy server and disarm the deferred shutdown
+	// Deregister from shared daemon or stop standalone proxy
+	if daemonClient != nil {
+		if err := daemonClient.Deregister(proxyd.DeregisterRequest{
+			ProjectDir: cwd,
+			PID:        os.Getpid(),
+		}); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to deregister from proxy daemon: %v\n", err)
+		}
+	}
 	if proxyService != nil {
 		if err := proxyService.Shutdown(shutdownCtx); err != nil {
 			fmt.Fprintf(os.Stderr, "Error stopping proxy: %v\n", err)
@@ -555,6 +537,137 @@ func proxyStartError(err error) error {
 		return fmt.Errorf("%w\n\nAnother process is listening on this port. To identify it:\n  lsof -i :%d\n\nTo start without the proxy:\n  prox up --no-proxy", portErr, portErr.Port)
 	}
 	return fmt.Errorf("proxy failed to start: %w", err)
+}
+
+// startProxy attempts to register with the shared proxy daemon. If the daemon
+// cannot be reached (e.g., sandboxed environment), it falls back to starting a
+// standalone proxy. Returns the daemon client (if using daemon) and/or the
+// standalone proxy service (if using fallback).
+func startProxy(cfg *config.Config, cwd string, ctx context.Context, handlers *api.Handlers) (*proxyd.Client, *proxy.Service) {
+	// Try shared daemon first
+	client, ok, fatal := tryDaemonProxy(cfg, cwd, ctx, handlers)
+	if ok {
+		return client, nil
+	}
+	if fatal {
+		// Daemon is running but registration failed (conflict, version mismatch, etc.)
+		// Don't fall back to standalone — it would just fail on port binding too.
+		return nil, nil
+	}
+
+	// Fallback to standalone proxy (daemon unavailable or sandboxed)
+	return nil, startStandaloneProxy(cfg, cwd, ctx, handlers)
+}
+
+// tryDaemonProxy attempts to register with the shared proxy daemon.
+// Returns (client, true, false) on success, (nil, false, false) when daemon is
+// unavailable (fall back to standalone), (nil, false, true) when daemon is running
+// but registration failed (don't fall back).
+func tryDaemonProxy(cfg *config.Config, cwd string, ctx context.Context, handlers *api.Handlers) (*proxyd.Client, bool, bool) {
+	// Check if we can access the daemon directory
+	if err := proxyd.EnsureDaemonDir(); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: %v — running proxy in standalone mode\n", err)
+		return nil, false, false
+	}
+
+	// Ensure daemon is running
+	client, err := proxyd.EnsureRunning()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: proxy daemon unavailable: %v — running proxy in standalone mode\n", err)
+		return nil, false, false
+	}
+
+	// Build registration request
+	services := make(map[string]proxyd.ServiceTarget, len(cfg.Services))
+	for name, svc := range cfg.Services {
+		services[name] = proxyd.ServiceTarget{Host: svc.Host, Port: svc.Port}
+	}
+
+	req := proxyd.RegisterRequest{
+		ProjectDir:     cwd,
+		PID:            os.Getpid(),
+		Version:        version.Version,
+		Domain:         cfg.Proxy.Domain,
+		Services:       services,
+		HTTPPort:       cfg.Proxy.HTTPPort,
+		HTTPSPort:      cfg.Proxy.HTTPSPort,
+		CaptureEnabled: cfg.Proxy.Capture != nil && cfg.Proxy.Capture.Enabled,
+	}
+
+	resp, err := client.Register(req)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return nil, false, true // fatal — daemon running but registration failed
+	}
+
+	// Print registered routes
+	var proxyAddrs []string
+	if cfg.Proxy.HTTPPort > 0 {
+		proxyAddrs = append(proxyAddrs, fmt.Sprintf("http://*.%s:%d", cfg.Proxy.Domain, cfg.Proxy.HTTPPort))
+	}
+	if cfg.Proxy.HTTPSPort > 0 {
+		proxyAddrs = append(proxyAddrs, fmt.Sprintf("https://*.%s:%d", cfg.Proxy.Domain, cfg.Proxy.HTTPSPort))
+	}
+	if len(proxyAddrs) > 0 {
+		fmt.Printf("Proxy (shared daemon): %s\n", strings.Join(proxyAddrs, ", "))
+	}
+	if len(resp.Registered) > 0 {
+		fmt.Printf("Registered domains: %s\n", strings.Join(resp.Registered, ", "))
+	}
+
+	// Create a local RequestManager and start the SSE forwarder to bridge
+	// daemon proxy requests into this project's TUI and API.
+	localRM := proxy.NewRequestManager(constants.DefaultProxyRequestBufferSize)
+	handlers.SetRequestManager(localRM)
+	go proxyd.ForwardRequests(ctx, proxyd.SocketPath(), resp.Registered, localRM)
+
+	return client, true, false
+}
+
+// startStandaloneProxy creates and starts a standalone proxy (current behavior).
+func startStandaloneProxy(cfg *config.Config, cwd string, ctx context.Context, handlers *api.Handlers) *proxy.Service {
+	level := slog.LevelInfo
+	if verbose {
+		level = slog.LevelDebug
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level}))
+
+	proxyService, err := proxy.NewService(cfg.Proxy, cfg.Services, cfg.Certs, logger, cwd)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to create proxy: %v\n", err)
+		return nil
+	}
+	if err := proxyService.Start(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: %v\n", proxyStartError(err))
+		return nil
+	}
+
+	var proxyAddrs []string
+	if cfg.Proxy.HTTPPort > 0 {
+		proxyAddrs = append(proxyAddrs, fmt.Sprintf("http://*.%s:%d", cfg.Proxy.Domain, cfg.Proxy.HTTPPort))
+	}
+	if cfg.Proxy.HTTPSPort > 0 {
+		proxyAddrs = append(proxyAddrs, fmt.Sprintf("https://*.%s:%d", cfg.Proxy.Domain, cfg.Proxy.HTTPSPort))
+	}
+	if len(proxyAddrs) > 0 {
+		fmt.Printf("Proxy (standalone): %s\n", strings.Join(proxyAddrs, ", "))
+	}
+	handlers.SetRequestManager(proxyService.RequestManager())
+	handlers.SetCaptureManager(proxyService.CaptureManager())
+
+	return proxyService
+}
+
+// localRequestManager returns the RequestManager for use by the TUI.
+// In daemon mode, a local request manager is created (will be fed via SSE in Phase 5).
+// In standalone mode, the proxy service's request manager is returned.
+func localRequestManager(proxyService *proxy.Service, handlers *api.Handlers) *proxy.RequestManager {
+	if proxyService != nil {
+		return proxyService.RequestManager()
+	}
+	// In daemon mode, we return the request manager from the handlers
+	// (which may be nil if no proxy is configured, which is fine for TUI)
+	return handlers.GetRequestManager()
 }
 
 // printLogs subscribes to logs and prints them to terminal

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -143,9 +143,8 @@ func Parse(data []byte) (*Config, error) {
 	}
 
 	// Apply defaults
-	if config.API.Port == 0 {
-		config.API.Port = constants.DefaultAPIPort
-	}
+	// Note: API.Port == 0 means dynamic assignment (handled by cli/up.go).
+	// Users can still set api.port explicitly in their config if needed.
 	if config.API.Host == "" {
 		config.API.Host = constants.DefaultAPIHost
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -12,7 +12,7 @@ func TestLoad_SimpleForm(t *testing.T) {
 	cfg, err := Load(filepath.Join("..", "..", "testdata", "configs", "simple.yaml"))
 	require.NoError(t, err)
 
-	assert.Equal(t, 5555, cfg.API.Port)
+	assert.Equal(t, 0, cfg.API.Port) // 0 means dynamic assignment
 	assert.Equal(t, "127.0.0.1", cfg.API.Host)
 	assert.Len(t, cfg.Processes, 3)
 

--- a/internal/proxy/requests.go
+++ b/internal/proxy/requests.go
@@ -279,6 +279,7 @@ func (m *RequestManager) matchesFilter(record RequestRecord, filter RequestFilte
 
 // PurgeByHostnames removes all records matching any of the given hostnames
 // from the ring buffer and calls the eviction callback for each.
+// It compacts the buffer to preserve the contiguous ring invariant.
 func (m *RequestManager) PurgeByHostnames(hostnames []string) {
 	if len(hostnames) == 0 {
 		return
@@ -294,8 +295,12 @@ func (m *RequestManager) PurgeByHostnames(hostnames []string) {
 
 	m.mu.Lock()
 	onEvict = m.onEvict
-	for i := 0; i < m.capacity; i++ {
-		rec := &m.buffer[i]
+
+	// Rebuild the buffer keeping only non-matching records in order.
+	kept := make([]RequestRecord, 0, m.count)
+	for i := 0; i < m.count; i++ {
+		idx := (m.head - m.count + i + m.capacity) % m.capacity
+		rec := m.buffer[idx]
 		if rec.ID == "" {
 			continue
 		}
@@ -303,12 +308,16 @@ func (m *RequestManager) PurgeByHostnames(hostnames []string) {
 			if rec.Details != nil {
 				evictIDs = append(evictIDs, rec.ID)
 			}
-			m.buffer[i] = RequestRecord{} // zero out
-			if m.count > 0 {
-				m.count--
-			}
+			continue
 		}
+		kept = append(kept, rec)
 	}
+
+	compacted := make([]RequestRecord, m.capacity)
+	copy(compacted, kept)
+	m.buffer = compacted
+	m.count = len(kept)
+	m.head = m.count % m.capacity
 	m.mu.Unlock()
 
 	// Call eviction callbacks outside of lock

--- a/internal/proxy/requests.go
+++ b/internal/proxy/requests.go
@@ -16,6 +16,7 @@ type RequestRecord struct {
 	Method     string        `json:"method"`
 	URL        string        `json:"url"`
 	Subdomain  string        `json:"subdomain"`
+	Hostname   string        `json:"hostname,omitempty"` // full hostname (e.g., api.local.dev)
 	StatusCode int           `json:"status_code"`
 	Duration   time.Duration `json:"duration"`
 	RemoteAddr string        `json:"remote_addr"`
@@ -52,6 +53,7 @@ func generateRequestID(timestamp time.Time, method, url string) string {
 // RequestFilter specifies criteria for filtering requests.
 type RequestFilter struct {
 	Subdomain string
+	Hostnames []string // match if record.Hostname is in this list (empty = match all)
 	Method    string
 	MinStatus int
 	MaxStatus int
@@ -248,6 +250,18 @@ func (m *RequestManager) matchesFilter(record RequestRecord, filter RequestFilte
 	if filter.Subdomain != "" && record.Subdomain != filter.Subdomain {
 		return false
 	}
+	if len(filter.Hostnames) > 0 {
+		matched := false
+		for _, h := range filter.Hostnames {
+			if record.Hostname == h {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
 	if filter.Method != "" && record.Method != filter.Method {
 		return false
 	}
@@ -261,4 +275,46 @@ func (m *RequestManager) matchesFilter(record RequestRecord, filter RequestFilte
 		return false
 	}
 	return true
+}
+
+// PurgeByHostnames removes all records matching any of the given hostnames
+// from the ring buffer and calls the eviction callback for each.
+func (m *RequestManager) PurgeByHostnames(hostnames []string) {
+	if len(hostnames) == 0 {
+		return
+	}
+
+	hostSet := make(map[string]struct{}, len(hostnames))
+	for _, h := range hostnames {
+		hostSet[h] = struct{}{}
+	}
+
+	var evictIDs []string
+	var onEvict EvictionCallback
+
+	m.mu.Lock()
+	onEvict = m.onEvict
+	for i := 0; i < m.capacity; i++ {
+		rec := &m.buffer[i]
+		if rec.ID == "" {
+			continue
+		}
+		if _, match := hostSet[rec.Hostname]; match {
+			if rec.Details != nil {
+				evictIDs = append(evictIDs, rec.ID)
+			}
+			m.buffer[i] = RequestRecord{} // zero out
+			if m.count > 0 {
+				m.count--
+			}
+		}
+	}
+	m.mu.Unlock()
+
+	// Call eviction callbacks outside of lock
+	if onEvict != nil {
+		for _, id := range evictIDs {
+			onEvict(id)
+		}
+	}
 }

--- a/internal/proxyd/certs.go
+++ b/internal/proxyd/certs.go
@@ -1,0 +1,101 @@
+package proxyd
+
+import (
+	"crypto/tls"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/charliek/prox/internal/proxy/certs"
+)
+
+// MultiDomainCertManager manages TLS certificates for multiple base domains.
+// It wraps the existing certs.Manager, creating one per base domain, and
+// provides a GetCertificate callback for TLS SNI-based cert selection.
+type MultiDomainCertManager struct {
+	mu       sync.RWMutex
+	certsDir string
+	managers map[string]*certs.Manager    // base domain -> cert manager
+	loaded   map[string]*tls.Certificate  // base domain -> loaded cert
+}
+
+// NewMultiDomainCertManager creates a new multi-domain cert manager.
+func NewMultiDomainCertManager(certsDir string) *MultiDomainCertManager {
+	return &MultiDomainCertManager{
+		certsDir: certsDir,
+		managers: make(map[string]*certs.Manager),
+		loaded:   make(map[string]*tls.Certificate),
+	}
+}
+
+// EnsureDomain ensures a wildcard certificate exists for the given base domain.
+// It generates one via mkcert if it doesn't exist yet.
+func (m *MultiDomainCertManager) EnsureDomain(domain string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Already loaded
+	if _, ok := m.loaded[domain]; ok {
+		return nil
+	}
+
+	// Create or reuse manager for this domain
+	mgr, ok := m.managers[domain]
+	if !ok {
+		mgr = certs.NewManager(m.certsDir, domain)
+		m.managers[domain] = mgr
+	}
+
+	// Ensure certs exist (generate if needed)
+	paths, err := mgr.EnsureCerts()
+	if err != nil {
+		return fmt.Errorf("ensuring certs for %s: %w", domain, err)
+	}
+
+	// Load the certificate
+	cert, err := tls.LoadX509KeyPair(paths.CertFile, paths.KeyFile)
+	if err != nil {
+		return fmt.Errorf("loading cert for %s: %w", domain, err)
+	}
+
+	m.loaded[domain] = &cert
+	return nil
+}
+
+// GetCertificate is the TLS SNI callback. It selects the appropriate
+// certificate based on the server name in the TLS ClientHello.
+func (m *MultiDomainCertManager) GetCertificate(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	if hello.ServerName == "" {
+		return nil, fmt.Errorf("no SNI server name provided")
+	}
+
+	domain := extractBaseDomain(hello.ServerName)
+
+	m.mu.RLock()
+	cert, ok := m.loaded[domain]
+	m.mu.RUnlock()
+
+	if !ok {
+		return nil, fmt.Errorf("no certificate for domain %s (from %s)", domain, hello.ServerName)
+	}
+	return cert, nil
+}
+
+// RemoveDomain removes a domain from the cache. Cert files are left on disk
+// for reuse if the domain is registered again later.
+func (m *MultiDomainCertManager) RemoveDomain(domain string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.loaded, domain)
+	delete(m.managers, domain)
+}
+
+// extractBaseDomain extracts the base domain from a full hostname.
+// e.g., "api.local.stridelabs.ai" -> "local.stridelabs.ai"
+func extractBaseDomain(hostname string) string {
+	parts := strings.SplitN(hostname, ".", 2)
+	if len(parts) == 2 {
+		return parts[1]
+	}
+	return hostname
+}

--- a/internal/proxyd/certs.go
+++ b/internal/proxyd/certs.go
@@ -15,8 +15,8 @@ import (
 type MultiDomainCertManager struct {
 	mu       sync.RWMutex
 	certsDir string
-	managers map[string]*certs.Manager    // base domain -> cert manager
-	loaded   map[string]*tls.Certificate  // base domain -> loaded cert
+	managers map[string]*certs.Manager   // base domain -> cert manager
+	loaded   map[string]*tls.Certificate // base domain -> loaded cert
 }
 
 // NewMultiDomainCertManager creates a new multi-domain cert manager.

--- a/internal/proxyd/client.go
+++ b/internal/proxyd/client.go
@@ -1,0 +1,174 @@
+package proxyd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"time"
+)
+
+// Client communicates with the proxy daemon over its Unix socket.
+type Client struct {
+	socketPath string
+	httpClient *http.Client
+}
+
+// NewClient creates a new daemon client that connects via Unix socket.
+func NewClient(socketPath string) *Client {
+	dialer := &net.Dialer{}
+	return &Client{
+		socketPath: socketPath,
+		httpClient: &http.Client{
+			Transport: &http.Transport{
+				DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+					return dialer.DialContext(ctx, "unix", socketPath)
+				},
+			},
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// Health checks if the daemon is alive and returns its version.
+func (c *Client) Health() (string, error) {
+	resp, err := c.get("/health")
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	var result map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("decoding health response: %w", err)
+	}
+	return result["version"], nil
+}
+
+// Register registers a project's routes with the daemon.
+func (c *Client) Register(req RegisterRequest) (*RegisterResponse, error) {
+	resp, err := c.post("/api/v1/register", req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, c.readError(resp)
+	}
+
+	var result RegisterResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decoding register response: %w", err)
+	}
+	return &result, nil
+}
+
+// Deregister removes a project's routes from the daemon.
+func (c *Client) Deregister(req DeregisterRequest) error {
+	resp, err := c.post("/api/v1/deregister", req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return c.readError(resp)
+	}
+	return nil
+}
+
+// Status returns the daemon's current status.
+func (c *Client) Status() (*DaemonStatusResponse, error) {
+	resp, err := c.get("/api/v1/status")
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, c.readError(resp)
+	}
+
+	var result DaemonStatusResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decoding status response: %w", err)
+	}
+	return &result, nil
+}
+
+// Routes returns all registered routes.
+func (c *Client) Routes() ([]RouteInfo, error) {
+	resp, err := c.get("/api/v1/routes")
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, c.readError(resp)
+	}
+
+	var result struct {
+		Routes []RouteInfo `json:"routes"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decoding routes response: %w", err)
+	}
+	return result.Routes, nil
+}
+
+// Shutdown requests the daemon to shut down.
+func (c *Client) Shutdown(force bool) error {
+	path := "/api/v1/shutdown"
+	if force {
+		path += "?force=true"
+	}
+	resp, err := c.post(path, nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return c.readError(resp)
+	}
+	return nil
+}
+
+// get performs an HTTP GET to the daemon.
+func (c *Client) get(path string) (*http.Response, error) {
+	// "http://proxyd" is a dummy host — the Unix socket transport ignores it.
+	url := "http://proxyd" + path
+	return c.httpClient.Get(url)
+}
+
+// post performs an HTTP POST to the daemon with a JSON body.
+func (c *Client) post(path string, body any) (*http.Response, error) {
+	url := "http://proxyd" + path
+
+	var bodyReader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("encoding request: %w", err)
+		}
+		bodyReader = bytes.NewReader(data)
+	}
+
+	return c.httpClient.Post(url, "application/json", bodyReader)
+}
+
+// readError reads an error response from the daemon.
+func (c *Client) readError(resp *http.Response) error {
+	body, _ := io.ReadAll(resp.Body)
+
+	var errResp ErrorResponse
+	if json.Unmarshal(body, &errResp) == nil && errResp.Error != "" {
+		return fmt.Errorf("%s", errResp.Error)
+	}
+	return fmt.Errorf("daemon returned %d: %s", resp.StatusCode, string(body))
+}

--- a/internal/proxyd/client.go
+++ b/internal/proxyd/client.go
@@ -41,6 +41,10 @@ func (c *Client) Health() (string, error) {
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("daemon health check returned %d", resp.StatusCode)
+	}
+
 	var result map[string]string
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return "", fmt.Errorf("decoding health response: %w", err)

--- a/internal/proxyd/client_server_test.go
+++ b/internal/proxyd/client_server_test.go
@@ -11,8 +11,13 @@ import (
 func startTestServer(t *testing.T) (*Server, *Client, string) {
 	t.Helper()
 
-	tmpDir := t.TempDir()
-	socketPath := filepath.Join(tmpDir, "test.sock")
+	// Use a short temp dir to stay under Unix socket 104-byte path limit on macOS
+	tmpDir, err := os.MkdirTemp("/tmp", "prox-ut-")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(tmpDir) })
+	socketPath := filepath.Join(tmpDir, "t.sock")
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
 

--- a/internal/proxyd/client_server_test.go
+++ b/internal/proxyd/client_server_test.go
@@ -1,0 +1,246 @@
+package proxyd
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func startTestServer(t *testing.T) (*Server, *Client, string) {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	socketPath := filepath.Join(tmpDir, "test.sock")
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	server := NewServer(ServerConfig{
+		SocketPath: socketPath,
+		Logger:     logger,
+		Version:    "test-version",
+	})
+
+	registry := NewRegistry()
+	server.SetRegistry(registry)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- server.Start()
+	}()
+
+	// Wait for socket to be available
+	deadline := time.Now().Add(2 * time.Second)
+	client := NewClient(socketPath)
+	for time.Now().Before(deadline) {
+		if _, err := client.Health(); err == nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Cleanup(func() {
+		server.Shutdown(t.Context())
+	})
+
+	return server, client, socketPath
+}
+
+func TestHealthEndpoint(t *testing.T) {
+	_, client, _ := startTestServer(t)
+
+	ver, err := client.Health()
+	if err != nil {
+		t.Fatalf("Health: %v", err)
+	}
+	if ver != "test-version" {
+		t.Errorf("version = %q, want %q", ver, "test-version")
+	}
+}
+
+func TestStatusEndpoint(t *testing.T) {
+	_, client, _ := startTestServer(t)
+
+	status, err := client.Status()
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if status.Version != "test-version" {
+		t.Errorf("version = %q, want %q", status.Version, "test-version")
+	}
+	if status.PID == 0 {
+		t.Error("PID should not be 0")
+	}
+	if status.RouteCount != 0 {
+		t.Errorf("route count = %d, want 0", status.RouteCount)
+	}
+}
+
+func TestRegisterAndRoutes(t *testing.T) {
+	_, client, _ := startTestServer(t)
+
+	resp, err := client.Register(RegisterRequest{
+		ProjectDir: "/test/project-a",
+		PID:        os.Getpid(),
+		Version:    "test-version",
+		Domain:     "local.dev",
+		Services: map[string]ServiceTarget{
+			"api": {Host: "localhost", Port: 3000},
+		},
+		HTTPSPort: 443,
+	})
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if len(resp.Registered) != 1 || resp.Registered[0] != "api.local.dev" {
+		t.Errorf("registered = %v, want [api.local.dev]", resp.Registered)
+	}
+
+	// Check routes
+	routes, err := client.Routes()
+	if err != nil {
+		t.Fatalf("Routes: %v", err)
+	}
+	if len(routes) != 1 {
+		t.Fatalf("got %d routes, want 1", len(routes))
+	}
+	if routes[0].Hostname != "api.local.dev" {
+		t.Errorf("hostname = %q, want %q", routes[0].Hostname, "api.local.dev")
+	}
+
+	// Check status
+	status, err := client.Status()
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if status.ProjectCount != 1 {
+		t.Errorf("project count = %d, want 1", status.ProjectCount)
+	}
+	if status.RouteCount != 1 {
+		t.Errorf("route count = %d, want 1", status.RouteCount)
+	}
+}
+
+func TestRegisterVersionMismatch(t *testing.T) {
+	_, client, _ := startTestServer(t)
+
+	_, err := client.Register(RegisterRequest{
+		ProjectDir: "/test/project-a",
+		PID:        os.Getpid(),
+		Version:    "wrong-version",
+		Domain:     "local.dev",
+		Services: map[string]ServiceTarget{
+			"api": {Host: "localhost", Port: 3000},
+		},
+		HTTPSPort: 443,
+	})
+	if err == nil {
+		t.Fatal("expected version mismatch error, got nil")
+	}
+	t.Logf("got expected error: %v", err)
+}
+
+func TestDeregister(t *testing.T) {
+	_, client, _ := startTestServer(t)
+
+	// Register first
+	_, err := client.Register(RegisterRequest{
+		ProjectDir: "/test/project-a",
+		PID:        os.Getpid(),
+		Version:    "test-version",
+		Domain:     "local.dev",
+		Services: map[string]ServiceTarget{
+			"api": {Host: "localhost", Port: 3000},
+		},
+		HTTPSPort: 443,
+	})
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	// Deregister
+	err = client.Deregister(DeregisterRequest{
+		ProjectDir: "/test/project-a",
+		PID:        os.Getpid(),
+	})
+	if err != nil {
+		t.Fatalf("Deregister: %v", err)
+	}
+
+	// Verify empty
+	routes, err := client.Routes()
+	if err != nil {
+		t.Fatalf("Routes: %v", err)
+	}
+	if len(routes) != 0 {
+		t.Errorf("got %d routes after deregister, want 0", len(routes))
+	}
+}
+
+func TestShutdownProtected(t *testing.T) {
+	_, client, _ := startTestServer(t)
+
+	// Register a project
+	_, err := client.Register(RegisterRequest{
+		ProjectDir: "/test/project-a",
+		PID:        os.Getpid(),
+		Version:    "test-version",
+		Domain:     "local.dev",
+		Services: map[string]ServiceTarget{
+			"api": {Host: "localhost", Port: 3000},
+		},
+		HTTPSPort: 443,
+	})
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	// Shutdown without force should fail
+	err = client.Shutdown(false)
+	if err == nil {
+		t.Fatal("expected error for shutdown with active routes, got nil")
+	}
+	t.Logf("got expected error: %v", err)
+
+	// Shutdown with force should succeed
+	err = client.Shutdown(true)
+	if err != nil {
+		t.Fatalf("Shutdown(force): %v", err)
+	}
+}
+
+func TestDomainConflictViaClient(t *testing.T) {
+	_, client, _ := startTestServer(t)
+
+	// Register project A
+	_, err := client.Register(RegisterRequest{
+		ProjectDir: "/test/project-a",
+		PID:        os.Getpid(),
+		Version:    "test-version",
+		Domain:     "local.dev",
+		Services: map[string]ServiceTarget{
+			"api": {Host: "localhost", Port: 3000},
+		},
+		HTTPSPort: 443,
+	})
+	if err != nil {
+		t.Fatalf("Register A: %v", err)
+	}
+
+	// Register project B with same domain — should conflict
+	_, err = client.Register(RegisterRequest{
+		ProjectDir: "/test/project-b",
+		PID:        os.Getpid(),
+		Version:    "test-version",
+		Domain:     "local.dev",
+		Services: map[string]ServiceTarget{
+			"api": {Host: "localhost", Port: 4000},
+		},
+		HTTPSPort: 443,
+	})
+	if err == nil {
+		t.Fatal("expected domain conflict error, got nil")
+	}
+	t.Logf("got expected error: %v", err)
+}

--- a/internal/proxyd/daemon.go
+++ b/internal/proxyd/daemon.go
@@ -1,0 +1,230 @@
+package proxyd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/charliek/prox/internal/constants"
+	"github.com/charliek/prox/internal/daemon"
+	"github.com/charliek/prox/internal/proxy"
+	"github.com/charliek/prox/internal/version"
+)
+
+const (
+	// ProxyDaemonEnvVar marks the process as the proxy daemon child.
+	ProxyDaemonEnvVar = "_PROX_PROXY_DAEMON"
+
+	// startupRetryInterval is the time between daemon health check retries.
+	startupRetryInterval = 100 * time.Millisecond
+
+	// startupTimeout is the maximum time to wait for the daemon to start.
+	startupTimeout = 5 * time.Second
+
+	// stalePIDCheckInterval is how often the daemon checks for dead project PIDs.
+	stalePIDCheckInterval = 30 * time.Second
+)
+
+// IsDaemonProcess returns true if this process is the proxy daemon child.
+func IsDaemonProcess() bool {
+	return os.Getenv(ProxyDaemonEnvVar) == "1"
+}
+
+// EnsureRunning ensures the proxy daemon is running and returns a connected client.
+// If the daemon is not running, it starts one. Verifies version compatibility.
+func EnsureRunning() (*Client, error) {
+	socketPath := SocketPath()
+	client := NewClient(socketPath)
+
+	// Try to connect to an existing daemon
+	daemonVersion, err := client.Health()
+	if err == nil {
+		// Daemon is running — check version
+		if daemonVersion != version.Version {
+			return nil, fmt.Errorf(
+				"proxy daemon is running version %s, but this process is version %s.\n"+
+					"Stop all projects and restart, or run 'prox proxy stop --force' to reset.",
+				daemonVersion, version.Version,
+			)
+		}
+		return client, nil
+	}
+
+	// Daemon is not running — start it
+	if err := startDaemon(); err != nil {
+		return nil, fmt.Errorf("starting proxy daemon: %w", err)
+	}
+
+	// Wait for daemon to become ready
+	deadline := time.Now().Add(startupTimeout)
+	for time.Now().Before(deadline) {
+		daemonVersion, err = client.Health()
+		if err == nil {
+			if daemonVersion != version.Version {
+				return nil, fmt.Errorf("started daemon has version %s, expected %s", daemonVersion, version.Version)
+			}
+			return client, nil
+		}
+		time.Sleep(startupRetryInterval)
+	}
+
+	return nil, fmt.Errorf("proxy daemon did not become ready within %s", startupTimeout)
+}
+
+// startDaemon forks the proxy daemon as a background process.
+func startDaemon() error {
+	executable, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("getting executable path: %w", err)
+	}
+
+	// Re-exec with the daemon env var. The daemon will be intercepted in
+	// Execute() and run RunDaemon() instead of normal CLI dispatch.
+	// We pass a minimal set of args — just the binary name.
+	cmd := exec.Command(executable, "up", "--no-proxy")
+	cmd.Env = append(os.Environ(), ProxyDaemonEnvVar+"=1")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	cmd.Stdin = nil
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("starting daemon process: %w", err)
+	}
+
+	// Detach — don't wait for the child
+	cmd.Process.Release()
+	return nil
+}
+
+// RunDaemon is the main entry point for the proxy daemon process.
+// It sets up logging, the registry, proxy, and socket server, then waits
+// for a shutdown signal (no routes remaining or SIGTERM).
+func RunDaemon(ctx context.Context) error {
+	if err := EnsureDaemonDir(); err != nil {
+		return err
+	}
+
+	// Set up logging to file
+	logPath := DaemonLogPath()
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, constants.FilePermissionPrivate)
+	if err != nil {
+		return fmt.Errorf("opening daemon log: %w", err)
+	}
+	defer logFile.Close()
+
+	logger := slog.New(slog.NewTextHandler(logFile, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	logger.Info("proxy daemon starting", "version", version.Version, "pid", os.Getpid())
+
+	// Create and lock PID file
+	pidFile := daemon.NewPIDFile(DaemonPIDPath())
+	if err := pidFile.Create(); err != nil {
+		if err == daemon.ErrPIDFileLocked {
+			logger.Info("another daemon is already running")
+			return fmt.Errorf("proxy daemon is already running")
+		}
+		return fmt.Errorf("creating daemon PID file: %w", err)
+	}
+	defer pidFile.Release()
+
+	// Write state file
+	state := &DaemonState{
+		PID:       os.Getpid(),
+		Version:   version.Version,
+		StartedAt: time.Now(),
+	}
+	if err := WriteDaemonState(state); err != nil {
+		return fmt.Errorf("writing daemon state: %w", err)
+	}
+	defer CleanupDaemonState()
+
+	// Create core components
+	registry := NewRegistry()
+	certMgr := NewMultiDomainCertManager(constants.DefaultCertsDir)
+	requestMgr := proxy.NewRequestManager(constants.DefaultProxyRequestBufferSize)
+	dynamicProxy := NewDynamicProxy(registry, certMgr, requestMgr, logger)
+
+	// Create and configure the socket server
+	server := NewServer(ServerConfig{
+		SocketPath: SocketPath(),
+		Logger:     logger,
+		Version:    version.Version,
+	})
+	server.SetRegistry(registry)
+	server.SetProxy(dynamicProxy)
+	server.SetRequestManager(requestMgr)
+
+	// Handle OS signals
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+
+	// Start stale PID cleanup loop
+	go func() {
+		ticker := time.NewTicker(stalePIDCheckInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				stale := registry.CleanStalePIDs()
+				for _, dir := range stale {
+					logger.Warn("cleaned stale project registration", "project", dir)
+				}
+				if len(stale) > 0 && registry.IsEmpty() {
+					logger.Info("all routes cleaned up, shutting down")
+					server.RequestShutdown()
+				}
+			}
+		}
+	}()
+
+	// Start socket server in background
+	serverErr := make(chan error, 1)
+	go func() {
+		if err := server.Start(); err != nil && !errors.Is(err, http.ErrServerClosed) && !errors.Is(err, net.ErrClosed) {
+			serverErr <- err
+		}
+		close(serverErr)
+	}()
+
+	// Wait for shutdown signal
+	select {
+	case sig := <-sigCh:
+		logger.Info("received signal", "signal", sig)
+	case <-server.ShutdownCh():
+		logger.Info("shutdown requested")
+	case err := <-serverErr:
+		if err != nil {
+			logger.Error("server error", "error", err)
+			return err
+		}
+	}
+
+	// Graceful shutdown
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer shutdownCancel()
+
+	cancel() // stop cleanup loop
+
+	if err := dynamicProxy.Shutdown(shutdownCtx); err != nil {
+		logger.Error("error shutting down proxy", "error", err)
+	}
+	if err := server.Shutdown(shutdownCtx); err != nil {
+		logger.Error("error shutting down server", "error", err)
+	}
+
+	logger.Info("proxy daemon stopped")
+	return nil
+}

--- a/internal/proxyd/daemon.go
+++ b/internal/proxyd/daemon.go
@@ -50,8 +50,8 @@ func EnsureRunning() (*Client, error) {
 		// Daemon is running — check version
 		if daemonVersion != version.Version {
 			return nil, fmt.Errorf(
-				"proxy daemon is running version %s, but this process is version %s.\n"+
-					"Stop all projects and restart, or run 'prox proxy stop --force' to reset.",
+				"proxy daemon is running version %s, but this process is version %s; "+
+					"stop all projects and restart, or run 'prox proxy stop --force' to reset",
 				daemonVersion, version.Version,
 			)
 		}
@@ -101,7 +101,7 @@ func startDaemon() error {
 	}
 
 	// Detach — don't wait for the child
-	cmd.Process.Release()
+	_ = cmd.Process.Release()
 	return nil
 }
 
@@ -133,7 +133,7 @@ func RunDaemon(ctx context.Context) error {
 		}
 		return fmt.Errorf("creating daemon PID file: %w", err)
 	}
-	defer pidFile.Release()
+	defer func() { _ = pidFile.Release() }()
 
 	// Write state file
 	state := &DaemonState{

--- a/internal/proxyd/dynamic_proxy.go
+++ b/internal/proxyd/dynamic_proxy.go
@@ -1,0 +1,263 @@
+package proxyd
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/charliek/prox/internal/constants"
+	"github.com/charliek/prox/internal/proxy"
+)
+
+// managedListener tracks a dynamically created port listener.
+type managedListener struct {
+	port     int
+	protocol string
+	listener net.Listener
+	server   *http.Server
+}
+
+// DynamicProxy manages multiple HTTP/HTTPS listeners that can be added and
+// removed at runtime as projects register and deregister routes.
+type DynamicProxy struct {
+	mu             sync.RWMutex
+	listeners      map[int]*managedListener
+	registry       *Registry
+	transport      *http.Transport
+	certMgr        *MultiDomainCertManager
+	requestManager *proxy.RequestManager
+	logger         *slog.Logger
+}
+
+// NewDynamicProxy creates a new dynamic proxy.
+func NewDynamicProxy(registry *Registry, certMgr *MultiDomainCertManager, requestManager *proxy.RequestManager, logger *slog.Logger) *DynamicProxy {
+	return &DynamicProxy{
+		listeners:      make(map[int]*managedListener),
+		registry:       registry,
+		certMgr:        certMgr,
+		requestManager: requestManager,
+		logger:         logger,
+		transport: &http.Transport{
+			DialContext: (&net.Dialer{
+				Timeout:   constants.DefaultProxyDialTimeout,
+				KeepAlive: constants.DefaultProxyKeepAlive,
+			}).DialContext,
+			MaxIdleConns:        constants.DefaultProxyMaxIdleConns,
+			IdleConnTimeout:     constants.DefaultProxyIdleConnTimeout,
+			TLSHandshakeTimeout: 10 * time.Second,
+		},
+	}
+}
+
+// AddListener binds a new port and starts serving proxy requests on it.
+func (dp *DynamicProxy) AddListener(port int, protocol string) error {
+	dp.mu.Lock()
+	defer dp.mu.Unlock()
+
+	if _, exists := dp.listeners[port]; exists {
+		return fmt.Errorf("listener already exists on port %d", port)
+	}
+
+	addr := fmt.Sprintf(":%d", port)
+	handler := dp.handler(port)
+
+	var ln net.Listener
+	var err error
+
+	if protocol == "https" {
+		tlsCfg := &tls.Config{
+			GetCertificate: dp.certMgr.GetCertificate,
+			MinVersion:     tls.VersionTLS12,
+		}
+		tcpLn, err2 := net.Listen("tcp", addr)
+		if err2 != nil {
+			return fmt.Errorf("binding port %d: %w", port, err2)
+		}
+		ln = tls.NewListener(tcpLn, tlsCfg)
+	} else {
+		ln, err = net.Listen("tcp", addr)
+		if err != nil {
+			return fmt.Errorf("binding port %d: %w", port, err)
+		}
+	}
+
+	server := &http.Server{
+		Handler:      handler,
+		ReadTimeout:  constants.DefaultProxyReadTimeout,
+		WriteTimeout: constants.DefaultProxyWriteTimeout,
+		IdleTimeout:  constants.DefaultProxyIdleTimeout,
+	}
+
+	ml := &managedListener{
+		port:     port,
+		protocol: protocol,
+		listener: ln,
+		server:   server,
+	}
+
+	dp.listeners[port] = ml
+	dp.logger.Info("started listener", "port", port, "protocol", protocol)
+
+	go func() {
+		if err := server.Serve(ln); err != nil && err != http.ErrServerClosed {
+			dp.logger.Error("listener error", "port", port, "error", err)
+		}
+	}()
+
+	return nil
+}
+
+// RemoveListener gracefully shuts down the listener on the given port.
+func (dp *DynamicProxy) RemoveListener(port int) error {
+	dp.mu.Lock()
+	ml, ok := dp.listeners[port]
+	if !ok {
+		dp.mu.Unlock()
+		return fmt.Errorf("no listener on port %d", port)
+	}
+	delete(dp.listeners, port)
+	dp.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	dp.logger.Info("stopping listener", "port", port)
+	return ml.server.Shutdown(ctx)
+}
+
+// Shutdown stops all listeners.
+func (dp *DynamicProxy) Shutdown(ctx context.Context) error {
+	dp.mu.Lock()
+	all := make([]*managedListener, 0, len(dp.listeners))
+	for _, ml := range dp.listeners {
+		all = append(all, ml)
+	}
+	dp.listeners = make(map[int]*managedListener)
+	dp.mu.Unlock()
+
+	var lastErr error
+	for _, ml := range all {
+		if err := ml.server.Shutdown(ctx); err != nil {
+			lastErr = err
+			dp.logger.Error("error shutting down listener", "port", ml.port, "error", err)
+		}
+	}
+	return lastErr
+}
+
+// handler returns an http.Handler that routes requests by full hostname lookup.
+func (dp *DynamicProxy) handler(port int) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		startTime := time.Now()
+		hostname := extractHostname(r.Host)
+
+		route, ok := dp.registry.Lookup(hostname, port)
+		if !ok {
+			http.Error(w, fmt.Sprintf("no route for %s on port %d", hostname, port), http.StatusNotFound)
+			return
+		}
+
+		target := &url.URL{
+			Scheme: "http",
+			Host:   fmt.Sprintf("%s:%d", route.Target.Host, route.Target.Port),
+		}
+
+		rp := httputil.NewSingleHostReverseProxy(target)
+		rp.Transport = dp.transport
+
+		// Determine protocol from the listener
+		proto := route.Protocol
+
+		originalDirector := rp.Director
+		rp.Director = func(req *http.Request) {
+			originalDirector(req)
+			req.Header.Set("X-Forwarded-Host", r.Host)
+			req.Header.Set("X-Forwarded-Proto", proto)
+			req.Header.Set("X-Real-IP", getClientIP(r))
+		}
+
+		// Wrap response writer to capture status code
+		rw := &statusResponseWriter{ResponseWriter: w, statusCode: http.StatusOK}
+
+		rp.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
+			dp.logger.Error("proxy error",
+				"hostname", hostname,
+				"target", target.String(),
+				"error", err,
+			)
+			rw.statusCode = http.StatusBadGateway
+			http.Error(w, "Backend unavailable", http.StatusBadGateway)
+		}
+
+		rp.ServeHTTP(rw, r)
+
+		// Record the request
+		if dp.requestManager != nil {
+			// Extract subdomain for backward compat
+			subdomain := ""
+			if idx := strings.Index(hostname, "."); idx != -1 {
+				subdomain = hostname[:idx]
+			}
+			dp.requestManager.Record(proxy.RequestRecord{
+				Timestamp:  startTime,
+				Method:     r.Method,
+				URL:        r.URL.String(),
+				Subdomain:  subdomain,
+				Hostname:   hostname,
+				StatusCode: rw.statusCode,
+				Duration:   time.Since(startTime),
+				RemoteAddr: r.RemoteAddr,
+			})
+		}
+	})
+}
+
+// statusResponseWriter wraps http.ResponseWriter to capture the status code.
+type statusResponseWriter struct {
+	http.ResponseWriter
+	statusCode  int
+	wroteHeader bool
+}
+
+func (w *statusResponseWriter) WriteHeader(code int) {
+	if !w.wroteHeader {
+		w.statusCode = code
+		w.wroteHeader = true
+	}
+	w.ResponseWriter.WriteHeader(code)
+}
+
+// extractHostname strips the port from a Host header value.
+func extractHostname(host string) string {
+	// Handle [IPv6]:port
+	if i := strings.LastIndex(host, "]:"); i != -1 {
+		return host[:i+1]
+	}
+	// Handle host:port
+	if i := strings.LastIndex(host, ":"); i != -1 {
+		return host[:i]
+	}
+	return host
+}
+
+// getClientIP extracts the client IP from the request.
+func getClientIP(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		if i := strings.Index(xff, ","); i != -1 {
+			return strings.TrimSpace(xff[:i])
+		}
+		return xff
+	}
+	if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+		return host
+	}
+	return r.RemoteAddr
+}

--- a/internal/proxyd/forwarder.go
+++ b/internal/proxyd/forwarder.go
@@ -1,0 +1,92 @@
+package proxyd
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/charliek/prox/internal/proxy"
+)
+
+// ForwardRequests subscribes to the daemon's SSE request stream and forwards
+// matching records into the local RequestManager. This bridges the daemon's
+// proxy request data into the project's TUI and API.
+//
+// It runs until ctx is cancelled. On disconnect, it reconnects with backoff.
+func ForwardRequests(ctx context.Context, socketPath string, domains []string, localRM *proxy.RequestManager) {
+	domainsParam := strings.Join(domains, ",")
+	backoff := 500 * time.Millisecond
+
+	for {
+		err := streamRequests(ctx, socketPath, domainsParam, localRM)
+		if ctx.Err() != nil {
+			return // context cancelled, clean shutdown
+		}
+		_ = err // reconnect silently
+
+		// Backoff before reconnecting
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+		if backoff < 5*time.Second {
+			backoff *= 2
+		}
+	}
+}
+
+// streamRequests opens an SSE connection to the daemon and processes events.
+func streamRequests(ctx context.Context, socketPath, domainsParam string, localRM *proxy.RequestManager) error {
+	// Create HTTP client that dials the Unix socket
+	dialer := &net.Dialer{}
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				return dialer.DialContext(ctx, "unix", socketPath)
+			},
+		},
+	}
+
+	url := fmt.Sprintf("http://proxyd/api/v1/requests/stream?domains=%s", domainsParam)
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return fmt.Errorf("creating SSE request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("connecting to daemon SSE: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("daemon SSE returned %d", resp.StatusCode)
+	}
+
+	// Read SSE events line by line
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// SSE format: "data: {json}"
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+
+		jsonData := strings.TrimPrefix(line, "data: ")
+		var record proxy.RequestRecord
+		if err := json.Unmarshal([]byte(jsonData), &record); err != nil {
+			continue // skip malformed events
+		}
+
+		localRM.Record(record)
+	}
+
+	return scanner.Err()
+}

--- a/internal/proxyd/registry.go
+++ b/internal/proxyd/registry.go
@@ -45,7 +45,7 @@ type ListenerInfo struct {
 // Registry tracks route registrations from multiple projects.
 type Registry struct {
 	mu        sync.RWMutex
-	routes    map[string]*Route              // key: "hostname:port"
+	routes    map[string]*Route               // key: "hostname:port"
 	projects  map[string]*ProjectRegistration // key: project dir
 	listeners map[int]*ListenerInfo           // key: port
 }

--- a/internal/proxyd/registry.go
+++ b/internal/proxyd/registry.go
@@ -75,6 +75,11 @@ func (r *Registry) Register(req RegisterRequest) (hostnames []string, newPorts [
 		return nil, nil, fmt.Errorf("project %s is already registered; deregister first", req.ProjectDir)
 	}
 
+	// Reject same port for both HTTP and HTTPS
+	if req.HTTPPort > 0 && req.HTTPSPort > 0 && req.HTTPPort == req.HTTPSPort {
+		return nil, nil, fmt.Errorf("http_port and https_port cannot be the same (%d)", req.HTTPPort)
+	}
+
 	// Build the set of routes this project wants to register.
 	type pendingRoute struct {
 		hostname string

--- a/internal/proxyd/registry.go
+++ b/internal/proxyd/registry.go
@@ -1,0 +1,284 @@
+package proxyd
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/charliek/prox/internal/daemon"
+)
+
+// PortSpec describes a port that needs a new listener.
+type PortSpec struct {
+	Port     int
+	Protocol string // "http" or "https"
+}
+
+// Route represents a single registered proxy route.
+type Route struct {
+	Hostname     string
+	Port         int
+	Protocol     string // "http" or "https"
+	Target       ServiceTarget
+	ProjectDir   string
+	PID          int
+	RegisteredAt time.Time
+}
+
+// ProjectRegistration tracks all routes belonging to a project.
+type ProjectRegistration struct {
+	Dir          string
+	PID          int
+	Domain       string
+	RouteKeys    []string // "hostname:port" keys into the routes map
+	RegisteredAt time.Time
+}
+
+// ListenerInfo tracks the protocol and route count for a port.
+type ListenerInfo struct {
+	Port       int
+	Protocol   string
+	RouteCount int
+}
+
+// Registry tracks route registrations from multiple projects.
+type Registry struct {
+	mu        sync.RWMutex
+	routes    map[string]*Route              // key: "hostname:port"
+	projects  map[string]*ProjectRegistration // key: project dir
+	listeners map[int]*ListenerInfo           // key: port
+}
+
+// NewRegistry creates a new empty route registry.
+func NewRegistry() *Registry {
+	return &Registry{
+		routes:    make(map[string]*Route),
+		projects:  make(map[string]*ProjectRegistration),
+		listeners: make(map[int]*ListenerInfo),
+	}
+}
+
+// routeKey builds the map key for a route.
+func routeKey(hostname string, port int) string {
+	return fmt.Sprintf("%s:%d", hostname, port)
+}
+
+// Register adds a project's routes to the registry.
+// Returns the registered hostnames, any new ports that need listeners, or an error on conflict.
+func (r *Registry) Register(req RegisterRequest) (hostnames []string, newPorts []PortSpec, err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Check if this project is already registered
+	if _, exists := r.projects[req.ProjectDir]; exists {
+		return nil, nil, fmt.Errorf("project %s is already registered; deregister first", req.ProjectDir)
+	}
+
+	// Build the set of routes this project wants to register.
+	type pendingRoute struct {
+		hostname string
+		port     int
+		protocol string
+		target   ServiceTarget
+	}
+
+	var pending []pendingRoute
+
+	for svcName, target := range req.Services {
+		hostname := fmt.Sprintf("%s.%s", svcName, req.Domain)
+
+		if req.HTTPSPort > 0 {
+			pending = append(pending, pendingRoute{
+				hostname: hostname,
+				port:     req.HTTPSPort,
+				protocol: "https",
+				target:   target,
+			})
+		}
+		if req.HTTPPort > 0 {
+			pending = append(pending, pendingRoute{
+				hostname: hostname,
+				port:     req.HTTPPort,
+				protocol: "http",
+				target:   target,
+			})
+		}
+	}
+
+	if len(pending) == 0 {
+		return nil, nil, fmt.Errorf("no routes to register (no services or no ports configured)")
+	}
+
+	// Validate: check for hostname:port conflicts and port protocol mismatches.
+	for _, p := range pending {
+		key := routeKey(p.hostname, p.port)
+		if existing, ok := r.routes[key]; ok {
+			return nil, nil, fmt.Errorf(
+				"domain %s on port %d is already registered by %s (PID %d)",
+				p.hostname, p.port, existing.ProjectDir, existing.PID,
+			)
+		}
+
+		if li, ok := r.listeners[p.port]; ok {
+			if li.Protocol != p.protocol {
+				return nil, nil, fmt.Errorf(
+					"port %d is already bound as %s, cannot register %s route for %s",
+					p.port, li.Protocol, p.protocol, p.hostname,
+				)
+			}
+		}
+	}
+
+	// All checks passed — commit the registration.
+	now := time.Now()
+	var routeKeys []string
+	portsNeeded := make(map[int]string) // port -> protocol
+
+	for _, p := range pending {
+		key := routeKey(p.hostname, p.port)
+		r.routes[key] = &Route{
+			Hostname:     p.hostname,
+			Port:         p.port,
+			Protocol:     p.protocol,
+			Target:       p.target,
+			ProjectDir:   req.ProjectDir,
+			PID:          req.PID,
+			RegisteredAt: now,
+		}
+		routeKeys = append(routeKeys, key)
+		hostnames = append(hostnames, p.hostname)
+
+		// Track listener info
+		if li, ok := r.listeners[p.port]; ok {
+			li.RouteCount++
+		} else {
+			r.listeners[p.port] = &ListenerInfo{
+				Port:       p.port,
+				Protocol:   p.protocol,
+				RouteCount: 1,
+			}
+			portsNeeded[p.port] = p.protocol
+		}
+	}
+
+	r.projects[req.ProjectDir] = &ProjectRegistration{
+		Dir:          req.ProjectDir,
+		PID:          req.PID,
+		Domain:       req.Domain,
+		RouteKeys:    routeKeys,
+		RegisteredAt: now,
+	}
+
+	for port, proto := range portsNeeded {
+		newPorts = append(newPorts, PortSpec{Port: port, Protocol: proto})
+	}
+
+	return hostnames, newPorts, nil
+}
+
+// Deregister removes all routes for a project.
+// Returns the removed hostnames and ports that now have zero routes.
+func (r *Registry) Deregister(projectDir string) (removedHostnames []string, emptyPorts []int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	proj, ok := r.projects[projectDir]
+	if !ok {
+		return nil, nil
+	}
+
+	for _, key := range proj.RouteKeys {
+		route, ok := r.routes[key]
+		if !ok {
+			continue
+		}
+		removedHostnames = append(removedHostnames, route.Hostname)
+
+		if li, ok := r.listeners[route.Port]; ok {
+			li.RouteCount--
+			if li.RouteCount <= 0 {
+				emptyPorts = append(emptyPorts, route.Port)
+				delete(r.listeners, route.Port)
+			}
+		}
+
+		delete(r.routes, key)
+	}
+
+	delete(r.projects, projectDir)
+	return removedHostnames, emptyPorts
+}
+
+// Lookup finds the route for a given hostname and port.
+func (r *Registry) Lookup(hostname string, port int) (*Route, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	route, ok := r.routes[routeKey(hostname, port)]
+	return route, ok
+}
+
+// AllRoutes returns all registered routes.
+func (r *Registry) AllRoutes() []RouteInfo {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	routes := make([]RouteInfo, 0, len(r.routes))
+	for _, route := range r.routes {
+		routes = append(routes, RouteInfo{
+			Hostname:     route.Hostname,
+			Port:         route.Port,
+			Protocol:     route.Protocol,
+			Target:       route.Target,
+			ProjectDir:   route.ProjectDir,
+			PID:          route.PID,
+			RegisteredAt: route.RegisteredAt,
+		})
+	}
+	return routes
+}
+
+// ListenerPorts returns all ports with active listeners.
+func (r *Registry) ListenerPorts() []int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	ports := make([]int, 0, len(r.listeners))
+	for port := range r.listeners {
+		ports = append(ports, port)
+	}
+	sort.Ints(ports)
+	return ports
+}
+
+// ProjectCount returns the number of registered projects.
+func (r *Registry) ProjectCount() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.projects)
+}
+
+// IsEmpty returns true if no routes are registered.
+func (r *Registry) IsEmpty() bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.routes) == 0
+}
+
+// CleanStalePIDs checks each registered project's PID and deregisters any
+// that are no longer running. Returns the project dirs that were cleaned up.
+func (r *Registry) CleanStalePIDs() []string {
+	r.mu.RLock()
+	var stale []string
+	for dir, proj := range r.projects {
+		if !daemon.ProcessExists(proj.PID) {
+			stale = append(stale, dir)
+		}
+	}
+	r.mu.RUnlock()
+
+	for _, dir := range stale {
+		r.Deregister(dir)
+	}
+	return stale
+}

--- a/internal/proxyd/registry_test.go
+++ b/internal/proxyd/registry_test.go
@@ -1,0 +1,322 @@
+package proxyd
+
+import (
+	"testing"
+)
+
+func newTestRequest(projectDir, domain string, services map[string]ServiceTarget, httpPort, httpsPort int) RegisterRequest {
+	return RegisterRequest{
+		ProjectDir: projectDir,
+		PID:        12345,
+		Version:    "dev",
+		Domain:     domain,
+		Services:   services,
+		HTTPPort:   httpPort,
+		HTTPSPort:  httpsPort,
+	}
+}
+
+func TestRegistry_RegisterAndLookup(t *testing.T) {
+	reg := NewRegistry()
+
+	req := newTestRequest("/projects/a", "local.dev",
+		map[string]ServiceTarget{"api": {Host: "localhost", Port: 3000}},
+		0, 443,
+	)
+
+	hostnames, newPorts, err := reg.Register(req)
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	if len(hostnames) != 1 || hostnames[0] != "api.local.dev" {
+		t.Errorf("hostnames = %v, want [api.local.dev]", hostnames)
+	}
+	if len(newPorts) != 1 || newPorts[0].Port != 443 || newPorts[0].Protocol != "https" {
+		t.Errorf("newPorts = %v, want [{443 https}]", newPorts)
+	}
+
+	route, ok := reg.Lookup("api.local.dev", 443)
+	if !ok {
+		t.Fatal("Lookup returned false for registered route")
+	}
+	if route.Target.Port != 3000 {
+		t.Errorf("route target port = %d, want 3000", route.Target.Port)
+	}
+	if route.Protocol != "https" {
+		t.Errorf("route protocol = %q, want https", route.Protocol)
+	}
+
+	// Verify counts
+	if reg.ProjectCount() != 1 {
+		t.Errorf("ProjectCount = %d, want 1", reg.ProjectCount())
+	}
+	if reg.IsEmpty() {
+		t.Error("IsEmpty should be false")
+	}
+}
+
+func TestRegistry_MultipleServices(t *testing.T) {
+	reg := NewRegistry()
+
+	req := newTestRequest("/projects/a", "local.dev",
+		map[string]ServiceTarget{
+			"api": {Host: "localhost", Port: 3000},
+			"web": {Host: "localhost", Port: 3001},
+		},
+		80, 443,
+	)
+
+	hostnames, newPorts, err := reg.Register(req)
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	// 2 services * 2 ports = 4 routes
+	if len(hostnames) != 4 {
+		t.Errorf("got %d hostnames, want 4", len(hostnames))
+	}
+	if len(newPorts) != 2 {
+		t.Errorf("got %d new ports, want 2", len(newPorts))
+	}
+
+	// Verify all routes are lookupable
+	for _, hn := range []string{"api.local.dev", "web.local.dev"} {
+		for _, port := range []int{80, 443} {
+			if _, ok := reg.Lookup(hn, port); !ok {
+				t.Errorf("Lookup(%s, %d) returned false", hn, port)
+			}
+		}
+	}
+}
+
+func TestRegistry_DomainConflict(t *testing.T) {
+	reg := NewRegistry()
+
+	reqA := newTestRequest("/projects/a", "local.dev",
+		map[string]ServiceTarget{"api": {Host: "localhost", Port: 3000}},
+		0, 443,
+	)
+	if _, _, err := reg.Register(reqA); err != nil {
+		t.Fatalf("Register A: %v", err)
+	}
+
+	// Same domain+port, different project
+	reqB := newTestRequest("/projects/b", "local.dev",
+		map[string]ServiceTarget{"api": {Host: "localhost", Port: 4000}},
+		0, 443,
+	)
+	_, _, err := reg.Register(reqB)
+	if err == nil {
+		t.Fatal("expected conflict error, got nil")
+	}
+	t.Logf("got expected error: %v", err)
+}
+
+func TestRegistry_DifferentDomainsSharePort(t *testing.T) {
+	reg := NewRegistry()
+
+	reqA := newTestRequest("/projects/a", "local.alpha.dev",
+		map[string]ServiceTarget{"api": {Host: "localhost", Port: 3000}},
+		0, 443,
+	)
+	if _, _, err := reg.Register(reqA); err != nil {
+		t.Fatalf("Register A: %v", err)
+	}
+
+	// Different domain, same port — should work
+	reqB := newTestRequest("/projects/b", "local.beta.dev",
+		map[string]ServiceTarget{"api": {Host: "localhost", Port: 4000}},
+		0, 443,
+	)
+	hostnames, newPorts, err := reg.Register(reqB)
+	if err != nil {
+		t.Fatalf("Register B: %v", err)
+	}
+
+	if len(hostnames) != 1 || hostnames[0] != "api.local.beta.dev" {
+		t.Errorf("hostnames = %v, want [api.local.beta.dev]", hostnames)
+	}
+	// Port 443 already has a listener, so no new ports needed
+	if len(newPorts) != 0 {
+		t.Errorf("newPorts = %v, want empty (port already bound)", newPorts)
+	}
+}
+
+func TestRegistry_ProtocolMismatch(t *testing.T) {
+	reg := NewRegistry()
+
+	// Register HTTPS on port 443
+	reqA := newTestRequest("/projects/a", "local.dev",
+		map[string]ServiceTarget{"api": {Host: "localhost", Port: 3000}},
+		0, 443,
+	)
+	if _, _, err := reg.Register(reqA); err != nil {
+		t.Fatalf("Register A: %v", err)
+	}
+
+	// Try HTTP on same port 443
+	reqB := newTestRequest("/projects/b", "other.dev",
+		map[string]ServiceTarget{"web": {Host: "localhost", Port: 4000}},
+		443, 0,
+	)
+	_, _, err := reg.Register(reqB)
+	if err == nil {
+		t.Fatal("expected protocol mismatch error, got nil")
+	}
+	t.Logf("got expected error: %v", err)
+}
+
+func TestRegistry_Deregister(t *testing.T) {
+	reg := NewRegistry()
+
+	reqA := newTestRequest("/projects/a", "local.dev",
+		map[string]ServiceTarget{"api": {Host: "localhost", Port: 3000}},
+		0, 443,
+	)
+	if _, _, err := reg.Register(reqA); err != nil {
+		t.Fatalf("Register A: %v", err)
+	}
+
+	removed, emptyPorts := reg.Deregister("/projects/a")
+	if len(removed) != 1 || removed[0] != "api.local.dev" {
+		t.Errorf("removed = %v, want [api.local.dev]", removed)
+	}
+	if len(emptyPorts) != 1 || emptyPorts[0] != 443 {
+		t.Errorf("emptyPorts = %v, want [443]", emptyPorts)
+	}
+	if !reg.IsEmpty() {
+		t.Error("registry should be empty after deregister")
+	}
+
+	// Lookup should fail now
+	if _, ok := reg.Lookup("api.local.dev", 443); ok {
+		t.Error("Lookup should return false after deregister")
+	}
+}
+
+func TestRegistry_DeregisterLeavesOtherProjects(t *testing.T) {
+	reg := NewRegistry()
+
+	reqA := newTestRequest("/projects/a", "local.alpha.dev",
+		map[string]ServiceTarget{"api": {Host: "localhost", Port: 3000}},
+		0, 443,
+	)
+	if _, _, err := reg.Register(reqA); err != nil {
+		t.Fatalf("Register A: %v", err)
+	}
+
+	reqB := newTestRequest("/projects/b", "local.beta.dev",
+		map[string]ServiceTarget{"web": {Host: "localhost", Port: 4000}},
+		0, 443,
+	)
+	if _, _, err := reg.Register(reqB); err != nil {
+		t.Fatalf("Register B: %v", err)
+	}
+
+	// Deregister A — port 443 should not become empty
+	_, emptyPorts := reg.Deregister("/projects/a")
+	if len(emptyPorts) != 0 {
+		t.Errorf("emptyPorts = %v, want empty (B still uses 443)", emptyPorts)
+	}
+
+	// B's route should still work
+	if _, ok := reg.Lookup("web.local.beta.dev", 443); !ok {
+		t.Error("B's route should still be reachable")
+	}
+
+	// A's route should be gone
+	if _, ok := reg.Lookup("api.local.alpha.dev", 443); ok {
+		t.Error("A's route should be gone")
+	}
+}
+
+func TestRegistry_DuplicateProject(t *testing.T) {
+	reg := NewRegistry()
+
+	req := newTestRequest("/projects/a", "local.dev",
+		map[string]ServiceTarget{"api": {Host: "localhost", Port: 3000}},
+		0, 443,
+	)
+	if _, _, err := reg.Register(req); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	// Try to register the same project again
+	_, _, err := reg.Register(req)
+	if err == nil {
+		t.Fatal("expected duplicate project error, got nil")
+	}
+}
+
+func TestRegistry_AllRoutes(t *testing.T) {
+	reg := NewRegistry()
+
+	req := newTestRequest("/projects/a", "local.dev",
+		map[string]ServiceTarget{
+			"api": {Host: "localhost", Port: 3000},
+			"web": {Host: "localhost", Port: 3001},
+		},
+		0, 443,
+	)
+	if _, _, err := reg.Register(req); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	routes := reg.AllRoutes()
+	if len(routes) != 2 {
+		t.Errorf("got %d routes, want 2", len(routes))
+	}
+}
+
+func TestRegistry_ListenerPorts(t *testing.T) {
+	reg := NewRegistry()
+
+	req := newTestRequest("/projects/a", "local.dev",
+		map[string]ServiceTarget{"api": {Host: "localhost", Port: 3000}},
+		80, 443,
+	)
+	if _, _, err := reg.Register(req); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	ports := reg.ListenerPorts()
+	if len(ports) != 2 {
+		t.Errorf("got %d ports, want 2", len(ports))
+	}
+	// Should be sorted
+	if ports[0] != 80 || ports[1] != 443 {
+		t.Errorf("ports = %v, want [80, 443]", ports)
+	}
+}
+
+func TestRegistry_DifferentPorts(t *testing.T) {
+	reg := NewRegistry()
+
+	// Project A on port 443
+	reqA := newTestRequest("/projects/a", "local.alpha.dev",
+		map[string]ServiceTarget{"api": {Host: "localhost", Port: 3000}},
+		0, 443,
+	)
+	if _, _, err := reg.Register(reqA); err != nil {
+		t.Fatalf("Register A: %v", err)
+	}
+
+	// Project B on port 8888
+	reqB := newTestRequest("/projects/b", "local.beta.dev",
+		map[string]ServiceTarget{"api": {Host: "localhost", Port: 4000}},
+		0, 8888,
+	)
+	_, newPorts, err := reg.Register(reqB)
+	if err != nil {
+		t.Fatalf("Register B: %v", err)
+	}
+	if len(newPorts) != 1 || newPorts[0].Port != 8888 {
+		t.Errorf("newPorts = %v, want [{8888 https}]", newPorts)
+	}
+
+	ports := reg.ListenerPorts()
+	if len(ports) != 2 {
+		t.Errorf("got %d ports, want 2", len(ports))
+	}
+}

--- a/internal/proxyd/server.go
+++ b/internal/proxyd/server.go
@@ -411,5 +411,5 @@ func (s *Server) Shutdown(ctx context.Context) error {
 func writeJSON(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	json.NewEncoder(w).Encode(v)
+	_ = json.NewEncoder(w).Encode(v)
 }

--- a/internal/proxyd/server.go
+++ b/internal/proxyd/server.go
@@ -152,11 +152,32 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Ensure certs exist for HTTPS domains before starting listeners
+	if s.proxy != nil && s.proxy.certMgr != nil {
+		for _, ps := range newPorts {
+			if ps.Protocol == "https" {
+				if err := s.proxy.certMgr.EnsureDomain(req.Domain); err != nil {
+					s.registry.Deregister(req.ProjectDir)
+					writeJSON(w, http.StatusInternalServerError, ErrorResponse{
+						Error: fmt.Sprintf("failed to generate certs for %s: %v", req.Domain, err),
+						Code:  "CERT_GENERATION_FAILED",
+					})
+					return
+				}
+				break // one EnsureDomain per domain is sufficient
+			}
+		}
+	}
+
 	// Start listeners for new ports
 	if s.proxy != nil {
+		var startedPorts []int
 		for _, ps := range newPorts {
 			if err := s.proxy.AddListener(ps.Port, ps.Protocol); err != nil {
-				// Rollback: deregister the routes we just added
+				// Rollback: stop listeners we already started, then deregister
+				for _, p := range startedPorts {
+					_ = s.proxy.RemoveListener(p)
+				}
 				s.registry.Deregister(req.ProjectDir)
 				writeJSON(w, http.StatusInternalServerError, ErrorResponse{
 					Error: fmt.Sprintf("failed to bind port %d: %v", ps.Port, err),
@@ -164,6 +185,7 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 				})
 				return
 			}
+			startedPorts = append(startedPorts, ps.Port)
 		}
 	}
 

--- a/internal/proxyd/server.go
+++ b/internal/proxyd/server.go
@@ -1,0 +1,415 @@
+package proxyd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/charliek/prox/internal/proxy"
+	"github.com/go-chi/chi/v5"
+)
+
+// Server is the daemon's Unix socket HTTP server.
+type Server struct {
+	socketPath string
+	version    string
+	router     *chi.Mux
+	httpServer *http.Server
+	listener   net.Listener
+	logger     *slog.Logger
+
+	// shutdownCh is closed when the daemon should exit (e.g., no more routes).
+	shutdownCh chan struct{}
+	shutdownMu sync.Mutex
+	startedAt  time.Time
+
+	// Core components
+	registry       *Registry
+	proxy          *DynamicProxy
+	requestManager *proxy.RequestManager
+}
+
+// ServerConfig holds configuration for creating a daemon server.
+type ServerConfig struct {
+	SocketPath string
+	Logger     *slog.Logger
+	Version    string
+}
+
+// NewServer creates a new daemon Unix socket server.
+func NewServer(cfg ServerConfig) *Server {
+	r := chi.NewRouter()
+
+	s := &Server{
+		socketPath: cfg.SocketPath,
+		version:    cfg.Version,
+		router:     r,
+		logger:     cfg.Logger,
+		shutdownCh: make(chan struct{}),
+		startedAt:  time.Now(),
+	}
+
+	s.registerRoutes()
+	return s
+}
+
+// SetRegistry sets the route registry (called during daemon setup).
+func (s *Server) SetRegistry(reg *Registry) {
+	s.registry = reg
+}
+
+// SetProxy sets the dynamic proxy (called during daemon setup).
+func (s *Server) SetProxy(p *DynamicProxy) {
+	s.proxy = p
+}
+
+// SetRequestManager sets the request manager (called during daemon setup).
+func (s *Server) SetRequestManager(rm *proxy.RequestManager) {
+	s.requestManager = rm
+}
+
+// ShutdownCh returns a channel that is closed when the daemon should exit.
+func (s *Server) ShutdownCh() <-chan struct{} {
+	return s.shutdownCh
+}
+
+// RequestShutdown signals the daemon to exit.
+func (s *Server) RequestShutdown() {
+	s.shutdownMu.Lock()
+	defer s.shutdownMu.Unlock()
+	select {
+	case <-s.shutdownCh:
+		// already closed
+	default:
+		close(s.shutdownCh)
+	}
+}
+
+func (s *Server) registerRoutes() {
+	// Health check — no prefix, lightweight
+	s.router.Get("/health", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]string{
+			"status":  "ok",
+			"version": s.version,
+		})
+	})
+
+	s.router.Route("/api/v1", func(r chi.Router) {
+		r.Post("/register", s.handleRegister)
+		r.Post("/deregister", s.handleDeregister)
+		r.Get("/status", s.handleStatus)
+		r.Get("/routes", s.handleRoutes)
+		r.Post("/shutdown", s.handleShutdown)
+		r.Get("/requests/stream", s.handleStreamRequests)
+		r.Get("/requests", s.handleGetRequests)
+	})
+}
+
+func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
+	var req RegisterRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, ErrorResponse{
+			Error: fmt.Sprintf("invalid request body: %v", err),
+			Code:  "BAD_REQUEST",
+		})
+		return
+	}
+
+	// Version check: exact match required
+	if req.Version != s.version {
+		writeJSON(w, http.StatusConflict, ErrorResponse{
+			Error: fmt.Sprintf(
+				"version mismatch: daemon is %s, client is %s. Stop all projects and restart, or run 'prox proxy stop --force'",
+				s.version, req.Version,
+			),
+			Code: "VERSION_MISMATCH",
+		})
+		return
+	}
+
+	if s.registry == nil {
+		writeJSON(w, http.StatusServiceUnavailable, ErrorResponse{
+			Error: "daemon is starting up",
+			Code:  "NOT_READY",
+		})
+		return
+	}
+
+	// Register routes
+	hostnames, newPorts, err := s.registry.Register(req)
+	if err != nil {
+		writeJSON(w, http.StatusConflict, ErrorResponse{
+			Error: err.Error(),
+			Code:  "REGISTRATION_CONFLICT",
+		})
+		return
+	}
+
+	// Start listeners for new ports
+	if s.proxy != nil {
+		for _, ps := range newPorts {
+			if err := s.proxy.AddListener(ps.Port, ps.Protocol); err != nil {
+				// Rollback: deregister the routes we just added
+				s.registry.Deregister(req.ProjectDir)
+				writeJSON(w, http.StatusInternalServerError, ErrorResponse{
+					Error: fmt.Sprintf("failed to bind port %d: %v", ps.Port, err),
+					Code:  "PORT_BIND_FAILED",
+				})
+				return
+			}
+		}
+	}
+
+	s.logger.Info("registered project",
+		"project", req.ProjectDir,
+		"pid", req.PID,
+		"domain", req.Domain,
+		"hostnames", hostnames,
+	)
+
+	writeJSON(w, http.StatusOK, RegisterResponse{Registered: hostnames})
+}
+
+func (s *Server) handleDeregister(w http.ResponseWriter, r *http.Request) {
+	var req DeregisterRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, ErrorResponse{
+			Error: fmt.Sprintf("invalid request body: %v", err),
+			Code:  "BAD_REQUEST",
+		})
+		return
+	}
+
+	if s.registry == nil {
+		writeJSON(w, http.StatusServiceUnavailable, ErrorResponse{
+			Error: "daemon is starting up",
+			Code:  "NOT_READY",
+		})
+		return
+	}
+
+	removedHostnames, emptyPorts := s.registry.Deregister(req.ProjectDir)
+
+	// Close listeners for ports with no remaining routes
+	if s.proxy != nil {
+		for _, port := range emptyPorts {
+			if err := s.proxy.RemoveListener(port); err != nil {
+				s.logger.Warn("failed to remove listener", "port", port, "error", err)
+			}
+		}
+	}
+
+	s.logger.Info("deregistered project",
+		"project", req.ProjectDir,
+		"pid", req.PID,
+		"removed_hostnames", removedHostnames,
+		"closed_ports", emptyPorts,
+	)
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"removed": removedHostnames,
+	})
+
+	// If registry is empty, shut down the daemon
+	if s.registry.IsEmpty() {
+		s.logger.Info("no routes registered, shutting down daemon")
+		go func() {
+			// Brief grace period for rapid down/up cycles
+			time.Sleep(5 * time.Second)
+			if s.registry.IsEmpty() {
+				s.RequestShutdown()
+			}
+		}()
+	}
+}
+
+func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
+	resp := DaemonStatusResponse{
+		Version:   s.version,
+		PID:       os.Getpid(),
+		StartedAt: s.startedAt,
+		Uptime:    time.Since(s.startedAt).Truncate(time.Second).String(),
+	}
+
+	if s.registry != nil {
+		resp.Routes = s.registry.AllRoutes()
+		resp.ListenerPorts = s.registry.ListenerPorts()
+		resp.ProjectCount = s.registry.ProjectCount()
+		resp.RouteCount = len(resp.Routes)
+	}
+	if resp.Routes == nil {
+		resp.Routes = []RouteInfo{}
+	}
+	if resp.ListenerPorts == nil {
+		resp.ListenerPorts = []int{}
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) handleRoutes(w http.ResponseWriter, r *http.Request) {
+	var routes []RouteInfo
+	if s.registry != nil {
+		routes = s.registry.AllRoutes()
+	}
+	if routes == nil {
+		routes = []RouteInfo{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"routes": routes})
+}
+
+func (s *Server) handleShutdown(w http.ResponseWriter, r *http.Request) {
+	force := r.URL.Query().Get("force") == "true"
+
+	if s.registry != nil && !s.registry.IsEmpty() && !force {
+		routes := s.registry.AllRoutes()
+		writeJSON(w, http.StatusConflict, ErrorResponse{
+			Error: fmt.Sprintf(
+				"proxy has %d active route(s) from %d project(s). Use --force to stop anyway.",
+				len(routes), s.registry.ProjectCount(),
+			),
+			Code: "ACTIVE_ROUTES",
+		})
+		return
+	}
+
+	s.logger.Info("shutdown requested", "force", force)
+	writeJSON(w, http.StatusOK, map[string]string{"status": "shutting down"})
+
+	go s.RequestShutdown()
+}
+
+func (s *Server) handleStreamRequests(w http.ResponseWriter, r *http.Request) {
+	if s.requestManager == nil {
+		writeJSON(w, http.StatusServiceUnavailable, ErrorResponse{
+			Error: "request manager not available",
+			Code:  "NOT_READY",
+		})
+		return
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeJSON(w, http.StatusInternalServerError, ErrorResponse{
+			Error: "streaming not supported",
+			Code:  "STREAMING_NOT_SUPPORTED",
+		})
+		return
+	}
+
+	// Parse domain filter from query params
+	var hostnames []string
+	if domains := r.URL.Query().Get("domains"); domains != "" {
+		hostnames = strings.Split(domains, ",")
+	}
+
+	filter := proxy.RequestFilter{Hostnames: hostnames}
+	sub := s.requestManager.Subscribe(filter)
+	defer s.requestManager.Unsubscribe(sub.ID)
+
+	// Set SSE headers
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	fmt.Fprintf(w, ": connected\n\n")
+	flusher.Flush()
+
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case rec, ok := <-sub.Ch:
+			if !ok {
+				return
+			}
+			data, err := json.Marshal(rec)
+			if err != nil {
+				continue
+			}
+			if _, err := fmt.Fprintf(w, "data: %s\n\n", data); err != nil {
+				return
+			}
+			flusher.Flush()
+		}
+	}
+}
+
+func (s *Server) handleGetRequests(w http.ResponseWriter, r *http.Request) {
+	if s.requestManager == nil {
+		writeJSON(w, http.StatusServiceUnavailable, ErrorResponse{
+			Error: "request manager not available",
+			Code:  "NOT_READY",
+		})
+		return
+	}
+
+	var hostnames []string
+	if domains := r.URL.Query().Get("domains"); domains != "" {
+		hostnames = strings.Split(domains, ",")
+	}
+
+	limit := 100
+	filter := proxy.RequestFilter{
+		Hostnames: hostnames,
+		Limit:     limit,
+	}
+
+	records := s.requestManager.Recent(filter)
+	writeJSON(w, http.StatusOK, map[string]any{"requests": records})
+}
+
+// Start starts listening on the Unix socket.
+func (s *Server) Start() error {
+	// Remove stale socket file
+	if err := os.Remove(s.socketPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("removing stale socket: %w", err)
+	}
+
+	ln, err := net.Listen("unix", s.socketPath)
+	if err != nil {
+		return fmt.Errorf("listening on unix socket %s: %w", s.socketPath, err)
+	}
+
+	// Set socket permissions so only the owner can connect
+	if err := os.Chmod(s.socketPath, 0700); err != nil {
+		ln.Close()
+		return fmt.Errorf("setting socket permissions: %w", err)
+	}
+
+	s.listener = ln
+	s.httpServer = &http.Server{
+		Handler:      s.router,
+		ReadTimeout:  15 * time.Second,
+		WriteTimeout: 0, // Disable for SSE
+		IdleTimeout:  60 * time.Second,
+	}
+
+	s.logger.Info("daemon listening", "socket", s.socketPath)
+	return s.httpServer.Serve(ln)
+}
+
+// Shutdown gracefully shuts down the server.
+func (s *Server) Shutdown(ctx context.Context) error {
+	if s.httpServer == nil {
+		return nil
+	}
+	// Remove socket file
+	defer os.Remove(s.socketPath)
+	return s.httpServer.Shutdown(ctx)
+}
+
+// writeJSON encodes v as JSON and writes it to w with the given status code.
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(v)
+}

--- a/internal/proxyd/state.go
+++ b/internal/proxyd/state.go
@@ -1,0 +1,117 @@
+package proxyd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/charliek/prox/internal/constants"
+)
+
+const (
+	// DaemonDirName is the directory under $HOME for daemon state.
+	DaemonDirName = ".prox"
+	// DaemonSocketName is the Unix socket filename.
+	DaemonSocketName = "proxy.sock"
+	// DaemonPIDFileName is the daemon PID filename.
+	DaemonPIDFileName = "proxy.pid"
+	// DaemonStateFileName is the daemon state filename.
+	DaemonStateFileName = "proxy.state"
+	// DaemonLogFileName is the daemon log filename.
+	DaemonLogFileName = "proxy.log"
+)
+
+// DaemonState holds the runtime state of the proxy daemon.
+type DaemonState struct {
+	PID       int       `json:"pid"`
+	Version   string    `json:"version"`
+	StartedAt time.Time `json:"started_at"`
+}
+
+// DaemonDir returns the path to the ~/.prox directory.
+func DaemonDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return DaemonDirName
+	}
+	return filepath.Join(home, DaemonDirName)
+}
+
+// SocketPath returns the path to the daemon Unix socket.
+func SocketPath() string {
+	return filepath.Join(DaemonDir(), DaemonSocketName)
+}
+
+// DaemonPIDPath returns the path to the daemon PID file.
+func DaemonPIDPath() string {
+	return filepath.Join(DaemonDir(), DaemonPIDFileName)
+}
+
+// DaemonStatePath returns the path to the daemon state file.
+func DaemonStatePath() string {
+	return filepath.Join(DaemonDir(), DaemonStateFileName)
+}
+
+// DaemonLogPath returns the path to the daemon log file.
+func DaemonLogPath() string {
+	return filepath.Join(DaemonDir(), DaemonLogFileName)
+}
+
+// EnsureDaemonDir creates the ~/.prox directory if it doesn't exist.
+// Returns an error if the directory cannot be created (e.g., sandboxed environment).
+func EnsureDaemonDir() error {
+	dir := DaemonDir()
+	if err := os.MkdirAll(dir, constants.DirPermissionPrivate); err != nil {
+		return fmt.Errorf("cannot create daemon directory %s: %w", dir, err)
+	}
+	return nil
+}
+
+// WriteDaemonState writes the daemon state to ~/.prox/proxy.state.
+func WriteDaemonState(state *DaemonState) error {
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling daemon state: %w", err)
+	}
+
+	statePath := DaemonStatePath()
+	f, err := os.OpenFile(statePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, constants.FilePermissionPrivate)
+	if err != nil {
+		return fmt.Errorf("opening daemon state file: %w", err)
+	}
+	defer f.Close()
+
+	if _, err := f.Write(data); err != nil {
+		return fmt.Errorf("writing daemon state file: %w", err)
+	}
+	if err := f.Sync(); err != nil {
+		return fmt.Errorf("syncing daemon state file: %w", err)
+	}
+	return nil
+}
+
+// LoadDaemonState reads the daemon state from ~/.prox/proxy.state.
+func LoadDaemonState() (*DaemonState, error) {
+	data, err := os.ReadFile(DaemonStatePath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("daemon state not found")
+		}
+		return nil, fmt.Errorf("reading daemon state: %w", err)
+	}
+
+	var state DaemonState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, fmt.Errorf("unmarshaling daemon state: %w", err)
+	}
+	return &state, nil
+}
+
+// CleanupDaemonState removes daemon state files (state, PID, socket).
+func CleanupDaemonState() {
+	os.Remove(DaemonStatePath())
+	os.Remove(DaemonPIDPath())
+	os.Remove(SocketPath())
+}

--- a/internal/proxyd/state.go
+++ b/internal/proxyd/state.go
@@ -31,10 +31,14 @@ type DaemonState struct {
 }
 
 // DaemonDir returns the path to the ~/.prox directory.
+// Falls back to a relative path only as a last resort; EnsureDaemonDir
+// should be called to validate the path is usable before relying on it.
 func DaemonDir() string {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return DaemonDirName
+		// This fallback is intentionally fragile — EnsureDaemonDir will
+		// fail and trigger standalone mode rather than silently using cwd.
+		return filepath.Join(os.TempDir(), DaemonDirName)
 	}
 	return filepath.Join(home, DaemonDirName)
 }

--- a/internal/proxyd/state_test.go
+++ b/internal/proxyd/state_test.go
@@ -1,0 +1,120 @@
+package proxyd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestDaemonPaths(t *testing.T) {
+	// These should not panic and should return non-empty strings
+	if p := DaemonDir(); p == "" {
+		t.Error("DaemonDir() returned empty string")
+	}
+	if p := SocketPath(); p == "" {
+		t.Error("SocketPath() returned empty string")
+	}
+	if p := DaemonPIDPath(); p == "" {
+		t.Error("DaemonPIDPath() returned empty string")
+	}
+	if p := DaemonStatePath(); p == "" {
+		t.Error("DaemonStatePath() returned empty string")
+	}
+	if p := DaemonLogPath(); p == "" {
+		t.Error("DaemonLogPath() returned empty string")
+	}
+}
+
+func TestWriteAndLoadDaemonState(t *testing.T) {
+	// Override the daemon dir to a temp directory for testing
+	tmpDir := t.TempDir()
+	origHome := os.Getenv("HOME")
+	t.Setenv("HOME", tmpDir)
+	defer os.Setenv("HOME", origHome)
+
+	// Ensure the .prox directory exists
+	if err := EnsureDaemonDir(); err != nil {
+		t.Fatalf("EnsureDaemonDir: %v", err)
+	}
+
+	now := time.Now().Truncate(time.Second)
+	state := &DaemonState{
+		PID:       12345,
+		Version:   "test-version",
+		StartedAt: now,
+	}
+
+	if err := WriteDaemonState(state); err != nil {
+		t.Fatalf("WriteDaemonState: %v", err)
+	}
+
+	loaded, err := LoadDaemonState()
+	if err != nil {
+		t.Fatalf("LoadDaemonState: %v", err)
+	}
+
+	if loaded.PID != 12345 {
+		t.Errorf("PID = %d, want 12345", loaded.PID)
+	}
+	if loaded.Version != "test-version" {
+		t.Errorf("Version = %q, want %q", loaded.Version, "test-version")
+	}
+	if !loaded.StartedAt.Equal(now) {
+		t.Errorf("StartedAt = %v, want %v", loaded.StartedAt, now)
+	}
+}
+
+func TestLoadDaemonState_NotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	_, err := LoadDaemonState()
+	if err == nil {
+		t.Error("expected error for missing state, got nil")
+	}
+}
+
+func TestEnsureDaemonDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	if err := EnsureDaemonDir(); err != nil {
+		t.Fatalf("EnsureDaemonDir: %v", err)
+	}
+
+	info, err := os.Stat(filepath.Join(tmpDir, DaemonDirName))
+	if err != nil {
+		t.Fatalf("stat daemon dir: %v", err)
+	}
+	if !info.IsDir() {
+		t.Error("daemon dir is not a directory")
+	}
+}
+
+func TestCleanupDaemonState(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	if err := EnsureDaemonDir(); err != nil {
+		t.Fatalf("EnsureDaemonDir: %v", err)
+	}
+
+	// Create some files
+	state := &DaemonState{PID: 1, Version: "v", StartedAt: time.Now()}
+	if err := WriteDaemonState(state); err != nil {
+		t.Fatalf("WriteDaemonState: %v", err)
+	}
+
+	// Write a dummy socket and PID file
+	os.WriteFile(SocketPath(), []byte("dummy"), 0600)
+	os.WriteFile(DaemonPIDPath(), []byte("1"), 0600)
+
+	CleanupDaemonState()
+
+	for _, path := range []string{DaemonStatePath(), DaemonPIDPath(), SocketPath()} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Errorf("file %s should have been removed", path)
+		}
+	}
+}

--- a/internal/proxyd/types.go
+++ b/internal/proxyd/types.go
@@ -1,0 +1,66 @@
+// Package proxyd implements the shared proxy daemon that allows multiple
+// prox instances to register routes through a single set of proxy ports.
+// Communication happens over a Unix socket HTTP API at ~/.prox/proxy.sock.
+package proxyd
+
+import (
+	"time"
+)
+
+// ServiceTarget represents a backend service to proxy to.
+type ServiceTarget struct {
+	Host string `json:"host"`
+	Port int    `json:"port"`
+}
+
+// RegisterRequest is sent by prox up to register a project's routes.
+type RegisterRequest struct {
+	ProjectDir     string                   `json:"project_dir"`
+	PID            int                      `json:"pid"`
+	Version        string                   `json:"version"`
+	Domain         string                   `json:"domain"`
+	Services       map[string]ServiceTarget `json:"services"`
+	HTTPPort       int                      `json:"http_port,omitempty"`
+	HTTPSPort      int                      `json:"https_port,omitempty"`
+	CaptureEnabled bool                     `json:"capture_enabled,omitempty"`
+}
+
+// RegisterResponse is returned after a successful registration.
+type RegisterResponse struct {
+	Registered []string `json:"registered"` // fully-qualified hostnames registered
+}
+
+// DeregisterRequest is sent by prox down to remove a project's routes.
+type DeregisterRequest struct {
+	ProjectDir string `json:"project_dir"`
+	PID        int    `json:"pid"`
+}
+
+// RouteInfo describes a single registered route.
+type RouteInfo struct {
+	Hostname     string        `json:"hostname"`
+	Port         int           `json:"port"`
+	Protocol     string        `json:"protocol"` // "http" or "https"
+	Target       ServiceTarget `json:"target"`
+	ProjectDir   string        `json:"project_dir"`
+	PID          int           `json:"pid"`
+	RegisteredAt time.Time     `json:"registered_at"`
+}
+
+// DaemonStatusResponse is returned by the status endpoint.
+type DaemonStatusResponse struct {
+	Version       string      `json:"version"`
+	PID           int         `json:"pid"`
+	Uptime        string      `json:"uptime"`
+	StartedAt     time.Time   `json:"started_at"`
+	Routes        []RouteInfo `json:"routes"`
+	ListenerPorts []int       `json:"listener_ports"`
+	ProjectCount  int         `json:"project_count"`
+	RouteCount    int         `json:"route_count"`
+}
+
+// ErrorResponse is the standard error format for daemon API responses.
+type ErrorResponse struct {
+	Error string `json:"error"`
+	Code  string `json:"code,omitempty"`
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,9 @@
+// Package version provides the application version, set at build time via ldflags.
+package version
+
+// Version is set during build via:
+//
+//	-X github.com/charliek/prox/internal/version.Version=<version>
+//
+// It defaults to "dev" for development builds.
+var Version = "dev"

--- a/test/integration/proxy_daemon_test.go
+++ b/test/integration/proxy_daemon_test.go
@@ -1,0 +1,395 @@
+package integration
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/charliek/prox/internal/proxy"
+	"github.com/charliek/prox/internal/proxyd"
+)
+
+// startDaemonServer starts a daemon server on a Unix socket in a temp dir.
+func startDaemonServer(t *testing.T) (*proxyd.Client, func()) {
+	t.Helper()
+
+	// Use a short temp dir path to stay under Unix socket 104-byte limit on macOS
+	tmpDir, err := os.MkdirTemp("/tmp", "prox-test-")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(tmpDir) })
+	socketPath := filepath.Join(tmpDir, "d.sock")
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	registry := proxyd.NewRegistry()
+	requestMgr := proxy.NewRequestManager(100)
+	server := proxyd.NewServer(proxyd.ServerConfig{
+		SocketPath: socketPath,
+		Logger:     logger,
+		Version:    "test",
+	})
+	server.SetRegistry(registry)
+	server.SetRequestManager(requestMgr)
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- server.Start() }()
+
+	// Wait for server to be ready
+	client := proxyd.NewClient(socketPath)
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := client.Health(); err == nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	cleanup := func() {
+		server.Shutdown(t.Context())
+	}
+
+	return client, cleanup
+}
+
+func TestProxyDaemon_SingleProject(t *testing.T) {
+	skipShort(t)
+	client, cleanup := startDaemonServer(t)
+	defer cleanup()
+
+	// Register
+	resp, err := client.Register(proxyd.RegisterRequest{
+		ProjectDir: "/test/project-a",
+		PID:        os.Getpid(),
+		Version:    "test",
+		Domain:     "local.alpha.dev",
+		Services: map[string]proxyd.ServiceTarget{
+			"app": {Host: "localhost", Port: 13000},
+			"api": {Host: "localhost", Port: 13001},
+		},
+		HTTPSPort: 16443,
+	})
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	if len(resp.Registered) != 2 {
+		t.Fatalf("registered %d hostnames, want 2", len(resp.Registered))
+	}
+
+	// Verify status
+	status, err := client.Status()
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if status.ProjectCount != 1 {
+		t.Errorf("ProjectCount = %d, want 1", status.ProjectCount)
+	}
+	if status.RouteCount != 2 {
+		t.Errorf("RouteCount = %d, want 2", status.RouteCount)
+	}
+
+	// Deregister
+	err = client.Deregister(proxyd.DeregisterRequest{
+		ProjectDir: "/test/project-a",
+		PID:        os.Getpid(),
+	})
+	if err != nil {
+		t.Fatalf("Deregister: %v", err)
+	}
+
+	// Verify empty
+	status, err = client.Status()
+	if err != nil {
+		t.Fatalf("Status after deregister: %v", err)
+	}
+	if status.RouteCount != 0 {
+		t.Errorf("RouteCount after deregister = %d, want 0", status.RouteCount)
+	}
+}
+
+func TestProxyDaemon_TwoProjectsSamePort(t *testing.T) {
+	skipShort(t)
+	client, cleanup := startDaemonServer(t)
+	defer cleanup()
+
+	// Register Project A
+	_, err := client.Register(proxyd.RegisterRequest{
+		ProjectDir: "/test/project-a",
+		PID:        os.Getpid(),
+		Version:    "test",
+		Domain:     "local.alpha.dev",
+		Services:   map[string]proxyd.ServiceTarget{"app": {Host: "localhost", Port: 13000}},
+		HTTPSPort:  16443,
+	})
+	if err != nil {
+		t.Fatalf("Register A: %v", err)
+	}
+
+	// Register Project B — same port, different domain
+	_, err = client.Register(proxyd.RegisterRequest{
+		ProjectDir: "/test/project-b",
+		PID:        os.Getpid(),
+		Version:    "test",
+		Domain:     "local.beta.dev",
+		Services:   map[string]proxyd.ServiceTarget{"frontend": {Host: "localhost", Port: 14000}},
+		HTTPSPort:  16443,
+	})
+	if err != nil {
+		t.Fatalf("Register B: %v", err)
+	}
+
+	// Verify both registered
+	status, err := client.Status()
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if status.ProjectCount != 2 {
+		t.Errorf("ProjectCount = %d, want 2", status.ProjectCount)
+	}
+	if status.RouteCount != 2 {
+		t.Errorf("RouteCount = %d, want 2", status.RouteCount)
+	}
+
+	// Verify routes
+	routes, err := client.Routes()
+	if err != nil {
+		t.Fatalf("Routes: %v", err)
+	}
+
+	hostnames := make(map[string]bool)
+	for _, r := range routes {
+		hostnames[r.Hostname] = true
+	}
+	if !hostnames["app.local.alpha.dev"] {
+		t.Error("missing route for app.local.alpha.dev")
+	}
+	if !hostnames["frontend.local.beta.dev"] {
+		t.Error("missing route for frontend.local.beta.dev")
+	}
+}
+
+func TestProxyDaemon_DifferentPorts(t *testing.T) {
+	skipShort(t)
+	client, cleanup := startDaemonServer(t)
+	defer cleanup()
+
+	// Project A: HTTPS on 16443
+	_, err := client.Register(proxyd.RegisterRequest{
+		ProjectDir: "/test/project-a",
+		PID:        os.Getpid(),
+		Version:    "test",
+		Domain:     "local.alpha.dev",
+		Services:   map[string]proxyd.ServiceTarget{"api": {Host: "localhost", Port: 13000}},
+		HTTPSPort:  16443,
+	})
+	if err != nil {
+		t.Fatalf("Register A: %v", err)
+	}
+
+	// Project C: HTTP on 18080
+	_, err = client.Register(proxyd.RegisterRequest{
+		ProjectDir: "/test/project-c",
+		PID:        os.Getpid(),
+		Version:    "test",
+		Domain:     "local.gamma.dev",
+		Services:   map[string]proxyd.ServiceTarget{"app": {Host: "localhost", Port: 15000}},
+		HTTPPort:   18080,
+	})
+	if err != nil {
+		t.Fatalf("Register C: %v", err)
+	}
+
+	status, err := client.Status()
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if len(status.ListenerPorts) != 2 {
+		t.Errorf("ListenerPorts = %v, want 2 ports", status.ListenerPorts)
+	}
+}
+
+func TestProxyDaemon_DomainConflict(t *testing.T) {
+	skipShort(t)
+	client, cleanup := startDaemonServer(t)
+	defer cleanup()
+
+	// Register Project A
+	_, err := client.Register(proxyd.RegisterRequest{
+		ProjectDir: "/test/project-a",
+		PID:        os.Getpid(),
+		Version:    "test",
+		Domain:     "local.alpha.dev",
+		Services:   map[string]proxyd.ServiceTarget{"app": {Host: "localhost", Port: 13000}},
+		HTTPSPort:  16443,
+	})
+	if err != nil {
+		t.Fatalf("Register A: %v", err)
+	}
+
+	// Try conflicting registration — same domain+port
+	_, err = client.Register(proxyd.RegisterRequest{
+		ProjectDir: "/test/project-conflict",
+		PID:        os.Getpid(),
+		Version:    "test",
+		Domain:     "local.alpha.dev",
+		Services:   map[string]proxyd.ServiceTarget{"app": {Host: "localhost", Port: 16000}},
+		HTTPSPort:  16443,
+	})
+	if err == nil {
+		t.Fatal("expected domain conflict error, got nil")
+	}
+	t.Logf("got expected conflict error: %v", err)
+}
+
+func TestProxyDaemon_ProtocolMismatch(t *testing.T) {
+	skipShort(t)
+	client, cleanup := startDaemonServer(t)
+	defer cleanup()
+
+	// Register HTTPS on port 16443
+	_, err := client.Register(proxyd.RegisterRequest{
+		ProjectDir: "/test/project-a",
+		PID:        os.Getpid(),
+		Version:    "test",
+		Domain:     "local.alpha.dev",
+		Services:   map[string]proxyd.ServiceTarget{"api": {Host: "localhost", Port: 13000}},
+		HTTPSPort:  16443,
+	})
+	if err != nil {
+		t.Fatalf("Register A: %v", err)
+	}
+
+	// Try HTTP on same port 16443
+	_, err = client.Register(proxyd.RegisterRequest{
+		ProjectDir: "/test/project-mismatch",
+		PID:        os.Getpid(),
+		Version:    "test",
+		Domain:     "local.mismatch.dev",
+		Services:   map[string]proxyd.ServiceTarget{"app": {Host: "localhost", Port: 17000}},
+		HTTPPort:   16443,
+	})
+	if err == nil {
+		t.Fatal("expected protocol mismatch error, got nil")
+	}
+	t.Logf("got expected protocol mismatch error: %v", err)
+}
+
+func TestProxyDaemon_LastDeregisterStopsDaemon(t *testing.T) {
+	skipShort(t)
+	client, cleanup := startDaemonServer(t)
+	defer cleanup()
+
+	// Register two projects
+	_, err := client.Register(proxyd.RegisterRequest{
+		ProjectDir: "/test/project-a",
+		PID:        os.Getpid(),
+		Version:    "test",
+		Domain:     "local.alpha.dev",
+		Services:   map[string]proxyd.ServiceTarget{"api": {Host: "localhost", Port: 13000}},
+		HTTPSPort:  16443,
+	})
+	if err != nil {
+		t.Fatalf("Register A: %v", err)
+	}
+
+	_, err = client.Register(proxyd.RegisterRequest{
+		ProjectDir: "/test/project-b",
+		PID:        os.Getpid(),
+		Version:    "test",
+		Domain:     "local.beta.dev",
+		Services:   map[string]proxyd.ServiceTarget{"web": {Host: "localhost", Port: 14000}},
+		HTTPSPort:  16443,
+	})
+	if err != nil {
+		t.Fatalf("Register B: %v", err)
+	}
+
+	// Deregister A — daemon should still be alive
+	err = client.Deregister(proxyd.DeregisterRequest{
+		ProjectDir: "/test/project-a",
+		PID:        os.Getpid(),
+	})
+	if err != nil {
+		t.Fatalf("Deregister A: %v", err)
+	}
+
+	status, err := client.Status()
+	if err != nil {
+		t.Fatalf("Status after deregister A: %v", err)
+	}
+	if status.ProjectCount != 1 {
+		t.Errorf("ProjectCount = %d, want 1", status.ProjectCount)
+	}
+
+	// Deregister B — daemon route count should be 0
+	err = client.Deregister(proxyd.DeregisterRequest{
+		ProjectDir: "/test/project-b",
+		PID:        os.Getpid(),
+	})
+	if err != nil {
+		t.Fatalf("Deregister B: %v", err)
+	}
+
+	status, err = client.Status()
+	if err != nil {
+		t.Fatalf("Status after deregister B: %v", err)
+	}
+	if status.RouteCount != 0 {
+		t.Errorf("RouteCount = %d, want 0", status.RouteCount)
+	}
+}
+
+func TestProxyDaemon_VersionMismatch(t *testing.T) {
+	skipShort(t)
+	client, cleanup := startDaemonServer(t)
+	defer cleanup()
+
+	// Register with wrong version
+	_, err := client.Register(proxyd.RegisterRequest{
+		ProjectDir: "/test/project-a",
+		PID:        os.Getpid(),
+		Version:    "wrong-version",
+		Domain:     "local.dev",
+		Services:   map[string]proxyd.ServiceTarget{"api": {Host: "localhost", Port: 3000}},
+		HTTPSPort:  443,
+	})
+	if err == nil {
+		t.Fatal("expected version mismatch error, got nil")
+	}
+	t.Logf("got expected version error: %v", err)
+}
+
+func TestProxyDaemon_ProxyStopProtected(t *testing.T) {
+	skipShort(t)
+	client, cleanup := startDaemonServer(t)
+	defer cleanup()
+
+	// Register a project
+	_, err := client.Register(proxyd.RegisterRequest{
+		ProjectDir: "/test/project-a",
+		PID:        os.Getpid(),
+		Version:    "test",
+		Domain:     "local.dev",
+		Services:   map[string]proxyd.ServiceTarget{"api": {Host: "localhost", Port: 3000}},
+		HTTPSPort:  443,
+	})
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	// Shutdown without force should fail
+	err = client.Shutdown(false)
+	if err == nil {
+		t.Fatal("expected error for shutdown with active routes, got nil")
+	}
+
+	// Shutdown with force should succeed
+	err = client.Shutdown(true)
+	if err != nil {
+		t.Fatalf("Shutdown(force): %v", err)
+	}
+}

--- a/testdata/configs/proxy_conflict.yaml
+++ b/testdata/configs/proxy_conflict.yaml
@@ -1,0 +1,10 @@
+# Test config: Conflict - same domain+port as Project A
+processes:
+  web: echo "conflict test"
+
+proxy:
+  https_port: 16443
+  domain: local.alpha.dev
+
+services:
+  app: 16000

--- a/testdata/configs/proxy_protocol_mismatch.yaml
+++ b/testdata/configs/proxy_protocol_mismatch.yaml
@@ -1,0 +1,10 @@
+# Test config: Protocol mismatch - HTTP on port used as HTTPS by Project A
+processes:
+  web: echo "protocol mismatch test"
+
+proxy:
+  http_port: 16443
+  domain: local.mismatch.dev
+
+services:
+  app: 17000

--- a/testdata/configs/proxy_shared_a.yaml
+++ b/testdata/configs/proxy_shared_a.yaml
@@ -1,0 +1,11 @@
+# Test config: Project A - HTTPS on port 16443
+processes:
+  web: bash -c 'while true; do echo "project-a tick"; sleep 2; done'
+
+proxy:
+  https_port: 16443
+  domain: local.alpha.dev
+
+services:
+  app: 13000
+  api: 13001

--- a/testdata/configs/proxy_shared_b.yaml
+++ b/testdata/configs/proxy_shared_b.yaml
@@ -1,0 +1,10 @@
+# Test config: Project B - HTTPS on same port 16443, different domain
+processes:
+  web: bash -c 'while true; do echo "project-b tick"; sleep 2; done'
+
+proxy:
+  https_port: 16443
+  domain: local.beta.dev
+
+services:
+  frontend: 14000

--- a/testdata/configs/proxy_shared_c.yaml
+++ b/testdata/configs/proxy_shared_c.yaml
@@ -1,0 +1,10 @@
+# Test config: Project C - HTTP on different port 18080
+processes:
+  web: bash -c 'while true; do echo "project-c tick"; sleep 2; done'
+
+proxy:
+  http_port: 18080
+  domain: local.gamma.dev
+
+services:
+  app: 15000


### PR DESCRIPTION
## Summary

- Adds a shared proxy daemon that allows multiple `prox up` instances to share proxy ports (e.g., 443) through a Unix socket API at `~/.prox/proxy.sock`
- The daemon starts automatically with the first `prox up` and shuts down when the last project deregisters — completely transparent to users
- Supports multiple base domains via TLS SNI, dynamic port binding/release, domain conflict detection, protocol enforcement, and stale PID cleanup
- Adds `prox proxy status/routes/stop` commands for advanced debugging
- Changes API port to always auto-assign (removes default 5555) to prevent collisions between projects

### Architecture

```
prox up (Project A)                     Daemon (~/.prox/)
┌─────────────────────┐                ┌─────────────────────────┐
│ Supervisor           │    register    │ Unix socket API          │
│  └─ processes        │───────────────→│  └─ /routes              │
│ API server (:auto)   │  unix sock    │  └─ /requests/stream     │
│ Local RequestManager │←──────────────│                          │
│  └─ TUI              │  SSE stream   │ Listeners (dynamic)      │
└─────────────────────┘                │  └─ :443  ← Project A    │
                                        │  └─ :8888 ← Project B   │
prox up (Project B)                     │                          │
┌─────────────────────┐    register    │ Route table               │
│ (same structure)     │───────────────→│  auth.x.ai:443 → :3000  │
└─────────────────────┘                │  admin.y.com:8888 → :4000│
                                        └─────────────────────────┘
```

### New package: `internal/proxyd/` (9 files)

| File | Purpose |
|------|---------|
| `types.go` | API request/response types |
| `state.go` | Daemon state at `~/.prox/` |
| `server.go` | Unix socket HTTP server (register, deregister, status, routes, SSE, shutdown) |
| `client.go` | Client library for Unix socket communication |
| `registry.go` | Route registry with conflict detection and protocol enforcement |
| `dynamic_proxy.go` | Multi-port reverse proxy with dynamic listener add/remove |
| `certs.go` | Multi-domain cert manager with TLS SNI |
| `daemon.go` | Daemon lifecycle (auto-start, run, detect, stale cleanup, shutdown) |
| `forwarder.go` | SSE bridge from daemon to local RequestManager |

### Design doc
See `docs/discovery/shared-proxy-across-projects.md` for full design discussion.

## Test plan

- [x] Unit tests: 23 tests in `internal/proxyd/` (registry conflicts, protocol mismatch, client/server round-trip, state management)
- [x] Integration tests: 8 tests in `test/integration/proxy_daemon_test.go` (single project, two projects same port, different ports, domain conflict, protocol mismatch, deregister lifecycle, version mismatch, stop protection)
- [x] Manual testing: single project lifecycle, two projects sharing port, domain conflict error, protocol mismatch error, different ports (HTTP+HTTPS), `prox proxy stop` protection, stale PID cleanup via `kill -9`, JSON output
- [x] Existing tests: all pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shared proxy daemon with lifecycle, registration, dynamic HTTP/HTTPS listeners, and CLI commands to view status, routes, and stop
  * Multi-domain TLS support, request forwarding, and request recording (hostname captured) with hostname-based purge/filtering

* **Infrastructure**
  * Version reporting switched to a build-time injectable value
  * API port handling updated to allow dynamic assignment

* **Tests**
  * Extensive unit and integration tests covering daemon, registry, client, proxy, and state persistence
<!-- end of auto-generated comment: release notes by coderabbit.ai -->