### PR TITLE
docs(skills): sync api reference with canonical docs

### DIFF
--- a/skills/prox/references/api.md
+++ b/skills/prox/references/api.md
@@ -2,7 +2,7 @@
 
 ## Base URL
 
-```text
+```
 http://{host}:{port}/api/v1
 ```
 
@@ -38,6 +38,10 @@ All errors return JSON:
 | `PROCESS_NOT_RUNNING` | Process is not running |
 | `INVALID_PATTERN` | Invalid regex pattern |
 | `SHUTDOWN_IN_PROGRESS` | Supervisor is shutting down |
+| `PROXY_NOT_ENABLED` | Proxy request inspection is unavailable because the proxy is disabled |
+| `STREAMING_NOT_SUPPORTED` | The server cannot provide an SSE stream for this request |
+| `REQUEST_NOT_FOUND` | Proxy request ID does not exist in the request buffer |
+| `MISSING_REQUEST_ID` | Request detail endpoint was called without an ID |
 
 ## Endpoints
 
@@ -162,11 +166,10 @@ Retrieve logs from buffer.
 |-------|------|---------|-------------|
 | `process` | string | all | Comma-separated process names |
 | `lines` | int | 100 | Max lines to return |
-| `bytes` | int | — | Max bytes to return |
 | `pattern` | string | — | Filter pattern |
 | `regex` | bool | false | Treat pattern as regex |
 
-If both `lines` and `bytes` are specified, whichever limit hits first applies.
+The `lines` parameter is capped at 10000.
 
 **Response:**
 
@@ -189,11 +192,11 @@ If both `lines` and `bytes` are specified, whichever limit hits first applies.
 
 Stream logs via Server-Sent Events (SSE).
 
-**Query Parameters:** Same as `GET /logs`, excluding `lines` and `bytes` (not applicable to streaming)
+**Query Parameters:** Same as `GET /logs` (except `lines`)
 
 **Response:** SSE stream
 
-```text
+```
 data: {"timestamp":"2025-01-19T10:32:01.123Z","process":"web","stream":"stdout","line":"GET /api/users 200 12ms"}
 
 data: {"timestamp":"2025-01-19T10:32:01.456Z","process":"api","stream":"stderr","line":"WARN: connection pool low"}
@@ -255,17 +258,60 @@ curl "http://localhost:5555/api/v1/proxy/requests?subdomain=api"
 curl "http://localhost:5555/api/v1/proxy/requests?min_status=500"
 ```
 
+### GET /proxy/requests/{id}
+
+Retrieve details for one proxied request.
+
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `include` | string | — | Set to `body` to include captured request and response body data |
+
+Body data is available only when capture was enabled with `prox up --capture` or `proxy.capture.enabled: true`.
+
+**Response:**
+
+```json
+{
+  "id": "a1b2c3d",
+  "timestamp": "2025-01-19T10:32:01.123Z",
+  "method": "POST",
+  "url": "/api/users",
+  "subdomain": "api",
+  "status_code": 201,
+  "duration_ms": 45,
+  "remote_addr": "127.0.0.1",
+  "details": {
+    "request_headers": {
+      "Content-Type": ["application/json"]
+    },
+    "request_body": {
+      "size": 27,
+      "truncated": false,
+      "content_type": "application/json",
+      "is_binary": false,
+      "data": "{\"name\":\"Ada\"}"
+    }
+  }
+}
+```
+
+**Examples:**
+
+```bash
+curl http://localhost:5555/api/v1/proxy/requests/a1b2c3d
+curl "http://localhost:5555/api/v1/proxy/requests/a1b2c3d?include=body"
+```
+
 ### GET /proxy/requests/stream
 
 Stream proxy requests via Server-Sent Events (SSE).
 
-**Query Parameters:** Same as `GET /proxy/requests`, excluding `limit` (not applicable to streaming)
+**Query Parameters:** Same as `GET /proxy/requests` (except `limit`)
 
 **Response:** SSE stream
 
-```text
-event: connected
-data: {}
+```
+: connected
 
 data: {"id":"a1b2c3d","timestamp":"2025-01-19T10:32:01.123Z","method":"GET","url":"/api/users","subdomain":"api","status_code":200,"duration_ms":45,"remote_addr":"127.0.0.1"}
 ```


### PR DESCRIPTION
Second half of the mirror-drift cleanup (after #38 fixed `configuration.md`).

## Problem

`skills/prox/references/api.md` had drifted from the canonical `docs/reference/api.md` and documented stale API behavior:
- still listed the removed `bytes` log parameter (and the "lines vs bytes" note)
- used the old `event: connected` SSE framing instead of the current `: connected` comment
- missing four error codes: `PROXY_NOT_ENABLED`, `STREAMING_NOT_SUPPORTED`, `REQUEST_NOT_FOUND`, `MISSING_REQUEST_ID`
- missing the entire `GET /proxy/requests/{id}` endpoint (request detail + body capture)

## What changed

Unlike `configuration.md` (which has docs-site `../guides/…` links that must be stripped for the skill), `api.md` is pure API content with no relative links — so the skills copy is simply mirrored to match `docs/reference/api.md` exactly. Verified byte-identical, no relative links, balanced code fences.

Docs-only, single file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGkrwspiQ6eHyVJfzHFDfx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated HTTP API reference formatting and response examples.
  * Added error codes for proxy enablement, streaming support, and invalid request IDs.
  * Clarified log retrieval limits and query parameters.
  * Documented the `GET /proxy/requests/{id}` endpoint, including optional request body details.
  * Updated streaming endpoint documentation and SSE examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->