### PR TITLE
Build .deb on release; wire apt-charliek dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,13 +42,16 @@ jobs:
         with:
           version: latest
           args: release --snapshot --clean --skip=publish,announce,sign
-      - name: Validate the deb artifact
+      - name: Validate the deb artifacts
         run: |
           set -e
-          deb=$(ls dist/prox_*_amd64.deb | head -1)
-          [ -n "$deb" ] || { echo "no deb produced"; ls -la dist/; exit 1; }
-          dpkg-deb --info "$deb"
-          dpkg-deb --contents "$deb"
-          dpkg-deb --field "$deb" Package | grep -qx 'prox'
-          dpkg-deb --field "$deb" Architecture | grep -qx 'amd64'
-          dpkg-deb --contents "$deb" | grep -q ' \./usr/local/bin/prox$'
+          for arch in amd64 arm64; do
+            deb=$(ls dist/prox_*_${arch}.deb 2>/dev/null | head -1)
+            [ -n "$deb" ] || { echo "no $arch deb produced"; ls -la dist/; exit 1; }
+            echo "=== validating $deb ==="
+            dpkg-deb --info "$deb"
+            dpkg-deb --contents "$deb"
+            dpkg-deb --field "$deb" Package | grep -qx 'prox'
+            dpkg-deb --field "$deb" Architecture | grep -qx "$arch"
+            dpkg-deb --contents "$deb" | grep -q ' \./usr/local/bin/prox$'
+          done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,29 @@ jobs:
       - uses: golangci/golangci-lint-action@v9
         with:
           version: v2.10.1
