### PR TITLE
fix(api): return JSON error from logs stream when flushing unsupported

### DIFF
--- a/internal/api/sse.go
+++ b/internal/api/sse.go
@@ -12,18 +12,22 @@ import (
 
 // StreamLogs handles GET /api/v1/logs/stream (SSE)
 func (h *Handlers) StreamLogs(w http.ResponseWriter, r *http.Request) {
+	// Check if flusher is available before writing any SSE headers, so the
+	// error path can return a clean JSON error (matching StreamProxyRequests).
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeJSON(w, http.StatusInternalServerError, ErrorResponse{
+			Error: "streaming not supported",
+			Code:  domain.ErrCodeStreamingNotSupported,
+		})
+		return
+	}
+
 	// Set SSE headers
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
 	w.Header().Set("X-Accel-Buffering", "no")
-
-	// Check if flusher is available
-	flusher, ok := w.(http.Flusher)
-	if !ok {
-		http.Error(w, "Streaming not supported", http.StatusInternalServerError)
-		return
-	}
 
 	// Parse filter parameters
 	filter := domain.LogFilter{}

--- a/internal/api/sse_test.go
+++ b/internal/api/sse_test.go
@@ -282,6 +282,13 @@ func TestStreamLogs_NoFlusher_ReturnsJSONError(t *testing.T) {
 	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
 		t.Errorf("expected Content-Type 'application/json', got %q", ct)
 	}
+	// The error path must run before any SSE headers are written; assert none
+	// leaked (Content-Type alone is insufficient, since writeJSON overwrites it).
+	for _, header := range []string{"Cache-Control", "Connection", "X-Accel-Buffering"} {
+		if got := w.Header().Get(header); got != "" {
+			t.Errorf("expected %s to be unset on the error path, got %q", header, got)
+		}
+	}
 
 	var errResp ErrorResponse
 	if err := json.Unmarshal(w.body, &errResp); err != nil {

--- a/internal/api/sse_test.go
+++ b/internal/api/sse_test.go
@@ -238,3 +238,56 @@ func TestStreamLogs_InvalidPattern(t *testing.T) {
 		t.Errorf("expected code %q, got %q", domain.ErrCodeInvalidPattern, errResp.Code)
 	}
 }
+
+// noFlushWriter is a minimal http.ResponseWriter that deliberately does NOT
+// implement http.Flusher, so it exercises StreamLogs' no-flusher branch.
+// (httptest.ResponseRecorder implements Flusher, so it cannot.)
+type noFlushWriter struct {
+	headers http.Header
+	status  int
+	body    []byte
+}
+
+func (w *noFlushWriter) Header() http.Header {
+	if w.headers == nil {
+		w.headers = make(http.Header)
+	}
+	return w.headers
+}
+
+func (w *noFlushWriter) Write(p []byte) (int, error) {
+	w.body = append(w.body, p...)
+	return len(p), nil
+}
+
+func (w *noFlushWriter) WriteHeader(status int) { w.status = status }
+
+func TestStreamLogs_NoFlusher_ReturnsJSONError(t *testing.T) {
+	logMgr := logs.NewManager(logs.ManagerConfig{
+		BufferSize:         100,
+		SubscriptionBuffer: 10,
+	})
+	defer logMgr.Close()
+
+	handlers := NewHandlers(nil, logMgr, "test.yaml", nil)
+
+	req := httptest.NewRequest("GET", "/api/v1/logs/stream", nil)
+	w := &noFlushWriter{}
+
+	handlers.StreamLogs(w, req)
+
+	if w.status != http.StatusInternalServerError {
+		t.Errorf("expected status %d, got %d", http.StatusInternalServerError, w.status)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected Content-Type 'application/json', got %q", ct)
+	}
+
+	var errResp ErrorResponse
+	if err := json.Unmarshal(w.body, &errResp); err != nil {
+		t.Fatalf("response body is not JSON: %v (body=%q)", err, w.body)
+	}
+	if errResp.Code != domain.ErrCodeStreamingNotSupported {
+		t.Errorf("expected code %q, got %q", domain.ErrCodeStreamingNotSupported, errResp.Code)
+	}
+}


### PR DESCRIPTION
Follow-up from CodeRabbit's review of #39 — a genuine doc/code mismatch (pre-existing on `main`).

## Problem

`docs/reference/api.md` documents `STREAMING_NOT_SUPPORTED` as a JSON error code, and it *is* returned as `{error, code}` JSON by the sibling stream handler `StreamProxyRequests` (`internal/api/handlers.go:428`) and by `internal/proxyd/server.go:323`. But `StreamLogs` (`/api/v1/logs/stream`) was the outlier: on the no-`http.Flusher` branch it returned a **plain-text** `http.Error("Streaming not supported", 500)` instead of the documented JSON.

## Fix

- `StreamLogs` now returns `writeJSON(500, ErrorResponse{Error: "streaming not supported", Code: domain.ErrCodeStreamingNotSupported})`, matching the sibling handler and the documented contract.
- Moved the flusher check ahead of the SSE header writes so the error path emits a clean `application/json` response (same ordering as `StreamProxyRequests`). When a flusher is present, behavior is unchanged (verified by the existing `TestStreamLogs_Headers`).
- Added `TestStreamLogs_NoFlusher_ReturnsJSONError`, which drives a `ResponseWriter` that deliberately does not implement `http.Flusher` (since `httptest.ResponseRecorder` does).

The path is effectively unreachable in normal serving (Go's HTTP/1.1 and HTTP/2 `ResponseWriter` implement `Flusher`), so this is a consistency/correctness fix rather than a live-bug fix. Gate green: build, full test suite, `golangci-lint` (0 issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGkrwspiQ6eHyVJfzHFDfx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log streaming error handling when the connection does not support streaming.
  * Returns a clean JSON error response with an appropriate status and content type instead of malformed streaming output.
  * Preserved existing real-time log streaming behavior for supported connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->