### PR TITLE
fix(sanity-check): remove overly-strict installation count assertion

### DIFF
--- a/.github/workflows/sanity-check-app.yml
+++ b/.github/workflows/sanity-check-app.yml
@@ -51,17 +51,16 @@ jobs:
           gh api "/repos/${GITHUB_REPOSITORY}" --jq '.full_name'
           echo "::endgroup::"
 
-          echo "::group::Installation repository count (must be ≥3 — prox + homebrew-tap + apt-charliek)"
-          # Count only — the App also installs on private repos and printing
-          # names in this public workflow log would leak them. The release
-          # flow needs the App installed on all three repos; a count below
-          # 3 means at least one cross-repo target is missing.
-          count="$(gh api /installation/repositories --jq '.total_count')"
-          echo "installation repository count: ${count}"
-          if [ "${count}" -lt 3 ]; then
-            echo "::error::App is missing at least one installation; expected ≥3 (prox + homebrew-tap + apt-charliek)"
-            exit 1
-          fi
+          echo "::group::Installation repository count"
+          # Per-repo selective installs (the typical pattern) show count=1
+          # from each repo's own installation perspective — the App's
+          # installation on charliek/prox sees just prox. Cross-repo
+          # minting (the per-target blocks below) reaches OTHER
+          # installations via the App's private key + owner+repositories
+          # inputs. So this count is informational only; the per-target
+          # reach checks below are the actual verification of whether
+          # the App can reach homebrew-tap and apt-charliek.
+          gh api /installation/repositories --jq '.total_count'
           echo "::endgroup::"
 
           # Installation tokens can't call /user (403 "Resource not accessible


### PR DESCRIPTION
Quick fix for the I4 finding from #21's review — the installation
count assertion was based on a misread of the GitHub App install model.

## What broke

When I ran `sanity-check-app.yml` on main right after #21 merged, the
self-block's `total_count >= 3` assertion fired:

> ::error::App is missing at least one installation; expected ≥3
> (prox + homebrew-tap + apt-charliek)

But the App **is** installed on all three repos —
`gh secret list -R charliek/{prox,homebrew-tap,apt-charliek}` shows
`RELEASE_BOT_APP_*` on each.

## Why the assertion was wrong

`gh api /installation/repositories` is scoped to **the calling
installation**. The release-bot App was installed per-repo selectively
(the typical pattern), so each repo's installation sees only itself:
count=1 from any of them. Cross-repo minting via
`owner+repositories` reaches the *other* installations through the
App's private key — not via this installation's enumerated repos.

## What this PR does

Drops the assertion. The per-target reach checks (blocks 2 and 3 —
mint a homebrew-tap-scoped token + `gh api /repos/charliek/homebrew-tap`,
same for apt-charliek) are the real verification; they fail loudly if
the App can't reach a target. The count check was killing those
blocks before they could run.

The count itself stays as informational output so a maintainer can
still see it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Modified the CI workflow verification to report repository installation count as informational data instead of enforcing a strict threshold requirement, with expanded documentation on visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->