### PR TITLE
[codex] Document shared proxy daemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A modern process manager for development with an API-first design.
 - **Simple by default** - Procfile-like experience with minimal configuration
 - **API-first** - Full process control and log access via HTTP
 - **Interactive TUI** - Real-time log viewing with filtering and search
+- **HTTP/HTTPS proxy** - Friendly local hostnames with shared multi-project port support
 - **Health checks** - Optional health monitoring for processes
 
 ## Installation
@@ -142,6 +143,29 @@ prox restart <process>           # Restart a process
 prox status                      # Show process status
 prox logs [process]              # Show recent logs
 prox logs -f [process]           # Stream logs
+prox requests                     # Show recent proxy requests
+prox proxy routes                 # Show shared proxy route ownership
+```
+
+## Proxy
+
+Configure `proxy` and `services` to expose local processes through HTTP or HTTPS hostnames. When more than one project uses the same proxy port, prox automatically uses a shared per-user daemon so each project can own distinct hostnames on one port.
+
+```yaml
+proxy:
+  enabled: true
+  https_port: 443
+  domain: local.example.dev
+
+services:
+  app: 3000
+  api: 8000
+```
+
+With another project using the same `https_port`, both can participate on `443` as long as the service hostnames differ. Inspect ownership with:
+
+```bash
+prox proxy routes
 ```
 
 ## HTTP API
@@ -170,7 +194,7 @@ When binding to non-localhost interfaces, authentication is automatically enable
 
 Full documentation is available at [charliek.github.io/prox](https://charliek.github.io/prox/).
 
-See [docs/spec.md](docs/spec.md) for the complete specification including TUI keybindings, API details, and architecture.
+Local docs live under [docs](docs/), including the [CLI reference](docs/reference/cli.md), [configuration reference](docs/reference/configuration.md), [HTTP API reference](docs/reference/api.md), and [architecture notes](docs/development/architecture.md).
 
 ## Development
 

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -4,7 +4,7 @@ This document describes the internal design of prox for contributors.
 
 ## Design Principles
 
-1. **Subscriber-based log output** — Terminal output is a subscriber to the log buffer, not a special case. This enables TUI, API streaming, and future daemon mode without architectural changes.
+1. **Subscriber-based log output** — Terminal output is a subscriber to the log buffer, not a special case. This enables TUI, API streaming, and daemon mode without architectural changes.
 
 2. **API always available** — Even in foreground mode, the HTTP API runs and accepts connections.
 
@@ -87,28 +87,28 @@ This document describes the internal design of prox for contributors.
 
 ## HTTP/HTTPS Reverse Proxy
 
-The optional reverse proxy provides subdomain-based routing to local services over HTTP and/or HTTPS.
+The optional reverse proxy provides hostname-based routing to local services over HTTP and/or HTTPS. In normal operation, projects register their routes with a per-user shared proxy daemon so several projects can use the same port.
 
 ### Proxy Architecture
 
 ```
 ┌──────────────────────────────────────────────────────────────────┐
-│                   HTTP/HTTPS Reverse Proxy                        │
+│                   Shared HTTP/HTTPS Proxy                         │
 │                                                                    │
 │  Browser Request                                                   │
 │  http(s)://app.local.dev:port/api/users                           │
 │         │                                                          │
 │         ▼                                                          │
 │  ┌─────────────────────┐                                          │
-│  │  Subdomain Router   │  Extract "app" from host                 │
+│  │  Hostname Router    │  Match full hostname                     │
 │  │  (extract + lookup) │                                          │
 │  └──────────┬──────────┘                                          │
 │             │                                                      │
 │             ▼                                                      │
 │  ┌─────────────────────┐     ┌─────────────────────┐              │
 │  │   Route Table       │────▶│   Request Manager   │              │
-│  │   app → :3000       │     │   (ring buffer)     │              │
-│  │   api → :8000       │     └─────────────────────┘              │
+│  │ app.local → :3000   │     │   (ring buffer)     │              │
+│  │ api.local → :8000   │     └─────────────────────┘              │
 │  └──────────┬──────────┘                                          │
 │             │                                                      │
 │             ▼                                                      │
