### PR TITLE
fix(supervisor): reload env_file on restart and never orphan grandchildren (#29)

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -264,6 +264,13 @@ func writeError(w http.ResponseWriter, err error) {
 		status = http.StatusInternalServerError
 		code = domain.ErrCodeEnvReloadFailed
 		message = err.Error()
+	case errors.Is(err, domain.ErrProcessGroupNotReaped):
+		// Surface the process name/detail so `prox stop`/`restart` report which
+		// process's group could not be terminated (systemd/docker-style loud
+		// failure). Non-sensitive: it's the user's own process name.
+		status = http.StatusInternalServerError
+		code = domain.ErrCodeProcessGroupNotReaped
+		message = err.Error()
 	default:
 		// For unknown errors, log the actual error but return a sanitized message
 		// to avoid leaking internal paths or sensitive information

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -258,6 +258,12 @@ func writeError(w http.ResponseWriter, err error) {
 		status = http.StatusServiceUnavailable
 		code = domain.ErrCodeShutdownInProgress
 		message = err.Error()
+	case errors.Is(err, domain.ErrEnvReloadFailed):
+		// The detail (e.g. which env_file failed to load) is the user's own
+		// config path, not sensitive, so it's safe to surface directly.
+		status = http.StatusInternalServerError
+		code = domain.ErrCodeEnvReloadFailed
+		message = err.Error()
 	default:
 		// For unknown errors, log the actual error but return a sanitized message
 		// to avoid leaking internal paths or sensitive information

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -31,6 +31,14 @@ const (
 
 	// DefaultShutdownTimeout is the default timeout for graceful shutdown
 	DefaultShutdownTimeout = 10 * time.Second
+
+	// KillGrace is the window reserved at the tail of a process's shutdown
+	// budget for the SIGKILL escalation and post-kill group-liveness
+	// verification. It is carved out of ShutdownTimeout: the graceful (SIGTERM)
+	// phase runs until (deadline - KillGrace), after which the group is
+	// SIGKILLed and given up to KillGrace more to disappear before Stop reports
+	// the group could not be reaped.
+	KillGrace = 2 * time.Second
 )
 
 // Log configuration

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -12,6 +12,7 @@ var (
 	ErrConfigNotFound        = errors.New("config file not found")
 	ErrInvalidConfig         = errors.New("invalid configuration")
 	ErrEnvReloadFailed       = errors.New("environment reload failed")
+	ErrProcessGroupNotReaped = errors.New("process group could not be terminated")
 )
 
 // Error codes for API responses
@@ -22,6 +23,7 @@ const (
 	ErrCodeInvalidPattern        = "INVALID_PATTERN"
 	ErrCodeShutdownInProgress    = "SHUTDOWN_IN_PROGRESS"
 	ErrCodeEnvReloadFailed       = "ENV_RELOAD_FAILED"
+	ErrCodeProcessGroupNotReaped = "PROCESS_GROUP_NOT_REAPED"
 
 	// Proxy-related error codes (API-only, no sentinel errors as they
 	// are only used for HTTP response formatting in the API layer)
@@ -46,6 +48,8 @@ func ErrorCode(err error) string {
 		return ErrCodeShutdownInProgress
 	case errors.Is(err, ErrEnvReloadFailed):
 		return ErrCodeEnvReloadFailed
+	case errors.Is(err, ErrProcessGroupNotReaped):
+		return ErrCodeProcessGroupNotReaped
 	default:
 		return "INTERNAL_ERROR"
 	}

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -11,6 +11,7 @@ var (
 	ErrShutdownInProgress    = errors.New("shutdown in progress")
 	ErrConfigNotFound        = errors.New("config file not found")
 	ErrInvalidConfig         = errors.New("invalid configuration")
+	ErrEnvReloadFailed       = errors.New("environment reload failed")
 )
 
 // Error codes for API responses
@@ -20,6 +21,7 @@ const (
 	ErrCodeProcessNotRunning     = "PROCESS_NOT_RUNNING"
 	ErrCodeInvalidPattern        = "INVALID_PATTERN"
 	ErrCodeShutdownInProgress    = "SHUTDOWN_IN_PROGRESS"
+	ErrCodeEnvReloadFailed       = "ENV_RELOAD_FAILED"
 
 	// Proxy-related error codes (API-only, no sentinel errors as they
 	// are only used for HTTP response formatting in the API layer)
@@ -42,6 +44,8 @@ func ErrorCode(err error) string {
 		return ErrCodeInvalidPattern
 	case errors.Is(err, ErrShutdownInProgress):
 		return ErrCodeShutdownInProgress
+	case errors.Is(err, ErrEnvReloadFailed):
+		return ErrCodeEnvReloadFailed
 	default:
 		return "INTERNAL_ERROR"
 	}

--- a/internal/domain/errors_test.go
+++ b/internal/domain/errors_test.go
@@ -19,6 +19,7 @@ func TestErrorCode(t *testing.T) {
 		{"invalid pattern", ErrInvalidPattern, ErrCodeInvalidPattern},
 		{"shutdown in progress", ErrShutdownInProgress, ErrCodeShutdownInProgress},
 		{"env reload failed", ErrEnvReloadFailed, ErrCodeEnvReloadFailed},
+		{"process group not reaped", ErrProcessGroupNotReaped, ErrCodeProcessGroupNotReaped},
 		{"unknown error", errors.New("some error"), "INTERNAL_ERROR"},
 	}
 	for _, tt := range tests {

--- a/internal/domain/errors_test.go
+++ b/internal/domain/errors_test.go
@@ -18,6 +18,7 @@ func TestErrorCode(t *testing.T) {
 		{"process not running", ErrProcessNotRunning, ErrCodeProcessNotRunning},
 		{"invalid pattern", ErrInvalidPattern, ErrCodeInvalidPattern},
 		{"shutdown in progress", ErrShutdownInProgress, ErrCodeShutdownInProgress},
+		{"env reload failed", ErrEnvReloadFailed, ErrCodeEnvReloadFailed},
 		{"unknown error", errors.New("some error"), "INTERNAL_ERROR"},
 	}
 	for _, tt := range tests {

--- a/internal/supervisor/fake_runner_test.go
+++ b/internal/supervisor/fake_runner_test.go
@@ -1,0 +1,218 @@
+package supervisor
+
+import (
+	"context"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/charliek/prox/internal/domain"
+)
+
+// fakeProcess is a fully controllable Process for deterministic supervisor
+// tests. It decouples three things that are entangled in a real process so a
+// test can drive each independently:
+//
+//   - leader liveness: Wait() blocks until the "leader" exits (exitLeader).
+//   - group liveness: GroupAlive() reports the alive flag, independent of the
+//     leader -- modelling a grandchild that can outlive the leader.
+//   - signals: every Signal is recorded (value + timestamp + order) and an
+//     optional onSignal hook lets the test react (e.g. die on SIGTERM/SIGKILL).
+//
+// This lets a single type simulate: (a) a group that dies gracefully on
+// SIGTERM, (b) a stubborn group that ignores SIGTERM but dies on SIGKILL, and
+// (c) an unreapable group whose leader dies but whose group never does.
+type fakeProcess struct {
+	pid int
+
+	mu         sync.Mutex
+	alive      bool
+	aliveErr   error
+	signals    []sigRecord
+	waitCh     chan struct{}
+	waitClosed bool
+	waitErr    error
+
+	// onSignal, when set, is invoked (synchronously, outside fp.mu) for every
+	// signal received so the test can drive liveness/leader-exit in response.
+	onSignal func(fp *fakeProcess, sig os.Signal)
+
+	stdout io.Reader
+	stderr io.Reader
+}
+
+type sigRecord struct {
+	sig os.Signal
+	at  time.Time
+}
+
+// newFakeProcess returns a fake that starts alive with an open (blocking)
+// Wait() and empty output streams.
+func newFakeProcess(pid int) *fakeProcess {
+	return &fakeProcess{
+		pid:    pid,
+		alive:  true,
+		waitCh: make(chan struct{}),
+		stdout: strings.NewReader(""),
+		stderr: strings.NewReader(""),
+	}
+}
+
+func (fp *fakeProcess) PID() int { return fp.pid }
+
+func (fp *fakeProcess) Wait() error {
+	<-fp.waitCh
+	fp.mu.Lock()
+	defer fp.mu.Unlock()
+	return fp.waitErr
+}
+
+func (fp *fakeProcess) Signal(sig os.Signal) error {
+	fp.mu.Lock()
+	fp.signals = append(fp.signals, sigRecord{sig: sig, at: time.Now()})
+	cb := fp.onSignal
+	fp.mu.Unlock()
+	if cb != nil {
+		cb(fp, sig)
+	}
+	return nil
+}
+
+func (fp *fakeProcess) GroupAlive() (bool, error) {
+	fp.mu.Lock()
+	defer fp.mu.Unlock()
+	return fp.alive, fp.aliveErr
+}
+
+func (fp *fakeProcess) Stdout() io.Reader { return fp.stdout }
+func (fp *fakeProcess) Stderr() io.Reader { return fp.stderr }
+
+// setAlive sets the group liveness flag reported by GroupAlive.
+func (fp *fakeProcess) setAlive(a bool) {
+	fp.mu.Lock()
+	fp.alive = a
+	fp.mu.Unlock()
+}
+
+// exitLeader makes Wait() return (once) with err, modelling the leader process
+// being reaped. It does not by itself change group liveness.
+func (fp *fakeProcess) exitLeader(err error) {
+	fp.mu.Lock()
+	defer fp.mu.Unlock()
+	if !fp.waitClosed {
+		fp.waitErr = err
+		fp.waitClosed = true
+		close(fp.waitCh)
+	}
+}
+
+// signalsReceived returns a copy of the signals recorded so far.
+func (fp *fakeProcess) signalsReceived() []sigRecord {
+	fp.mu.Lock()
+	defer fp.mu.Unlock()
+	out := make([]sigRecord, len(fp.signals))
+	copy(out, fp.signals)
+	return out
+}
+
+// sawSignal reports whether the given signal was ever received.
+func (fp *fakeProcess) sawSignal(sig os.Signal) bool {
+	for _, r := range fp.signalsReceived() {
+		if r.sig == sig {
+			return true
+		}
+	}
+	return false
+}
+
+// --- behaviour constructors -------------------------------------------------
+
+// gracefulOnTerm makes the group die synchronously on SIGTERM: liveness flips
+// false and the leader exits, all within the Signal call, so Stop's very next
+// GroupAlive probe observes the group gone (no SIGKILL needed).
+func gracefulOnTerm(fp *fakeProcess, sig os.Signal) {
+	if sig == sigterm {
+		fp.setAlive(false)
+		fp.exitLeader(nil)
+	}
+}
+
+// stubbornOnKill ignores SIGTERM and dies synchronously on SIGKILL.
+func stubbornOnKill(fp *fakeProcess, sig os.Signal) {
+	if sig == sigkill {
+		fp.setAlive(false)
+		fp.exitLeader(nil)
+	}
+}
+
+// unreapableOnKill models a surviving grandchild: the leader exits on SIGKILL
+// (so monitor finishes and done closes promptly) but group liveness never
+// flips false, so GroupAlive stays true forever.
+func unreapableOnKill(fp *fakeProcess, sig os.Signal) {
+	if sig == sigkill {
+		fp.exitLeader(nil)
+	}
+}
+
+// newGracefulFake / newStubbornFake / newUnreapableFake are convenience
+// wrappers for the three canonical behaviours.
+func newGracefulFake(pid int) *fakeProcess {
+	fp := newFakeProcess(pid)
+	fp.onSignal = gracefulOnTerm
+	return fp
+}
+
+func newStubbornFake(pid int) *fakeProcess {
+	fp := newFakeProcess(pid)
+	fp.onSignal = stubbornOnKill
+	return fp
+}
+
+func newUnreapableFake(pid int) *fakeProcess {
+	fp := newFakeProcess(pid)
+	fp.onSignal = unreapableOnKill
+	return fp
+}
+
+// fakeRunner is a ProcessRunner that hands out fakeProcess instances produced
+// by factory, one per Start call (call index passed in). It records every
+// process it produced.
+type fakeRunner struct {
+	mu      sync.Mutex
+	factory func(call int) *fakeProcess
+	procs   []*fakeProcess
+	calls   int
+}
+
+func newFakeRunner(factory func(call int) *fakeProcess) *fakeRunner {
+	return &fakeRunner{factory: factory}
+}
+
+func (r *fakeRunner) Start(ctx context.Context, config domain.ProcessConfig, env map[string]string) (Process, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	call := r.calls
+	r.calls++
+	fp := r.factory(call)
+	r.procs = append(r.procs, fp)
+	return fp, nil
+}
+
+// last returns the most recently produced fake process.
+func (r *fakeRunner) last() *fakeProcess {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.procs) == 0 {
+		return nil
+	}
+	return r.procs[len(r.procs)-1]
+}
+
+// count returns how many processes the runner has produced.
+func (r *fakeRunner) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.procs)
+}

--- a/internal/supervisor/process.go
+++ b/internal/supervisor/process.go
@@ -452,11 +452,12 @@ func (p *ManagedProcess) monitor(inst *processInstance) {
 		close(outputDone)
 	}()
 
+	drainTimedOut := false
 	select {
 	case <-outputDone:
 		// Output readers finished normally
 	case <-time.After(outputDrainTimeout):
-		p.logf(domain.StreamStderr, "output capture timed out (some logs may be missing)")
+		drainTimedOut = true
 	}
 
 	exitCode := exitCodeFromWaitErr(err)
@@ -464,8 +465,12 @@ func (p *ManagedProcess) monitor(inst *processInstance) {
 	p.mu.Lock()
 	// Generation guard: a stale monitor -- one whose instance has already been
 	// replaced by a newer Start -- must touch nothing shared and emit no
-	// (misleading) exit log. It only closes its own done below.
+	// (misleading) logs (drain-timeout notice or exit code) attributed to a run
+	// that is no longer current. It only closes its own done below.
 	if p.current == inst {
+		if drainTimedOut {
+			p.logf(domain.StreamStderr, "output capture timed out (some logs may be missing)")
+		}
 		switch p.state {
 		case domain.ProcessStateStopping:
 			// Stop owns the transition to stopped; here we only record the exit

--- a/internal/supervisor/process.go
+++ b/internal/supervisor/process.go
@@ -19,6 +19,29 @@ import (
 // final writes before we stop reading.
 const outputDrainTimeout = 5 * time.Second
 
+// groupPollInterval is how often Stop probes the process group's liveness
+// while waiting for a graceful (SIGTERM) or forced (SIGKILL) shutdown.
+const groupPollInterval = 100 * time.Millisecond
+
+// processInstance represents a single run of a managed process. Every Start
+// creates a fresh instance; ManagedProcess.current points at the live (or
+// most-recent) one. Keeping per-run state on an instance -- rather than flat
+// fields on ManagedProcess -- lets a stale monitor from a previous run close
+// only its own done channel and never clobber a newer run's state (see the
+// generation guard in monitor and the finalization gate in Stop).
+type processInstance struct {
+	proc     Process
+	done     chan struct{}
+	doneOnce sync.Once
+	cancel   context.CancelFunc
+	outputWg sync.WaitGroup
+}
+
+// closeDone closes the instance's done channel exactly once.
+func (i *processInstance) closeDone() {
+	i.doneOnce.Do(func() { close(i.done) })
+}
+
 // ManagedProcess handles the lifecycle of a single process
 type ManagedProcess struct {
 	mu sync.RWMutex
@@ -35,22 +58,25 @@ type ManagedProcess struct {
 	loadEnv func() (map[string]string, error)
 
 	state        domain.ProcessState
-	process      Process
 	startedAt    time.Time
 	restartCount int
 
-	// Health checker
+	// current is the live (or most-recent) run of this process. It is retained
+	// even after the run stops/crashes so a surviving process group stays
+	// reapable by a later Stop and so Info can report the last PID.
+	//
+	// Invariant: a non-nil current always has a non-nil proc (a failed
+	// runner.Start is never published as current).
+	current *processInstance
+
+	// Health checker for the current run.
 	healthChecker *HealthChecker
 
-	// Context for the current process instance
-	cancel context.CancelFunc
-
-	// Channel to signal when process exits
-	done     chan struct{}
-	doneOnce sync.Once // Ensures done channel is closed only once
-
-	// outputWg tracks completion of output reader goroutines
-	outputWg sync.WaitGroup
+	// shutdownTimeout overrides constants.DefaultShutdownTimeout for the
+	// no-context-deadline fallback in computeDeadlines. It is a test seam only
+	// (kept small so the no-deadline escalation path runs fast); production
+	// code leaves it zero, which means "use constants.DefaultShutdownTimeout".
+	shutdownTimeout time.Duration
 }
 
 // NewManagedProcess creates a new managed process
@@ -61,7 +87,6 @@ func NewManagedProcess(config domain.ProcessConfig, env map[string]string, runne
 		runner:     runner,
 		logManager: logManager,
 		state:      domain.ProcessStateStopped,
-		done:       make(chan struct{}),
 	}
 }
 
@@ -89,8 +114,10 @@ func (p *ManagedProcess) Info() domain.ProcessInfo {
 		Env:          p.env,
 	}
 
-	if p.process != nil {
-		info.PID = p.process.PID()
+	// PID is only meaningful while the process is active. Once stopped or
+	// crashed we report 0 even though current is retained for reap/retry.
+	if !p.state.IsStopped() && p.current != nil && p.current.proc != nil {
+		info.PID = p.current.proc.PID()
 	}
 
 	if !p.startedAt.IsZero() {
@@ -119,58 +146,70 @@ func (p *ManagedProcess) Start(ctx context.Context) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	if p.state == domain.ProcessStateRunning || p.state == domain.ProcessStateStarting {
+	// Reject starting over an active run. `stopping` is included so a Start
+	// racing an in-flight Stop is refused rather than launching a duplicate
+	// while the previous group is still being reaped.
+	if p.state == domain.ProcessStateRunning ||
+		p.state == domain.ProcessStateStarting ||
+		p.state == domain.ProcessStateStopping {
 		return domain.ErrProcessAlreadyRunning
 	}
 
 	// Reload the environment from disk on every Start (covers both `start`
 	// after `stop` and the replacement half of `restart`). This must happen
-	// before any of the done/doneOnce/cancel state is mutated so a failure
-	// here leaves no dangling channel behind.
+	// before any per-instance state is created so a failure here leaves no
+	// dangling instance behind.
 	if p.loadEnv != nil {
 		env, err := p.loadEnv()
 		if err != nil {
 			p.state = domain.ProcessStateCrashed
-			p.logManager.Write(domain.LogEntry{
-				Timestamp: time.Now(),
-				Process:   p.config.Name,
-				Stream:    domain.StreamStderr,
-				Line:      fmt.Sprintf("failed to reload environment: %v", err),
-			})
+			p.logf(domain.StreamStderr, "failed to reload environment: %v", err)
 			return fmt.Errorf("%w: %v", domain.ErrEnvReloadFailed, err)
 		}
 		p.env = env
 	}
 
+	// Never launch a duplicate over a surviving previous group. If the prior
+	// run's group is still alive (e.g. a prior Stop failed to reap it), refuse
+	// rather than orphan it -- the caller must stop it first.
+	if p.current != nil && p.current.proc != nil {
+		if alive, _ := p.current.proc.GroupAlive(); alive {
+			return fmt.Errorf("%w: %s (previous instance still running; stop it first)",
+				domain.ErrProcessGroupNotReaped, p.config.Name)
+		}
+	}
+
 	p.state = domain.ProcessStateStarting
 
-	// Create a new context for this process instance
+	// Build a fresh instance for this run.
+	inst := &processInstance{done: make(chan struct{})}
 	processCtx, cancel := context.WithCancel(ctx)
-	p.cancel = cancel
-	p.done = make(chan struct{})
-	p.doneOnce = sync.Once{} // Reset for new process instance
+	inst.cancel = cancel
 
-	// Start the process
 	proc, err := p.runner.Start(processCtx, p.config, p.env)
 	if err != nil {
 		p.state = domain.ProcessStateCrashed
-		p.cancel = nil
-		p.closeDone()
+		inst.cancel()
+		inst.closeDone()
+		// Do not publish the failed instance: p.current is left unchanged (the
+		// prior dead instance, or nil), preserving the "non-nil current => non-nil
+		// proc" invariant.
 		return err
 	}
 
-	p.process = proc
+	inst.proc = proc
+	p.current = inst
 	p.startedAt = time.Now()
 	p.state = domain.ProcessStateRunning
 
-	// Start output readers with WaitGroup tracking
-	p.outputWg.Add(2)
+	// Start output readers, tracked on this instance's WaitGroup.
+	inst.outputWg.Add(2)
 	go func() {
-		defer p.outputWg.Done()
+		defer inst.outputWg.Done()
 		p.readOutput(proc.Stdout(), domain.StreamStdout)
 	}()
 	go func() {
-		defer p.outputWg.Done()
+		defer inst.outputWg.Done()
 		p.readOutput(proc.Stderr(), domain.StreamStderr)
 	}()
 
@@ -180,26 +219,89 @@ func (p *ManagedProcess) Start(ctx context.Context) error {
 		p.healthChecker.Start(processCtx)
 	}
 
-	// Monitor the process
-	go p.monitor()
+	// Monitor this specific instance.
+	go p.monitor(inst)
 
 	return nil
 }
 
-// Stop stops the process gracefully
+// computeDeadlines derives the graceful (SIGTERM) and kill (SIGKILL/verify)
+// deadlines for a Stop from the caller's context.
+//
+//   - If ctx has no deadline, a fallback of shutdownTimeout (or
+//     constants.DefaultShutdownTimeout when unset) is used.
+//   - KillGrace is reserved at the tail for the SIGKILL phase, so the graceful
+//     phase ends at (deadline - KillGrace).
+//   - If the budget is already spent (remaining <= 0) or too small to reserve
+//     the kill grace (remaining <= KillGrace), the graceful deadline is "now"
+//     and Stop escalates immediately.
+//   - killDeadline is always gracefulDeadline + KillGrace. The SIGKILL phase
+//     times against killDeadline (its own timer, not ctx) so a near-expired ctx
+//     cannot cut the kill/verify short.
+func (p *ManagedProcess) computeDeadlines(ctx context.Context) (gracefulDeadline, killDeadline time.Time) {
+	now := time.Now()
+
+	dl, ok := ctx.Deadline()
+	if !ok {
+		timeout := p.shutdownTimeout
+		if timeout <= 0 {
+			timeout = constants.DefaultShutdownTimeout
+		}
+		dl = now.Add(timeout)
+	}
+
+	// If the budget is already spent (remaining <= 0) or too small to reserve
+	// the kill grace (remaining <= KillGrace), escalate immediately -- the
+	// former is a subset of the latter since KillGrace is positive.
+	if remaining := time.Until(dl); remaining <= constants.KillGrace {
+		gracefulDeadline = now
+	} else {
+		gracefulDeadline = dl.Add(-constants.KillGrace)
+	}
+	killDeadline = gracefulDeadline.Add(constants.KillGrace)
+	return gracefulDeadline, killDeadline
+}
+
+// Stop stops the process gracefully, escalating to SIGKILL if the group does
+// not exit within the graceful window, and reports an error only if the group
+// truly survives. See design doc D3.
 func (p *ManagedProcess) Stop(ctx context.Context) error {
 	p.mu.Lock()
 
-	if p.state == domain.ProcessStateStopped || p.state == domain.ProcessStateCrashed {
+	switch p.state {
+	case domain.ProcessStateStopped, domain.ProcessStateCrashed:
+		// Nothing running, unless a group survived a prior stop / unexpected
+		// leader exit -- in which case fall through and reap it (retry path).
+		if p.current == nil || p.current.proc == nil {
+			p.mu.Unlock()
+			return domain.ErrProcessNotRunning
+		}
+		if alive, _ := p.current.proc.GroupAlive(); !alive {
+			p.mu.Unlock()
+			return domain.ErrProcessNotRunning
+		}
+		// Surviving group: fall through to reap it.
+	case domain.ProcessStateStopping:
+		// A stop is already in flight; wait for it (or ctx) on the in-flight
+		// run's done channel.
+		//
+		// Known limitation: inst.done closing means the run's monitor finished
+		// (leader reaped), not that the PRIMARY Stop finished its group polling
+		// and verdict. So a concurrent secondary Stop can return nil slightly
+		// before the primary's verdict, and -- only in the doubly-rare case of
+		// two concurrent Stops on the same process AND a genuinely unreapable
+		// group -- can report success while the primary returns
+		// ErrProcessGroupNotReaped. The common (killable) case is consistent:
+		// both return nil. Serializing concurrent same-process stops (or
+		// propagating the primary's result to waiters) is tracked as future
+		// work; the primary always reaps/reports correctly.
+		inst := p.current
 		p.mu.Unlock()
-		return domain.ErrProcessNotRunning
-	}
-
-	if p.state == domain.ProcessStateStopping {
-		p.mu.Unlock()
-		// Wait for existing stop to complete
+		if inst == nil {
+			return nil
+		}
 		select {
-		case <-p.done:
+		case <-inst.done:
 			return nil
 		case <-ctx.Done():
 			return ctx.Err()
@@ -207,66 +309,106 @@ func (p *ManagedProcess) Stop(ctx context.Context) error {
 	}
 
 	p.state = domain.ProcessStateStopping
-	proc := p.process
-	cancel := p.cancel
-	done := p.done
+	inst := p.current
 	healthChecker := p.healthChecker
 	p.healthChecker = nil
 	p.mu.Unlock()
 
-	// Stop health checker if running
+	// Stop the health checker for this run.
 	if healthChecker != nil {
 		healthChecker.Stop()
 	}
 
-	if proc == nil {
+	if inst == nil || inst.proc == nil {
+		p.mu.Lock()
+		p.state = domain.ProcessStateStopped
+		p.mu.Unlock()
 		return nil
 	}
 
-	// Send SIGTERM
-	if err := proc.Signal(sigterm); err != nil {
-		// Log the error - process might already be dead, but this is useful for debugging
-		p.logManager.Write(domain.LogEntry{
-			Timestamp: time.Now(),
-			Process:   p.config.Name,
-			Stream:    domain.StreamStderr,
-			Line:      "SIGTERM failed (process may have already exited): " + err.Error(),
-		})
+	gracefulDeadline, killDeadline := p.computeDeadlines(ctx)
+
+	// Send SIGTERM to the whole group.
+	if err := inst.proc.Signal(sigterm); err != nil {
+		p.logf(domain.StreamStderr, "SIGTERM failed (process may have already exited): %v", err)
 	}
 
-	// Wait for graceful shutdown or timeout
-	select {
-	case <-done:
-		// Process exited
-	case <-ctx.Done():
-		// Timeout - send SIGKILL
+	// Graceful phase: poll group liveness until it is gone or the graceful
+	// deadline passes. Escalation is purely time-based -- we deliberately do
+	// NOT key off done/output-drain, so a slow-but-graceful grandchild that
+	// takes longer than the poll interval is not killed early.
+	gone := waitGroupGone(inst.proc, gracefulDeadline)
+
+	// Escalation: if still alive at the graceful deadline, SIGKILL the group
+	// and poll again until it is gone or the kill deadline passes.
+	if !gone {
 		p.logManager.Write(domain.LogEntry{
 			Timestamp: time.Now(),
 			Process:   "system",
 			Stream:    domain.StreamStdout,
 			Line:      fmt.Sprintf("sending SIGKILL to %s (graceful shutdown timed out)", p.config.Name),
 		})
-		if err := proc.Signal(sigkill); err != nil {
-			p.logManager.Write(domain.LogEntry{
-				Timestamp: time.Now(),
-				Process:   p.config.Name,
-				Stream:    domain.StreamStderr,
-				Line:      "SIGKILL failed: " + err.Error(),
-			})
+		if err := inst.proc.Signal(sigkill); err != nil {
+			p.logf(domain.StreamStderr, "SIGKILL failed: %v", err)
 		}
-		// Wait a bit for SIGKILL
-		select {
-		case <-done:
-		case <-time.After(time.Second):
-		}
+		// Poll until the group is gone or the kill deadline passes. The return
+		// value is intentionally discarded: the authoritative verdict below
+		// re-probes after the finalization gate has reaped the leader (a zombie
+		// leader keeps the group "alive" until reaped). This call exists for its
+		// bounded wait, giving the group time to disappear after SIGKILL.
+		waitGroupGone(inst.proc, killDeadline)
 	}
 
-	// Cancel context to clean up
-	if cancel != nil {
-		cancel()
+	// Finalization gate (fixes the restart-clobber race): wait for this run's
+	// monitor to finish its critical section and reap the leader before any
+	// replacement can start. The cap is a safety net; after SIGKILL the leader
+	// is dead and done closes promptly.
+	select {
+	case <-inst.done:
+	case <-time.After(outputDrainTimeout + time.Second):
 	}
 
+	// Verdict: a fresh probe now that the leader has been reaped is
+	// authoritative.
+	alive, _ := inst.proc.GroupAlive()
+
+	p.mu.Lock()
+	if p.current == inst {
+		if alive {
+			// Group survived: keep current so a later stop/restart can retry.
+			p.state = domain.ProcessStateCrashed
+		} else {
+			p.state = domain.ProcessStateStopped
+		}
+	}
+	if inst.cancel != nil {
+		inst.cancel()
+	}
+	p.mu.Unlock()
+
+	if alive {
+		return fmt.Errorf("%w: %s", domain.ErrProcessGroupNotReaped, p.config.Name)
+	}
 	return nil
+}
+
+// waitGroupGone polls proc's group liveness on groupPollInterval until the
+// group is gone (GroupAlive returns false) or deadline passes. A probe error
+// is treated conservatively as "still alive", so a transient probe failure
+// never masquerades as a successful reap. It returns true iff the group is gone.
+func waitGroupGone(proc Process, deadline time.Time) bool {
+	ticker := time.NewTicker(groupPollInterval)
+	defer ticker.Stop()
+
+	for {
+		if alive, _ := proc.GroupAlive(); !alive {
+			return true
+		}
+		if !time.Now().Before(deadline) {
+			return false
+		}
+		<-ticker.C
+	}
 }
 
 // Restart restarts the process.
@@ -278,6 +420,9 @@ func (p *ManagedProcess) Stop(ctx context.Context) error {
 // supervisor's own context). Using a request-scoped context for startCtx
 // would cancel the replacement's health checker and lifecycle context as
 // soon as the request context is cancelled/expires (see RestartProcess).
+//
+// If Stop fails (e.g. the old group could not be reaped) Restart aborts before
+// Start, so a surviving group is never shadowed by a replacement.
 func (p *ManagedProcess) Restart(stopCtx, startCtx context.Context) error {
 	if err := p.Stop(stopCtx); err != nil && err != domain.ErrProcessNotRunning {
 		return err
@@ -290,24 +435,20 @@ func (p *ManagedProcess) Restart(stopCtx, startCtx context.Context) error {
 	return p.Start(startCtx)
 }
 
-// monitor watches for process exit
-func (p *ManagedProcess) monitor() {
-	proc := p.process
-	if proc == nil {
-		return
-	}
+// monitor watches a single instance for exit. It owns draining that instance's
+// output and closing its done channel, but only the live instance
+// (generation guard) may mutate ManagedProcess state.
+func (p *ManagedProcess) monitor(inst *processInstance) {
+	err := inst.proc.Wait()
 
-	err := proc.Wait()
-
-	// Wait for output readers to finish draining pipes with a timeout.
-	// With manual pipes (not cmd.StdoutPipe), the pipes stay open until
-	// all processes (including grandchildren) close them. This ensures
-	// graceful shutdown messages from child processes are captured.
-	// However, if a grandchild holds the pipe open indefinitely, we don't
-	// want to block forever.
+	// Wait for this instance's output readers to finish draining pipes with a
+	// timeout. With manual pipes (not cmd.StdoutPipe), the pipes stay open
+	// until all processes (including grandchildren) close them, so graceful
+	// shutdown messages from child processes are captured -- but a grandchild
+	// holding the pipe open must not block us forever.
 	outputDone := make(chan struct{})
 	go func() {
-		p.outputWg.Wait()
+		inst.outputWg.Wait()
 		close(outputDone)
 	}()
 
@@ -315,59 +456,67 @@ func (p *ManagedProcess) monitor() {
 	case <-outputDone:
 		// Output readers finished normally
 	case <-time.After(outputDrainTimeout):
-		p.logManager.Write(domain.LogEntry{
-			Timestamp: time.Now(),
-			Process:   p.config.Name,
-			Stream:    domain.StreamStderr,
-			Line:      "output capture timed out (some logs may be missing)",
-		})
+		p.logf(domain.StreamStderr, "output capture timed out (some logs may be missing)")
 	}
 
-	// Extract exit code from error
-	// For signal termination, we use negative signal number (e.g., -15 for SIGTERM)
-	exitCode := 0
-	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			if status, ok := exitErr.Sys().(syscall.WaitStatus); ok {
-				if status.Signaled() {
-					// Process was killed by signal - use negative signal number
-					exitCode = -int(status.Signal())
-				} else {
-					exitCode = status.ExitStatus()
-				}
-			} else {
-				exitCode = exitErr.ExitCode()
-			}
-		} else {
-			exitCode = 1 // Generic error
-		}
-	}
+	exitCode := exitCodeFromWaitErr(err)
 
 	p.mu.Lock()
-	defer p.mu.Unlock()
-
-	if p.state == domain.ProcessStateStopping {
-		p.state = domain.ProcessStateStopped
-		// Log the stopped message with exit code
-		p.logManager.Write(domain.LogEntry{
-			Timestamp: time.Now(),
-			Process:   p.config.Name,
-			Stream:    domain.StreamStdout,
-			Line:      fmt.Sprintf("stopped (rc=%d)", exitCode),
-		})
-	} else {
-		// Unexpected exit
-		p.state = domain.ProcessStateCrashed
-		p.logManager.Write(domain.LogEntry{
-			Timestamp: time.Now(),
-			Process:   p.config.Name,
-			Stream:    domain.StreamStderr,
-			Line:      fmt.Sprintf("exited unexpectedly (rc=%d)", exitCode),
-		})
+	// Generation guard: a stale monitor -- one whose instance has already been
+	// replaced by a newer Start -- must touch nothing shared and emit no
+	// (misleading) exit log. It only closes its own done below.
+	if p.current == inst {
+		switch p.state {
+		case domain.ProcessStateStopping:
+			// Stop owns the transition to stopped; here we only record the exit
+			// code. Stop's finalization gate normally waits on inst.done, so
+			// this log precedes Stop's final verdict.
+			p.logf(domain.StreamStdout, "stopped (rc=%d)", exitCode)
+		case domain.ProcessStateRunning, domain.ProcessStateStarting:
+			// Genuine unexpected exit (crash / natural exit not driven by Stop).
+			p.state = domain.ProcessStateCrashed
+			p.logf(domain.StreamStderr, "exited unexpectedly (rc=%d)", exitCode)
+		default:
+			// State is already terminal (stopped/crashed) -- Stop committed a
+			// verdict before this monitor ran (only reachable if Stop's
+			// finalization gate timed out instead of receiving inst.done). Do
+			// NOT override it: Stop owns the terminal state.
+		}
 	}
+	// Deliberately do NOT null p.current: retaining it keeps the pgid reapable
+	// for a retry Stop.
+	p.mu.Unlock()
 
-	p.process = nil
-	p.closeDone()
+	inst.closeDone()
+}
+
+// exitCodeFromWaitErr derives an exit code from a Wait() error. Signal
+// termination is reported as the negative signal number (e.g. -15 for SIGTERM).
+func exitCodeFromWaitErr(err error) int {
+	if err == nil {
+		return 0
+	}
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		if status, ok := exitErr.Sys().(syscall.WaitStatus); ok {
+			if status.Signaled() {
+				return -int(status.Signal())
+			}
+			return status.ExitStatus()
+		}
+		return exitErr.ExitCode()
+	}
+	return 1 // Generic error
+}
+
+// logf writes a formatted log line attributed to this process on the given
+// stream. It is the per-process mirror of Supervisor.SystemLog.
+func (p *ManagedProcess) logf(stream domain.Stream, format string, args ...interface{}) {
+	p.logManager.Write(domain.LogEntry{
+		Timestamp: time.Now(),
+		Process:   p.config.Name,
+		Stream:    stream,
+		Line:      fmt.Sprintf(format, args...),
+	})
 }
 
 // readOutput reads from a stream and writes to the log manager
@@ -393,18 +542,6 @@ func (p *ManagedProcess) readOutput(r interface{}, stream domain.Stream) {
 
 	// Log any scanner errors (e.g., I/O errors during output capture)
 	if err := scanner.Err(); err != nil {
-		p.logManager.Write(domain.LogEntry{
-			Timestamp: time.Now(),
-			Process:   p.config.Name,
-			Stream:    domain.StreamStderr,
-			Line:      fmt.Sprintf("output reader error: %v", err),
-		})
+		p.logf(domain.StreamStderr, "output reader error: %v", err)
 	}
-}
-
-// closeDone safely closes the done channel using sync.Once to prevent double-close panic
-func (p *ManagedProcess) closeDone() {
-	p.doneOnce.Do(func() {
-		close(p.done)
-	})
 }

--- a/internal/supervisor/process.go
+++ b/internal/supervisor/process.go
@@ -269,9 +269,17 @@ func (p *ManagedProcess) Stop(ctx context.Context) error {
 	return nil
 }
 
-// Restart restarts the process
-func (p *ManagedProcess) Restart(ctx context.Context) error {
-	if err := p.Stop(ctx); err != nil && err != domain.ErrProcessNotRunning {
+// Restart restarts the process.
+//
+// stopCtx and startCtx are intentionally distinct: stopCtx bounds the graceful
+// stop of the current instance (typically a short-lived, request/timeout
+// context), while startCtx becomes the lifecycle context for the replacement
+// instance's process/health-checker and must be long-lived (e.g. a
+// supervisor's own context). Using a request-scoped context for startCtx
+// would cancel the replacement's health checker and lifecycle context as
+// soon as the request context is cancelled/expires (see RestartProcess).
+func (p *ManagedProcess) Restart(stopCtx, startCtx context.Context) error {
+	if err := p.Stop(stopCtx); err != nil && err != domain.ErrProcessNotRunning {
 		return err
 	}
 
@@ -279,7 +287,7 @@ func (p *ManagedProcess) Restart(ctx context.Context) error {
 	p.restartCount++
 	p.mu.Unlock()
 
-	return p.Start(ctx)
+	return p.Start(startCtx)
 }
 
 // monitor watches for process exit

--- a/internal/supervisor/process.go
+++ b/internal/supervisor/process.go
@@ -28,6 +28,12 @@ type ManagedProcess struct {
 	runner     ProcessRunner
 	logManager *logs.Manager
 
+	// loadEnv, if set, is called at the top of every Start to (re)load the
+	// process's environment from disk (env_file(s)) merged with inline env.
+	// When nil, Start uses the stored env as-is (back-compat for tests that
+	// construct ManagedProcess directly via NewManagedProcess).
+	loadEnv func() (map[string]string, error)
+
 	state        domain.ProcessState
 	process      Process
 	startedAt    time.Time
@@ -115,6 +121,25 @@ func (p *ManagedProcess) Start(ctx context.Context) error {
 
 	if p.state == domain.ProcessStateRunning || p.state == domain.ProcessStateStarting {
 		return domain.ErrProcessAlreadyRunning
+	}
+
+	// Reload the environment from disk on every Start (covers both `start`
+	// after `stop` and the replacement half of `restart`). This must happen
+	// before any of the done/doneOnce/cancel state is mutated so a failure
+	// here leaves no dangling channel behind.
+	if p.loadEnv != nil {
+		env, err := p.loadEnv()
+		if err != nil {
+			p.state = domain.ProcessStateCrashed
+			p.logManager.Write(domain.LogEntry{
+				Timestamp: time.Now(),
+				Process:   p.config.Name,
+				Stream:    domain.StreamStderr,
+				Line:      fmt.Sprintf("failed to reload environment: %v", err),
+			})
+			return fmt.Errorf("%w: %v", domain.ErrEnvReloadFailed, err)
+		}
+		p.env = env
 	}
 
 	p.state = domain.ProcessStateStarting

--- a/internal/supervisor/process_stop_test.go
+++ b/internal/supervisor/process_stop_test.go
@@ -1,0 +1,282 @@
+package supervisor
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/charliek/prox/internal/constants"
+	"github.com/charliek/prox/internal/domain"
+	"github.com/charliek/prox/internal/logs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newFakeManagedProcess builds a ManagedProcess wired to the given runner with
+// a throwaway log manager. loadEnv is left nil so Start uses the stored env.
+func newFakeManagedProcess(t *testing.T, runner ProcessRunner) *ManagedProcess {
+	t.Helper()
+	logMgr := logs.NewManager(logs.ManagerConfig{BufferSize: 100})
+	t.Cleanup(func() { logMgr.Close() })
+	return NewManagedProcess(domain.ProcessConfig{
+		Name: "fake",
+		Cmd:  "irrelevant",
+	}, nil, runner, logMgr)
+}
+
+// waitForState polls mp until it reaches want or timeout elapses.
+func waitForState(t *testing.T, mp *ManagedProcess, want domain.ProcessState, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if mp.State() == want {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("process did not reach state %q within %v (last: %q)", want, timeout, mp.State())
+}
+
+// firstIndexOf returns the index of the first recorded signal equal to sig, or
+// -1 if never seen.
+func firstIndexOf(sigs []sigRecord, sig os.Signal) int {
+	for i, r := range sigs {
+		if r.sig == sig {
+			return i
+		}
+	}
+	return -1
+}
+
+// TestManagedProcess_Stop_GracefulGroupDeath (A7-ish): a group that dies
+// promptly on SIGTERM -- before the graceful deadline -- is reaped without ever
+// receiving SIGKILL; Stop returns nil and the process ends stopped.
+func TestManagedProcess_Stop_GracefulGroupDeath(t *testing.T) {
+	runner := newFakeRunner(func(call int) *fakeProcess { return newGracefulFake(1000 + call) })
+	mp := newFakeManagedProcess(t, runner)
+
+	require.NoError(t, mp.Start(context.Background()))
+	require.Equal(t, domain.ProcessStateRunning, mp.State())
+	fp := runner.last()
+
+	stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	require.NoError(t, mp.Stop(stopCtx))
+
+	assert.Equal(t, domain.ProcessStateStopped, mp.State())
+	assert.True(t, fp.sawSignal(sigterm), "SIGTERM should have been sent")
+	assert.False(t, fp.sawSignal(sigkill), "SIGKILL must NOT be sent when the group dies gracefully")
+}
+
+// TestManagedProcess_Stop_StubbornGroupEscalatesToSIGKILL: a group that ignores
+// SIGTERM but dies on SIGKILL is escalated and reaped; Stop returns nil, SIGKILL
+// was sent after SIGTERM, and the process ends stopped. A short ctx keeps it
+// fast (with KillGrace=2s the tiny budget drives the graceful deadline to now,
+// so escalation is immediate).
+func TestManagedProcess_Stop_StubbornGroupEscalatesToSIGKILL(t *testing.T) {
+	runner := newFakeRunner(func(call int) *fakeProcess { return newStubbornFake(2000 + call) })
+	mp := newFakeManagedProcess(t, runner)
+
+	require.NoError(t, mp.Start(context.Background()))
+	fp := runner.last()
+
+	stopCtx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	require.NoError(t, mp.Stop(stopCtx))
+
+	assert.Equal(t, domain.ProcessStateStopped, mp.State())
+
+	sigs := fp.signalsReceived()
+	termIdx := firstIndexOf(sigs, sigterm)
+	killIdx := firstIndexOf(sigs, sigkill)
+	require.GreaterOrEqual(t, termIdx, 0, "SIGTERM should have been sent")
+	require.GreaterOrEqual(t, killIdx, 0, "SIGKILL should have been sent after graceful timeout")
+	assert.Less(t, termIdx, killIdx, "SIGTERM must precede SIGKILL")
+}
+
+// TestManagedProcess_Stop_UnreapableGroupReturnsError (A6): a group whose
+// liveness probe is stuck true (a surviving grandchild) cannot be reaped, so
+// Stop returns ErrProcessGroupNotReaped, the process ends crashed, current is
+// retained, and a second Stop re-attempts the reap rather than short-circuiting
+// to ErrProcessNotRunning.
+func TestManagedProcess_Stop_UnreapableGroupReturnsError(t *testing.T) {
+	runner := newFakeRunner(func(call int) *fakeProcess { return newUnreapableFake(3000 + call) })
+	mp := newFakeManagedProcess(t, runner)
+
+	require.NoError(t, mp.Start(context.Background()))
+	fp := runner.last()
+
+	stopCtx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	err := mp.Stop(stopCtx)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, domain.ErrProcessGroupNotReaped)
+	assert.Contains(t, err.Error(), "fake", "error should name the process")
+	assert.Equal(t, domain.ProcessStateCrashed, mp.State())
+
+	// current must be retained so a later stop/restart can retry the reap.
+	mp.mu.RLock()
+	require.NotNil(t, mp.current, "current instance must be retained after a failed reap")
+	mp.mu.RUnlock()
+
+	termsAfterFirst := len(signalsOfType(fp, sigterm))
+
+	// A second Stop must NOT short-circuit to ErrProcessNotRunning: the group is
+	// still (fake-)alive, so it re-runs the reap and reports the same error.
+	stopCtx2, cancel2 := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel2()
+	err2 := mp.Stop(stopCtx2)
+	require.Error(t, err2)
+	assert.ErrorIs(t, err2, domain.ErrProcessGroupNotReaped)
+	assert.NotErrorIs(t, err2, domain.ErrProcessNotRunning)
+	assert.Greater(t, len(signalsOfType(fp, sigterm)), termsAfterFirst,
+		"second Stop should re-attempt the reap (send SIGTERM again), not short-circuit")
+}
+
+// signalsOfType returns all recorded signals of the given type.
+func signalsOfType(fp *fakeProcess, sig os.Signal) []sigRecord {
+	var out []sigRecord
+	for _, r := range fp.signalsReceived() {
+		if r.sig == sig {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// TestManagedProcess_RestartClobberSafety (A9): a tight start->restart loop
+// ends running with a non-nil PID and an advanced restart count, and no stale
+// monitor from a prior run flips the live run to crashed. Run under -race, this
+// is the key concurrency test.
+func TestManagedProcess_RestartClobberSafety(t *testing.T) {
+	runner := newFakeRunner(func(call int) *fakeProcess { return newGracefulFake(4000 + call) })
+	mp := newFakeManagedProcess(t, runner)
+
+	require.NoError(t, mp.Start(context.Background()))
+
+	const restarts = 10
+	for i := 0; i < restarts; i++ {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		err := mp.Restart(stopCtx, context.Background())
+		cancel()
+		require.NoErrorf(t, err, "restart %d", i)
+		require.Equalf(t, domain.ProcessStateRunning, mp.State(), "restart %d should leave the process running", i)
+	}
+
+	// Give any straggler monitor goroutines a chance to run their critical
+	// sections; the generation guard must prevent them from mutating state.
+	time.Sleep(100 * time.Millisecond)
+
+	info := mp.Info()
+	assert.Equal(t, domain.ProcessStateRunning, info.State, "no stale monitor may flip the live run to crashed")
+	assert.Greater(t, info.PID, 0, "the live run must report a non-nil PID")
+	assert.Equal(t, restarts, info.RestartCount)
+	assert.Equal(t, runner.last().PID(), info.PID, "PID must belong to the most-recent run")
+
+	// Clean up the final live run.
+	stopCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	require.NoError(t, mp.Stop(stopCtx))
+}
+
+// TestManagedProcess_StartDuringStopRejected: while a Stop is mid-graceful
+// (state=stopping, group still alive), a concurrent Start is rejected with
+// ErrProcessAlreadyRunning rather than launching a duplicate.
+func TestManagedProcess_StartDuringStopRejected(t *testing.T) {
+	// The graceful death is gated on a channel the test controls so Stop stays
+	// in its graceful phase until we release it -- fully deterministic.
+	release := make(chan struct{})
+	runner := newFakeRunner(func(call int) *fakeProcess {
+		fp := newFakeProcess(5000 + call)
+		fp.onSignal = func(fp *fakeProcess, sig os.Signal) {
+			if sig == sigterm {
+				go func() {
+					<-release
+					fp.setAlive(false)
+					fp.exitLeader(nil)
+				}()
+			}
+		}
+		return fp
+	})
+	mp := newFakeManagedProcess(t, runner)
+
+	require.NoError(t, mp.Start(context.Background()))
+
+	stopDone := make(chan error, 1)
+	go func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		stopDone <- mp.Stop(stopCtx)
+	}()
+
+	// Wait until Stop has transitioned to stopping (SIGTERM sent, group still
+	// alive because we haven't released it).
+	waitForState(t, mp, domain.ProcessStateStopping, time.Second)
+
+	// A concurrent Start while stopping must be rejected.
+	err := mp.Start(context.Background())
+	assert.ErrorIs(t, err, domain.ErrProcessAlreadyRunning)
+
+	// Only one process was ever created (no duplicate launched).
+	assert.Equal(t, 1, runner.count(), "no duplicate process should be started during Stop")
+
+	// Release the graceful death and let Stop finish cleanly.
+	close(release)
+	require.NoError(t, <-stopDone)
+	assert.Equal(t, domain.ProcessStateStopped, mp.State())
+}
+
+// TestComputeDeadlines_NoContextDeadlineUsesFallback: with no ctx deadline,
+// computeDeadlines falls back to the shutdown timeout; graceful ends KillGrace
+// before the fallback deadline and kill lands at it.
+func TestComputeDeadlines_NoContextDeadlineUsesFallback(t *testing.T) {
+	mp := newFakeManagedProcess(t, newFakeRunner(func(int) *fakeProcess { return newFakeProcess(1) }))
+
+	before := time.Now()
+	graceful, kill := mp.computeDeadlines(context.Background())
+
+	assert.WithinDuration(t, before.Add(constants.DefaultShutdownTimeout-constants.KillGrace), graceful, 500*time.Millisecond)
+	assert.WithinDuration(t, before.Add(constants.DefaultShutdownTimeout), kill, 500*time.Millisecond)
+	assert.Equal(t, constants.KillGrace, kill.Sub(graceful), "kill deadline is always KillGrace after graceful")
+}
+
+// TestComputeDeadlines_NearExpiredCtxEscalatesImmediately: an already-expired
+// ctx drives the graceful deadline to ~now so Stop escalates immediately, while
+// the kill deadline still reserves a full KillGrace (its own timer, not ctx).
+func TestComputeDeadlines_NearExpiredCtxEscalatesImmediately(t *testing.T) {
+	mp := newFakeManagedProcess(t, newFakeRunner(func(int) *fakeProcess { return newFakeProcess(1) }))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	time.Sleep(40 * time.Millisecond) // let ctx expire
+
+	before := time.Now()
+	graceful, kill := mp.computeDeadlines(ctx)
+
+	assert.WithinDuration(t, before, graceful, 50*time.Millisecond, "graceful deadline should be ~now for an expired ctx")
+	assert.Equal(t, constants.KillGrace, kill.Sub(graceful), "kill deadline still reserves a full KillGrace")
+}
+
+// TestManagedProcess_Stop_NoDeadlineFallbackEscalates: Stop(context.Background())
+// (no deadline) uses the shutdown-timeout fallback and still escalates to
+// SIGKILL against a stubborn group, succeeding within a bounded time. The
+// fallback is shrunk via the shutdownTimeout test seam so the graceful window
+// is ~1s instead of the 10s production default.
+func TestManagedProcess_Stop_NoDeadlineFallbackEscalates(t *testing.T) {
+	runner := newFakeRunner(func(call int) *fakeProcess { return newStubbornFake(6000 + call) })
+	mp := newFakeManagedProcess(t, runner)
+	mp.shutdownTimeout = 3 * time.Second // graceful window == 3s - KillGrace(2s) == 1s
+
+	require.NoError(t, mp.Start(context.Background()))
+	fp := runner.last()
+
+	start := time.Now()
+	require.NoError(t, mp.Stop(context.Background()))
+	elapsed := time.Since(start)
+
+	assert.Equal(t, domain.ProcessStateStopped, mp.State())
+	assert.True(t, fp.sawSignal(sigkill), "stubborn group should be SIGKILLed after the graceful window")
+	assert.Less(t, elapsed, 3*time.Second, "escalation must use the ~1s fallback window, not the 10s default")
+}

--- a/internal/supervisor/process_test.go
+++ b/internal/supervisor/process_test.go
@@ -2,6 +2,7 @@ package supervisor
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -183,6 +184,85 @@ func TestManagedProcess_StopLogsExitCode(t *testing.T) {
 	}
 
 	assert.True(t, foundStoppedMessage, "should log 'stopped (rc=-15)' message when process is terminated by SIGTERM")
+}
+
+// TestManagedProcess_LoadEnvReloadsOnEveryStart verifies D1/A1c: a loadEnv
+// closure is invoked at the top of every Start, so an edited env source
+// (here a mutable closure over a variable, standing in for a rewritten
+// env_file) is reflected on the very next Start after a Stop - not just
+// once at process creation.
+func TestManagedProcess_LoadEnvReloadsOnEveryStart(t *testing.T) {
+	logMgr := logs.NewManager(logs.ManagerConfig{BufferSize: 100})
+	defer logMgr.Close()
+
+	runner := NewExecRunner()
+
+	mp := NewManagedProcess(domain.ProcessConfig{
+		Name: "test",
+		Cmd:  "sleep 5",
+	}, nil, runner, logMgr)
+
+	current := "v1"
+	mp.loadEnv = func() (map[string]string, error) {
+		return map[string]string{"RELOAD_VAL": current}, nil
+	}
+
+	ctx := context.Background()
+	require.NoError(t, mp.Start(ctx))
+	assert.Equal(t, "v1", mp.Info().Env["RELOAD_VAL"])
+
+	stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	require.NoError(t, mp.Stop(stopCtx))
+	cancel()
+
+	// Mutate the source the loader reads from, simulating an edited env_file.
+	current = "v2"
+
+	require.NoError(t, mp.Start(ctx))
+	assert.Equal(t, "v2", mp.Info().Env["RELOAD_VAL"])
+
+	// Cleanup
+	stopCtx2, cancel2 := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel2()
+	require.NoError(t, mp.Stop(stopCtx2))
+}
+
+// TestManagedProcess_LoadEnvFailureCrashesProcess verifies A2: when loadEnv
+// fails, Start returns a typed error wrapping domain.ErrEnvReloadFailed, the
+// state becomes crashed, no process is launched, and a subsequent Stop
+// behaves sanely (ErrProcessNotRunning) rather than hanging or panicking on
+// a dangling done channel.
+func TestManagedProcess_LoadEnvFailureCrashesProcess(t *testing.T) {
+	logMgr := logs.NewManager(logs.ManagerConfig{BufferSize: 100})
+	defer logMgr.Close()
+
+	runner := NewExecRunner()
+
+	mp := NewManagedProcess(domain.ProcessConfig{
+		Name: "test",
+		Cmd:  "sleep 5",
+	}, nil, runner, logMgr)
+
+	loadErr := errors.New("env file missing")
+	mp.loadEnv = func() (map[string]string, error) {
+		return nil, loadErr
+	}
+
+	ctx := context.Background()
+	err := mp.Start(ctx)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, domain.ErrEnvReloadFailed)
+	assert.Contains(t, err.Error(), "env file missing")
+
+	assert.Equal(t, domain.ProcessStateCrashed, mp.State())
+	assert.Equal(t, 0, mp.Info().PID, "no process should have been launched")
+
+	// A subsequent Stop should behave sanely rather than hang on a dangling
+	// done channel or panic on a double-close.
+	stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	err = mp.Stop(stopCtx)
+	assert.ErrorIs(t, err, domain.ErrProcessNotRunning)
 }
 
 func TestManagedProcess_CrashLogsExitCode(t *testing.T) {

--- a/internal/supervisor/process_test.go
+++ b/internal/supervisor/process_test.go
@@ -115,7 +115,7 @@ func TestManagedProcess_Restart(t *testing.T) {
 	restartCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	err = mp.Restart(restartCtx)
+	err = mp.Restart(restartCtx, context.Background())
 	require.NoError(t, err)
 
 	assert.Equal(t, domain.ProcessStateRunning, mp.State())

--- a/internal/supervisor/runner.go
+++ b/internal/supervisor/runner.go
@@ -11,6 +11,7 @@ package supervisor
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -30,6 +31,12 @@ type Process interface {
 	PID() int
 	Wait() error
 	Signal(sig os.Signal) error
+	// GroupAlive reports whether any member of the process group is still
+	// alive, using a signal-0 liveness probe. It returns (false, nil) once the
+	// group is gone (ESRCH). Any surfaced error is returned alongside a
+	// conservative "alive" verdict so callers never treat an ambiguous probe
+	// as a confirmed reap.
+	GroupAlive() (bool, error)
 	Stdout() io.Reader
 	Stderr() io.Reader
 }
@@ -101,8 +108,15 @@ func (r *ExecRunner) Start(ctx context.Context, config domain.ProcessConfig, env
 	stdoutW.Close()
 	stderrW.Close()
 
+	// Capture the process group ID (PGID) at launch. Because SysProcAttr sets
+	// Setpgid without an explicit Pgid, the child starts a brand-new process
+	// group whose PGID equals the child's own PID (the child is the group
+	// leader). We record the leader PID directly rather than calling
+	// syscall.Getpgid: the leader PID is authoritative and this avoids a race
+	// where the leader has already exited by the time we'd query it.
 	return &execProcess{
 		cmd:    cmd,
+		pgid:   cmd.Process.Pid,
 		stdout: stdoutR,
 		stderr: stderrR,
 	}, nil
@@ -111,6 +125,7 @@ func (r *ExecRunner) Start(ctx context.Context, config domain.ProcessConfig, env
 // execProcess wraps exec.Cmd to implement Process interface
 type execProcess struct {
 	cmd    *exec.Cmd
+	pgid   int // process group ID captured at launch (== leader PID); <= 0 means unknown
 	stdout io.Reader
 	stderr io.Reader
 }
@@ -127,18 +142,66 @@ func (p *execProcess) Wait() error {
 }
 
 func (p *execProcess) Signal(sig os.Signal) error {
-	if p.cmd.Process == nil {
-		return nil
+	// Signal the entire process group using the PGID captured at launch. We
+	// hard-guard pgid > 0: syscall.Kill(-pgid, ...) with pgid <= 0 would signal
+	// prox's own process group (pgid 0 means "my group"), which is exactly the
+	// orphan/self-signal bug this replaces. We intentionally do NOT re-derive
+	// the pgid via syscall.Getpgid at signal time, since after the leader exits
+	// that lookup fails and we'd silently fall back to signaling nothing.
+	if p.pgid > 0 {
+		return syscall.Kill(-p.pgid, sig.(syscall.Signal))
 	}
 
-	// Kill entire process group
-	pgid, err := syscall.Getpgid(p.cmd.Process.Pid)
-	if err != nil {
-		// Fall back to killing just the process
+	// Fallback: no known group, signal the leader only if it exists.
+	if p.cmd.Process != nil {
 		return p.cmd.Process.Signal(sig)
 	}
 
-	return syscall.Kill(-pgid, sig.(syscall.Signal))
+	return nil
+}
+
+// GroupAlive reports whether any member of the process group is still alive
+// using a signal-0 liveness probe.
+//
+// When pgid > 0 it probes the whole group via syscall.Kill(-pgid, 0). When
+// pgid <= 0 it never touches a group (that would hit prox's own process group)
+// and falls back to a leader-only probe.
+//
+// Result mapping:
+//   - err == nil                   -> (true, nil)   process/group exists
+//   - errors.Is(err, ESRCH)        -> (false, nil)  process/group is gone
+//   - errors.Is(err, EPERM)        -> (true, nil)   exists, not permitted to signal
+//   - any other error              -> (true, err)   conservatively alive, surface err
+//
+// Note: a zombie leader remains a group member until it is reaped, so a probe
+// can report the group as alive until monitor()'s Wait() reaps the leader.
+func (p *execProcess) GroupAlive() (bool, error) {
+	var err error
+	if p.pgid > 0 {
+		err = syscall.Kill(-p.pgid, syscall.Signal(0))
+	} else {
+		// No known group: probe the leader only, never a group.
+		if p.cmd.Process == nil {
+			return false, nil
+		}
+		err = p.cmd.Process.Signal(syscall.Signal(0))
+	}
+
+	switch {
+	case err == nil:
+		return true, nil
+	case errors.Is(err, syscall.ESRCH):
+		return false, nil
+	case errors.Is(err, os.ErrProcessDone):
+		// Reached only via the pgid<=0 leader-only fallback: os.Process.Signal
+		// reports a reaped process as os.ErrProcessDone (and normalizes raw
+		// ESRCH to it), not syscall.ESRCH. Treat it as gone.
+		return false, nil
+	case errors.Is(err, syscall.EPERM):
+		return true, nil
+	default:
+		return true, err
+	}
 }
 
 func (p *execProcess) Stdout() io.Reader {

--- a/internal/supervisor/runner_test.go
+++ b/internal/supervisor/runner_test.go
@@ -3,6 +3,7 @@ package supervisor
 import (
 	"context"
 	"io"
+	"os/exec"
 	"testing"
 	"time"
 
@@ -139,6 +140,86 @@ func TestExecRunner_Start(t *testing.T) {
 		err = proc.Wait()
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "42")
+	})
+
+	t.Run("captures pgid and GroupAlive flips true to false", func(t *testing.T) {
+		ctx := context.Background()
+
+		proc, err := runner.Start(ctx, domain.ProcessConfig{
+			Name: "test",
+			// `exec` guarantees the shell replaces itself with sleep, so the
+			// leader IS sleep (no forked shell that could leave a zombie sleep
+			// reparented to init and keep the group "alive" past the deadline).
+			Cmd: "exec sleep 30",
+		}, nil)
+		require.NoError(t, err)
+
+		// The leader PID (== captured PGID) must be present.
+		require.Greater(t, proc.PID(), 0)
+
+		// Give it time to be fully scheduled.
+		time.Sleep(100 * time.Millisecond)
+
+		// The group is alive while the process runs.
+		alive, err := proc.GroupAlive()
+		require.NoError(t, err)
+		assert.True(t, alive, "group should be alive while the process runs")
+
+		// Terminate the whole group, then reap the leader. A zombie leader
+		// stays a group member until reaped, so Wait() (which reaps) must run
+		// before GroupAlive can flip to false.
+		require.NoError(t, proc.Signal(sigkill))
+		_ = proc.Wait()
+
+		// Poll until the group is gone (ESRCH => (false, nil)).
+		deadline := time.Now().Add(2 * time.Second)
+		for {
+			alive, err = proc.GroupAlive()
+			require.NoError(t, err)
+			if !alive {
+				break
+			}
+			if time.Now().After(deadline) {
+				t.Fatal("group did not become gone within deadline")
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
+		assert.False(t, alive, "group should be gone after SIGKILL + reap")
+	})
+
+	t.Run("pgid<=0 never performs a group operation", func(t *testing.T) {
+		// Construct an execProcess directly with pgid == 0 and an un-started
+		// command (cmd.Process == nil). This must NEVER perform a group
+		// operation: syscall.Kill(-0, ...) / Kill(0, ...) target the test
+		// binary's OWN process group, which could kill the test runner. With a
+		// nil leader process the code must take the no-op / already-gone paths.
+		p := &execProcess{
+			pgid: 0,
+			cmd:  exec.Command("sh", "-c", "sleep 30"), // never Start()ed => Process == nil
+		}
+		require.Nil(t, p.cmd.Process, "guard: the command must not have been started")
+
+		// GroupAlive with pgid<=0 and no leader process => gone, without ever
+		// probing a group.
+		alive, err := p.GroupAlive()
+		require.NoError(t, err)
+		assert.False(t, alive, "pgid<=0 with nil leader must report gone, not probe a group")
+
+		// Signal with pgid<=0 and no leader process => no-op, never signals a group.
+		require.NoError(t, p.Signal(sigkill))
+		require.NoError(t, p.Signal(sigterm))
+
+		// A negative pgid must take the same leader-only guard path (it is also
+		// not > 0), never Kill(-negativePgid, ...) against some other group.
+		pNeg := &execProcess{
+			pgid: -1,
+			cmd:  exec.Command("sh", "-c", "sleep 30"), // never Start()ed => Process == nil
+		}
+		require.Nil(t, pNeg.cmd.Process)
+		aliveNeg, errNeg := pNeg.GroupAlive()
+		require.NoError(t, errNeg)
+		assert.False(t, aliveNeg, "negative pgid with nil leader must report gone, not probe a group")
+		require.NoError(t, pNeg.Signal(sigkill))
 	})
 
 	t.Run("context cancellation does not kill process", func(t *testing.T) {

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -331,6 +331,14 @@ func (s *Supervisor) StartProcess(ctx context.Context, name string) error {
 		return domain.ErrProcessNotFound
 	}
 
+	// s.ctx is nil until Supervisor.Start() runs. Passing a nil context into
+	// mp.Start -> context.WithCancel would panic; guard against being called
+	// before the supervisor has started (unreachable via the normal API wiring,
+	// which serves requests only after Start, but defensive).
+	if supCtx == nil {
+		return domain.ErrShutdownInProgress
+	}
+
 	// Use supervisor context for the process lifecycle.
 	// The passed ctx is only used for the API request timeout, but the process
 	// should continue running after the request completes.
@@ -381,6 +389,13 @@ func (s *Supervisor) RestartProcess(ctx context.Context, name string) error {
 
 	if !ok {
 		return domain.ErrProcessNotFound
+	}
+
+	// s.ctx is nil until Supervisor.Start() runs; the replacement is started on
+	// it, so guard against a pre-start call that would panic in
+	// context.WithCancel (defensive; unreachable via the normal API wiring).
+	if supCtx == nil {
+		return domain.ErrShutdownInProgress
 	}
 
 	// Create timeout context to bound the stop half of the restart.

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -369,17 +369,22 @@ func (s *Supervisor) StopProcess(ctx context.Context, name string) error {
 func (s *Supervisor) RestartProcess(ctx context.Context, name string) error {
 	s.mu.RLock()
 	mp, ok := s.processes[name]
+	supCtx := s.ctx // Use supervisor context for the replacement's lifecycle, not request context
 	s.mu.RUnlock()
 
 	if !ok {
 		return domain.ErrProcessNotFound
 	}
 
-	// Create timeout context
+	// Create timeout context to bound the stop half of the restart.
 	restartCtx, cancel := context.WithTimeout(ctx, s.supConfig.ShutdownTimeout)
 	defer cancel()
 
-	err := mp.Restart(restartCtx)
+	// Stop uses restartCtx (bounded by the request/shutdown timeout); Start
+	// uses supCtx so the replacement's process lifecycle and health checker
+	// survive after this request's context is cancelled/expires (mirrors
+	// StartProcess).
+	err := mp.Restart(restartCtx, supCtx)
 	if err == nil {
 		s.emit(SupervisorEvent{
 			Type:      EventTypeProcessStarted,

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -2,6 +2,7 @@ package supervisor
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"sync"
@@ -256,6 +257,12 @@ func (s *Supervisor) Stop(ctx context.Context) error {
 					Stream:    domain.StreamStderr,
 					Line:      fmt.Sprintf("Error stopping: %v", err),
 				})
+				// Full-instance stop is best-effort, but surface an
+				// un-reapable group prominently so operators can see which
+				// process leaked (D4). We do not abort the rest of shutdown.
+				if errors.Is(err, domain.ErrProcessGroupNotReaped) {
+					s.SystemLog("could not reap process group for %s", mp.Name())
+				}
 			}
 			s.emit(SupervisorEvent{
 				Type:      EventTypeProcessStopped,

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -155,23 +155,24 @@ func (s *Supervisor) startWithFilter(ctx context.Context, filter map[string]bool
 }
 
 // createManagedProcess creates a new managed process from configuration.
+//
+// Environment loading is deferred to a closure invoked at the top of every
+// Start (see ManagedProcess.loadEnv / D1): this avoids an eager load here
+// that would (a) double-read the env files on the very first start and
+// (b) prevent process creation entirely if the env file is transiently
+// unreadable. A bad env file now fails loudly at Start instead.
 func (s *Supervisor) createManagedProcess(name string, procConfig config.ProcessConfig) (*ManagedProcess, error) {
-	// Load environment for this process
-	env, err := config.LoadProcessEnv(s.config.EnvFile, procConfig.EnvFile, procConfig.Env, s.supConfig.ConfigDir)
-	if err != nil {
-		s.logManager.Write(domain.LogEntry{
-			Timestamp: time.Now(),
-			Process:   name,
-			Stream:    domain.StreamStderr,
-			Line:      fmt.Sprintf("Failed to load environment: %v", err),
-		})
-		return nil, fmt.Errorf("failed to load environment: %w", err)
+	globalEnvFile := s.config.EnvFile
+	procEnvFile := procConfig.EnvFile
+	inlineEnv := procConfig.Env
+	configDir := s.supConfig.ConfigDir
+	loadEnv := func() (map[string]string, error) {
+		return config.LoadProcessEnv(globalEnvFile, procEnvFile, inlineEnv, configDir)
 	}
 
 	domainConfig := domain.ProcessConfig{
 		Name:    name,
 		Cmd:     procConfig.Cmd,
-		Env:     env,
 		EnvFile: procConfig.EnvFile,
 	}
 	if procConfig.Healthcheck != nil {
@@ -180,7 +181,9 @@ func (s *Supervisor) createManagedProcess(name string, procConfig config.Process
 		}
 	}
 
-	return NewManagedProcess(domainConfig, env, s.runner, s.logManager), nil
+	mp := NewManagedProcess(domainConfig, nil, s.runner, s.logManager)
+	mp.loadEnv = loadEnv
+	return mp, nil
 }
 
 // startProcessesConcurrently starts all managed processes concurrently and updates the result.

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -271,3 +271,132 @@ func TestSupervisor_StopLogsSIGTERM(t *testing.T) {
 
 	assert.True(t, foundSIGTERMMessage, "Stop should log 'sending SIGTERM to test (pid X)' message")
 }
+
+// TestSupervisor_RestartProcess_HealthCheckerSurvivesRequestContext is the
+// regression test for the C2 restart-context bug: RestartProcess must start
+// the replacement process on the supervisor's long-lived context, not on a
+// context derived from the (request-scoped) ctx the caller passed in.
+//
+// Before the fix, Supervisor.RestartProcess built a single timeout context
+// from the caller's ctx and threaded it through ManagedProcess.Restart into
+// both Stop and Start. Start derives processCtx (and the health checker's
+// context) from whatever context it's given, so once an HTTP handler
+// returns and its request context is cancelled, the replacement's
+// processCtx -- and therefore its health checker -- was torn down even
+// though the process itself kept running. This test simulates exactly that:
+// a cancelable "request" context that is cancelled the instant
+// RestartProcess returns, then asserts the replacement's health checker
+// keeps ticking (status becomes and remains "healthy") well past that
+// cancellation.
+//
+// Health-check ticking is used as the observable here (rather than a new
+// production accessor into the process's internal context) because it is
+// the most direct symptom described by the bug report and is fully exposed
+// via Supervisor.Process already.
+func TestSupervisor_RestartProcess_HealthCheckerSurvivesRequestContext(t *testing.T) {
+	logMgr := logs.NewManager(logs.ManagerConfig{BufferSize: 100})
+	defer logMgr.Close()
+
+	runner := NewExecRunner()
+
+	// Supervisor.createManagedProcess currently only propagates
+	// Healthcheck.Cmd from config.ProcessConfig into domain.HealthConfig --
+	// Interval/Timeout/StartPeriod are dropped (a separate, pre-existing gap
+	// unrelated to this fix). To get a fast, deterministic health check we
+	// build the ManagedProcess directly with a full domain.HealthConfig and
+	// register it on the supervisor, then drive everything else through the
+	// real Supervisor.StartProcess/RestartProcess API used in production.
+	cfg := makeTestConfig(map[string]string{})
+	sup := New(cfg, logMgr, runner, DefaultSupervisorConfig())
+
+	ctx := context.Background()
+	_, err := sup.Start(ctx)
+	require.NoError(t, err)
+	defer func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		sup.Stop(stopCtx)
+	}()
+
+	mp := NewManagedProcess(domain.ProcessConfig{
+		Name: "test",
+		Cmd:  "sleep 30",
+		Healthcheck: &domain.HealthConfig{
+			Cmd:         "true", // always succeeds, cheap
+			Interval:    50 * time.Millisecond,
+			Timeout:     1 * time.Second,
+			Retries:     1,
+			StartPeriod: 50 * time.Millisecond,
+		},
+	}, nil, runner, logMgr)
+
+	sup.mu.Lock()
+	sup.processes["test"] = mp
+	sup.mu.Unlock()
+
+	require.NoError(t, sup.StartProcess(ctx, "test"))
+
+	// Establish the checker is healthy before restarting.
+	waitForHealthCheckerHealthy(t, sup, "test", 2*time.Second)
+
+	firstInfo, err := sup.Process("test")
+	require.NoError(t, err)
+	firstPID := firstInfo.PID
+
+	// Simulate an HTTP handler: a cancelable request context that is
+	// cancelled the instant the handler (RestartProcess) returns -- this is
+	// exactly what net/http does once a response has been written.
+	requestCtx, cancelRequest := context.WithCancel(context.Background())
+	err = sup.RestartProcess(requestCtx, "test")
+	cancelRequest()
+	require.NoError(t, err)
+
+	info, err := sup.Process("test")
+	require.NoError(t, err)
+	assert.Equal(t, domain.ProcessStateRunning, info.State)
+	assert.NotEqual(t, firstPID, info.PID, "restart should replace the process with a new PID")
+	assert.Equal(t, 1, info.RestartCount)
+
+	// The replacement's health checker must keep ticking even though the
+	// request context that initiated the restart is now cancelled. Without
+	// the C2 fix this never becomes healthy (status stays "unknown" forever
+	// because the health checker's context was cancelled along with the
+	// request context).
+	waitForHealthCheckerHealthy(t, sup, "test", 2*time.Second)
+
+	postCancelInfo, err := sup.Process("test")
+	require.NoError(t, err)
+	require.NotNil(t, postCancelInfo.HealthDetails)
+	lastCheck1 := postCancelInfo.HealthDetails.LastCheck
+	require.False(t, lastCheck1.IsZero())
+
+	// Confirm the checker is still actively ticking rather than frozen on a
+	// single successful check that happened to sneak in before teardown.
+	time.Sleep(300 * time.Millisecond)
+	laterInfo, err := sup.Process("test")
+	require.NoError(t, err)
+	require.NotNil(t, laterInfo.HealthDetails)
+	assert.True(t, laterInfo.HealthDetails.LastCheck.After(lastCheck1),
+		"health checker should still be ticking after the request context is cancelled")
+	assert.Equal(t, domain.ProcessStateRunning, laterInfo.State)
+}
+
+// waitForHealthCheckerHealthy polls the supervisor until the named process
+// reports domain.HealthStatusHealthy, failing the test if timeout elapses
+// first.
+func waitForHealthCheckerHealthy(t *testing.T, sup *Supervisor, name string, timeout time.Duration) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	var lastStatus domain.HealthStatus
+	for time.Now().Before(deadline) {
+		info, err := sup.Process(name)
+		require.NoError(t, err)
+		lastStatus = info.Health
+		if info.Health == domain.HealthStatusHealthy {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("process %s did not become/remain healthy within %v (last health status: %q)", name, timeout, lastStatus)
+}

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -138,6 +138,49 @@ func stopProx(t *testing.T, addr string) error {
 	return nil
 }
 
+// restartProcess sends a POST /api/v1/processes/{name}/restart request and
+// returns the parsed error response (Code/Error) when the request did not
+// return 200, or a zero-value response and nil error on success.
+func restartProcess(t *testing.T, addr, name string) (int, ErrorResponse) {
+	t.Helper()
+	return postProcessAction(t, addr, name, "restart")
+}
+
+// stopProcess sends a POST /api/v1/processes/{name}/stop request and returns
+// the HTTP status code and parsed error response (empty Code/Error on
+// success).
+func stopProcess(t *testing.T, addr, name string) (int, ErrorResponse) {
+	t.Helper()
+	return postProcessAction(t, addr, name, "stop")
+}
+
+// postProcessAction posts to /api/v1/processes/{name}/{action} (start, stop,
+// restart) and returns the status code plus a decoded error body (zero value
+// if the response wasn't an error payload).
+func postProcessAction(t *testing.T, addr, name, action string) (int, ErrorResponse) {
+	t.Helper()
+
+	url := fmt.Sprintf("%s/api/v1/processes/%s/%s", addr, name, action)
+	resp, err := http.Post(url, "application/json", nil)
+	if err != nil {
+		t.Fatalf("failed to POST %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+
+	var errResp ErrorResponse
+	if resp.StatusCode != http.StatusOK {
+		_ = json.NewDecoder(resp.Body).Decode(&errResp)
+	}
+	return resp.StatusCode, errResp
+}
+
+// ErrorResponse mirrors internal/api.ErrorResponse for decoding error bodies
+// in integration tests without importing the internal/api package.
+type ErrorResponse struct {
+	Error string `json:"error"`
+	Code  string `json:"code"`
+}
+
 // killProx forcefully kills the prox process
 func killProx(cmd *exec.Cmd) {
 	if cmd != nil && cmd.Process != nil {

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -139,8 +139,8 @@ func stopProx(t *testing.T, addr string) error {
 }
 
 // restartProcess sends a POST /api/v1/processes/{name}/restart request and
-// returns the parsed error response (Code/Error) when the request did not
-// return 200, or a zero-value response and nil error on success.
+// returns the HTTP status code and the parsed error response (empty Code/Error
+// on success).
 func restartProcess(t *testing.T, addr, name string) (int, ErrorResponse) {
 	t.Helper()
 	return postProcessAction(t, addr, name, "restart")

--- a/test/integration/restart_test.go
+++ b/test/integration/restart_test.go
@@ -1,0 +1,339 @@
+package integration
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// stubbornAPIAddr is the API address for the stubborn.yaml fixture, used by
+// every test in this file that drives the real orphan-grandchild scenario
+// (#29): a leader shell that exits cleanly on SIGTERM while a backgrounded
+// python grandchild ignores SIGTERM and holds a real TCP port. Tests in this
+// file run sequentially (no t.Parallel), so reusing one port across them is
+// safe -- each test fully tears down its prox instance before the next runs.
+const stubbornAPIAddr = "http://127.0.0.1:15560"
+
+// stubbornListenerPort is the TCP port testdata/scripts/stubborn_grandchild.sh
+// tells its python grandchild to bind (see testdata/configs/stubborn.yaml's
+// STUBBORN_PORT inline env).
+const stubbornListenerPort = "15561"
+
+// logLines fetches the most recent log lines for a process via
+// GET /api/v1/logs. It returns nil (rather than failing the test) on a
+// transient request/decode error so callers can poll it in a retry loop.
+func logLines(t *testing.T, addr, process string) []string {
+	t.Helper()
+
+	url := fmt.Sprintf("%s/api/v1/logs?process=%s&lines=1000", addr, process)
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil
+	}
+	defer resp.Body.Close()
+
+	var parsed struct {
+		Logs []struct {
+			Line string `json:"line"`
+		} `json:"logs"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return nil
+	}
+
+	lines := make([]string, len(parsed.Logs))
+	for i, e := range parsed.Logs {
+		lines[i] = e.Line
+	}
+	return lines
+}
+
+// waitForLogContains polls a process's logs until a line contains substr, or
+// fails the test after timeout.
+func waitForLogContains(t *testing.T, addr, process, substr string, timeout time.Duration) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	var last []string
+	for time.Now().Before(deadline) {
+		last = logLines(t, addr, process)
+		for _, l := range last {
+			if strings.Contains(l, substr) {
+				return
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("process %q logs did not contain %q within %v; last lines: %v", process, substr, timeout, last)
+}
+
+// waitForMarkerValue polls a process's logs for a line containing prefix and
+// returns the trimmed text following it, skipping any value equal to
+// exclude. This is used both to capture a marker (exclude="") and, after a
+// restart, to detect a genuinely *new* marker value such as a fresh
+// GRANDCHILD_PID (exclude=<old value>). Fails the test if no matching,
+// non-excluded marker appears within timeout.
+func waitForMarkerValue(t *testing.T, addr, process, prefix, exclude string, timeout time.Duration) string {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		for _, l := range logLines(t, addr, process) {
+			_, after, found := strings.Cut(l, prefix)
+			if !found {
+				continue
+			}
+			val := strings.TrimSpace(after)
+			if val != "" && val != exclude {
+				return val
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("marker %q (excluding %q) not found in %q logs within %v", prefix, exclude, process, timeout)
+	return ""
+}
+
+// processAlive reports whether pid refers to a live process using a signal-0
+// liveness probe (mirrors execProcess.GroupAlive's leader-only fallback).
+func processAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	err := syscall.Kill(pid, 0)
+	if err == nil {
+		return true
+	}
+	return !errors.Is(err, syscall.ESRCH)
+}
+
+// killIfAlive SIGKILLs pid iff it is still alive. Every stubborn-grandchild
+// test below registers this via t.Cleanup for every PID it records, so a
+// failed assertion (or, for the restart test, an intentionally-still-running
+// replacement grandchild) can never leak an orphaned stubborn_listener.py
+// process into CI. Guarded by a signal-0 probe first so it never signals a
+// pid that has already been reaped (and, vanishingly rarely, reused by an
+// unrelated process).
+func killIfAlive(pid int) {
+	if pid <= 0 {
+		return
+	}
+	if err := syscall.Kill(pid, 0); err == nil {
+		_ = syscall.Kill(pid, syscall.SIGKILL)
+	}
+}
+
+// waitForPIDGone polls until pid is no longer alive, up to timeout. It returns
+// true once the pid is gone (or was never alive) and false if it is still alive
+// at the deadline, so each caller can craft its own context-specific failure
+// message.
+func waitForPIDGone(pid int, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) && processAlive(pid) {
+		time.Sleep(100 * time.Millisecond)
+	}
+	return !processAlive(pid)
+}
+
+// TestRestart_ReloadsEnvFile (A1): a process echoes a value sourced from its
+// env_file in a loop; editing the file and restarting must cause the
+// replacement to observe the new value -- proving env_file reload works
+// end-to-end through the real binary and API (D1).
+func TestRestart_ReloadsEnvFile(t *testing.T) {
+	skipShort(t)
+
+	binary := buildBinary(t)
+	addr := "http://127.0.0.1:15562"
+
+	dir := t.TempDir()
+	envFile := filepath.Join(dir, "worker.env")
+	requireNoError(t, os.WriteFile(envFile, []byte("MYVAL=v1\n"), 0644), "writing initial env file")
+
+	cfgContent := fmt.Sprintf(`api:
+  port: 15562
+  host: 127.0.0.1
+
+processes:
+  echoenv:
+    cmd: 'while :; do echo "MYVAL=$MYVAL"; sleep 0.3; done'
+    env_file: %q
+`, envFile)
+	cfgPath := filepath.Join(dir, "prox.yaml")
+	requireNoError(t, os.WriteFile(cfgPath, []byte(cfgContent), 0644), "writing temp config")
+
+	prox := startProxWithOutput(t, binary, "up", "-c", cfgPath)
+	defer killProx(prox.cmd)
+
+	waitForAPI(t, addr, 10*time.Second)
+
+	// Confirm the process is running with the initial value before mutating
+	// the env file out from under it.
+	waitForLogContains(t, addr, "echoenv", "MYVAL=v1", 5*time.Second)
+
+	// Mutate the (mutable, t.TempDir-owned) env file -- never a committed
+	// fixture -- and restart.
+	requireNoError(t, os.WriteFile(envFile, []byte("MYVAL=v2\n"), 0644), "rewriting env file")
+
+	status, errResp := restartProcess(t, addr, "echoenv")
+	if status != http.StatusOK {
+		t.Fatalf("restart failed: status=%d code=%s error=%s", status, errResp.Code, errResp.Error)
+	}
+
+	// The replacement instance must reload env_file from disk and observe
+	// the new value.
+	waitForLogContains(t, addr, "echoenv", "MYVAL=v2", 5*time.Second)
+}
+
+// TestStop_KillsStubbornGrandchild (A3): the leader exits gracefully on
+// SIGTERM but a backgrounded grandchild ignores it and holds a real TCP port.
+// `stop` must return only once the grandchild is verified gone (escalating to
+// SIGKILL after the graceful window). This test is inherently slow (~the
+// graceful deadline, ~8s by default) because that escalation window is real.
+func TestStop_KillsStubbornGrandchild(t *testing.T) {
+	skipShort(t)
+
+	binary := buildBinary(t)
+	addr := stubbornAPIAddr
+
+	prox := startProxWithOutput(t, binary, "up", "-c", configPath("stubborn"))
+	defer killProx(prox.cmd)
+
+	var grandchildPID int
+	t.Cleanup(func() { killIfAlive(grandchildPID) })
+
+	waitForAPI(t, addr, 10*time.Second)
+
+	pidStr := waitForMarkerValue(t, addr, "worker", "GRANDCHILD_PID=", "", 5*time.Second)
+	pid, err := strconv.Atoi(pidStr)
+	requireNoError(t, err, "parsing GRANDCHILD_PID")
+	grandchildPID = pid
+
+	waitForMarkerValue(t, addr, "worker", "LISTENING=", "", 5*time.Second)
+
+	start := time.Now()
+	status, errResp := stopProcess(t, addr, "worker")
+	elapsed := time.Since(start)
+	if status != http.StatusOK {
+		t.Fatalf("stop failed: status=%d code=%s error=%s (after %v)", status, errResp.Code, errResp.Error, elapsed)
+	}
+	t.Logf("stop of stubborn worker took %v", elapsed)
+
+	// Stop() only returns after its finalization gate + verdict, so the
+	// grandchild should already be gone -- poll with a deadline as a
+	// robustness net rather than asserting instantaneously.
+	if !waitForPIDGone(grandchildPID, 15*time.Second) {
+		t.Fatalf("grandchild pid %d still alive %v after stop returned (stop took %v)", grandchildPID, 15*time.Second, elapsed)
+	}
+}
+
+// TestRestart_StubbornGrandchildPortRebinds (A4): same stubborn-grandchild
+// scenario, but via restart. The old group must be fully reaped before the
+// replacement starts, so the replacement's grandchild can rebind the same
+// port (no EADDRINUSE) -- proof the old listener genuinely released it since
+// SO_REUSEADDR is deliberately off in stubborn_listener.py.
+func TestRestart_StubbornGrandchildPortRebinds(t *testing.T) {
+	skipShort(t)
+
+	binary := buildBinary(t)
+	addr := stubbornAPIAddr
+
+	prox := startProxWithOutput(t, binary, "up", "-c", configPath("stubborn"))
+	defer killProx(prox.cmd)
+
+	var oldPID, newPID int
+	t.Cleanup(func() {
+		killIfAlive(newPID)
+		killIfAlive(oldPID)
+	})
+
+	waitForAPI(t, addr, 10*time.Second)
+
+	oldPIDStr := waitForMarkerValue(t, addr, "worker", "GRANDCHILD_PID=", "", 5*time.Second)
+	oldPID, err := strconv.Atoi(oldPIDStr)
+	requireNoError(t, err, "parsing initial GRANDCHILD_PID")
+	waitForMarkerValue(t, addr, "worker", "LISTENING=", "", 5*time.Second)
+
+	start := time.Now()
+	status, errResp := restartProcess(t, addr, "worker")
+	elapsed := time.Since(start)
+	if status != http.StatusOK {
+		t.Fatalf("restart failed: status=%d code=%s error=%s (after %v)", status, errResp.Code, errResp.Error, elapsed)
+	}
+	t.Logf("restart of stubborn worker took %v", elapsed)
+
+	// The old grandchild must be gone -- restart's internal Stop only
+	// launches the replacement once the old group was verified reaped.
+	if processAlive(oldPID) {
+		t.Fatalf("old grandchild pid %d still alive after restart returned", oldPID)
+	}
+
+	// A new, distinct grandchild must appear (this marker is only printed
+	// after a successful bind+listen, so its mere presence proves the
+	// rebind succeeded -- a failed rebind would crash the python script
+	// before it ever printed GRANDCHILD_PID/LISTENING).
+	newPIDStr := waitForMarkerValue(t, addr, "worker", "GRANDCHILD_PID=", oldPIDStr, 10*time.Second)
+	newPID, err = strconv.Atoi(newPIDStr)
+	requireNoError(t, err, "parsing new GRANDCHILD_PID")
+	if newPID == oldPID {
+		t.Fatalf("expected a new grandchild pid distinct from %d, got the same pid", oldPID)
+	}
+
+	listeningPort := waitForMarkerValue(t, addr, "worker", "LISTENING=", "", 5*time.Second)
+	if listeningPort != stubbornListenerPort {
+		t.Fatalf("expected grandchild to listen on port %s, got %q", stubbornListenerPort, listeningPort)
+	}
+
+	// The replacement should have settled into "running" (not crashed on
+	// EADDRINUSE).
+	waitForProcessState(t, addr, "worker", "running", 3*time.Second)
+}
+
+// TestFullStop_NoOrphanedGrandchild (A5): the same stubborn-grandchild
+// scenario via a full-instance `prox stop` (POST /api/v1/shutdown). After the
+// daemon process exits, no member of the original group -- in particular the
+// grandchild holding the port -- may remain.
+func TestFullStop_NoOrphanedGrandchild(t *testing.T) {
+	skipShort(t)
+
+	binary := buildBinary(t)
+	addr := stubbornAPIAddr
+
+	prox := startProxWithOutput(t, binary, "up", "-c", configPath("stubborn"))
+	defer killProx(prox.cmd)
+
+	var grandchildPID int
+	t.Cleanup(func() { killIfAlive(grandchildPID) })
+
+	waitForAPI(t, addr, 10*time.Second)
+
+	pidStr := waitForMarkerValue(t, addr, "worker", "GRANDCHILD_PID=", "", 5*time.Second)
+	pid, err := strconv.Atoi(pidStr)
+	requireNoError(t, err, "parsing GRANDCHILD_PID")
+	grandchildPID = pid
+	waitForMarkerValue(t, addr, "worker", "LISTENING=", "", 5*time.Second)
+
+	requireNoError(t, stopProx(t, addr), "requesting full shutdown")
+
+	done := make(chan error, 1)
+	go func() { done <- prox.cmd.Wait() }()
+
+	select {
+	case <-done:
+		// Process exited.
+	case <-time.After(20 * time.Second):
+		killProx(prox.cmd)
+		t.Fatal("prox did not shut down within timeout")
+	}
+
+	if !waitForPIDGone(grandchildPID, 5*time.Second) {
+		t.Fatalf("grandchild pid %d still alive after full shutdown", grandchildPID)
+	}
+}

--- a/testdata/configs/stubborn.yaml
+++ b/testdata/configs/stubborn.yaml
@@ -1,0 +1,9 @@
+api:
+  port: 15560  # Dedicated port for the orphan-grandchild integration tests
+  host: 127.0.0.1
+
+processes:
+  worker:
+    cmd: ./testdata/scripts/stubborn_grandchild.sh
+    env:
+      STUBBORN_PORT: "15561"

--- a/testdata/scripts/stubborn_grandchild.sh
+++ b/testdata/scripts/stubborn_grandchild.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Leader shell for the #29 orphan-grandchild integration tests.
+#
+# prox launches this via `sh -c '<cmd>'`. Because this script is the sole
+# command in that invocation, the launching shell execs directly into it, so
+# this script's own process is the process-group leader (Setpgid'd by prox at
+# launch). It backgrounds stubborn_listener.py, which is therefore a true
+# *grandchild* relative to prox.
+#
+# On SIGTERM the leader exits cleanly (like a well-behaved process would), but
+# the backgrounded python grandchild ignores SIGTERM (see stubborn_listener.py)
+# and keeps holding its TCP port -- exactly the scenario where naive
+# leader-only shutdown reports success while an orphan lingers.
+
+PORT="${STUBBORN_PORT:-15561}"
+SCRIPT_DIR=$(dirname "$0")
+
+echo "LEADER_PID=$$"
+
+trap 'echo LEADER_GOT_TERM; exit 0' TERM
+
+python3 "$SCRIPT_DIR/stubborn_listener.py" "$PORT" &
+CHILD_PID=$!
+
+wait "$CHILD_PID"

--- a/testdata/scripts/stubborn_listener.py
+++ b/testdata/scripts/stubborn_listener.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Grandchild process that ignores SIGTERM and holds a real TCP listener.
+
+Used by testdata/scripts/stubborn_grandchild.sh to reproduce the #29 orphan
+scenario: a leader shell exits gracefully on SIGTERM while a backgrounded
+grandchild ignores SIGTERM and keeps the port bound. It must be reaped with
+SIGKILL -- this script deliberately has no clean way to exit otherwise.
+
+Dependency-free: stdlib only (socket/signal/os/sys/time), so it needs no
+virtualenv or installed packages in CI.
+
+Markers printed (flush=True) once bound:
+  GRANDCHILD_PID=<pid>
+  LISTENING=<port>
+"""
+import os
+import signal
+import socket
+import sys
+import time
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("usage: stubborn_listener.py <port>", file=sys.stderr, flush=True)
+        sys.exit(1)
+    port = int(sys.argv[1])
+
+    # Ignore SIGTERM: this process must survive a graceful shutdown attempt so
+    # the integration tests can prove that Stop/Restart escalate to SIGKILL
+    # for a stubborn grandchild that outlives its leader.
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    # Deliberately do NOT set SO_REUSEADDR: a surviving listener must
+    # genuinely block a rebind attempt on the same port, so a successful
+    # rebind after restart/stop is proof the old grandchild is truly gone.
+    sock.bind(("127.0.0.1", port))
+    sock.listen(1)
+
+    print(f"GRANDCHILD_PID={os.getpid()}", flush=True)
+    print(f"LISTENING={port}", flush=True)
+
+    while True:
+        time.sleep(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes #29.

`prox restart` could report success while (a) running the replacement with a **stale environment** and (b) leaving the previous process's **grandchildren alive**, so an updated secret/config appeared applied while the old worker kept its listening port (`EADDRINUSE`). `prox stop` could leave the same orphan and still report success. Two independent root causes are fixed here, each as its own commit.

## What changed, per workstream

### 1. `env_file` is reloaded on every start (`dfc93ce`)
`config.LoadProcessEnv` was called once at supervisor start and the result cached for the supervisor's lifetime. Env loading now happens in a `loadEnv` closure invoked at the top of `ManagedProcess.Start` (before any lifecycle state is created), so `start`-after-`stop` and the replacement half of `restart` both re-read the global + process `env_file` and re-merge inline `env`. A failing reload fails loudly (process marked crashed, `Start` returns a wrapped `ErrEnvReloadFailed`) instead of launching with a stale environment.

### 2. Restart starts the replacement on the supervisor context (`a36de9a`)
`RestartProcess` threaded the request-scoped context into the replacement's `Start`, so once the HTTP handler returned, the fresh process's health checker and lifecycle context were torn down. `Restart` now takes distinct stop/start contexts and starts the replacement on the supervisor's long-lived `s.ctx` (matching `StartProcess`).

### 3. PGID captured at launch + group-liveness probe (`4faf583`)
The process group id is recorded at launch (the leader PID, since we `Setpgid`) instead of being re-derived via `Getpgid` at signal time (which fails once the leader exits, dropping the surviving group). Adds `Process.GroupAlive() (bool, error)` — a signal-0 probe — and hard-guards group signaling to `pgid > 0` so it can never signal prox's own group.

### 4. Stop/restart gate on the whole process group and kill orphans (`332ad8b`)
- Per-run `processInstance` with a **generation guard**, so a stale `monitor` from a previous run can never clobber a newer run; the live instance (and its pgid) is retained so a surviving group stays reapable.
- `Stop` now: SIGTERM the group → poll `GroupAlive()` until a **time-based graceful deadline** (never keyed off the leader's exit, so a slow-but-graceful grandchild isn't killed early) → **SIGKILL the group** at the deadline → finalization gate (wait for the run's monitor to finish and reap the leader) → authoritative re-probe. Group gone ⇒ `stopped`; group survived ⇒ `crashed` + `ErrProcessGroupNotReaped`.
- **Failure contract:** `prox stop <name>` / `prox restart <name>` now return a non-zero exit / typed API error (`PROCESS_GROUP_NOT_REAPED`) when a group can't be reaped, instead of always reporting success (matches the systemd/docker convention). Full `prox stop` best-effort-kills each group and logs `could not reap process group for <name>`.

## Verification

- **`make lint` (0 issues), `make build`, `make test`, `go test -race ./internal/supervisor/...` green.**
- **Unit tests** (deterministic, via a fake `ProcessRunner`/`Process`, run under `-race`): graceful death → success + *no* SIGKILL; stubborn → SIGKILL escalation → success; unreapable → `ErrProcessGroupNotReaped` + retry; restart-clobber loop; `Start`-during-`Stop` rejection; deadline edge cases; PGID capture / `GroupAlive`; env reload + typed failure; restart health-checker survival.
- **Integration tests** (real binary, real processes/ports): a stubborn grandchild (Python `SIG_IGN` on SIGTERM holding a TCP port, under a leader shell that exits on SIGTERM) is killed by `stop`, its port rebinds after `restart`, and full `stop` leaves no orphan; env reload is exercised end-to-end through an edited env file. Each stubborn test kills recorded grandchild PIDs in `t.Cleanup` (no CI orphan leak). The pre-existing graceful-shutdown output-capture test still passes (no premature SIGKILL).
- **Manual, real CLI:** `prox restart` picked up an edited `env_file` value (exit 0); `prox stop worker` reaped a stubborn orphan after the ~8s graceful window (log: `sending SIGKILL to worker (graceful shutdown timed out)`), returned exit 0, and freed the port.

## Impact / notes

- **Behavior change:** `stop`/`restart` can now take up to the graceful window (~8s) before SIGKILLing a stuck group, and `prox stop <name>` / `prox restart <name>` can now return a **non-zero exit** when a group genuinely can't be reaped. Scripts that assumed `stop` always succeeds should be aware.
- **No new dependencies. No secrets touched** — env values are never logged (only the failing env-file path is surfaced in an error, which is the user's own config path). Unix-only, consistent with the existing supervisor.
- **Accepted/known limitations (documented):** pgid-reuse window and `setsid`/detached-group escape (inherent to pgid-based signaling; a cgroup-scoped kill is future work); PID-1-without-reaping zombie lingering; a concurrent same-process `Stop` may report success just before the primary's verdict (only inconsistent given a genuinely unreapable group); no-arg `prox stop` reports async and best-effort. Reloading a changed `cmd`/`prox.yaml` on restart is intentionally **out of scope** (env values only) — a good follow-up.

## Process

Plan authored, pressure-tested by an AI panel (Codex + Kimi + CodeRabbit), then implemented as four gated commits (lint/test/build + `-race` per commit), each simplified and correctness-reviewed by an adversarial Codex pass. Two Codex findings on the concurrency were dispositioned: the finalization-gate/monitor state-override race was **fixed**; the concurrent-same-process-`Stop` edge was **documented** as future work.

<details>
<summary>Plan excerpt — pinned design decisions (D1–D4)</summary>

**D1 — Reload `env_file` inside every `Start`:** a `loadEnv` closure captures the env-file paths + inline map + configDir by value and re-reads on each start; failure ⇒ crashed + `ErrEnvReloadFailed` with no dangling instance.

**D2 — Capture PGID at launch; group-aware probe:** store `cmd.Process.Pid` as the pgid; `GroupAlive() (bool,error)` maps ESRCH/`os.ErrProcessDone` ⇒ gone, nil/EPERM/other ⇒ conservatively alive; hard `pgid>0` guards in `Signal`/`GroupAlive`.

**D3 — Per-run instance model + group-gated stop:** `processInstance{proc,done,cancel,outputWg}`; `current` retained; generation-guarded `monitor` (only `running→crashed`, never overrides a terminal state); `Stop` = SIGTERM → time-based graceful poll → SIGKILL at `gracefulDeadline` → finalization gate on `inst.done` → verdict; `computeDeadlines` reserves `KillGrace` (2s) inside `ShutdownTimeout` and handles no-deadline / near-expired ctx; `Start` rejects `stopping` and refuses to launch over a surviving group.

**D4 — Failure contract:** `ErrProcessGroupNotReaped`/`PROCESS_GROUP_NOT_REAPED` + `writeError` case ⇒ non-zero CLI exit; full stop best-effort + logs the un-reaped group.

Acceptance criteria A1–A11 map 1:1 to these workstreams and are covered by the unit + integration + manual verification above.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process stopping/restarting to reliably handle stubborn processes and prevent stale monitors from impacting newer runs.
  * Added stronger cleanup checks to ensure process groups are fully reaped (with dedicated error codes when reaping fails).
  * Reloads environment files on every start and rejects start attempts while a stop is still in progress.
* **Tests**
  * Expanded unit tests for stop/restart deadlines, error mapping, and start-during-stop protection.
  * Added integration tests covering stubborn grandchild shutdown, port rebinds on restart, env reload, and no orphaned processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->