### PR TITLE
Add prox as a distributable Claude Code plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "prox",
+  "description": "prox skills for driving the prox process manager from your agent.",
+  "owner": {
+    "name": "Charlie Knudsen",
+    "url": "https://github.com/charliek"
+  },
+  "plugins": [
+    {
+      "name": "prox",
+      "source": "./",
+      "description": "Guidance for driving the prox process manager: prox.yaml config, CLI, proxy/subdomain routing, logs, and request inspection."
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "prox",
+  "version": "0.1.1",
+  "description": "Guidance for driving the prox process manager: prox.yaml config, CLI, proxy/subdomain routing, logs, and request inspection.",
+  "author": {
+    "name": "Charlie Knudsen",
+    "url": "https://github.com/charliek"
+  },
+  "homepage": "https://github.com/charliek/prox",
+  "repository": "https://github.com/charliek/prox",
+  "license": "MIT",
+  "keywords": ["prox", "skills", "process-manager", "development"]
+}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,3 +65,38 @@ jobs:
           done
         env:
           GH_TOKEN: ${{ secrets.APT_DISPATCH_TOKEN }}
+
+  sync-version:
+    name: Commit plugin version to main
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Set plugin version from tag
+        run: scripts/set-version.sh "${GITHUB_REF_NAME#v}"
+
+      - name: Commit and push if plugin.json drifted
+        # Keeps the committed .claude-plugin/plugin.json in lockstep with the
+        # released tag (Claude Code reads it from main, not from a build
+        # artifact). Idempotent: a no-op when the version was bumped by hand
+        # before tagging. The GITHUB_TOKEN push does not re-trigger this
+        # workflow (GitHub blocks recursive workflow runs).
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ -z "$(git status --porcelain .claude-plugin/plugin.json)" ]; then
+            echo "plugin.json already matches ${GITHUB_REF_NAME}; nothing to commit"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .claude-plugin/plugin.json
+          git commit -m "chore: set plugin version ${GITHUB_REF_NAME}"
+          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:main

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-# Binary
-prox
+# Binary (root build output only; do not match skills/prox/ or cmd/prox/)
+/prox
 
 # IDE
 .idea/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Charlie Knudsen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,23 @@ cd prox
 make build
 ```
 
+### Claude Code / agent skills
+
+prox ships a skill that teaches your coding agent to drive the prox CLI (read `prox.yaml`, start/stop processes, tail logs, reach services through the proxy, inspect requests). Install the CLI (above) first, since the skill drives it.
+
+The general route ([`skills`](https://skills.sh)) installs into Claude Code, GitHub Copilot, OpenCode, and other agents:
+
+```bash
+npx skills add charliek/prox
+```
+
+For Claude Code, a native plugin is also available (it namespaces the skill as `prox:prox`):
+
+```text
+/plugin marketplace add charliek/prox
+/plugin install prox@prox
+```
+
 ## Quick Start
 
 Create a `prox.yaml` in your project directory:
@@ -147,7 +164,7 @@ The API runs at `http://127.0.0.1:5555/api/v1` by default.
 
 Configuration files are executed as code (via shell). Only use configuration from trusted sources, similar to Makefiles or Procfiles.
 
-When binding to non-localhost interfaces, authentication is automatically enabled. A bearer token is generated and stored in `~/.config/prox/`.
+When binding to non-localhost interfaces, authentication is automatically enabled. A bearer token is generated and stored in `~/.prox/token`.
 
 ## Documentation
 

