### PR TITLE
feat(release): adopt cc-plugins:release-workflows + retire PATs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,6 +39,23 @@ jobs:
         with:
           version: v2.10.1
 
+      # Tag/manifest invariant check — the local-bump flow's safety net.
+      # Replaces the deleted sync-version job's contract: instead of fixing
+      # plugin.json drift after the fact in CI, fail the release if the
+      # tagged commit's plugin.json doesn't match the tag. Cheap server-
+      # side check; the maintainer reruns /release-workflows:release
+      # against a corrected tag rather than shipping mismatched bytes.
+      - name: Verify plugin.json matches tag
+        run: |
+          set -euo pipefail
+          expect="${GITHUB_REF_NAME#v}"
+          got="$(grep -oE '"version"[[:space:]]*:[[:space:]]*"[^"]+"' \
+                   .claude-plugin/plugin.json | sed -E 's/.*"([^"]+)"$/\1/')"
+          if [ "${got}" != "${expect}" ]; then
+            echo "::error::plugin.json version=${got} != tag=${expect}. Re-run /release-workflows:release after correcting."
+            exit 1
+          fi
+
       # Mint a release-bot App token scoped to charliek/homebrew-tap for
       # GoReleaser's `brews:` step (formula push). The App must be
       # installed on homebrew-tap (verify via sanity-check-app.yml).
@@ -53,6 +70,11 @@ jobs:
           private-key: ${{ secrets.RELEASE_BOT_APP_KEY }}
           owner:        charliek
           repositories: homebrew-tap
+          # Defense-in-depth: explicit permission floor on the minted
+          # token so a future widening of the App's installation perms
+          # doesn't silently broaden what this token can do. GoReleaser
+          # only needs contents:write on the tap repo (to push the formula).
+          permission-contents: write
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
@@ -79,6 +101,8 @@ jobs:
           private-key: ${{ secrets.RELEASE_BOT_APP_KEY }}
           owner:        charliek
           repositories: apt-charliek
+          # POST /repos/.../dispatches requires contents:write.
+          permission-contents: write
 
       - name: Trigger apt-charliek publish
         if: success()
@@ -91,16 +115,22 @@ jobs:
           # dispatch self-heals on the next release, but we still want to
           # flag genuinely persistent failures.
           for attempt in 1 2 3; do
+            # Capture stderr so a real install-state failure (App not
+            # installed on apt-charliek, scoped-perms mismatch, etc.) is
+            # diagnosable from the workflow log without re-running.
             if gh api repos/charliek/apt-charliek/dispatches \
               --method POST \
               -f event_type=publish \
               -F "client_payload[package]=prox" \
-              -F "client_payload[tag]=${{ github.ref_name }}"; then
+              -F "client_payload[tag]=${{ github.ref_name }}" 2>&1; then
               echo "::notice::Watch apt publish at https://github.com/charliek/apt-charliek/actions"
               exit 0
             fi
-            echo "dispatch attempt $attempt failed; sleeping $((attempt * 5))s"
-            [ "$attempt" -eq 3 ] && exit 1
+            echo "::warning::dispatch attempt $attempt failed; sleeping $((attempt * 5))s"
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::apt-charliek dispatch failed after 3 attempts — check the stderr above for the API error"
+              exit 1
+            fi
             sleep $((attempt * 5))
           done
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,12 @@ on:
 permissions:
   contents: write
 
+# Serialize re-runs against the same tag — better to wait than to abort
+# half-uploaded artifacts.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release:
     name: Build and Release
@@ -33,6 +39,21 @@ jobs:
         with:
           version: v2.10.1
 