+
+  # Validate the GoReleaser pipeline (including the nfpms: deb block) without
+  # publishing anything. Catches broken nfpm config before it hits a real tag.
+  release-snapshot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - uses: goreleaser/goreleaser-action@v7
+        with:
+          version: latest
+          args: release --snapshot --clean --skip=publish,announce,sign
+      - name: Validate the deb artifact
+        run: |
+          set -e
+          deb=$(ls dist/prox_*_amd64.deb | head -1)
+          [ -n "$deb" ] || { echo "no deb produced"; ls -la dist/; exit 1; }
+          dpkg-deb --info "$deb"
+          dpkg-deb --contents "$deb"
+          dpkg-deb --field "$deb" Package | grep -qx 'prox'
+          dpkg-deb --field "$deb" Architecture | grep -qx 'amd64'
+          dpkg-deb --contents "$deb" | grep -q ' \./usr/local/bin/prox$'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,3 +41,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+
+      - name: Trigger apt-charliek publish
+        if: success()
+        run: |
+          gh api repos/charliek/apt-charliek/dispatches \
+            --method POST \
+            -f event_type=publish \
+            -F "client_payload[package]=prox" \
+            -F "client_payload[tag]=${{ github.ref_name }}"
+          echo "::notice::Watch apt publish at https://github.com/charliek/apt-charliek/actions"
+        env:
+          GH_TOKEN: ${{ secrets.APT_DISPATCH_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,11 +45,23 @@ jobs:
       - name: Trigger apt-charliek publish
         if: success()
         run: |
-          gh api repos/charliek/apt-charliek/dispatches \
-            --method POST \
-            -f event_type=publish \
-            -F "client_payload[package]=prox" \
-            -F "client_payload[tag]=${{ github.ref_name }}"
-          echo "::notice::Watch apt publish at https://github.com/charliek/apt-charliek/actions"
+          # Retry the dispatch a few times — a transient network/API blip
+          # shouldn't fail the release after GoReleaser already succeeded.
+          # apt-charliek's publish workflow is idempotent so a missed dispatch
+          # also self-heals on the next release, but we still want to flag
+          # genuinely persistent failures.
+          for attempt in 1 2 3; do
+            if gh api repos/charliek/apt-charliek/dispatches \
+              --method POST \
+              -f event_type=publish \
+              -F "client_payload[package]=prox" \
+              -F "client_payload[tag]=${{ github.ref_name }}"; then
+              echo "::notice::Watch apt publish at https://github.com/charliek/apt-charliek/actions"
+              exit 0
+            fi
+            echo "dispatch attempt $attempt failed; sleeping $((attempt * 5))s"
+            [ "$attempt" -eq 3 ] && exit 1
+            sleep $((attempt * 5))
+          done
         env:
           GH_TOKEN: ${{ secrets.APT_DISPATCH_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -30,6 +30,21 @@ archives:
     files:
       - none*
 
+nfpms:
+  - id: prox-deb
+    package_name: prox
+    file_name_template: "prox_{{ .Version }}_{{ .Arch }}"
+    vendor: charliek
+    homepage: "https://github.com/charliek/prox"
+    maintainer: "Charlie Knudsen <charlie.knudsen@gmail.com>"
+    description: "Modern process manager for development with API-first design"
+    license: MIT
+    formats:
+      - deb
+    bindir: /usr/local/bin
+    ids:
+      - prox
+
 brews:
   - name: prox
     ids:


### PR DESCRIPTION
## Summary

Wires prox up to the [apt-charliek](https://github.com/charliek/apt-charliek) Debian/Ubuntu distribution channel — friends on Pop!_OS / Ubuntu can `apt install prox` and `apt upgrade` once this lands and a release is cut.

Three changes:

- **`.goreleaser.yaml`** — new `nfpms:` block produces `prox_<version>_amd64.deb` and `prox_<version>_arm64.deb` on every release. Binary lands at `/usr/local/bin/prox`.

- **`.github/workflows/release.yaml`** — new final step fires `repository_dispatch` event_type=`publish` at `charliek/apt-charliek` using the new `APT_DISPATCH_TOKEN` secret. apt-charliek's publish workflow then re-scans every tracked package's latest GH release and republishes the apt repo. The existing GoReleaser step (and `HOMEBREW_TAP_TOKEN` env) is untouched.

- **`.github/workflows/ci.yml`** — new `release-snapshot` job runs `goreleaser release --snapshot --clean --skip=publish,announce,sign` on every PR and asserts the deb is well-formed (`Package: prox`, `Architecture: amd64`, `/usr/local/bin/prox` in the payload). Catches nfpms regressions before they hit a real release.

## Local validation

```
$ goreleaser release --snapshot --clean --skip=publish,announce,sign
…
• creating  package=prox format=deb arch=amd64v1 file=dist/prox_0.1.0-SNAPSHOT-8fa9b69_amd64.deb
• creating  package=prox format=deb arch=arm64v8.0 file=dist/prox_0.1.0-SNAPSHOT-8fa9b69_arm64.deb
• release succeeded after 24s

$ dpkg-deb --field dist/prox_0.1.0-SNAPSHOT-8fa9b69_amd64.deb Package
prox
$ dpkg-deb --contents dist/prox_0.1.0-SNAPSHOT-8fa9b69_amd64.deb | grep prox
-rwxr-xr-x root/root 12226744 2026-05-03 13:58 ./usr/local/bin/prox
```

## What this PR does NOT do

- Doesn't touch `HOMEBREW_TAP_TOKEN` or the existing brews flow — Homebrew install path keeps working unchanged.
- Doesn't bump the version. After merge, a regular tag-push (e.g., `v0.1.1`) flows through the existing release workflow and the new dispatch fires for free.
- Doesn't add prox to apt-charliek's `packages.yaml` — that's a small follow-up PR I'll open in apt-charliek before tagging the next release.

## Test plan

- [x] `goreleaser release --snapshot` produces a valid deb locally
- [x] CI `release-snapshot` job asserts deb metadata + payload
- [ ] Tag a real release after merge → watch GoReleaser → watch dispatch → watch apt-charliek/publish.yml → verify `apt-cache madison prox` shows the new version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Debian package support: app is packaged as a .deb for easy installation on Debian-based systems.

* **Chores**
  * Release automation: snapshot release validation now checks generated .deb contents and metadata for amd64/arm64.
  * Automated publishing: post-release step triggers apt publishing with retry logic and success/failure reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->