### PR TITLE
chore(ci): switch app-id → client-id (resolve create-github-app-token v3 deprecation)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -69,7 +69,7 @@ jobs:
         id: tap
         uses: actions/create-github-app-token@v3
         with:
-          app-id:      ${{ secrets.RELEASE_BOT_APP_ID }}
+          client-id:      ${{ secrets.RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_BOT_APP_KEY }}
           owner:        charliek
           repositories: homebrew-tap
@@ -100,7 +100,7 @@ jobs:
         id: apt
         uses: actions/create-github-app-token@v3
         with:
-          app-id:      ${{ secrets.RELEASE_BOT_APP_ID }}
+          client-id:      ${{ secrets.RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_BOT_APP_KEY }}
           owner:        charliek
           repositories: apt-charliek

--- a/.github/workflows/sanity-check-app.yml
+++ b/.github/workflows/sanity-check-app.yml
@@ -38,7 +38,7 @@ jobs:
       - id: self-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id:      ${{ secrets.RELEASE_BOT_APP_ID }}
+          client-id:      ${{ secrets.RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_BOT_APP_KEY }}
 
       - name: Token sees prox + bot identity
@@ -73,7 +73,7 @@ jobs:
       - id: tap-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id:      ${{ secrets.RELEASE_BOT_APP_ID }}
+          client-id:      ${{ secrets.RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_BOT_APP_KEY }}
           owner:        charliek
           repositories: homebrew-tap
@@ -96,7 +96,7 @@ jobs:
       - id: apt-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id:      ${{ secrets.RELEASE_BOT_APP_ID }}
+          client-id:      ${{ secrets.RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_BOT_APP_KEY }}
           owner:        charliek
           repositories: apt-charliek


### PR DESCRIPTION
## What

Swaps deprecated `app-id` → `client-id` in `release.yaml` (2 refs) and `sanity-check-app.yml` (3 refs). Secret reference `RELEASE_BOT_APP_ID` → `RELEASE_BOT_CLIENT_ID`.

## Why

After the Node 24 sweep, every release prints the `app-id` deprecation warning. Noise reduction.

## Compatibility

`@v3.1.0+` accepts both; `client-id` is recommended. `RELEASE_BOT_APP_ID` left as a safety net.

## Impact

Workflow-only changes; no release fires. Coordinated with cc-plugins#11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)