@@ -123,19 +123,26 @@ The optional reverse proxy provides subdomain-based routing to local services ov
 
 ```
 internal/proxy/
-├── proxy.go          # Main proxy service, router, request handling
+├── proxy.go          # Standalone proxy service and request handling
 ├── requests.go       # Request manager (ring buffer, subscriptions)
+├── capture.go        # Optional request/response body capture
 ├── certs/
 │   └── certs.go      # mkcert integration for certificate management
-└── hosts/
-    └── hosts.go      # /etc/hosts management
+
+internal/proxyd/
+├── daemon.go         # Shared daemon lifecycle and auto-start
+├── dynamic_proxy.go  # Runtime listener and route management
+├── registry.go       # Project route registry and conflict checks
+├── server.go         # Unix-socket HTTP API for registration/control
+├── client.go         # Client used by project supervisors
+└── certs.go          # Multi-domain certificate management
 ```
 
 ### Request Flow
 
-1. Incoming HTTP or HTTPS request to `*.domain:port`
-2. Extract subdomain from Host header
-3. Look up service in route table
+1. Incoming HTTP or HTTPS request to `hostname:port`
+2. Use the Host header for HTTP or SNI for HTTPS routing
+3. Look up the full hostname in the route table
 4. Forward request via `httputil.ReverseProxy`
 5. Set `X-Forwarded-Proto` based on connection type (HTTP or HTTPS)
 6. Record request in RequestManager
@@ -145,7 +152,7 @@ internal/proxy/
 
 | Component | Technology | Notes |
 |-----------|------------|-------|
