### PR TITLE
Use `apt install` for direct .deb fallback (no `dpkg -i`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,10 @@ For one-off installs without configuring the apt repo (CI runners, locked-down h
 ARCH=$(dpkg --print-architecture)        # amd64 or arm64
 VERSION=0.1.1                            # check https://github.com/charliek/prox/releases for the latest
 curl -fLO "https://github.com/charliek/prox/releases/download/v${VERSION}/prox_${VERSION}_${ARCH}.deb"
-sudo dpkg -i "prox_${VERSION}_${ARCH}.deb"
+sudo apt install -y "./prox_${VERSION}_${ARCH}.deb"
 ```
+
+The `apt install ./...deb` form resolves dependencies; plain `dpkg -i` would skip that step.
 
 ### Other Methods
 


### PR DESCRIPTION
## Summary

CodeRabbit's review of [apt-charliek#5](https://github.com/charliek/apt-charliek/pull/5) flagged that `dpkg -i` doesn't resolve dependencies, so users hitting the direct `.deb` fallback can land in "unmet dependencies" land. Fix landed there; mirroring it here so prox's README stays consistent with the canonical template.

```diff
- sudo dpkg -i "prox_${VERSION}_${ARCH}.deb"
+ sudo apt install -y "./prox_${VERSION}_${ARCH}.deb"
```

prox today has zero declared dependencies (static Go binary), so the change is functionally a no-op — but the README should teach the right idiom regardless, since future packages onboarded to apt-charliek will likely have real dependencies.

## Test plan

- [x] No code changes; CI runs unchanged