### PR TITLE
Fix WebSocket and SSE connections dying after 30s through proxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,3 +16,4 @@ install: build
 	mkdir -p ~/.local/bin
 	cp prox ~/.local/bin/prox
 	@if [ "$$(uname)" = "Linux" ]; then sudo setcap 'cap_net_bind_service=+ep' ~/.local/bin/prox; fi
+	@if [ "$$(uname)" = "Darwin" ]; then codesign --force --sign - ~/.local/bin/prox; fi

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -89,11 +89,11 @@ const (
 	// DefaultProxyBackendTimeout is the timeout for backend connections
 	DefaultProxyBackendTimeout = 30 * time.Second
 
-	// DefaultProxyReadTimeout is the timeout for reading the entire request
-	DefaultProxyReadTimeout = 30 * time.Second
-
-	// DefaultProxyWriteTimeout is the timeout for writing the response
-	DefaultProxyWriteTimeout = 30 * time.Second
+	// DefaultProxyReadHeaderTimeout is the timeout for reading request headers only.
+	// Unlike ReadTimeout/WriteTimeout, this does not set a deadline on the full
+	// connection lifetime, allowing long-lived connections (WebSocket, SSE) to
+	// remain open indefinitely.
+	DefaultProxyReadHeaderTimeout = 10 * time.Second
 
 	// DefaultProxyIdleTimeout is the timeout for idle connections
 	DefaultProxyIdleTimeout = 120 * time.Second

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -134,11 +134,10 @@ func (s *Service) Start(ctx context.Context) error {
 func (s *Service) startHTTP(router http.Handler) error {
 	addr := fmt.Sprintf(":%d", s.cfg.HTTPPort)
 	server := &http.Server{
-		Addr:         addr,
-		Handler:      router,
-		ReadTimeout:  constants.DefaultProxyReadTimeout,
-		WriteTimeout: constants.DefaultProxyWriteTimeout,
-		IdleTimeout:  constants.DefaultProxyIdleTimeout,
+		Addr:              addr,
+		Handler:           router,
+		ReadHeaderTimeout: constants.DefaultProxyReadHeaderTimeout,
+		IdleTimeout:       constants.DefaultProxyIdleTimeout,
 	}
 
 	listener, err := net.Listen("tcp", addr)
@@ -195,12 +194,11 @@ func (s *Service) startHTTPS(router http.Handler) error {
 
 	addr := fmt.Sprintf(":%d", s.cfg.HTTPSPort)
 	server := &http.Server{
-		Addr:         addr,
-		Handler:      router,
-		TLSConfig:    tlsConfig,
-		ReadTimeout:  constants.DefaultProxyReadTimeout,
-		WriteTimeout: constants.DefaultProxyWriteTimeout,
-		IdleTimeout:  constants.DefaultProxyIdleTimeout,
+		Addr:              addr,
+		Handler:           router,
+		TLSConfig:         tlsConfig,
+		ReadHeaderTimeout: constants.DefaultProxyReadHeaderTimeout,
+		IdleTimeout:       constants.DefaultProxyIdleTimeout,
 	}
 
 	listener, err := net.Listen("tcp", addr)

--- a/internal/proxy/streaming_test.go
+++ b/internal/proxy/streaming_test.go
@@ -1,0 +1,233 @@
+package proxy
+
+import (
+	"bufio"
+	"context"
+	"crypto/sha1"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charliek/prox/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSSEThroughProxy verifies that SSE connections stream events through the
+// proxy without being terminated by server timeouts.
+func TestSSEThroughProxy(t *testing.T) {
+	// Backend sends an SSE event every 500ms
+	eventInterval := 500 * time.Millisecond
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+		w.WriteHeader(http.StatusOK)
+
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "streaming not supported", http.StatusInternalServerError)
+			return
+		}
+
+		for i := 0; ; i++ {
+			select {
+			case <-r.Context().Done():
+				return
+			case <-time.After(eventInterval):
+				fmt.Fprintf(w, "data: event-%d\n\n", i)
+				flusher.Flush()
+			}
+		}
+	}))
+	defer backend.Close()
+
+	proxyPort := findFreePort(t)
+	svc := startProxyService(t, proxyPort, backend)
+	defer svc.Shutdown(context.Background())
+
+	// Connect to the SSE endpoint through the proxy
+	client := &http.Client{Timeout: 0}
+	req, err := http.NewRequest("GET", fmt.Sprintf("http://127.0.0.1:%d/events", proxyPort), nil)
+	require.NoError(t, err)
+	req.Host = "app.local.test.dev"
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "text/event-stream", resp.Header.Get("Content-Type"))
+
+	// Read events for 3 seconds — well beyond any short timeout
+	scanner := bufio.NewScanner(resp.Body)
+	var events []string
+	deadline := time.After(3 * time.Second)
+
+	for {
+		select {
+		case <-deadline:
+			goto done
+		default:
+			// Set a per-read deadline so we don't block forever
+			if scanner.Scan() {
+				line := scanner.Text()
+				if strings.HasPrefix(line, "data: ") {
+					events = append(events, line)
+				}
+			} else {
+				t.Fatalf("SSE stream ended unexpectedly after %d events: %v", len(events), scanner.Err())
+			}
+		}
+	}
+done:
+	// With 500ms interval over 3s, we expect at least 4 events
+	assert.GreaterOrEqual(t, len(events), 4,
+		"expected at least 4 SSE events over 3 seconds, got %d", len(events))
+	t.Logf("received %d SSE events through proxy", len(events))
+}
+
+// TestWebSocketUpgradeThroughProxy verifies that WebSocket upgrade requests
+// are properly proxied with bidirectional data flow.
+func TestWebSocketUpgradeThroughProxy(t *testing.T) {
+	// Backend that accepts WebSocket upgrades and echoes messages
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Upgrade") != "websocket" {
+			http.Error(w, "expected websocket upgrade", http.StatusBadRequest)
+			return
+		}
+
+		// Compute the accept key per RFC 6455
+		key := r.Header.Get("Sec-WebSocket-Key")
+		acceptKey := computeWebSocketAccept(key)
+
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			http.Error(w, "hijacking not supported", http.StatusInternalServerError)
+			return
+		}
+
+		conn, bufrw, err := hj.Hijack()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		defer conn.Close()
+
+		// Send 101 Switching Protocols response
+		bufrw.WriteString("HTTP/1.1 101 Switching Protocols\r\n")
+		bufrw.WriteString("Upgrade: websocket\r\n")
+		bufrw.WriteString("Connection: Upgrade\r\n")
+		bufrw.WriteString("Sec-WebSocket-Accept: " + acceptKey + "\r\n")
+		bufrw.WriteString("\r\n")
+		bufrw.Flush()
+
+		// Simple echo: read raw bytes and write them back
+		buf := make([]byte, 1024)
+		for {
+			n, err := conn.Read(buf)
+			if err != nil {
+				return
+			}
+			if _, err := conn.Write(buf[:n]); err != nil {
+				return
+			}
+		}
+	}))
+	defer backend.Close()
+
+	proxyPort := findFreePort(t)
+	svc := startProxyService(t, proxyPort, backend)
+	defer svc.Shutdown(context.Background())
+
+	// Connect via raw TCP and send a WebSocket upgrade request
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", proxyPort), 2*time.Second)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	wsKey := base64.StdEncoding.EncodeToString([]byte("test-key-1234567"))
+	upgradeReq := fmt.Sprintf(
+		"GET /ws HTTP/1.1\r\n"+
+			"Host: app.local.test.dev\r\n"+
+			"Upgrade: websocket\r\n"+
+			"Connection: Upgrade\r\n"+
+			"Sec-WebSocket-Key: %s\r\n"+
+			"Sec-WebSocket-Version: 13\r\n"+
+			"\r\n", wsKey)
+
+	_, err = conn.Write([]byte(upgradeReq))
+	require.NoError(t, err)
+
+	// Read the 101 response
+	reader := bufio.NewReader(conn)
+	statusLine, err := reader.ReadString('\n')
+	require.NoError(t, err)
+	assert.Contains(t, statusLine, "101", "expected 101 Switching Protocols, got: %s", statusLine)
+
+	// Read remaining headers
+	for {
+		line, err := reader.ReadString('\n')
+		require.NoError(t, err)
+		if strings.TrimSpace(line) == "" {
+			break
+		}
+	}
+
+	// Verify bidirectional data flow
+	testMsg := []byte("hello from client")
+	_, err = conn.Write(testMsg)
+	require.NoError(t, err)
+
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	echoBuf := make([]byte, len(testMsg))
+	_, err = io.ReadFull(reader, echoBuf)
+	require.NoError(t, err)
+	assert.Equal(t, testMsg, echoBuf, "expected echo of sent message")
+}
+
+// startProxyService creates and starts a proxy service with the backend as "app".
+func startProxyService(t *testing.T, proxyPort int, backend *httptest.Server) *Service {
+	t.Helper()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	workDir := t.TempDir()
+	backendPort := backend.Listener.Addr().(*net.TCPAddr).Port
+
+	cfg := &config.ProxyConfig{
+		Enabled:  true,
+		HTTPPort: proxyPort,
+		Domain:   "local.test.dev",
+	}
+	services := map[string]config.ServiceConfig{
+		"app": {Port: backendPort, Host: "127.0.0.1"},
+	}
+
+	svc, err := NewService(cfg, services, nil, logger, workDir)
+	require.NoError(t, err)
+
+	err = svc.Start(context.Background())
+	require.NoError(t, err)
+
+	// Wait for proxy to be ready
+	require.Eventually(t, func() bool {
+		return isPortListening(proxyPort)
+	}, 2*time.Second, 10*time.Millisecond, "proxy did not start in time")
+
+	return svc
+}
+
+// computeWebSocketAccept computes the Sec-WebSocket-Accept value per RFC 6455.
+func computeWebSocketAccept(key string) string {
+	const websocketGUID = "258EAFA5-E914-47DA-95CA-5AB5DC587D35"
+	h := sha1.New()
+	h.Write([]byte(key + websocketGUID))
+	return base64.StdEncoding.EncodeToString(h.Sum(nil))
+}