--- a/scripts/set-version.sh
+++ b/scripts/set-version.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Set the plugin version in .claude-plugin/plugin.json (read by Claude Code at
+# install/update time). The Go CLI version comes from the git tag via GoReleaser
+# ldflags, so this is the only committed file that hardcodes a version.
+# Usage: scripts/set-version.sh 0.1.2
+set -euo pipefail
+
+version="${1:?usage: set-version.sh <X.Y.Z>}"
+root="$(cd "$(dirname "$0")/.." && pwd)"
+plugin="$root/.claude-plugin/plugin.json"
+
+tmp="$(mktemp)"
+sed -E 's/("version"[[:space:]]*:[[:space:]]*")[^"]*"/\1'"$version"'"/' "$plugin" > "$tmp"
+mv "$tmp" "$plugin"
+
+echo "plugin version set to $version"

--- a/skills/prox/SKILL.md
+++ b/skills/prox/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: prox
+description: "Use when a prox.yaml file exists in the project root, or the user mentions prox, or asks to start, stop, restart, or check development processes that prox manages, view their logs, reach a local service through the prox reverse proxy, inspect proxied requests, or work with the shared prox proxy daemon that lets several projects share a port. Also use when the user says a program is 'running via prox' or asks you to 'start it with prox'. This is specific to the prox CLI and prox.yaml; do not use it for lookalikes such as Proxmox, a generic nginx or Caddy reverse proxy, a corporate proxy.yaml, or foreman, pm2, or docker compose."
+---
+
+# Prox Process Manager
+
+prox is a process manager for local development written in Go. It provides process supervision with automatic restarts, real-time log aggregation, an HTTP/HTTPS reverse proxy with subdomain routing, an interactive TUI, and a background daemon mode with a REST API. A shared proxy daemon lets multiple projects serve their domains through the same proxy port.
+
+## First Step: Read prox.yaml
+
+**Always read the project's `prox.yaml` before taking any action.** This file defines the project's local development topology — what processes exist, what commands they run, what ports they use, and whether proxy routing is enabled. Without reading this file you cannot help effectively.
+
+If the config file is at a non-default path, the user or CLAUDE.md will specify it (the `--config` / `-c` flag overrides the default).
+
+## Process Management
+
+When a project has a `prox.yaml`, **use prox to manage processes** — do not run process commands directly.
+
+| Task | Command |
+|------|---------|
+| Start all processes (daemon) | `prox up -d` |
+| Start specific processes (daemon) | `prox up -d <name> [name...]` |
+| Start a single stopped process | `prox start <name>` |
+| Stop one process | `prox stop <name>` |
+| Restart one process | `prox restart <name>` |
+| Stop everything | `prox down` |
+| Check what's running | `prox status` |
+| Attach interactive TUI | `prox attach` |
+
+**Always use `-d` (daemon mode)** when starting prox so the CLI returns control immediately. Do not start prox in the foreground — it will block.
+
+**Never kill processes directly** (e.g., `kill <pid>`). Use prox commands so it can track state and handle restarts correctly.
+
+## Shared Proxy and Multiple Projects
+
+When a project enables a proxy (see "Making HTTP Requests" below), prox serves its services through a single background **proxy daemon** shared across all projects on the machine. This is what lets several projects expose their domains on the same port (e.g. 443) without conflicts. Routing is by full hostname, so two projects can share one port as long as their hostnames differ.
+
+You normally never manage the daemon directly: `prox up` starts it (or registers with the already-running one) and `prox down` deregisters the project, stopping the daemon when the last project leaves.
+
+These commands are for debugging "my service is unreachable" or "which project owns this domain" questions:
+
+```bash
+prox proxy status            # Is the shared daemon running?
+prox proxy routes            # Every registered hostname and the project/port it maps to
+prox proxy stop              # Stop the daemon (fails if projects still have routes)
+prox proxy stop --force      # Stop anyway, disconnecting all projects
+```
+
+If a proxied request returns a connection error or an unexpected 404, check `prox proxy routes` first to confirm the target hostname is actually registered.
+
+## Viewing Logs
+
+prox aggregates output from all processes. When debugging, check logs first.
+
+```bash
+prox logs --lines 50                          # Recent 50 lines, all processes
+prox logs --lines 50 --process api            # Recent 50 lines from "api"
+prox logs -f --process api                    # Stream logs from "api"
+prox logs --lines 100 --pattern ERROR         # Filter for "ERROR"
+prox logs --lines 100 --pattern "err.*" --regex  # Regex filter
+```
+
+**Always use `--lines N`** to limit output. Without it, prox may return hundreds of lines that flood context.
+
+**Pipe through bash tools when needed** — prox's built-in `--pattern` handles most filtering, but for counting (`| grep -c ERROR`), multi-pattern matching (`| grep -E "ERROR|WARN"`), or extracting specific fields, pipe through standard unix tools.
+
+For daemon startup issues, check the daemon log directly: `cat .prox/prox.log`
+
+## Making HTTP Requests
+
+How to reach services depends on whether the proxy is configured in prox.yaml.
+
+### With proxy enabled
+
+Read the `proxy` and `services` sections of prox.yaml. Services are accessible via subdomain routing:
+
+```
+http://<service>.<domain>:<http_port>/path
+```
+
+For example, if prox.yaml contains:
+```yaml
+proxy:
+  http_port: 6788
+  domain: lvh.me
+
+services:
+  api: 8000
+  app: 3000
+```
+
+Then:
+- `curl http://api.lvh.me:6788/endpoint` → reaches the api service on port 8000
+- `curl http://app.lvh.me:6788/` → reaches the app service on port 3000
+
+For HTTPS, use `https://<service>.<domain>:<https_port>/path` (requires mkcert setup).
+
+### Without proxy
+
+Use direct ports from the process commands in prox.yaml. For example, if a process runs `uvicorn ... --port 8000`, reach it at `http://localhost:8000/endpoint`.
+
+### Inspecting proxy traffic
+
+```bash
+prox requests                                  # Recent requests
+prox requests -f                               # Stream in real-time
+prox requests --subdomain api --min-status 400 # Filter for errors on api
+prox requests <id>                             # Details for specific request
+prox requests <id> --body                      # Include captured bodies
+```
+
+`prox requests` shows traffic that reached the proxy; if a request never arrives, use `prox proxy routes` (see "Shared Proxy and Multiple Projects") to check whether the service's hostname is registered at all.
+
+## Configuration (prox.yaml)
+
+Processes can be defined in simple form (string) or expanded form (object):
+
+```yaml
+processes:
+  # Simple: just a command
+  web: npm run dev
+
+  # Expanded: command with environment and health check
+  api:
+    cmd: go run ./cmd/server
+    env:
+      PORT: "8080"
+    env_file: .env.api
+    healthcheck:
+      cmd: curl -f http://localhost:8080/health
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+```
+
+Environment variable precedence (later overrides earlier):
+1. System environment
+2. Global `env_file`
+3. Process-specific `env_file`
+4. Process-specific `env` map
+
+For the full configuration reference including all proxy, service, and certificate fields, read `references/configuration.md`.
+
+## CLI Help
+
+For detailed flags and options on any command, run:
+```bash
+prox <command> --help
+```
+
+The CLI help is comprehensive and always up to date. Use it as the authoritative reference for command syntax.
+
+## References
+
+For detailed documentation beyond what's covered here:
+- `references/configuration.md` — all prox.yaml fields (proxy, services, certs, health checks)
+- `references/api.md` — HTTP API endpoints for scripting and automation
+
+## Runtime State
+
+prox stores state in `.prox/` within the project directory:
+- `.prox/prox.state` — API port, PID, host (used for auto-discovery by CLI commands)
+- `.prox/prox.pid` — process ID with file locking
+- `.prox/prox.log` — daemon logs (stdout/stderr in background mode)
+
+The `.prox/` directory should be in `.gitignore`.

--- a/skills/prox/SKILL.md
+++ b/skills/prox/SKILL.md
@@ -75,7 +75,7 @@ How to reach services depends on whether the proxy is configured in prox.yaml.
 
 Read the `proxy` and `services` sections of prox.yaml. Services are accessible via subdomain routing:
 
-```
+```text
 http://<service>.<domain>:<http_port>/path
 ```
 

--- a/skills/prox/references/api.md
+++ b/skills/prox/references/api.md
@@ -1,0 +1,292 @@
+# HTTP API Reference
+
+## Base URL
+
+```
+http://{host}:{port}/api/v1
+```
+
+Default: `http://127.0.0.1:5555/api/v1`
+
+## Authentication
+
+When prox binds to a non-localhost interface, authentication is required. A bearer token is generated and stored in `~/.prox/token`.
+
+Include the token in requests:
+
+```bash
+curl -H "Authorization: Bearer <token>" http://0.0.0.0:5555/api/v1/status
+```
+
+## Error Format
+
+All errors return JSON:
+
+```json
+{
+  "error": "human readable message",
+  "code": "MACHINE_READABLE_CODE"
+}
+```
+
+### Error Codes
+
+| Code | Description |
+|------|-------------|
+| `PROCESS_NOT_FOUND` | Process name does not exist |
+| `PROCESS_ALREADY_RUNNING` | Process is already running |
+| `PROCESS_NOT_RUNNING` | Process is not running |
+| `INVALID_PATTERN` | Invalid regex pattern |
+| `SHUTDOWN_IN_PROGRESS` | Supervisor is shutting down |
+
+## Endpoints
+
+### GET /status
+
+Supervisor status.
+
+**Response:**
+
+```json
+{
+  "status": "running",
+  "uptime_seconds": 7200,
+  "config_file": "/path/to/prox.yaml",
+  "api_version": "v1"
+}
+```
+
+### GET /processes
+
+List all processes.
+
+**Response:**
+
+```json
+{
+  "processes": [
+    {
+      "name": "web",
+      "status": "running",
+      "pid": 12345,
+      "uptime_seconds": 3600,
+      "restarts": 0,
+      "health": "healthy"
+    },
+    {
+      "name": "api",
+      "status": "running",
+      "pid": 12346,
+      "uptime_seconds": 3600,
+      "restarts": 1,
+      "health": "unhealthy"
+    }
+  ]
+}
+```
+
+**Status values:** `running`, `stopped`, `starting`, `stopping`, `crashed`
+
+**Health values:** `healthy`, `unhealthy`, `unknown` (no healthcheck configured)
+
+### GET /processes/{name}
+
+Get detailed process info.
+
+**Response:**
+
+```json
+{
+  "name": "api",
+  "status": "running",
+  "pid": 12345,
+  "uptime_seconds": 3600,
+  "restarts": 2,
+  "health": "healthy",
+  "healthcheck": {
+    "enabled": true,
+    "last_check": "2025-01-19T10:32:01.123Z",
+    "last_output": "OK",
+    "consecutive_failures": 0
+  },
+  "cmd": "go run ./cmd/server",
+  "env": {
+    "PORT": "8080"
+  }
+}
+```
+
+### POST /processes/{name}/start
+
+Start a stopped process.
+
+**Response:**
+
+```json
+{
+  "success": true
+}
+```
+
+### POST /processes/{name}/stop
+
+Stop a running process.
+
+**Response:**
+
+```json
+{
+  "success": true
+}
+```
+
+### POST /processes/{name}/restart
+
+Restart a process (stop then start).
+
+**Response:**
+
+```json
+{
+  "success": true
+}
+```
+
+### GET /logs
+
+Retrieve logs from buffer.
+
+**Query Parameters:**
+
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `process` | string | all | Comma-separated process names |
+| `lines` | int | 100 | Max lines to return |
+| `bytes` | int | — | Max bytes to return |
+| `pattern` | string | — | Filter pattern |
+| `regex` | bool | false | Treat pattern as regex |
+
+If both `lines` and `bytes` are specified, whichever limit hits first applies.
+
+**Response:**
+
+```json
+{
+  "logs": [
+    {
+      "timestamp": "2025-01-19T10:32:01.123Z",
+      "process": "web",
+      "stream": "stdout",
+      "line": "GET /api/users 200 12ms"
+    }
+  ],
+  "filtered_count": 100,
+  "total_count": 4523
+}
+```
+
+### GET /logs/stream
+
+Stream logs via Server-Sent Events (SSE).
+
+**Query Parameters:** Same as `GET /logs` (except `lines` and `bytes`)
+
+**Response:** SSE stream
+
+```
+data: {"timestamp":"2025-01-19T10:32:01.123Z","process":"web","stream":"stdout","line":"GET /api/users 200 12ms"}
+
+data: {"timestamp":"2025-01-19T10:32:01.456Z","process":"api","stream":"stderr","line":"WARN: connection pool low"}
+```
+
+**Example:**
+
+```bash
+curl -N http://localhost:5555/api/v1/logs/stream
+curl -N "http://localhost:5555/api/v1/logs/stream?process=web,api"
+curl -N "http://localhost:5555/api/v1/logs/stream?pattern=ERROR"
+```
+
+### GET /proxy/requests
+
+Retrieve recent proxy requests (requires proxy to be enabled).
+
+**Query Parameters:**
+
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `subdomain` | string | all | Filter by subdomain |
+| `method` | string | all | Filter by HTTP method (GET, POST, etc.) |
+| `min_status` | int | — | Minimum status code |
+| `max_status` | int | — | Maximum status code |
+| `limit` | int | 100 | Max requests to return (max 1000) |
+
+**Response:**
+
+```json
+{
+  "requests": [
+    {
+      "id": "a1b2c3d",
+      "timestamp": "2025-01-19T10:32:01.123Z",
+      "method": "GET",
+      "url": "/api/users",
+      "subdomain": "api",
+      "status_code": 200,
+      "duration_ms": 45,
+      "remote_addr": "127.0.0.1"
+    }
+  ],
+  "filtered_count": 50,
+  "total_count": 250
+}
+```
+
+**Example:**
+
+```bash
+# Get all recent requests
+curl http://localhost:5555/api/v1/proxy/requests
+
+# Filter by subdomain
+curl "http://localhost:5555/api/v1/proxy/requests?subdomain=api"
+
+# Filter for errors (5xx)
+curl "http://localhost:5555/api/v1/proxy/requests?min_status=500"
+```
+
+### GET /proxy/requests/stream
+
+Stream proxy requests via Server-Sent Events (SSE).
+
+**Query Parameters:** Same as `GET /proxy/requests` (except `limit`)
+
+**Response:** SSE stream
+
+```
+event: connected
+data: {}
+
+data: {"id":"a1b2c3d","timestamp":"2025-01-19T10:32:01.123Z","method":"GET","url":"/api/users","subdomain":"api","status_code":200,"duration_ms":45,"remote_addr":"127.0.0.1"}
+```
+
+**Example:**
+
+```bash
+curl -N http://localhost:5555/api/v1/proxy/requests/stream
+curl -N "http://localhost:5555/api/v1/proxy/requests/stream?subdomain=api"
+```
+
+### POST /shutdown
+
+Gracefully shut down supervisor and all processes.
+
+**Response:**
+
+```json
+{
+  "success": true
+}
+```
+
+Connection closes after response as supervisor terminates.

--- a/skills/prox/references/api.md
+++ b/skills/prox/references/api.md
@@ -2,7 +2,7 @@
 
 ## Base URL
 
-```
+```text
 http://{host}:{port}/api/v1
 ```
 
@@ -189,11 +189,11 @@ If both `lines` and `bytes` are specified, whichever limit hits first applies.
 
 Stream logs via Server-Sent Events (SSE).
 
-**Query Parameters:** Same as `GET /logs` (except `lines` and `bytes`)
+**Query Parameters:** Same as `GET /logs`, excluding `lines` and `bytes` (not applicable to streaming)
 
 **Response:** SSE stream
 
-```
+```text
 data: {"timestamp":"2025-01-19T10:32:01.123Z","process":"web","stream":"stdout","line":"GET /api/users 200 12ms"}
 
 data: {"timestamp":"2025-01-19T10:32:01.456Z","process":"api","stream":"stderr","line":"WARN: connection pool low"}
@@ -259,11 +259,11 @@ curl "http://localhost:5555/api/v1/proxy/requests?min_status=500"
 
 Stream proxy requests via Server-Sent Events (SSE).
 
-**Query Parameters:** Same as `GET /proxy/requests` (except `limit`)
+**Query Parameters:** Same as `GET /proxy/requests`, excluding `limit` (not applicable to streaming)
 
 **Response:** SSE stream
 
-```
+```text
 event: connected
 data: {}
 

--- a/skills/prox/references/configuration.md
+++ b/skills/prox/references/configuration.md
@@ -1,0 +1,275 @@
+# Configuration Reference
+
+## Config File
+
+prox looks for `prox.yaml` in the current directory by default. Use `--config` to specify a different path.
+
+## Minimal Example
+
+```yaml
+processes:
+  web: npm run dev
+  api: go run ./cmd/server
+  worker: python worker.py
+```
+
+## Full Example
+
+```yaml
+api:
+  port: 5555
+  host: 127.0.0.1
+
+env_file: .env
+
+processes:
+  # Simple form - string command
+  web: npm run dev
+  worker: python worker.py
+
+  # Expanded form - full configuration
+  api:
+    cmd: go run ./cmd/server
+    env:
+      PORT: "8080"
+      DEBUG: "true"
+    env_file: .env.api
+    healthcheck:
+      cmd: curl -f http://localhost:8080/health
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+```
+
+## Top-Level Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `api.port` | int | dynamic | HTTP API port (auto-assigned if not specified or port in use) |
+| `api.host` | string | `127.0.0.1` | API bind address |
+| `env_file` | string | — | Global .env file path, loaded for all processes |
+| `processes` | map | required | Process definitions |
+
+## Process Fields
+
+Processes can be defined in simple form (string) or expanded form (object).
+
+### Simple Form
+
+```yaml
+processes:
+  web: npm run dev
+```
+
+### Expanded Form
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `cmd` | string | required | Command to run |
+| `env` | map | — | Environment variables for this process |
+| `env_file` | string | — | Process-specific .env file |
+| `healthcheck` | object | — | Health check configuration |
+
+## Health Check Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `cmd` | string | required | Command to run for health check |
+| `interval` | duration | `10s` | Time between health checks |
+| `timeout` | duration | `5s` | Timeout for each check |
+| `retries` | int | `3` | Consecutive failures before marking unhealthy |
+| `start_period` | duration | `30s` | Grace period after startup before checks begin |
+
+## Environment Variable Precedence
+
+Environment variables are loaded in this order (later values override earlier):
+
+1. System environment
+2. Global `env_file` (if specified)
+3. Process-specific `env_file` (if specified)
+4. Process-specific `env` map (if specified)
+
+## Duration Format
+
+Duration fields accept Go duration strings:
+
+- `5s` - 5 seconds
+- `10m` - 10 minutes
+- `1h30m` - 1 hour 30 minutes
+
+## Runtime State
+
+When prox is running (in either foreground or daemon mode), runtime state is stored in the `.prox/` directory within your project:
+
+| File | Description |
+|------|-------------|
+| `.prox/prox.state` | JSON file with port, PID, host, start time, config path |
+| `.prox/prox.pid` | Process ID with file locking to prevent multiple instances |
+| `.prox/prox.log` | Daemon logs (stdout/stderr redirected here in background mode) |
+
+When running in daemon mode (`prox up -d`), all output that would normally go to stdout/stderr is redirected to `.prox/prox.log`. This is useful for debugging startup issues or reviewing daemon activity.
+
+**State File Format:**
+
+```json
+{
+  "pid": 12345,
+  "port": 5555,
+  "host": "127.0.0.1",
+  "started_at": "2024-01-15T10:30:00Z",
+  "config_file": "prox.yaml"
+}
+```
+
+CLI commands automatically discover the API address by reading `.prox/prox.state`. This enables:
+
+- Running multiple prox instances (different projects) simultaneously
+- Dynamic port allocation without port conflicts
+- No need to specify `--addr` for local commands
+
+The `.prox/` directory is project-local, so add it to your `.gitignore`:
+
+```gitignore
+.prox/
+```
+
+## Proxy Configuration
+
+prox can act as an HTTP and/or HTTPS reverse proxy, providing friendly subdomain URLs for your services. HTTP-only mode requires no certificate setup. HTTPS mode uses locally-trusted certificates via mkcert.
+
+### HTTP-Only Example
+
+The simplest proxy setup — no certificates required:
+
+```yaml
+processes:
+  frontend: npm run dev
+  backend: go run ./cmd/server
+
+proxy:
+  http_port: 6788
+  domain: local.myapp.dev
+
+services:
+  app: 3000
+  api: 8000
+```
+
+With this configuration:
+- `http://app.local.myapp.dev:6788` → `http://localhost:3000`
+- `http://api.local.myapp.dev:6788` → `http://localhost:8000`
+
+### HTTPS Example
+
+```yaml
+processes:
+  frontend: npm run dev
+  backend: go run ./cmd/server
+
+proxy:
+  https_port: 6789
+  domain: local.myapp.dev
+
+services:
+  app: 3000
+  api: 8000
+
+certs:
+  dir: ~/.prox/certs
+  auto_generate: true
+```
+
+With this configuration:
+- `https://app.local.myapp.dev:6789` → `http://localhost:3000`
+- `https://api.local.myapp.dev:6789` → `http://localhost:8000`
+
+### Dual-Stack Example
+
+Run both HTTP and HTTPS simultaneously:
+
+```yaml
+processes:
+  frontend: npm run dev
+  backend: go run ./cmd/server
+
+proxy:
+  http_port: 6788
+  https_port: 6789
+  domain: local.myapp.dev
+
+services:
+  app: 3000                    # Simple: subdomain → port
+  api:                         # Expanded: with options
+    port: 8000
+    host: localhost
+
+certs:
+  dir: ~/.prox/certs
+  auto_generate: true
+```
+
+### Proxy Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `proxy.enabled` | bool | auto | Enable reverse proxy (auto-enabled when a port is set) |
+| `proxy.http_port` | int | — | Port for the HTTP proxy server |
+| `proxy.https_port` | int | `6789` | Port for the HTTPS proxy server (default when enabled with no ports set) |
+| `proxy.domain` | string | required | Base domain for subdomain routing |
+
+### Service Fields
+
+Services can be defined in simple form (port only) or expanded form (object).
+
+#### Simple Form
+
+```yaml
+services:
+  app: 3000
+```
+
+#### Expanded Form
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `port` | int | required | Target port to proxy to |
+| `host` | string | `localhost` | Target host to proxy to |
+
+### Certificate Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `certs.dir` | string | `~/.prox/certs` | Directory for storing certificates |
+| `certs.auto_generate` | bool | `true` | Automatically generate certificates using mkcert |
+
+### Prerequisites (HTTPS only)
+
+HTTPS mode requires mkcert for certificate generation. HTTP-only mode has no prerequisites.
+
+```bash
+# macOS
+brew install mkcert
+
+# Install the CA (run once)
+mkcert -install
+```
+
+### DNS Setup
+
+Custom domains require DNS entries pointing to `127.0.0.1`. The simplest option is a public localhost-DNS service (no `/etc/hosts` editing; requires internet for DNS resolution):
+- `lvh.me` — `*.lvh.me` resolves to 127.0.0.1
+- `sslip.io` / `nip.io` — embed the IP, e.g. `app.127.0.0.1.sslip.io`
+- `localtest.me` — `*.localtest.me` resolves to 127.0.0.1
+
+For a custom offline domain, add `/etc/hosts` entries manually:
+
+```text
+127.0.0.1 local.myapp.dev app.local.myapp.dev api.local.myapp.dev
+```
+
+## Security Note
+
+Commands in `prox.yaml` are executed via shell. Only use configuration files from trusted sources, similar to Makefiles or Procfiles.
+
+When binding to non-localhost interfaces (`host: 0.0.0.0`), authentication is automatically enabled. A bearer token is generated and stored in `~/.prox/token`.


### PR DESCRIPTION
## What

Makes `charliek/prox` a distributable Claude Code plugin that hosts the `prox` skill, so this repo becomes the canonical place the skill is discovered and installed. The skill previously lived in `charliek/cc-plugins` (removed there in a companion PR).

## Changes

- **`skills/prox/`** — migrated `SKILL.md` + `references/`, reconciled to the current CLI:
  - Added the shared proxy daemon model and `prox proxy status|routes|stop` commands
  - Added `prox start <name>`
  - Removed the stale `prox hosts --add` reference (command no longer exists)
  - Optimized the triggering description (daemon-aware; guarded against lookalikes like Proxmox / a corporate `proxy.yaml`)
- **`.claude-plugin/plugin.json`** + **`marketplace.json`** — plugin manifest + self-contained marketplace (`source: "./"`), so `/plugin marketplace add charliek/prox` works in one step
- **`scripts/set-version.sh`** + **`release.yaml` `sync-version` job** — keep `plugin.json` version in lockstep with the released git tag (the only committed file that hardcodes the version; the Go binary version comes from the tag via GoReleaser)
- **README** — "Claude Code / agent skills" install section (skills.sh + Claude Code plugin); fixed the auth-token path to `~/.prox/token`
- **LICENSE** (MIT)
- **`.gitignore`** — anchored the binary ignore to `/prox` so it no longer silently ignores `skills/prox/`

## Install (after merge)

```
/plugin marketplace add charliek/prox
/plugin install prox@prox
```

The skill is namespaced `prox:prox`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Prox is now available as a Claude Code skill and registered in the plugin marketplace
  * Added comprehensive documentation including skill guide, HTTP API reference, and configuration reference

* **Chores**
  * Added MIT License
  * Implemented automated version synchronization in release workflow

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/charliek/prox/pull/20?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->