### PR TITLE
chore(ci): bump create-github-app-token v2 → v3 (Node 24)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,7 +67,7 @@ jobs:
       # env for git authentication.
       - name: Mint a homebrew-tap App token
         id: tap
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id:      ${{ secrets.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_APP_KEY }}
@@ -98,7 +98,7 @@ jobs:
       - name: Mint an apt-charliek App token
         if: success()
         id: apt
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id:      ${{ secrets.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_APP_KEY }}

--- a/.github/workflows/sanity-check-app.yml
+++ b/.github/workflows/sanity-check-app.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       # ── 1. self (charliek/prox) ──
       - id: self-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id:      ${{ secrets.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_APP_KEY }}
@@ -71,7 +71,7 @@ jobs:
 
       # ── 2. charliek/homebrew-tap (GoReleaser brews push target) ──
       - id: tap-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id:      ${{ secrets.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_APP_KEY }}
@@ -94,7 +94,7 @@ jobs:
 
       # ── 3. charliek/apt-charliek (publish dispatch target) ──
       - id: apt-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id:      ${{ secrets.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_APP_KEY }}


### PR DESCRIPTION
## What

Bumps `actions/create-github-app-token@v2` → `@v3` in `release.yaml` (2 refs) and `sanity-check-app.yml` (3 refs). v3.0.0 is the Node 24 release.

## Why

Every workflow run that uses the action currently emits:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/create-github-app-token@v2. Actions will be forced to run with Node.js 24 by default starting June 16th, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

## Compatibility

| v3 release | Relevant change |
|---|---|
| v3.0.0 | feat!: Node 24 support; fix!: `NODE_USE_ENV_PROXY` env var required for proxy support (no-op for us) |
| v3.1.0 | Added `client-id` input (additive; `app-id` still supported) |
| v3.2.0 | Enterprise apps + full-repo-name `repositories` input (short names still work) |

Our usage (`app-id` + scoped `owner` + `repositories` + `permission-contents: write`) is byte-identical between v2 and v3.

## Impact

This PR only touches workflow files. `release.yaml` only fires on tag push, and `sanity-check-app.yml` is `workflow_dispatch: {}` only — so this PR triggers no release. Just the normal CI gate (the repo's `ci.yml` test/lint/release-snapshot jobs).

Coordinated with charliek/cc-plugins#10 (the convention template bump) so the convention and every consumer end up on `@v3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)