### PR TITLE
Document Linux (apt) install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,31 @@ A modern process manager for development with an API-first design.
 brew install charliek/tap/prox
 ```
 
+### Linux (apt)
+
+```bash
+sudo install -d -m 0755 /etc/apt/keyrings
+curl -fsSL https://apt.stridelabs.ai/pubkey.gpg | \
+  sudo tee /etc/apt/keyrings/apt-charliek.gpg > /dev/null
+echo 'deb [signed-by=/etc/apt/keyrings/apt-charliek.gpg] https://apt.stridelabs.ai noble main' | \
+  sudo tee /etc/apt/sources.list.d/apt-charliek.list
+sudo apt update
+sudo apt install prox
+```
+
+Tested on Pop!_OS 24.04 and Ubuntu 24.04+. Architectures: `amd64`, `arm64`. See [apt-charliek](https://github.com/charliek/apt-charliek) for the full repo.
+
+### Linux (`.deb` download, no apt repo)
+
+For one-off installs without configuring the apt repo (CI runners, locked-down hosts, etc.):
+
+```bash
+ARCH=$(dpkg --print-architecture)        # amd64 or arm64
+VERSION=0.1.1                            # check https://github.com/charliek/prox/releases for the latest
+curl -fLO "https://github.com/charliek/prox/releases/download/v${VERSION}/prox_${VERSION}_${ARCH}.deb"
+sudo dpkg -i "prox_${VERSION}_${ARCH}.deb"
+```
+
 ### Other Methods
 
 ```bash


### PR DESCRIPTION
## Summary

Adds two new subsections to the README's Installation section now that prox ships `.deb` packages via [charliek/apt-charliek](https://github.com/charliek/apt-charliek):

- **Linux (apt)** — preferred path. Adds the repo + `apt install prox`. Free `apt update` / `apt upgrade` thereafter.
- **Linux (.deb download, no apt repo)** — fallback for CI runners, locked-down hosts, or anyone who doesn't want a third-party apt repo configured. Parameterised on `dpkg --print-architecture` and a `VERSION=` variable that points users at the [Releases page](https://github.com/charliek/prox/releases) for the latest.

Architecture coverage: `amd64`, `arm64`. Distros: Pop!_OS 24.04, Ubuntu 24.04+ (older LTS out of scope).

## Test plan

- [x] No code changes; `make test` and `make lint` should pass unchanged
- [x] `release-snapshot` CI job still validates both arch debs
- [ ] Verify the rendered Installation section reads cleanly on the PR diff page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded Linux installation documentation with apt repository installation method. Users can now configure the apt repository and install via `apt` as an alternative to the manual .deb download approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->