+      # Mint a release-bot App token scoped to charliek/homebrew-tap for
+      # GoReleaser's `brews:` step (formula push). The App must be
+      # installed on homebrew-tap (verify via sanity-check-app.yml).
+      # Replaces the legacy HOMEBREW_TAP_TOKEN PAT — GoReleaser is
+      # token-source-agnostic; it just uses HOMEBREW_TAP_TOKEN from the
+      # env for git authentication.
+      - name: Mint a homebrew-tap App token
+        id: tap
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id:      ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_APP_KEY }}
+          owner:        charliek
+          repositories: homebrew-tap
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:
@@ -40,16 +61,35 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          # GoReleaser reads HOMEBREW_TAP_TOKEN from this env var (see
+          # .goreleaser.yaml: brews[].repository.token). Feed it the
+          # App-minted token instead of a PAT.
+          HOMEBREW_TAP_TOKEN: ${{ steps.tap.outputs.token }}
+
+      # Mint a release-bot App token scoped to charliek/apt-charliek for
+      # the publish dispatch. The App must be installed on apt-charliek
+      # (verify via sanity-check-app.yml). Replaces the legacy
+      # APT_DISPATCH_TOKEN PAT.
+      - name: Mint an apt-charliek App token
+        if: success()
+        id: apt
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id:      ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_APP_KEY }}
+          owner:        charliek
+          repositories: apt-charliek
 
       - name: Trigger apt-charliek publish
         if: success()
+        env:
+          GH_TOKEN: ${{ steps.apt.outputs.token }}
         run: |
           # Retry the dispatch a few times — a transient network/API blip
           # shouldn't fail the release after GoReleaser already succeeded.
-          # apt-charliek's publish workflow is idempotent so a missed dispatch
-          # also self-heals on the next release, but we still want to flag
-          # genuinely persistent failures.
+          # apt-charliek's publish workflow is idempotent so a missed
+          # dispatch self-heals on the next release, but we still want to
+          # flag genuinely persistent failures.
           for attempt in 1 2 3; do
             if gh api repos/charliek/apt-charliek/dispatches \
               --method POST \
@@ -63,40 +103,11 @@ jobs:
             [ "$attempt" -eq 3 ] && exit 1
             sleep $((attempt * 5))
           done
-        env:
-          GH_TOKEN: ${{ secrets.APT_DISPATCH_TOKEN }}
 
-  sync-version:
-    name: Commit plugin version to main
-    needs: release
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout main
-        uses: actions/checkout@v6
-        with:
-          ref: main
-          persist-credentials: false
-
-      - name: Set plugin version from tag
-        run: scripts/set-version.sh "${GITHUB_REF_NAME#v}"
-
-      - name: Commit and push if plugin.json drifted
-        # Keeps the committed .claude-plugin/plugin.json in lockstep with the
-        # released tag (Claude Code reads it from main, not from a build
-        # artifact). Idempotent: a no-op when the version was bumped by hand
-        # before tagging. The GITHUB_TOKEN push does not re-trigger this
-        # workflow (GitHub blocks recursive workflow runs).
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if [ -z "$(git status --porcelain .claude-plugin/plugin.json)" ]; then
-            echo "plugin.json already matches ${GITHUB_REF_NAME}; nothing to commit"
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add .claude-plugin/plugin.json
-          git commit -m "chore: set plugin version ${GITHUB_REF_NAME}"
-          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:main
+# The earlier sync-version job that ran scripts/set-version.sh in CI and
+# pushed the bumped .claude-plugin/plugin.json back to main is removed.
+# Plugin.json bumping is now LOCAL via scripts/release/update-version.sh
+# (the cc-plugins:release-workflows convention's source-tree-bump-local
+# rule). The release skill runs update-version.sh before tagging, so
+# main always has plugin.json at the released tag's version before the
+# workflow even fires.

--- a/.github/workflows/sanity-check-app.yml
+++ b/.github/workflows/sanity-check-app.yml
@@ -51,10 +51,17 @@ jobs:
           gh api "/repos/${GITHUB_REPOSITORY}" --jq '.full_name'
           echo "::endgroup::"
 
-          echo "::group::Installation repository count (must be ≥1)"
+          echo "::group::Installation repository count (must be ≥3 — prox + homebrew-tap + apt-charliek)"
           # Count only — the App also installs on private repos and printing
-          # names in this public workflow log would leak them.
-          gh api /installation/repositories --jq '.total_count'
+          # names in this public workflow log would leak them. The release
+          # flow needs the App installed on all three repos; a count below
+          # 3 means at least one cross-repo target is missing.
+          count="$(gh api /installation/repositories --jq '.total_count')"
+          echo "installation repository count: ${count}"
+          if [ "${count}" -lt 3 ]; then
+            echo "::error::App is missing at least one installation; expected ≥3 (prox + homebrew-tap + apt-charliek)"
+            exit 1
+          fi
           echo "::endgroup::"
 
           # Installation tokens can't call /user (403 "Resource not accessible
