### PR TITLE
Add Homebrew tap automation via GoReleaser

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,3 +40,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -30,6 +30,23 @@ archives:
     files:
       - none*
 
+brews:
+  - name: prox
+    ids:
+      - default
+    repository:
+      owner: charliek
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    directory: Formula
+    homepage: "https://github.com/charliek/prox"
+    description: "Modern process manager for development with API-first design"
+    license: "MIT"
+    install: |
+      bin.install "prox"
+    test: |
+      system bin/"prox", "version"
+
 checksum:
   name_template: "checksums.txt"
   algorithm: sha256


### PR DESCRIPTION
## Summary
- Add `brews` section to auto-publish `Formula/prox.rb` to `charliek/homebrew-tap` on release
- Pass `HOMEBREW_TAP_TOKEN` in release workflow for cross-repo push

## Test plan
- [ ] `goreleaser check` passes
- [ ] Tag a release and verify formula is auto-updated in homebrew-tap

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured Homebrew package distribution, enabling installation of the application via the Homebrew package manager.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->