-| Language | Go 1.23+ | Concurrency, single binary |
+| Language | Go 1.24+ | Concurrency, single binary |
 | TUI | [bubbletea](https://github.com/charmbracelet/bubbletea) | Elm-architecture TUI framework |
 | TUI styling | [lipgloss](https://github.com/charmbracelet/lipgloss) | Styling for bubbletea |
 | HTTP router | [chi](https://github.com/go-chi/chi) or stdlib | Lightweight, idiomatic |

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -38,6 +38,8 @@ prox/
 │   ├── supervisor/           # Process orchestration
 │   ├── logs/                 # Log buffer, subscriptions
 │   ├── api/                  # HTTP server and handlers
+│   ├── proxy/                # Standalone proxy, request tracking, capture
+│   ├── proxyd/               # Shared proxy daemon
 │   ├── tui/                  # Bubbletea TUI
 │   └── cli/                  # CLI command definitions
 ├── docs/                     # Documentation

--- a/docs/discovery/shared-proxy-across-projects.md
+++ b/docs/discovery/shared-proxy-across-projects.md
@@ -1,5 +1,9 @@
 # Shared Proxy Across Projects
 
+## Status
+
+Implemented in #12 on 2026-04-06 as an auto-started shared proxy daemon. The user-facing guide is [Shared Proxy Across Projects](../guides/shared-proxy.md).
+
 ## Problem Statement
 
 A common usage pattern for prox is running the proxy on well-known ports (443 for HTTPS, 80 for HTTP). Users often have multiple projects on the same machine that each define their own `prox.yaml`, and ideally each project's domains would be served through the same proxy port.
@@ -8,9 +12,22 @@ For example:
 - **Project A** (`~/projects/auth-service/prox.yaml`): `auth.local.stridelabs.ai` on port 443
 - **Project B** (`~/projects/audit-service/prox.yaml`): `audit.local.stridelabs.ai` on port 443
 
-Today, each `prox up` invocation starts its own independent proxy listener. If Project A already owns port 443, Project B's proxy silently fails to bind (see Issue 1: port conflict detection), and its domains are unreachable.
+Before the shared proxy daemon, each `prox up` invocation started its own independent proxy listener. If Project A already owned port 443, Project B could not bind the same port.
 
-## Current Architecture
+## Decision
+
+prox uses Option C: an auto-started daemon on demand.
+
+- `prox up` starts the shared daemon when a proxy is configured and no daemon is running.
+- Each project registers its own service hostnames with the daemon.
+- HTTP routes by Host header. HTTPS routes by SNI.
+- `prox down` deregisters only the current project.
+- The daemon stops automatically when the last project deregisters.
+- `prox proxy status`, `prox proxy routes`, and `prox proxy stop` provide explicit inspection and control.
+
+The daemon is per-user and per-machine. It stores state in `~/.prox/`, while each project's supervisor state remains in that project's `.prox/` directory.
+
+## Previous Architecture
 
 - All state is **per-project scoped**: `.prox/prox.state`, `.prox/prox.pid`, and `.prox/prox.log` live in each project's working directory.
 - Each `prox up` creates its own `proxy.Service` that binds its own HTTP/HTTPS ports.
@@ -29,7 +46,7 @@ Today, each `prox up` invocation starts its own independent proxy listener. If P
 
 A standalone, long-lived proxy process that multiple projects register with.
 
-- `prox proxy start` starts a background proxy daemon that owns port 443/80, stores state in `~/.prox/`.
+- An explicit command such as `prox proxy start` could start a background proxy daemon that owns port 443/80 and stores state in `~/.prox/`.
 - `prox up` in a project detects the running proxy daemon, registers its domains/services via API, deregisters on shutdown.
 - The proxy daemon has its own route table that projects dynamically add to and remove from.
 
@@ -39,7 +56,7 @@ A standalone, long-lived proxy process that multiple projects register with.
 - No "first project owns the port" ambiguity.
 
 **Cons:**
-- Extra thing to manage -- user needs to run `prox proxy start` (or it auto-starts).
+- Extra thing to manage if startup is explicit.
 - Requires a registration API/protocol between project instances and the daemon.
 - Daemon needs its own logging, status, and management commands.
 
@@ -66,7 +83,7 @@ Like Option A, but the daemon auto-starts when the first `prox up` needs a proxy
 - `prox up` checks `~/.prox/proxy.state` -- if no proxy daemon is running, it forks one off as a separate background process.
 - The proxy daemon has its own PID, independent of any project.
 - `prox proxy stop` (or stopping all registered projects) brings it down.
-- `prox proxy start` also available for explicit control.
+- An explicit start command was considered for manual control, but the shipped CLI relies on automatic startup.
 
 **Pros:**
 - No extra manual step for users -- seamless experience.
@@ -78,22 +95,22 @@ Like Option A, but the daemon auto-starts when the first `prox up` needs a proxy
 - Need clear status/stop commands (`prox proxy status`, `prox proxy stop`).
 - Auto-start logic adds complexity.
 
-## Open Design Questions
+## Resolved Design Questions
 
-1. **Opt-in vs default**: Should port sharing be the default behavior, or should projects explicitly opt in (e.g., `proxy: shared: true` in `prox.yaml`)? The default behavior change could surprise existing users.
+| Question | Resolution |
+|----------|------------|
+| Opt-in vs default | Shared proxy behavior is automatic for any project with a configured proxy. There is no `shared` config field. |
+| Domain conflicts | Duplicate `hostname:port` registrations fail. |
+| Certificate management | HTTPS certificates are managed by the shared daemon as routes are registered. |
+| Stale route cleanup | The daemon tracks project PIDs and removes stale registrations for dead processes. |
+| Visibility and debugging | `prox proxy status` and `prox proxy routes` expose daemon state. |
+| Registration protocol | Projects communicate with the daemon over the Unix socket at `~/.prox/proxy.sock`. |
 
-2. **Domain conflicts**: What happens if two projects both try to register the same domain (e.g., both claim `api.local.stridelabs.ai`)? Options: first-come-first-served, error on the second, or last-write-wins.
+## Caveats
 
-3. **Certificate management**: The shared proxy needs certs for all registered domains. Currently certs are per-project. A shared proxy would likely need wildcard certs or dynamic cert generation as routes are added.
-
-4. **Stale route cleanup**: If a project crashes without deregistering, the proxy has a stale route pointing at a dead backend. Options: heartbeat-based expiry, health checking registered backends, or relying on the project's PID liveness.
-
-5. **Visibility and debugging**: How does the user inspect the shared proxy's state? Something like `prox proxy routes` to list all registered domains and which project owns them.
-
-6. **Registration protocol**: Should project instances communicate with the proxy daemon via HTTP API, Unix socket, or filesystem-based coordination (e.g., writing route files to `~/.prox/routes.d/`)?
-
-## Current Recommendation
-
-Option C (auto-start daemon) likely provides the best user experience, but Option A (explicit daemon) is simpler and more predictable. Option B should be avoided due to the fragile ownership model.
-
-Before designing this in detail, Issue 1 (port conflict detection) should be resolved first, as it is a prerequisite -- clear error messages when ports conflict will be needed regardless of which shared-proxy approach is chosen.
+| Caveat | Behavior |
+|--------|----------|
+| Same hostname | A second project cannot take over an existing `hostname:port`; registration fails. |
+| Mixed protocol | A port can be HTTP or HTTPS, not both. |
+| Version mismatch | A project with a different `prox` version cannot join the running daemon. Reset with `prox proxy stop --force`. |
+| Sandboxed state | If `~/.prox/` is unavailable, prox falls back to a standalone per-project proxy without port sharing. |

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -183,7 +183,13 @@ Access your services:
 - `http://app.lvh.me:6788` → `http://localhost:3000` (HTTP mode)
 - `https://app.lvh.me:6789` → `http://localhost:3000` (HTTPS mode)
 
-See the [Local DNS & Certificates](../guides/local-dns.md) guide for custom domains, certificate management, and sharing CAs across machines. See the [Configuration Reference](../reference/configuration.md#proxy-configuration) for full proxy options.
+When several projects configure the same proxy port, prox uses a shared proxy daemon automatically. Each project can register its own hostnames on the same port, including `443`, and keep an independent `prox up` / `prox down` lifecycle.
+
+```bash
+prox proxy routes
+```
+
+See the [Shared Proxy Across Projects](../guides/shared-proxy.md) guide for multi-project routing. See the [Local DNS & Certificates](../guides/local-dns.md) guide for custom domains, certificate management, and sharing CAs across machines. See the [Configuration Reference](../reference/configuration.md#proxy-configuration) for full proxy options.
 
 ## HTTP API
 

--- a/docs/guides/local-dns.md
+++ b/docs/guides/local-dns.md
@@ -34,6 +34,8 @@ With this configuration:
 - `http://app.lvh.me:6788` → `http://localhost:3000`
 - `http://api.lvh.me:6788` → `http://localhost:8000`
 
+For multiple projects on the same port, keep DNS pointed at `127.0.0.1` and give each project distinct service hostnames. prox registers those hostnames with the shared proxy daemon automatically. See [Shared Proxy Across Projects](shared-proxy.md).
+
 If you prefer a custom domain like `local.myapp.dev`, add entries to `/etc/hosts` manually:
 
 ```text

--- a/docs/guides/shared-proxy.md
+++ b/docs/guides/shared-proxy.md
@@ -1,0 +1,103 @@
+# Shared Proxy Across Projects
+
+prox can run one shared proxy daemon per user account so multiple projects can use the same HTTP or HTTPS port. This is most useful for local HTTPS on port 443, where each project should have a stable hostname and no one should remember per-project ports.
+
+The shared daemon is automatic. When `prox up` starts a project with a `proxy` section, prox starts the daemon if needed and registers that project's service hostnames. When `prox down` stops the project, prox deregisters its routes. The daemon stops after the last project leaves.
+
+## Example
+
+Project A can expose auth services:
+
+```yaml
+proxy:
+  enabled: true
+  https_port: 443
+  domain: local.example.dev
+
+services:
+  auth: 3000
+  authapi: 8000
+```
+
+Project B can expose app services on the same port:
+
+```yaml
+proxy:
+  enabled: true
+  https_port: 443
+  domain: local.example.dev
+
+services:
+  app: 5173
+  api: 8002
+```
+
+Start each project from its own directory:
+
+```bash
+cd ~/projects/auth
+prox up -d
+
+cd ~/projects/app
+prox up -d
+```
+
+Both projects now share `:443`:
+
+| URL | Target |
+|-----|--------|
+| `https://auth.local.example.dev` | Project A, `localhost:3000` |
+| `https://authapi.local.example.dev` | Project A, `localhost:8000` |
+| `https://app.local.example.dev` | Project B, `localhost:5173` |
+| `https://api.local.example.dev` | Project B, `localhost:8002` |
+
+Routing uses the full hostname. Projects can share a port when their hostnames are distinct.
+
+## Inspect the Daemon
+
+The shared proxy is normally managed by `prox up` and `prox down`. Use these commands when debugging routing or ownership:
+
+| Command | Description |
+|---------|-------------|
+| `prox proxy status` | Show daemon version, PID, uptime, project count, route count, and listener ports |
+| `prox proxy status --json` | Show daemon status as JSON |
+| `prox proxy routes` | List every registered hostname, protocol, target, project directory, and PID |
+| `prox proxy routes --json` | Show registered routes as JSON |
+| `prox proxy stop` | Stop the daemon only when no projects have active routes |
+| `prox proxy stop --force` | Stop the daemon even when projects still have active routes |
+
+```bash
+prox proxy routes
+```
+
+Example output:
+
+```text
+HOSTNAME                    PORT  PROTOCOL  TARGET          PROJECT              PID
+--------                    ----  --------  ------          -------              ---
+auth.local.example.dev      443   https     localhost:3000  /projects/auth       12345
+app.local.example.dev       443   https     localhost:5173  /projects/app        12391
+```
+
+## Constraints
+
+| Constraint | Behavior |
+|------------|----------|
+| Scope | The daemon is per-user and per-machine. State lives in `~/.prox/`. |
+| Hostname ownership | The same `hostname:port` cannot be registered by two projects. The second registration fails. |
+| Protocol ownership | A listener port is HTTP or HTTPS. Mixing protocols on the same port is rejected. |
+| Version matching | A project can join only when its `prox` version matches the running daemon. Use `prox proxy stop --force` to reset a stale daemon after upgrading. |
+| Fallback | If `~/.prox/` is unavailable, prox runs a standalone per-project proxy. Port sharing is not available in fallback mode. |
+
+## Files
+
+Shared proxy state is stored under `~/.prox/`:
+
+| File | Description |
+|------|-------------|
+| `~/.prox/proxy.sock` | Unix socket used by project processes to register routes |
+| `~/.prox/proxy.pid` | Shared proxy daemon PID |
+| `~/.prox/proxy.state` | Daemon state, including version and address metadata |
+| `~/.prox/proxy.log` | Shared proxy daemon log |
+
+Project supervisor state remains project-local in `.prox/`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,8 @@ A modern process manager for development with an API-first design, enabling both
 - **Simple by default** - Procfile-like experience with minimal YAML configuration
 - **API-first** - Full process control and log access via HTTP, always available
 - **Interactive TUI** - Real-time log viewing with filtering and search
-- **HTTP/HTTPS Proxy** - Subdomain routing with optional locally-trusted certificates
+- **HTTP/HTTPS Proxy** - Friendly local hostnames with optional locally-trusted certificates
+- **Shared proxy daemon** - Multiple projects can use the same local HTTP or HTTPS port
 - **Health checks** - Optional health monitoring for processes
 - **LLM-friendly** - Structured output and filtering to support AI-assisted debugging
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -38,6 +38,10 @@ All errors return JSON:
 | `PROCESS_NOT_RUNNING` | Process is not running |
 | `INVALID_PATTERN` | Invalid regex pattern |
 | `SHUTDOWN_IN_PROGRESS` | Supervisor is shutting down |
+| `PROXY_NOT_ENABLED` | Proxy request inspection is unavailable because the proxy is disabled |
+| `STREAMING_NOT_SUPPORTED` | The server cannot provide an SSE stream for this request |
+| `REQUEST_NOT_FOUND` | Proxy request ID does not exist in the request buffer |
+| `MISSING_REQUEST_ID` | Request detail endpoint was called without an ID |
 
 ## Endpoints
 
@@ -162,11 +166,10 @@ Retrieve logs from buffer.
 |-------|------|---------|-------------|
 | `process` | string | all | Comma-separated process names |
 | `lines` | int | 100 | Max lines to return |
-| `bytes` | int | — | Max bytes to return |
 | `pattern` | string | — | Filter pattern |
 | `regex` | bool | false | Treat pattern as regex |
 
-If both `lines` and `bytes` are specified, whichever limit hits first applies.
+The `lines` parameter is capped at 10000.
 
 **Response:**
 
@@ -189,7 +192,7 @@ If both `lines` and `bytes` are specified, whichever limit hits first applies.
 
 Stream logs via Server-Sent Events (SSE).
 
-**Query Parameters:** Same as `GET /logs` (except `lines` and `bytes`)
+**Query Parameters:** Same as `GET /logs` (except `lines`)
 
 **Response:** SSE stream
 
@@ -255,6 +258,50 @@ curl "http://localhost:5555/api/v1/proxy/requests?subdomain=api"
 curl "http://localhost:5555/api/v1/proxy/requests?min_status=500"
 ```
 
+### GET /proxy/requests/{id}
+
+Retrieve details for one proxied request.
+
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `include` | string | — | Set to `body` to include captured request and response body data |
+
+Body data is available only when capture was enabled with `prox up --capture` or `proxy.capture.enabled: true`.
+
+**Response:**
+
+```json
+{
+  "id": "a1b2c3d",
+  "timestamp": "2025-01-19T10:32:01.123Z",
+  "method": "POST",
+  "url": "/api/users",
+  "subdomain": "api",
+  "status_code": 201,
+  "duration_ms": 45,
+  "remote_addr": "127.0.0.1",
+  "details": {
+    "request_headers": {
+      "Content-Type": ["application/json"]
+    },
+    "request_body": {
+      "size": 27,
+      "truncated": false,
+      "content_type": "application/json",
+      "is_binary": false,
+      "data": "{\"name\":\"Ada\"}"
+    }
+  }
+}
+```
+
+**Examples:**
+
+```bash
+curl http://localhost:5555/api/v1/proxy/requests/a1b2c3d
+curl "http://localhost:5555/api/v1/proxy/requests/a1b2c3d?include=body"
+```
+
 ### GET /proxy/requests/stream
 
 Stream proxy requests via Server-Sent Events (SSE).
@@ -264,8 +311,7 @@ Stream proxy requests via Server-Sent Events (SSE).
 **Response:** SSE stream
 
 ```
-event: connected
-data: {}
+: connected
 
 data: {"id":"a1b2c3d","timestamp":"2025-01-19T10:32:01.123Z","method":"GET","url":"/api/users","subdomain":"api","status_code":200,"duration_ms":45,"remote_addr":"127.0.0.1"}
 ```

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -13,6 +13,8 @@ prox <command> [options]
 | `--config, -c` | Config file path (default: `prox.yaml`) |
 | `--addr` | API address for client commands (auto-discovered from `.prox/prox.state`) |
 | `--detach, -d` | Run in background (daemon mode) |
+| `--verbose, -v` | Enable verbose output |
+| `--version` | Show version information |
 
 ## Commands
 
@@ -32,6 +34,7 @@ prox up [processes...]
 | `--http-port` | Override proxy HTTP port |
 | `--https-port` | Override proxy HTTPS port |
 | `--no-proxy` | Disable proxy even if configured |
+| `--capture` | Enable request/response body capture for proxied requests |
 
 **Examples:**
 
@@ -62,6 +65,9 @@ prox up --http-port 6788
 
 # Start with dual-stack proxy
 prox up --http-port 6788 --https-port 6789
+
+# Enable request/response body capture
+prox up --capture
 ```
 
 **Dynamic Port Allocation:**
@@ -219,10 +225,10 @@ prox restart worker
 
 ### requests
 
-Show or stream proxy requests.
+Show, stream, or inspect proxy requests.
 
 ```bash
-prox requests [options]
+prox requests [id] [options]
 ```
 
 | Flag | Description |
@@ -233,6 +239,7 @@ prox requests [options]
 | `--method` | Filter by HTTP method (GET, POST, etc.) |
 | `--min-status` | Filter by minimum status code (e.g., 400 for errors) |
 | `--json` | Output as JSON |
+| `--body` | Include captured request/response bodies when showing one request by ID |
 
 **Examples:**
 
@@ -254,11 +261,56 @@ prox requests --min-status 400
 
 # JSON output for piping
 prox requests --json | jq .
+
+# Show details for one request
+prox requests abc1234
+
+# Include captured bodies for one request
+prox requests abc1234 --body
 ```
 
 **Request IDs:**
 
 Each request is assigned a short hash ID (7 characters, git-style). These IDs are displayed in the output and can be used to reference specific requests.
+
+Body output requires request capture to be enabled with `prox up --capture` or `proxy.capture.enabled: true`.
+
+### proxy
+
+Inspect and control the shared proxy daemon.
+
+The proxy daemon is normally started and stopped automatically by `prox up` and `prox down`. These commands are for debugging route ownership, checking shared ports, and resetting a stale daemon.
+
+```bash
+prox proxy <command>
+```
+
+| Command | Description |
+|---------|-------------|
+| `prox proxy status` | Show daemon version, PID, uptime, projects, routes, and listener ports |
+| `prox proxy status --json` | Output daemon status as JSON |
+| `prox proxy routes` | List registered routes |
+| `prox proxy routes --json` | Output registered routes as JSON |
+| `prox proxy stop` | Stop the daemon when no active routes are registered |
+| `prox proxy stop --force` | Stop the daemon even with active routes |
+
+**Examples:**
+
+```bash
+# Show daemon status and routes
+prox proxy status
+
+# List route ownership
+prox proxy routes
+
+# Stop only when no projects are registered
+prox proxy stop
+
+# Reset a stale daemon after upgrading prox
+prox proxy stop --force
+```
+
+See the [Shared Proxy Across Projects](../guides/shared-proxy.md) guide for multi-project behavior and constraints.
 
 ### version
 
@@ -276,4 +328,12 @@ Show help for any command.
 prox help
 prox help up
 prox help logs
+```
+
+### completion
+
+Generate shell completion scripts.
+
+```bash
+prox completion [bash|zsh|fish|powershell]
 ```

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -217,6 +217,21 @@ certs:
 | `proxy.http_port` | int | — | Port for the HTTP proxy server |
 | `proxy.https_port` | int | `6789` | Port for the HTTPS proxy server (default when enabled with no ports set) |
 | `proxy.domain` | string | required | Base domain for subdomain routing |
+| `proxy.capture.enabled` | bool | `false` | Capture request and response body metadata for proxied requests |
+| `proxy.capture.max_body_size` | string | `1MB` | Maximum request or response body size to capture |
+
+### Shared Proxy Daemon
+
+When a proxy is configured, prox registers routes with a per-user shared proxy daemon under `~/.prox/`. This lets multiple projects use the same proxy port, including HTTPS on `443`, as long as each project owns distinct hostnames.
+
+The behavior is automatic:
+
+- `prox up` starts the daemon if needed and registers this project's services.
+- `prox down` deregisters only this project.
+- The daemon stops after the last project deregisters.
+- `prox proxy status` and `prox proxy routes` show daemon state.
+
+See the [Shared Proxy Across Projects](../guides/shared-proxy.md) guide for examples and constraints.
 
 ### Service Fields
 
@@ -242,6 +257,21 @@ services:
 |-------|------|---------|-------------|
 | `certs.dir` | string | `~/.prox/certs` | Directory for storing certificates |
 | `certs.auto_generate` | bool | `true` | Automatically generate certificates using mkcert |
+
+### Request Capture
+
+Request capture records request and response body metadata for the `prox requests <id>` detail view. Bodies up to `proxy.capture.max_body_size` are retained; larger bodies are truncated.
+
+```yaml
+proxy:
+  https_port: 6789
+  domain: local.myapp.dev
+  capture:
+    enabled: true
+    max_body_size: 1MB
+```
+
+Captured body files are stored under `.prox/capture/` and cleaned up as request records age out of the in-memory request buffer.
 
 ### Prerequisites (HTTPS only)
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -216,7 +216,7 @@ certs:
 | `proxy.enabled` | bool | auto | Enable reverse proxy (auto-enabled when a port is set) |
 | `proxy.http_port` | int | — | Port for the HTTP proxy server |
 | `proxy.https_port` | int | `6789` | Port for the HTTPS proxy server (default when enabled with no ports set) |
-| `proxy.domain` | string | required | Base domain for subdomain routing |
+| `proxy.domain` | string | required | Base domain used to derive hostnames for shared proxy routing |
 | `proxy.capture.enabled` | bool | `false` | Capture request and response body metadata for proxied requests |
 | `proxy.capture.max_body_size` | string | `1MB` | Maximum request or response body size to capture |
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,6 +92,8 @@ nav:
       - Quick Start: getting-started/quick-start.md
   - Guides:
       - Local DNS & Certificates: guides/local-dns.md
+      - Shared Proxy Across Projects: guides/shared-proxy.md
+      - Discovery: discovery/shared-proxy-across-projects.md
   - Reference:
       - CLI: reference/cli.md
       - Configuration: reference/configuration.md

--- a/skills/prox/SKILL.md
+++ b/skills/prox/SKILL.md
@@ -5,7 +5,7 @@ description: "Use when a prox.yaml file exists in the project root, or the user 
 
 # Prox Process Manager
 
-prox is a process manager for local development written in Go. It provides process supervision with automatic restarts, real-time log aggregation, an HTTP/HTTPS reverse proxy with subdomain routing, an interactive TUI, and a background daemon mode with a REST API. A shared proxy daemon lets multiple projects serve their domains through the same proxy port.
+prox is a process manager for local development written in Go. It provides process supervision with automatic restarts, real-time log aggregation, an HTTP/HTTPS reverse proxy with local hostname routing, an interactive TUI, and a background daemon mode with a REST API. A shared proxy daemon lets multiple projects serve their domains through the same proxy port.
 
 ## First Step: Read prox.yaml
 
@@ -73,7 +73,7 @@ How to reach services depends on whether the proxy is configured in prox.yaml.
 
 ### With proxy enabled
 
-Read the `proxy` and `services` sections of prox.yaml. Services are accessible via subdomain routing:
+Read the `proxy` and `services` sections of prox.yaml. Services are accessible via local hostname routing:
 
 ```text
 http://<service>.<domain>:<http_port>/path


### PR DESCRIPTION
## Summary

- document the shared multi-project proxy daemon across the guide, reference, README, and skill docs
- mark the shared-proxy discovery note as implemented and describe the shipped behavior/caveats
- audit adjacent CLI, config, API, and architecture docs for stale command and request-inspection details

Closes #27.

## Validation

- env UV_CACHE_DIR=/tmp/prox-uv-cache uv run mkdocs build --strict
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared local HTTP/HTTPS proxy daemon support so multiple projects can reuse the same local port using friendly hostname-based routing.
  * Added/expanded request capture support and proxy inspection tooling (status/routes/stop) plus new CLI options (e.g., body viewing with capture).
* **Documentation**
  * Updated guides and references for shared-proxy behavior, hostname/SNI routing, multi-project setup, and proxy operational caveats.
  * Expanded API and CLI docs (including new proxy request detail endpoint, revised logs query parameters, and updated shell completion info).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->