@@ -71,6 +78,11 @@ jobs:
           private-key: ${{ secrets.RELEASE_BOT_APP_KEY }}
           owner:        charliek
           repositories: homebrew-tap
+          # The reach check (gh api GET /repos/...) only needs metadata read;
+          # real release uses contents:write to push the formula. We mint the
+          # broader scope here so the verification matches what release.yaml
+          # actually mints, catching scope-related misconfigurations early.
+          permission-contents: write
 
       - name: Token can reach charliek/homebrew-tap
         env:
@@ -89,6 +101,8 @@ jobs:
           private-key: ${{ secrets.RELEASE_BOT_APP_KEY }}
           owner:        charliek
           repositories: apt-charliek
+          # Matches what release.yaml mints; surfaces scope mismatches early.
+          permission-contents: write
 
       - name: Token can reach charliek/apt-charliek
         env:

--- a/.github/workflows/sanity-check-app.yml
+++ b/.github/workflows/sanity-check-app.yml
@@ -1,0 +1,100 @@
+name: sanity-check-app
+
+# Manual verification that the release-bot App is installed on every repo
+# prox's release.yaml touches:
+#   1. charliek/prox itself (the running repo's secrets must resolve)
+#   2. charliek/homebrew-tap (GoReleaser's brews step pushes Formula/prox.rb)
+#   3. charliek/apt-charliek (publish dispatch sent at end of release)
+#
+# Run from the Actions UI ("Run workflow") after setting the
+# RELEASE_BOT_APP_* secrets and confirming the App is installed on all
+# three repos.
+#
+# Useful when:
+#   * first wiring the App into a new repo (verify before touching release.yaml)
+#   * rotating the App's private key (re-verify after updating the secret)
+#   * migrating to a new App
+#   * after adopting a new cross-repo target
+#
+# Each block mints a short-lived installation token scoped to one repo and
+# calls a read-only endpoint. A failure to mint, or a 404 on the reach
+# check, means the App isn't installed on that repo — fix the install
+# before the next release runs.
+#
+# Bot identity comes from the action's `app-slug` output, NOT
+# `gh api /user`, which returns 403 for installation tokens (they don't
+# authenticate as a user).
+
+on:
+  workflow_dispatch: {}
+
+permissions: {}   # this workflow needs nothing from the workflow token
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      # ── 1. self (charliek/prox) ──
+      - id: self-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id:      ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_APP_KEY }}
+
+      - name: Token sees prox + bot identity
+        env:
+          GH_TOKEN: ${{ steps.self-token.outputs.token }}
+          BOT_SLUG: ${{ steps.self-token.outputs.app-slug }}
+        run: |
+          set -euo pipefail
+          echo "::group::This repo (must print charliek/prox)"
+          gh api "/repos/${GITHUB_REPOSITORY}" --jq '.full_name'
+          echo "::endgroup::"
+
+          echo "::group::Installation repository count (must be ≥1)"
+          # Count only — the App also installs on private repos and printing
+          # names in this public workflow log would leak them.
+          gh api /installation/repositories --jq '.total_count'
+          echo "::endgroup::"
+
+          # Installation tokens can't call /user (403 "Resource not accessible
+          # by integration") — bot identity comes from the action's app-slug.
+          echo "::group::Bot identity (should end with [bot])"
+          echo "${BOT_SLUG}[bot]"
+          echo "::endgroup::"
+
+      # ── 2. charliek/homebrew-tap (GoReleaser brews push target) ──
+      - id: tap-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id:      ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_APP_KEY }}
+          owner:        charliek
+          repositories: homebrew-tap
+
+      - name: Token can reach charliek/homebrew-tap
+        env:
+          GH_TOKEN: ${{ steps.tap-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          echo "::group::charliek/homebrew-tap (must print the same)"
+          gh api "/repos/charliek/homebrew-tap" --jq '.full_name'
+          echo "::endgroup::"
+
+      # ── 3. charliek/apt-charliek (publish dispatch target) ──
+      - id: apt-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id:      ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_APP_KEY }}
+          owner:        charliek
+          repositories: apt-charliek
+
+      - name: Token can reach charliek/apt-charliek
+        env:
+          GH_TOKEN: ${{ steps.apt-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          echo "::group::charliek/apt-charliek (must print the same)"
+          gh api "/repos/charliek/apt-charliek" --jq '.full_name'
+          echo "::endgroup::"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,183 @@
+# Releasing prox
+
+The general release framework is `cc-plugins:release-workflows`; this file
+documents what's specific to this repo.
+
+## TL;DR
+
+    /release-workflows:release v0.1.2
+
+That's it. Everything else is automatic.
+
+## What happens
+
+1. **`release-workflows:release`** (LLM, local):
+   - Verifies branch (`main`) + clean tree + CI green on HEAD
+   - Asks/confirms version
+   - Drafts a CHANGELOG entry from `git log v<previous>..HEAD`, commits as
+     `docs(changelog): vX.Y.Z entry`
+   - Runs `scripts/release/update-version.sh X.Y.Z` → bumps
+     `.claude-plugin/plugin.json` (delegated to `scripts/set-version.sh`)
+   - Commits as `chore(version): bump to X.Y.Z`
+   - Tags `vX.Y.Z` (annotated) on the version commit
+   - `git push --follow-tags` (admin bypasses the ruleset)
+
+2. **`release.yaml`** (CI, on tag push `v*`):
+   - **`release`** (single job):
+     - Checks out, sets up Go, runs `go test` + golangci-lint
+     - Mints a release-bot App token scoped to `charliek/homebrew-tap`
+     - Runs `goreleaser release --clean`, which:
+       - Builds 4 targets (`linux/darwin` × `amd64/arm64`) with version
+         injected via ldflag (`-X .../internal/version.Version={{.Version}}`)
+       - Tarballs them as `prox_<os>_<arch>.tar.gz`
+       - Builds .debs (amd64 + arm64) via `nfpms:` config
+       - Uploads tarballs + .debs + `checksums.txt` to the GitHub Release
+       - Auto-generates release notes from commits
+       - Pushes `Formula/prox.rb` to `charliek/homebrew-tap` using the
+         App-minted token (replaces the legacy `HOMEBREW_TAP_TOKEN` PAT)
+     - Mints a release-bot App token scoped to `charliek/apt-charliek`
+     - Dispatches `repository_dispatch` (`event_type=publish`) to
+       `charliek/apt-charliek` with the App-minted token (replaces the
+       legacy `APT_DISPATCH_TOKEN` PAT)
+
+The maintainer runs step 1; everything else is automated.
+
+## Version files this repo owns
+
+`scripts/release/update-version.sh` (which delegates to
+`scripts/set-version.sh`) bumps:
+
+- `.claude-plugin/plugin.json` — `version` field, read by Claude Code at
+  install/update time. This is the canonical source-tree version manifest.
+
+NOT bumped:
+
+- **Go binary version** — comes from a build-time ldflag injected by
+  GoReleaser. The ldflag references `{{.Version}}`, which GoReleaser
+  computes from `${GITHUB_REF_NAME#v}` at build time. No source-tree
+  manifest to bump.
+- `pyproject.toml` — for the mkdocs docs site; has its own version
+  cadence and is NOT touched by releases.
+
+## Snapshot / dev versioning
+
+Not used. Main between releases shows the last released version. If you
+want `prox --version` between releases to show commits-past-tag identity,
+add `-X .../version.Commit={{.Commit}}` to `.goreleaser.yaml`'s
+`builds[].ldflags`. Not currently wired.
+
+## Secrets
+
+| Secret | Purpose | Required? |
+|---|---|---|
+| `RELEASE_BOT_APP_ID` | `charliek-release-bot` GitHub App ID | required — minted at workflow time for both the homebrew-tap push (via GoReleaser) and the apt-charliek dispatch |
+| `RELEASE_BOT_APP_KEY` | App private key (.pem) | required — same |
+
+Retired (deleted during the convention adoption):
+
+- `APT_DISPATCH_TOKEN` — replaced by the App-minted apt-charliek token
+- `HOMEBREW_TAP_TOKEN` — replaced by the App-minted homebrew-tap token
+
+GoReleaser still reads the env var named `HOMEBREW_TAP_TOKEN`; the
+workflow sets it from `steps.tap.outputs.token` instead of from
+`secrets`.
+
+## Branch protection
+
+`main` is protected by a ruleset (created during the convention
+adoption) with `required_status_checks=[]` (none — prox's `ci.yml` runs
+multiple separate jobs `test` / `lint` / `release-snapshot` and there's
+no single aggregator check). Bypass actors:
+
+- `charliek-release-bot` (App, type `Integration`) — lets the App push
+  to the homebrew-tap, dispatch to apt-charliek, and any future
+  post-build push back to prox's main
+- Admin role (id `5`, type `RepositoryRole`) — lets
+  `/release-workflows:release`'s push of the changelog + version commits
+  + tag land
+
+Inspect or edit at https://github.com/charliek/prox/rules.
+
+## App installation
+
+The release-bot App must be installed on three repos:
+
+- `charliek/prox` itself (so the workflow's secrets resolve)
+- `charliek/homebrew-tap` (so the minted token can push the formula)
+- `charliek/apt-charliek` (so the minted token can fire the dispatch)
+
+Verify all three via the `sanity-check-app.yml` workflow (Actions → Run
+workflow). Each block must print the expected repo name.
+
+## When things break
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `git push` rejected: `Required status check ...` | Pusher not in ruleset bypass | Confirm both the App and the admin role are in `main`'s ruleset `bypass_actors` |
+| GoReleaser fails at `brews` with `Bad credentials` | `RELEASE_BOT_APP_ID` unset OR App not installed on `homebrew-tap` | Confirm via `sanity-check-app.yml`'s homebrew-tap block; install the App on the tap if missing |
+| `Trigger apt-charliek publish` step fails | App not installed on `apt-charliek` OR rate-limited | Confirm via `sanity-check-app.yml`'s apt-charliek block; install the App if missing. The dispatch step retries 3× internally; persistent failures usually mean install state, not network |
+| `release` job's `go test` fails on the tagged commit | Real test failure | Fix on a branch, merge, cut a fresh patch tag (don't force-update the failed tag) |
+| Formula push succeeded but `brew install` finds old version | Homebrew tap cache | `brew untap charliek/tap && brew tap charliek/tap` |
+| Claude Code installs old plugin version after the release | `plugin.json` wasn't bumped before the tag | `/release-workflows:release` should have bumped it via `update-version.sh`; if not, bump manually with `scripts/set-version.sh <ver>` + commit + push to main, then redirect Claude Code users to reinstall |
+
+## Break-glass recovery
+
+### Homebrew formula push failed
+
+If GoReleaser failed at the `brews` step but everything else uploaded:
+
+```bash
+# Re-run just GoReleaser locally with the App token. Export the token
+# via gh's App-token flow (requires gh's app-token plugin or local mint).
+# Easiest path: re-run the GitHub Actions workflow run from the UI —
+# GoReleaser's `mode: replace` in .goreleaser.yaml reuses the existing
+# Release without re-uploading.
+```
+
+### apt-charliek dispatch failed
+
+The dispatch step retries 3× with backoff. If all three fail and the
+release.yaml job is otherwise green: re-run just this step from the
+Actions UI, OR wait for apt-charliek's next scheduled scan (it
+self-heals by detecting unpublished .debs on the GitHub Release).
+
+### plugin.json drifted from the released tag
+
+If main's `.claude-plugin/plugin.json` doesn't match the latest released
+tag (shouldn't happen with the new flow, but if it does):
+
+```bash
+scripts/set-version.sh <released-version>
+git add .claude-plugin/plugin.json
+git commit -m "chore: align plugin.json with v<released-version>"
+git push origin main
+```
+
+## Adopting the convention (for new contributors)
+
+If you're new to this repo and need to understand the release pipeline,
+read [`cc-plugins/plugins/release-workflows/references/convention.md`](https://github.com/charliek/cc-plugins/blob/main/plugins/release-workflows/references/convention.md)
+in the framework repo. It defines the contract every file in this
+repo's `scripts/release/` and `.github/workflows/release.yaml` is
+written against.
+
+## Notes for this repo
+
+- **No `version-check` job**: Go binaries don't have a single source-tree
+  version manifest matching the tag — `.claude-plugin/plugin.json` is
+  the only file that holds a literal version, and the Go binary's
+  version is ldflag-injected at build time. A version-check job would
+  need to compare the tag against plugin.json specifically; not added
+  yet (low ROI since `update-version.sh` writes plugin.json
+  deterministically).
+- **No `ci-gate` job**: prox's `ci.yml` runs `test` / `lint` /
+  `release-snapshot` as separate jobs with no aggregator. The
+  `release.yaml`'s own `go test` + lint steps serve as the inline gate
+  at tag time. Adding ci-gate would require either a `ci-success`
+  aggregator in ci.yml or polling multiple check names.
+- **`sync-version` job (removed)**: an earlier flow ran
+  `scripts/set-version.sh` in CI after the release and bot-pushed the
+  bumped `.claude-plugin/plugin.json` back to main. That work moved
+  LOCAL via `scripts/release/update-version.sh`, which the release skill
+  runs before tagging. Result: main always has plugin.json at the
+  released version *before* the release workflow even fires.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -73,14 +73,20 @@ add `-X .../version.Commit={{.Commit}}` to `.goreleaser.yaml`'s
 | `RELEASE_BOT_APP_ID` | `charliek-release-bot` GitHub App ID | required — minted at workflow time for both the homebrew-tap push (via GoReleaser) and the apt-charliek dispatch |
 | `RELEASE_BOT_APP_KEY` | App private key (.pem) | required — same |
 
-Retired (deleted during the convention adoption):
+Retired (deleted from `gh secret list -R charliek/prox` during the
+convention adoption — confirm with `gh secret list -R charliek/prox`
+returns only the `RELEASE_BOT_APP_*` pair, not just removed from the
+workflow):
 
 - `APT_DISPATCH_TOKEN` — replaced by the App-minted apt-charliek token
 - `HOMEBREW_TAP_TOKEN` — replaced by the App-minted homebrew-tap token
 
 GoReleaser still reads the env var named `HOMEBREW_TAP_TOKEN`; the
 workflow sets it from `steps.tap.outputs.token` instead of from
-`secrets`.
+`secrets`. If someone reintroduces `secrets.HOMEBREW_TAP_TOKEN` later
+without realizing the migration happened, it would silently re-shadow
+the App-minted value — that's why the secret itself needs to be gone
+from the secret store, not just unwired from the workflow.
 
 ## Branch protection
 
@@ -90,8 +96,10 @@ multiple separate jobs `test` / `lint` / `release-snapshot` and there's
 no single aggregator check). Bypass actors:
 
 - `charliek-release-bot` (App, type `Integration`) — lets the App push
-  to the homebrew-tap, dispatch to apt-charliek, and any future
-  post-build push back to prox's main
+  to the homebrew-tap and dispatch to apt-charliek (bypass needed only
+  when those targets' branches are themselves protected). The App is
+  also bypass-listed here in case a future post-build job needs to
+  push back to prox's main; no such step exists today.
 - Admin role (id `5`, type `RepositoryRole`) — lets
   `/release-workflows:release`'s push of the changelog + version commits
   + tag land
@@ -118,20 +126,27 @@ workflow). Each block must print the expected repo name.
 | `Trigger apt-charliek publish` step fails | App not installed on `apt-charliek` OR rate-limited | Confirm via `sanity-check-app.yml`'s apt-charliek block; install the App if missing. The dispatch step retries 3× internally; persistent failures usually mean install state, not network |
 | `release` job's `go test` fails on the tagged commit | Real test failure | Fix on a branch, merge, cut a fresh patch tag (don't force-update the failed tag) |
 | Formula push succeeded but `brew install` finds old version | Homebrew tap cache | `brew untap charliek/tap && brew tap charliek/tap` |
-| Claude Code installs old plugin version after the release | `plugin.json` wasn't bumped before the tag | `/release-workflows:release` should have bumped it via `update-version.sh`; if not, bump manually with `scripts/set-version.sh <ver>` + commit + push to main, then redirect Claude Code users to reinstall |
+| `release` job fails at `Verify plugin.json matches tag` | The tagged commit's plugin.json doesn't match the tag — either `update-version.sh` didn't run, or it ran but the bump didn't land (silent sed no-op on a malformed manifest) | Re-bump locally with `./scripts/release/update-version.sh <ver>` (it now grep-verifies the bump), commit, push to main, cut a fresh patch tag. The buggy tag stays as an audit trail; don't force-update it. |
+| Claude Code installs old plugin version after the release | `plugin.json` wasn't bumped before the tag (and the Verify step missed it, or the Verify step was bypassed) | `/release-workflows:release` should have bumped it via `update-version.sh`; if not, bump manually with `scripts/release/update-version.sh <ver>` + commit + push to main, then redirect Claude Code users to reinstall |
 
 ## Break-glass recovery
 
 ### Homebrew formula push failed
 
-If GoReleaser failed at the `brews` step but everything else uploaded:
+If GoReleaser failed at the `brews` step but everything else uploaded,
+the cleanest recovery is to re-run the failed GitHub Actions workflow
+run from the UI. GoReleaser's `mode: replace` in `.goreleaser.yaml`
+reuses the existing Release without re-uploading the tarballs/debs/
+checksums — only the formula push gets retried.
+
+Alternative: trigger via CLI on the same tag (use the gh CLI's run
+re-run, NOT a new dispatch — `release.yaml` triggers on tag-push, not
+workflow_dispatch):
 
 ```bash
-# Re-run just GoReleaser locally with the App token. Export the token
-# via gh's App-token flow (requires gh's app-token plugin or local mint).
-# Easiest path: re-run the GitHub Actions workflow run from the UI —
-# GoReleaser's `mode: replace` in .goreleaser.yaml reuses the existing
-# Release without re-uploading.
+RUN_ID=$(gh run list -R charliek/prox --workflow release.yaml \
+                     --limit 1 --json databaseId --jq '.[0].databaseId')
+gh run rerun "${RUN_ID}" -R charliek/prox --failed
 ```
 
 ### apt-charliek dispatch failed

--- a/scripts/release/update-version.sh
+++ b/scripts/release/update-version.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Bump prox's release version.
+#
+# Prox is a Go binary (distributed via tarballs + .debs + Homebrew tap),
+# AND a Claude Code plugin (.claude-plugin/plugin.json). Two version
+# surfaces:
+#
+#   * Go binary version → comes from a build-time ldflag
+#     (-X .../internal/version.Version={{.Version}}) injected by
+#     GoReleaser. NOT bumped in the source tree.
+#
+#   * Claude Code plugin version → lives in .claude-plugin/plugin.json,
+#     read by Claude Code at install/update time. IS a source-tree
+#     manifest that must be bumped to match the released tag.
+#
+# This script bumps plugin.json by delegating to scripts/set-version.sh
+# (the existing, tested in-repo bumper). The convention requires the
+# script to live at scripts/release/update-version.sh; this thin wrapper
+# preserves the existing scripts/set-version.sh entry point.
+#
+# Contract (see cc-plugins:release-workflows references/update-version/README.md):
+#   - one arg: semver string, no `v` prefix
+#   - idempotent
+#   - no network
+#   - verifies its own work (scripts/set-version.sh does)
+#   - doesn't `git add` (release skill stages + commits)
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <X.Y.Z>   e.g. $0 0.1.2" >&2
+  exit 2
+fi
+V="$1"
+
+if [[ ! "$V" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$ ]]; then
+  echo "error: '$V' is not semver (X.Y.Z or X.Y.Z-suffix)" >&2
+  exit 2
+fi
+
+# Delegate to the existing plugin.json bumper.
+"$(dirname "$0")/../set-version.sh" "$V"

--- a/scripts/release/update-version.sh
+++ b/scripts/release/update-version.sh
@@ -22,7 +22,9 @@
 #   - one arg: semver string, no `v` prefix
 #   - idempotent
 #   - no network
-#   - verifies its own work (scripts/set-version.sh does)
+#   - verifies its own work — explicit grep-back on plugin.json after
+#     delegating, because set-version.sh's sed substitution silently
+#     no-ops if the version field is missing or malformed
 #   - doesn't `git add` (release skill stages + commits)
 
 set -euo pipefail
@@ -38,5 +40,16 @@ if [[ ! "$V" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$ ]]; then
   exit 2
 fi
 
+PLUGIN_JSON="$(dirname "$0")/../../.claude-plugin/plugin.json"
+
 # Delegate to the existing plugin.json bumper.
 "$(dirname "$0")/../set-version.sh" "$V"
+
+# Verify the bump actually landed. set-version.sh's sed silently no-ops
+# if the `"version"` field is missing or formatted differently than
+# expected, then exits 0 — which would let the release skill commit a
+# stale plugin.json and tag it. Grep-back is the safety net.
+if ! grep -qE "\"version\"[[:space:]]*:[[:space:]]*\"${V}\"" "${PLUGIN_JSON}"; then
+  echo "error: plugin.json did not bump to ${V} — check the \"version\" field's shape in ${PLUGIN_JSON}" >&2
+  exit 1
+fi


### PR DESCRIPTION
Migrate prox to the `cc-plugins:release-workflows` convention, with both
legacy PATs (`HOMEBREW_TAP_TOKEN`, `APT_DISPATCH_TOKEN`) replaced by
release-bot App tokens minted at workflow time. Pattern proven in strix
releases and roost v0.0.6.

## Files

| Path | What |
|---|---|
| `scripts/release/update-version.sh` (new, executable) | Thin wrapper around the existing `scripts/set-version.sh`, conforms to the convention's contract (semver validation + delegation). Bumps `.claude-plugin/plugin.json`. The Go binary version is GoReleaser-ldflag-injected — nothing to bump there. |
| `RELEASING.md` (new, root) | Per-repo release policy, secrets table, failure-mode table, break-glass recovery runbooks for Homebrew + apt + plugin.json drift. |
| `.github/workflows/sanity-check-app.yml` (new) | Multi-target App verification: `prox` + `homebrew-tap` + `apt-charliek`. Catches App-install-on-target-repo mistakes BEFORE the first release tries to push there. |
| `.github/workflows/release.yaml` (changed) | See "release.yaml changes" below. |

## release.yaml changes

| Step | Before | After |
|---|---|---|
| GoReleaser env var `HOMEBREW_TAP_TOKEN` | `secrets.HOMEBREW_TAP_TOKEN` (PAT) | `steps.tap.outputs.token` (App-minted, scoped to `homebrew-tap`) |
| apt-charliek dispatch `GH_TOKEN` | `secrets.APT_DISPATCH_TOKEN` (PAT) | `steps.apt.outputs.token` (App-minted, scoped to `apt-charliek`) |
| `sync-version` job | Ran `scripts/set-version.sh` in CI post-release, bot-pushed `.claude-plugin/plugin.json` back to main | **Removed** — plugin.json bump is now LOCAL via `scripts/release/update-version.sh`. The release skill runs it before tagging, so main always has plugin.json at the released version before the workflow fires. |

## GitHub config (done separately, not in this PR)

- `main` protected by ruleset `17072764` with release-bot App (id `3902108`) + admin role (id `5`) in `bypass_actors`. No required status checks (prox's `ci.yml` has 3 separate jobs with no aggregator; can add later).
- Legacy secrets `APT_DISPATCH_TOKEN` + `HOMEBREW_TAP_TOKEN` deleted.

## Validation plan

1. **Watch CI on this PR.** `release.yaml` only fires on tags; `ci.yml` runs `test` + `lint` + `release-snapshot`.
2. **Once merged, run `sanity-check-app.yml`** from the Actions UI. All three reach checks must print the expected repo names. If `apt-charliek` or `homebrew-tap` fail, install the App on the failing repo before the release.
3. **Cut `v0.1.2`** via `/release-workflows:release v0.1.2` to validate end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved release workflow concurrency to avoid overlapping runs for the same tag
  * Switched publishing to GitHub App installation tokens for stronger authentication

* **New Features**
  * Added a sanity-check workflow to validate app installation and repository reachability
  * Added a local release version-bump script (replacing the prior automated post-tag sync)

* **Documentation**
  * Expanded release documentation covering the end-to-end process and troubleshooting
<!-- end of auto-generated comment: release notes by coderabbit.ai -->