--- a/internal/proxy/streaming_test.go
+++ b/internal/proxy/streaming_test.go
@@ -67,28 +67,43 @@ func TestSSEThroughProxy(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "text/event-stream", resp.Header.Get("Content-Type"))
 
-	// Read events for 3 seconds — well beyond any short timeout
-	scanner := bufio.NewScanner(resp.Body)
+	// Read events in a goroutine so the deadline timer can interrupt a blocked scan
+	type scanResult struct {
+		line string
+		err  error
+	}
+	lines := make(chan scanResult, 16)
+	go func() {
+		defer close(lines)
+		scanner := bufio.NewScanner(resp.Body)
+		for scanner.Scan() {
+			lines <- scanResult{line: scanner.Text()}
+		}
+		if err := scanner.Err(); err != nil {
+			lines <- scanResult{err: err}
+		}
+	}()
+
 	var events []string
 	deadline := time.After(3 * time.Second)
-
+loop:
 	for {
 		select {
 		case <-deadline:
-			goto done
-		default:
-			// Set a per-read deadline so we don't block forever
-			if scanner.Scan() {
-				line := scanner.Text()
-				if strings.HasPrefix(line, "data: ") {
-					events = append(events, line)
-				}
-			} else {
-				t.Fatalf("SSE stream ended unexpectedly after %d events: %v", len(events), scanner.Err())
+			break loop
+		case res, ok := <-lines:
+			if !ok {
+				t.Fatalf("SSE stream ended unexpectedly after %d events", len(events))
+			}
+			if res.err != nil {
+				t.Fatalf("SSE scan error after %d events: %v", len(events), res.err)
+			}
+			if strings.HasPrefix(res.line, "data: ") {
+				events = append(events, res.line)
 			}
 		}
 	}
-done:
+
 	// With 500ms interval over 3s, we expect at least 4 events
 	assert.GreaterOrEqual(t, len(events), 4,
 		"expected at least 4 SSE events over 3 seconds, got %d", len(events))
@@ -165,6 +180,9 @@ func TestWebSocketUpgradeThroughProxy(t *testing.T) {
 
 	_, err = conn.Write([]byte(upgradeReq))
 	require.NoError(t, err)
+
+	// Set a read deadline for the handshake to avoid hanging CI
+	conn.SetReadDeadline(time.Now().Add(5 * time.Second))
 
 	// Read the 101 response
 	reader := bufio.NewReader(conn)

--- a/internal/proxyd/dynamic_proxy.go
+++ b/internal/proxyd/dynamic_proxy.go
@@ -1,8 +1,10 @@
 package proxyd
 
 import (
+	"bufio"
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -90,10 +92,9 @@ func (dp *DynamicProxy) AddListener(port int, protocol string) error {
 	}
 
 	server := &http.Server{
-		Handler:      handler,
-		ReadTimeout:  constants.DefaultProxyReadTimeout,
-		WriteTimeout: constants.DefaultProxyWriteTimeout,
-		IdleTimeout:  constants.DefaultProxyIdleTimeout,
+		Handler:           handler,
+		ReadHeaderTimeout: constants.DefaultProxyReadHeaderTimeout,
+		IdleTimeout:       constants.DefaultProxyIdleTimeout,
 	}
 
 	ml := &managedListener{
@@ -233,6 +234,26 @@ func (w *statusResponseWriter) WriteHeader(code int) {
 		w.wroteHeader = true
 	}
 	w.ResponseWriter.WriteHeader(code)
+}
+
+// Flush implements http.Flusher for streaming responses (SSE).
+func (w *statusResponseWriter) Flush() {
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// Hijack implements http.Hijacker for WebSocket support.
+func (w *statusResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if h, ok := w.ResponseWriter.(http.Hijacker); ok {
+		return h.Hijack()
+	}
+	return nil, nil, errors.New("hijacking not supported")
+}
+
+// Unwrap returns the underlying ResponseWriter for http.ResponseController compatibility.
+func (w *statusResponseWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
 }
 
 // extractHostname strips the port from a Host header value.


### PR DESCRIPTION
## Summary

- **Root cause**: `ReadTimeout` and `WriteTimeout` (30s) on `http.Server` set absolute deadlines on TCP connections, terminating any long-lived connection (WebSocket, SSE) after ~30 seconds
- **Fix**: Replace with `ReadHeaderTimeout` (10s) which only limits header reading time (slowloris protection) without affecting connection lifetime — consistent with the pattern already used in `api/server.go` and `proxyd/server.go`
- **Daemon proxy fix**: Add `Flush()`, `Hijack()`, and `Unwrap()` to `statusResponseWriter` so SSE flushing and WebSocket upgrades work in daemon mode

## Test plan

- [x] New `TestSSEThroughProxy` — verifies SSE events stream through the proxy over 3+ seconds (7 events received)
- [x] New `TestWebSocketUpgradeThroughProxy` — verifies WebSocket upgrade (101) succeeds with bidirectional echo
- [x] All existing tests pass (`go test ./...`)
- [ ] Manual: start prox with a Vite app, verify HMR works through the proxy
- [ ] Manual: verify SSE endpoint streams continuously without reconnections

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved handling of streaming protocols (SSE and WebSocket) for more reliable proxied streams

* **Tests**
  * Added integration tests covering SSE and WebSocket upgrade scenarios

* **Chores**
  * Added macOS installation step to codesign the installed binary
  * Adjusted proxy timeouts to use a header-only read timeout to better support long-lived connections
<!-- end of auto-generated comment: release notes by coderabbit.ai -->