### PR TITLE
docs(skills): sync config reference with shared-proxy-daemon content

### DIFF
--- a/skills/prox/references/configuration.md
+++ b/skills/prox/references/configuration.md
@@ -218,7 +218,20 @@ certs:
 | `proxy.enabled` | bool | auto | Enable reverse proxy (auto-enabled when a port is set) |
 | `proxy.http_port` | int | — | Port for the HTTP proxy server |
 | `proxy.https_port` | int | `6789` | Port for the HTTPS proxy server (default when enabled with no ports set) |
-| `proxy.domain` | string | required | Base domain for subdomain routing |
+| `proxy.domain` | string | required | Base domain used to derive hostnames for shared proxy routing |
+| `proxy.capture.enabled` | bool | `false` | Capture request and response body metadata for proxied requests |
+| `proxy.capture.max_body_size` | string | `1MB` | Maximum request or response body size to capture |
+
+### Shared Proxy Daemon
+
+When a proxy is configured, prox registers routes with a per-user shared proxy daemon under `~/.prox/`. This lets multiple projects use the same proxy port, including HTTPS on `443`, as long as each project owns distinct hostnames.
+
+The behavior is automatic:
+
+- `prox up` starts the daemon if needed and registers this project's services.
+- `prox down` deregisters only this project.
+- The daemon stops after the last project deregisters.
+- `prox proxy status` and `prox proxy routes` show daemon state.
 
 ### Service Fields
 
@@ -245,13 +258,31 @@ services:
 | `certs.dir` | string | `~/.prox/certs` | Directory for storing certificates |
 | `certs.auto_generate` | bool | `true` | Automatically generate certificates using mkcert |
 
+### Request Capture
+
+Request capture records request and response body metadata for the `prox requests <id>` detail view. Bodies up to `proxy.capture.max_body_size` are retained; larger bodies are truncated.
+
+```yaml
+proxy:
+  https_port: 6789
+  domain: local.myapp.dev
+  capture:
+    enabled: true
+    max_body_size: 1MB
+```
+
+Captured body files are stored under `.prox/capture/` and cleaned up as request records age out of the in-memory request buffer.
+
 ### Prerequisites (HTTPS only)
 
-HTTPS mode requires mkcert for certificate generation. HTTP-only mode has no prerequisites.
+HTTPS mode requires [mkcert](https://github.com/FiloSottile/mkcert) for certificate generation. HTTP-only mode has no prerequisites.
 
 ```bash
 # macOS
 brew install mkcert
+
+# Linux
+# See https://github.com/FiloSottile/mkcert#installation
 
 # Install the CA (run once)
 mkcert -install


### PR DESCRIPTION
Follow-up to #37, which surfaced pre-existing drift between the two `configuration.md` mirrors.

## Problem

`skills/prox/references/configuration.md` was copied from `docs/reference/configuration.md` in #20, then the docs version gained the shared-proxy-daemon documentation (commit `7900e67`) that never propagated to the skills copy. `SKILL.md` advertises this file as the *full* configuration reference, so the omission left the skill's reference incomplete.

## What changed

Ported the missing content into the skills copy:
- `proxy.capture.enabled` / `proxy.capture.max_body_size` table rows
- reworded `proxy.domain` description (shared proxy routing)
- **Shared Proxy Daemon** section
- **Request Capture** section
- mkcert link + Linux install note

**Kept self-contained:** dropped the docs-only `../guides/…` relative links (they don't resolve inside the skill bundle) and left the skills copy's inline **DNS Setup** section, which is actually more detailed than the docs version's guide pointer. The two files now differ **only** in those two deliberate adaptations — verified by diff.

Docs-only, single file. No relative links that would break in the skill; code fences balanced.

## Related (not in this PR)

The sibling pair `docs/reference/api.md` (338 lines) vs `skills/prox/references/api.md` (292 lines) has similar drift. Left out to keep this PR scoped to the `configuration.md` drift that #37 flagged — happy to do the same reconciliation for `api.md` if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGkrwspiQ6eHyVJfzHFDfx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added configuration options for capturing request and response bodies, including size limits.
  * Documented request capture retention, truncation, storage, and cleanup behavior.
  * Added guidance for the shared proxy daemon and proxy status and routing commands.
  * Expanded HTTPS setup instructions with macOS and Linux installation guidance for `mkcert`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->