### PR TITLE
Add Homebrew as recommended install method in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,19 @@ A modern process manager for development with an API-first design.
 
 ## Installation
 
+### Homebrew (macOS)
+
 ```bash
-go install github.com/charliek/prox/cmd/prox@latest
+brew install charliek/tap/prox
 ```
 
-Or build from source:
+### Other Methods
 
 ```bash
+# Install via Go
+go install github.com/charliek/prox/cmd/prox@latest
+
+# Or build from source
 git clone https://github.com/charliek/prox.git
 cd prox
 make build


### PR DESCRIPTION
Add brew install as the first install option.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Homebrew installation option for macOS users
  * Expanded installation methods documentation to include alternative installation approaches

<!-- end of auto-generated comment: release notes by coderabbit.ai -->