### PR TITLE
fix(release): use jq for plugin.json version checks

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,10 +49,13 @@ jobs:
         run: |
           set -euo pipefail
           expect="${GITHUB_REF_NAME#v}"
-          got="$(grep -oE '"version"[[:space:]]*:[[:space:]]*"[^"]+"' \
-                   .claude-plugin/plugin.json | sed -E 's/.*"([^"]+)"$/\1/')"
+          # Use jq to anchor to the top-level .version field; a regex would
+          # also (incorrectly) match a future nested "version" field
+          # (e.g. in a future "dependencies" block). jq is preinstalled
+          # on ubuntu-latest and fails loudly on malformed JSON.
+          got="$(jq -r '.version' .claude-plugin/plugin.json)"
           if [ "${got}" != "${expect}" ]; then
-            echo "::error::plugin.json version=${got} != tag=${expect}. Re-run /release-workflows:release after correcting."
+            echo "::error::plugin.json .version=${got} != tag=${expect}. Re-run /release-workflows:release after correcting."
             exit 1
           fi
 

--- a/scripts/release/update-version.sh
+++ b/scripts/release/update-version.sh
@@ -22,7 +22,7 @@
 #   - one arg: semver string, no `v` prefix
 #   - idempotent
 #   - no network
-#   - verifies its own work — explicit grep-back on plugin.json after
+#   - verifies its own work — explicit jq-back on plugin.json after
 #     delegating, because set-version.sh's sed substitution silently
 #     no-ops if the version field is missing or malformed
 #   - doesn't `git add` (release skill stages + commits)
@@ -48,8 +48,10 @@ PLUGIN_JSON="$(dirname "$0")/../../.claude-plugin/plugin.json"
 # Verify the bump actually landed. set-version.sh's sed silently no-ops
 # if the `"version"` field is missing or formatted differently than
 # expected, then exits 0 — which would let the release skill commit a
-# stale plugin.json and tag it. Grep-back is the safety net.
-if ! grep -qE "\"version\"[[:space:]]*:[[:space:]]*\"${V}\"" "${PLUGIN_JSON}"; then
-  echo "error: plugin.json did not bump to ${V} — check the \"version\" field's shape in ${PLUGIN_JSON}" >&2
+# stale plugin.json and tag it. Use jq to anchor to the TOP-LEVEL
+# .version field; a regex would also (incorrectly) match a future
+# nested "version" field (e.g. in a future "dependencies" block).
+if [ "$(jq -r '.version' "${PLUGIN_JSON}")" != "${V}" ]; then
+  echo "error: plugin.json top-level .version did not bump to ${V}" >&2
   exit 1
 fi


### PR DESCRIPTION
Apply the codelens PR #47 reviewer's W1/W2 hardening to prox.

## What

The `grep -oE` + `sed -E` pattern for extracting plugin.json's `.version` field works for today's plugin.json shape but fails on a class of future drift:

- If `plugin.json` ever gains a nested `"version"` field (e.g. in a future `dependencies` block), `grep -oE` returns multiple matches, `sed -E` transforms each, and the comparison becomes a multi-line string vs a single value — fails even when the top-level version is correct.
- The script-level grep-back accepts ANY matching `"version"` substring, so a global sed in the delegated `set-version.sh` could silently clobber a nested field while the grep-back accepts it.

## Fix

`jq -r '.version'` anchors to the top-level field unambiguously, fails loudly on malformed JSON, and is preinstalled on ubuntu-latest. The `cc-plugins:release-workflows` template's `job-version-check.yml` comments already recommend `jq` for plugin.json — this just brings prox in line.

## Files

- `scripts/release/update-version.sh` — `grep -qE` → `jq -r '.version'` check
- `.github/workflows/release.yaml` — same swap in the inline `Verify plugin.json matches tag` step

Validated locally: forward bump idempotent; jq sees correct value. cc-plugins template recommendation also being hardened in a separate cc-plugins commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)