### PR TITLE
Fix SSE/streaming support in reverse proxy

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -57,17 +57,17 @@ func NewService(cfg *config.ProxyConfig, services map[string]config.ServiceConfi
 	}
 
 	// Create shared transport for connection pooling.
-	// Note: ResponseHeaderTimeout is intentionally omitted — it breaks
-	// long-lived streaming connections (SSE, chunked responses) by treating
-	// them as stalled after the timeout. Timeouts are handled at the
-	// HTTP server level (ReadHeaderTimeout) instead.
+	// ResponseHeaderTimeout bounds only the time waiting for backend response
+	// headers — it does not affect body streaming (SSE, chunked, WebSocket)
+	// once headers have been received.
 	transport := &http.Transport{
 		DialContext: (&net.Dialer{
 			Timeout:   constants.DefaultProxyDialTimeout,
 			KeepAlive: constants.DefaultProxyKeepAlive,
 		}).DialContext,
-		MaxIdleConns:    constants.DefaultProxyMaxIdleConns,
-		IdleConnTimeout: constants.DefaultProxyIdleConnTimeout,
+		ResponseHeaderTimeout: constants.DefaultProxyBackendTimeout,
+		MaxIdleConns:          constants.DefaultProxyMaxIdleConns,
+		IdleConnTimeout:       constants.DefaultProxyIdleConnTimeout,
 	}
 
 	// Create capture manager if capture is configured

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -56,15 +56,18 @@ func NewService(cfg *config.ProxyConfig, services map[string]config.ServiceConfi
 		certsMgr = certs.NewManager(certsCfg.Dir, cfg.Domain)
 	}
 
-	// Create shared transport for connection pooling
+	// Create shared transport for connection pooling.
+	// Note: ResponseHeaderTimeout is intentionally omitted — it breaks
+	// long-lived streaming connections (SSE, chunked responses) by treating
+	// them as stalled after the timeout. Timeouts are handled at the
+	// HTTP server level (ReadHeaderTimeout) instead.
 	transport := &http.Transport{
 		DialContext: (&net.Dialer{
 			Timeout:   constants.DefaultProxyDialTimeout,
 			KeepAlive: constants.DefaultProxyKeepAlive,
 		}).DialContext,
-		ResponseHeaderTimeout: constants.DefaultProxyBackendTimeout,
-		MaxIdleConns:          constants.DefaultProxyMaxIdleConns,
-		IdleConnTimeout:       constants.DefaultProxyIdleConnTimeout,
+		MaxIdleConns:    constants.DefaultProxyMaxIdleConns,
+		IdleConnTimeout: constants.DefaultProxyIdleConnTimeout,
 	}
 
 	// Create capture manager if capture is configured
@@ -330,6 +333,8 @@ func (s *Service) createRouter() http.Handler {
 
 		// Use shared transport for connection pooling
 		proxy.Transport = s.transport
+		// Flush immediately for streaming responses (SSE, chunked transfer)
+		proxy.FlushInterval = -1
 
 		// Capture request body and headers if capture is enabled
 		var reqBody *CapturedBody

--- a/internal/proxyd/dynamic_proxy.go
+++ b/internal/proxyd/dynamic_proxy.go
@@ -173,6 +173,8 @@ func (dp *DynamicProxy) handler(port int) http.Handler {
 
 		rp := httputil.NewSingleHostReverseProxy(target)
 		rp.Transport = dp.transport
+		// Flush immediately for streaming responses (SSE, chunked transfer)
+		rp.FlushInterval = -1
 
 		// Determine protocol from the listener
 		proto := route.Protocol


### PR DESCRIPTION
## Summary

- Removed `ResponseHeaderTimeout` from the shared HTTP transport — it kills long-lived streaming connections (SSE, chunked transfer) by treating them as stalled after 30 seconds
- Added `FlushInterval = -1` on both `proxy.go` and `dynamic_proxy.go` reverse proxies so streamed data is flushed immediately

## Context

Discovered while building an SSE-based real-time feature in a project using prox. Browser EventSource connections would connect, receive headers, then immediately disconnect because:

1. `ResponseHeaderTimeout: 30s` on the transport interferes with long-lived responses
2. Without `FlushInterval`, the reverse proxy buffers streamed data instead of flushing it to the client

Timeouts are still handled at the HTTP server level via `ReadHeaderTimeout`.

## Test plan

- [x] `go build` passes
- [x] Verified SSE connections stay alive through prox HTTPS proxy
- [ ] Run existing test suite

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming response handling so real-time and long-lived responses (e.g., server-sent events and chunked transfers) flush immediately rather than being buffered, reducing latency and improving live update delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->