### PR TITLE
chore(ci): pin goreleaser-action version to '~> v2'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           go-version-file: go.mod
       - uses: goreleaser/goreleaser-action@v7
         with:
-          version: latest
+          version: '~> v2'
           args: release --snapshot --clean --skip=publish,announce,sign
       - name: Validate the deb artifacts
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -82,7 +82,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:
-          version: latest
+          version: '~> v2'
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Pin `goreleaser/goreleaser-action`'s `version:` from `latest` to `'~> v2'` in
both the `ci.yml` release-snapshot job and the `release.yaml` publish job.

## Why

GoReleaser jobs emit: *"You are using 'latest' as default version. Will lock to
'~> v2'."* Pinning explicitly silences the warning and prevents a surprise jump
to a future GoReleaser v3 (which would require config-version 3). `'~> v2'` is
the action's own default, resolves the latest v2.x, and matches
`.goreleaser.yaml`'s `version: 2`. Behavior is unchanged.

Mirrors the matching change in `charliek/codelens` for cross-repo consistency.

## Verification

- The `release-snapshot` job (`ci.yml`) runs GoReleaser on this PR — confirm it
  stays green and the `latest` warning is gone.
- `actionlint` is clean on the changed lines. (It reports a pre-existing
  false-positive on `create-github-app-token@v3`'s `client-id` input due to a
  stale bundled schema — unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)