### PR TITLE
Configurable stop timeouts (#35) + restart/start config hot-reload (#33) + docs audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@ All notable changes to this project will be documented in this file.
 
 ### Fixes
 
+- `prox start <name>` now discovers the daemon's API address from `.prox/prox.state`
+  like the other client commands; previously it always used the default `:5555`
+  address and failed against daemons on dynamic API ports (found during #33
+  verification).
 - **Healthcheck `interval`/`timeout`/`retries`/`start_period` are now honored**
   (#31). Previously only `healthcheck.cmd` took effect; the timing/retry fields
   were silently dropped and replaced by the built-in defaults (`10s`/`5s`/`3`/
@@ -222,3 +226,4 @@ Initial release of prox, a modern process manager for local development.
 - Background daemon mode with `--detach` flag
 - CLI built with Cobra framework with shell completions
 - REST API for programmatic control
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- **`restart` and `start` apply the current `prox.yaml`** (#33). An API-driven
+  (re)start — `prox restart <name>`, and `prox start <name>` after a
+  `prox stop <name>` — now re-reads and validates the whole config file and runs
+  the process with its **current** config, so the edit → restart → observe loop
+  no longer needs a full `prox stop` + `prox up`. Applied on (re)start: `cmd`,
+  `healthcheck`, `stop_timeout` (the new value governs the next stop; the
+  restart's own stop half keeps the pre-edit budget), and environment inputs
+  (inline `env`, per-process and global `env_file`, including changed file
+  paths). Renames, added/removed processes, and `services`/`proxy`/port changes
+  still require `prox up`. The reload is **fail-closed**: an invalid file (even an
+  unrelated process or the proxy section), a missing referenced env file, or a
+  removed target aborts the (re)start with the existing process left running
+  unchanged, via two new error codes — `CONFIG_RELOAD_FAILED` (HTTP 422) and
+  `PROCESS_NOT_IN_CONFIG` (HTTP 409). The config swap is applied atomically inside
+  the start's locked critical section, so a start racing a restart never leaves
+  the running process and stored config mismatched.
 - **Configurable stop timeout** (#35). Two new duration fields control the
   SIGTERM→SIGKILL escalation budget: global `shutdown_timeout` (top-level) and
   per-process `stop_timeout` (overrides the global). The effective budget for a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Features
+
+- **Configurable stop timeout** (#35). Two new duration fields control the
+  SIGTERM→SIGKILL escalation budget: global `shutdown_timeout` (top-level) and
+  per-process `stop_timeout` (overrides the global). The effective budget for a
+  process is its own `stop_timeout`, else the global `shutdown_timeout`, else the
+  built-in `10s` default. The value is the escalation window — a fixed `2s` is
+  reserved for the SIGKILL phase, so the graceful drain window is `budget − 2s`.
+  Values must be greater than `2s` and at most `10m`; anything outside that range
+  (including `0s`/negatives) is rejected at load with a field-named error. The
+  budget is honored end-to-end — `prox stop`, `prox restart` (the stop half), and
+  full daemon shutdown — and the effective value is surfaced as `stop_timeout` in
+  the `GET /processes/{name}` response.
+
+### Changed
+
+- **Daemon shutdown now uses per-stage deadlines instead of one shared 10s
+  budget** (#35). Full `prox stop` / Ctrl-C previously wrapped proxy teardown,
+  API-server shutdown, and *all* process stops in a single 10-second context, so
+  slow proxy/API teardown silently ate into the time available to stop processes
+  — truncating an otherwise-valid graceful drain. Teardown now runs in stages,
+  each with its own deadline computed at shutdown time: the proxy and API server
+  get short fixed deadlines, then every process is stopped concurrently, each on
+  its **own** configured stop budget (read live, so a per-process budget raised at
+  runtime is respected). With nothing configured, per-process escalation timing is
+  unchanged (10s/2s); the daemon's outer window simply no longer truncates a stop.
+
 ### Fixes
 
 - **Healthcheck `interval`/`timeout`/`retries`/`start_period` are now honored**

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
-.PHONY: build test lint clean install
+.PHONY: build test test-race lint clean install
 
 build:
 	go build -o prox ./cmd/prox
 
 test:
 	go test -v ./...
+
+test-race:
+	go test -race ./...
 
 lint:
 	golangci-lint run

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ processes:
 prox up [processes...]           # Start processes (foreground)
 prox up --tui [processes...]     # Start with interactive TUI
 prox stop                        # Stop running instance
-prox restart <process>           # Restart a process
+prox restart <process>           # Restart a process (re-reads prox.yaml, applies its current config)
 prox status                      # Show process status
 prox logs [process]              # Show recent logs
 prox logs -f [process]           # Stream logs

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ For one-off installs without configuring the apt repo (CI runners, locked-down h
 
 ```bash
 ARCH=$(dpkg --print-architecture)        # amd64 or arm64
-VERSION=0.1.1                            # check https://github.com/charliek/prox/releases for the latest
+VERSION=0.1.3                            # check https://github.com/charliek/prox/releases for the latest
 curl -fLO "https://github.com/charliek/prox/releases/download/v${VERSION}/prox_${VERSION}_${ARCH}.deb"
 sudo apt install -y "./prox_${VERSION}_${ARCH}.deb"
 ```
@@ -170,7 +170,7 @@ prox proxy routes
 
 ## HTTP API
 
-The API runs at `http://127.0.0.1:5555/api/v1` by default.
+By default, the API binds to a dynamic (auto-assigned) localhost port. Discover the address with `prox status`, or pin a fixed port by setting `api.port` in `prox.yaml` (e.g. `api.port: 5555`).
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -89,10 +89,13 @@ into the supervisor's process-stop budget:
 
 ### Process Restart
 
-1. Stop the process: SIGTERM to its process group, graceful liveness polling, SIGKILL escalation to the group at the graceful deadline, then a post-kill liveness check. If the group could not be reaped, restart aborts before starting a replacement and reports `PROCESS_GROUP_NOT_REAPED` (a surviving group is never shadowed by a new one)
-2. Increment the restart counter
-3. Start the process again — `env_file` files are re-read from disk on every start (including this restart's start half) and merged with the inline `env` values captured at `up` time
-4. Reset health check state
+Every API-driven (re)start (`restart`, and `start` after a `stop`) re-reads `prox.yaml` and applies the target process's current config, so an edit → restart loop works without a full `prox stop` + `prox up`.
+
+1. **Reload + validate + preflight (before any stop):** re-read the whole config file from its absolute path and validate it, look up the target process in the fresh config, build its new runtime (`cmd`, `healthcheck`, `stop_timeout`, and a rebuilt env-loader closure over the fresh global/per-process `env_file` and inline `env`), and preflight that env load. Any failure here leaves the running process **completely untouched** and returns a typed error: `CONFIG_RELOAD_FAILED` (invalid/unreadable file, or a missing referenced env file — whole-file validation means an invalid *unrelated* section also blocks the restart) or `PROCESS_NOT_IN_CONFIG` (target removed from the file). Renames, added/removed processes, and `services`/`proxy`/port changes are out of scope and require `prox up`
+2. Stop the process: SIGTERM to its process group, graceful liveness polling, SIGKILL escalation to the group at the graceful deadline, then a post-kill liveness check. This stop half uses the process's **pre-edit** stop budget; a raised `stop_timeout` governs the next stop. If the group could not be reaped, restart aborts before starting a replacement and reports `PROCESS_GROUP_NOT_REAPED` (a surviving group is never shadowed by a new one)
+3. Increment the restart counter
+4. Start the process again, **swapping the reloaded config in atomically**: the swap happens inside the start's locked critical section, after the already-running / surviving-group guards pass and before the process launches, so a concurrent start that wins the race launches the old config and the loser is refused (`PROCESS_ALREADY_RUNNING`) without applying its swap — the running process and the stored config never mismatch. `env_file` files are re-read from disk on this start half. If the launch fails after the swap, the new config stays active for the next start ("the file is the truth")
+5. Reset health check state
 
 ### Health Checks
 

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -36,7 +36,7 @@ This document describes the internal design of prox for contributors.
 
 ## Log Manager
 
-- Ring buffer per process (configurable size, default 1000 lines or 1MB)
+- Ring buffer per process (configurable size, default 1000 lines)
 - Each entry: `{timestamp, process, stream (stdout|stderr), line}`
 - Supports multiple concurrent readers/subscribers
 - Filter primitives: by process, by pattern (substring or regex)
@@ -56,26 +56,25 @@ This document describes the internal design of prox for contributors.
 
 1. Parse config file
 2. Load environment (global .env, per-process env_file, per-process env)
-3. Start HTTP API server
-4. Start each process
-5. Begin health checks (if configured)
-6. Attach log subscribers (terminal or TUI)
+3. Start each process (and begin its health checks, if configured)
+4. Start HTTP API server
+5. Attach log subscribers (terminal or TUI)
 
 ### Shutdown (Ctrl+C or API)
 
 1. Stop accepting new API requests
-2. Send SIGTERM to all child processes
-3. Wait for graceful shutdown (default 10 seconds)
-4. Send SIGKILL to any remaining processes
-5. Exit
+2. For each process, send SIGTERM to its entire process group (not just the leader), so descendants spawned by the command are included
+3. Poll the group's liveness until it exits or the graceful deadline passes (by default ~8 seconds: a 10-second total shutdown budget minus a 2-second reserve for the SIGKILL/verify phase)
+4. If the group is still alive at the graceful deadline, send SIGKILL to the group and poll again until the kill deadline passes
+5. Verify the group is actually gone; if it survived SIGKILL, the stop reports `PROCESS_GROUP_NOT_REAPED` instead of succeeding
+6. Exit
 
 ### Process Restart
 
-1. Send SIGTERM to process
-2. Wait for shutdown (timeout → SIGKILL)
-3. Reset restart counter if appropriate
-4. Start process again
-5. Reset health check state
+1. Stop the process: SIGTERM to its process group, graceful liveness polling, SIGKILL escalation to the group at the graceful deadline, then a post-kill liveness check. If the group could not be reaped, restart aborts before starting a replacement and reports `PROCESS_GROUP_NOT_REAPED` (a surviving group is never shadowed by a new one)
+2. Increment the restart counter
+3. Start the process again — `env_file` files are re-read from disk on every start (including this restart's start half) and merged with the inline `env` values captured at `up` time
+4. Reset health check state
 
 ### Health Checks
 

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -62,12 +62,30 @@ This document describes the internal design of prox for contributors.
 
 ### Shutdown (Ctrl+C or API)
 
-1. Stop accepting new API requests
-2. For each process, send SIGTERM to its entire process group (not just the leader), so descendants spawned by the command are included
-3. Poll the group's liveness until it exits or the graceful deadline passes (by default ~8 seconds: a 10-second total shutdown budget minus a 2-second reserve for the SIGKILL/verify phase)
-4. If the group is still alive at the graceful deadline, send SIGKILL to the group and poll again until the kill deadline passes
-5. Verify the group is actually gone; if it survived SIGKILL, the stop reports `PROCESS_GROUP_NOT_REAPED` instead of succeeding
-6. Exit
+The daemon tears down in stages, each with its own deadline computed at shutdown
+time rather than one shared budget, so proxy/API teardown time can never eat
+into the supervisor's process-stop budget:
+
+1. Deregister from (or stop) the proxy — a short fixed stage deadline
+2. Stop the API server — a short fixed stage deadline. The server stops
+   accepting new connections and waits up to the stage deadline for in-flight
+   requests; a still-running lifecycle request is not force-closed, and the
+   supervisor stage below stops its process regardless
+3. Stop all processes (the supervisor stage), bounded by the maximum per-process
+   stop budget currently in force plus a small margin. Each process is stopped
+   concurrently on its **own** effective stop budget:
+   1. Send SIGTERM to its entire process group (not just the leader), so
+      descendants spawned by the command are included
+   2. Poll the group's liveness until it exits or the graceful deadline passes.
+      The graceful window is the process's configured stop budget minus a 2-second
+      reserve for the SIGKILL/verify phase — by default ~8 seconds (a 10-second
+      budget minus the 2-second reserve), but tunable via `shutdown_timeout` /
+      `stop_timeout`
+   3. If the group is still alive at the graceful deadline, send SIGKILL to the
+      group and poll again until the kill deadline passes
+   4. Verify the group is actually gone; if it survived SIGKILL, the stop reports
+      `PROCESS_GROUP_NOT_REAPED` instead of succeeding
+4. Exit
 
 ### Process Restart
 

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -34,14 +34,18 @@ prox/
 │   └── prox/
 │       └── main.go           # CLI entrypoint
 ├── internal/
-│   ├── config/               # YAML parsing, validation
-│   ├── supervisor/           # Process orchestration
-│   ├── logs/                 # Log buffer, subscriptions
 │   ├── api/                  # HTTP server and handlers
+│   ├── cli/                  # CLI command definitions
+│   ├── config/               # YAML parsing, validation
+│   ├── constants/            # Shared constants (timeouts, buffer sizes, defaults)
+│   ├── daemon/               # Background daemon lifecycle, PID file, state file
+│   ├── domain/               # Core domain types and error definitions
+│   ├── logs/                 # Log buffer, subscriptions
 │   ├── proxy/                # Standalone proxy, request tracking, capture
 │   ├── proxyd/               # Shared proxy daemon
+│   ├── supervisor/           # Process orchestration
 │   ├── tui/                  # Bubbletea TUI
-│   └── cli/                  # CLI command definitions
+│   └── version/              # Build/version metadata
 ├── docs/                     # Documentation
 ├── prox.yaml                 # Example config
 ├── go.mod

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -193,9 +193,14 @@ See the [Shared Proxy Across Projects](../guides/shared-proxy.md) guide for mult
 
 ## HTTP API
 
-The API runs at `http://127.0.0.1:5555/api/v1` by default.
+By default, the API binds to a dynamic (auto-assigned) localhost port chosen at startup. Run `prox status` to see the address currently in use, or pin a fixed port by adding this to `prox.yaml`:
 
-Check supervisor status:
+```yaml
+api:
+  port: 5555
+```
+
+With `api.port: 5555` set, check supervisor status:
 
 ```bash
 curl http://localhost:5555/api/v1/status

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -46,6 +46,8 @@ All errors return JSON:
 | `SHUTDOWN_IN_PROGRESS` | Supervisor is shutting down |
 | `ENV_RELOAD_FAILED` | A process's `env_file` could not be re-read from disk on start |
 | `PROCESS_GROUP_NOT_REAPED` | A process's group survived SIGKILL and could not be confirmed terminated |
+| `CONFIG_RELOAD_FAILED` | `prox.yaml` could not be re-read/validated on an API-driven (re)start (missing/unreadable file, YAML syntax, or validation failure); the running process is left untouched |
+| `PROCESS_NOT_IN_CONFIG` | The target process is no longer present in `prox.yaml` on a (re)start; run `prox up` to reconcile |
 | `PROXY_NOT_ENABLED` | Proxy request inspection is unavailable because the proxy is disabled |
 | `STREAMING_NOT_SUPPORTED` | The server cannot provide an SSE stream for this request |
 | `REQUEST_NOT_FOUND` | Proxy request ID does not exist in the request buffer |
@@ -145,6 +147,8 @@ Get detailed process info.
 
 Start a stopped process.
 
+`prox.yaml` is re-read first and the process is launched with its current config — see the reload behavior documented under [restart](#post-processesnamerestart) below (it applies identically to `start`).
+
 **Response:**
 
 ```json
@@ -168,6 +172,13 @@ Stop a running process.
 ### POST /processes/{name}/restart
 
 Restart a process (stop then start).
+
+**Config reload:** before launching, prox re-reads and validates the whole `prox.yaml` and applies the target process's **current** config. Applied on (re)start: `cmd`, `healthcheck`, `stop_timeout` (the new value governs the next stop; the restart's own stop half uses the pre-edit budget), and environment inputs (inline `env`, per-process and global `env_file`, including changed file paths). NOT applied (require `prox up`): renames, added/removed processes, and `services`/`proxy`/port changes.
+
+The reload is **fail-closed**: an invalid file (even an unrelated process or the proxy section), a missing referenced env file, or a removed target aborts the (re)start with an error and leaves the existing process running unchanged:
+
+- `CONFIG_RELOAD_FAILED` (HTTP 422) — the file could not be read/parsed/validated.
+- `PROCESS_NOT_IN_CONFIG` (HTTP 409) — the target process is no longer in the file; run `prox up` to reconcile.
 
 **Response:**
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -6,11 +6,17 @@
 http://{host}:{port}/api/v1
 ```
 
-Default: `http://127.0.0.1:5555/api/v1`
+By default, `{port}` is a dynamically assigned free localhost port chosen at startup — discover it with `prox status` (which reports the API address), or pin it by setting `api.port` in `prox.yaml`. The examples below assume `api.port: 5555` is set in `prox.yaml`.
 
 ## Authentication
 
-When prox binds to a non-localhost interface, authentication is required. A bearer token is generated and stored in `~/.prox/token`.
+By default, authentication is enabled automatically unless prox binds to a localhost-only address (`127.0.0.1`, `localhost`, or `::1`); binding to `0.0.0.0` or another non-localhost address turns auth on. When enabled, a bearer token is generated and stored in `~/.prox/token`.
+
+This can be overridden with the `api.auth` field in `prox.yaml`:
+
+- Omitted (default): auto-determine based on `api.host` as described above.
+- `true`: force authentication on, even when bound to localhost.
+- `false`: force authentication off, even when bound to a non-localhost address. prox prints a startup warning in this case, since any network client can then control the supervisor.
 
 Include the token in requests:
 
@@ -38,12 +44,24 @@ All errors return JSON:
 | `PROCESS_NOT_RUNNING` | Process is not running |
 | `INVALID_PATTERN` | Invalid regex pattern |
 | `SHUTDOWN_IN_PROGRESS` | Supervisor is shutting down |
+| `ENV_RELOAD_FAILED` | A process's `env_file` could not be re-read from disk on start |
+| `PROCESS_GROUP_NOT_REAPED` | A process's group survived SIGKILL and could not be confirmed terminated |
 | `PROXY_NOT_ENABLED` | Proxy request inspection is unavailable because the proxy is disabled |
 | `STREAMING_NOT_SUPPORTED` | The server cannot provide an SSE stream for this request |
 | `REQUEST_NOT_FOUND` | Proxy request ID does not exist in the request buffer |
 | `MISSING_REQUEST_ID` | Request detail endpoint was called without an ID |
 
 ## Endpoints
+
+### GET /health
+
+Plain liveness check, served at the server root (not under `/api/v1`). No authentication required.
+
+**Response:** `200 OK` with plain-text body `ok` (not JSON).
+
+```bash
+curl http://localhost:5555/health
+```
 
 ### GET /status
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -134,9 +134,12 @@ Get detailed process info.
   "cmd": "go run ./cmd/server",
   "env": {
     "PORT": "8080"
-  }
+  },
+  "stop_timeout": "30s"
 }
 ```
+
+`stop_timeout` is the effective SIGTERM→SIGKILL escalation budget in force for this process (its own `stop_timeout`, else the global `shutdown_timeout`, else the `10s` default), as a duration string. It is the budget governing a `POST /processes/{name}/stop` or `POST /processes/{name}/restart`. See [Stop Timeout](configuration.md#stop-timeout).
 
 ### POST /processes/{name}/start
 
@@ -354,3 +357,5 @@ Gracefully shut down supervisor and all processes.
 ```
 
 Connection closes after response as supervisor terminates.
+
+The daemon then tears down in stages, each with its own deadline: the proxy and API server are stopped on short fixed deadlines, then every process is stopped concurrently, each on its own configured stop budget (see [Stop Timeout](configuration.md#stop-timeout)). Graceful timing therefore derives from the configured `shutdown_timeout` / `stop_timeout` values, not a single fixed window.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -165,6 +165,8 @@ Without arguments, sends a shutdown signal to the daemon. All processes receive 
 
 With a process name, stops only that process while keeping prox and other processes running.
 
+The SIGTERM→SIGKILL timeout is configurable per process via `stop_timeout` (or globally via `shutdown_timeout`; default `10s`) — see [Stop Timeout](configuration.md#stop-timeout). A process with a large budget may make `prox stop` wait a while before returning: the server is authoritative and holds the request open until the process actually stops (up to the configured budget), so a long silent wait is expected rather than a hang. Pressing Ctrl-C on the CLI is safe — it only detaches the client; the daemon keeps stopping the process on its configured budget.
+
 **Examples:**
 
 ```bash
@@ -222,6 +224,8 @@ prox restart <process>
 prox restart api
 prox restart worker
 ```
+
+The stop half of a restart uses the process's **pre-edit** stop budget (see [Stop Timeout](configuration.md#stop-timeout)); a changed `stop_timeout` takes effect on the next stop after the restart.
 
 ### requests
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -146,6 +146,8 @@ Start a stopped process.
 prox start <process>
 ```
 
+Like `restart`, `start` re-reads `prox.yaml` and launches the process with its **current** config (see [Config reload on (re)start](#config-reload-on-restart) below). Editing a process's `cmd` and running `prox stop <process>` + `prox start <process>` applies the change, just as `prox restart <process>` does.
+
 **Examples:**
 
 ```bash
@@ -226,6 +228,30 @@ prox restart worker
 ```
 
 The stop half of a restart uses the process's **pre-edit** stop budget (see [Stop Timeout](configuration.md#stop-timeout)); a changed `stop_timeout` takes effect on the next stop after the restart.
+
+#### Config reload on (re)start
+
+Every API-driven (re)start — `prox restart <process>`, and `prox start <process>` after a `prox stop <process>` — re-reads `prox.yaml` first and runs the process with **what the file now says**. This makes the edit → restart → observe loop work without a full `prox stop` + `prox up`.
+
+**Applied on (re)start:**
+
+- `cmd`
+- `healthcheck`
+- `stop_timeout` (the new value governs the *next* stop; the restart's own stop half uses the pre-edit budget)
+- environment inputs — inline `env`, per-process `env_file`, and the global `env_file`, including **changed file paths** (the values are re-read from disk)
+
+**NOT applied on (re)start (require `prox up`):**
+
+- process **renames** (a rename is a delete + add)
+- **added or removed** processes
+- `services`, `proxy`, ports, and other top-level daemon settings
+
+**Failure semantics (fail-closed):** the whole file is re-validated, so an invalid edit — even in an *unrelated* process or the proxy section — or a referenced env file that is missing aborts the (re)start with an error, and the existing process keeps running unchanged. Two cases have dedicated errors:
+
+- an invalid/unreadable/malformed file → `CONFIG_RELOAD_FAILED` (HTTP 422)
+- the target process no longer present in the file → `PROCESS_NOT_IN_CONFIG` (HTTP 409)
+
+Fix the file (or run `prox up` to reconcile added/removed/renamed processes) and try again.
 
 ### requests
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -106,6 +106,27 @@ controls that escalation:
   [process detail API](api.md#get-processesname), so you can see the budget
   governing a long stop.
 
+## Config Reload on Restart
+
+Whenever a process is (re)started through the API — `prox restart <name>`, or
+`prox start <name>` after a `prox stop <name>` — prox re-reads `prox.yaml` and
+runs the process with the config the file **now** contains. So editing a
+process and restarting it is enough; a full `prox stop` + `prox up` is not
+needed for the fields below.
+
+- Applied on (re)start: `cmd`, `healthcheck`, `stop_timeout`, and environment
+  inputs (inline `env`, per-process and global `env_file`, including changed
+  file paths). A changed `stop_timeout` governs the **next** stop — the
+  restart's own stop half still uses the pre-edit budget.
+- NOT applied (these require `prox up`): process renames, added or removed
+  processes, and `services` / `proxy` / port changes.
+- The reload is **fail-closed**: the whole file is re-validated, so an invalid
+  edit anywhere in it — even in an unrelated process or the proxy section — or a
+  missing referenced env file aborts the (re)start and the existing process keeps
+  running unchanged. See the [restart API](api.md#post-processesnamerestart)
+  reference for the exact error codes (`CONFIG_RELOAD_FAILED`,
+  `PROCESS_NOT_IN_CONFIG`).
+
 ## Health Check Fields
 
 | Field | Type | Default | Description |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -22,6 +22,9 @@ api:
 
 env_file: .env
 
+# Default stop budget for every process (SIGTERM->SIGKILL escalation window).
+shutdown_timeout: 10s
+
 processes:
   # Simple form - string command
   web: npm run dev
@@ -30,6 +33,8 @@ processes:
   # Expanded form - full configuration
   api:
     cmd: go run ./cmd/server
+    # Give this process a longer graceful-drain window than the global default.
+    stop_timeout: 30s
     env:
       PORT: "8080"
       DEBUG: "true"
@@ -50,6 +55,7 @@ processes:
 | `api.host` | string | `127.0.0.1` | API bind address |
 | `api.auth` | bool | auto | Force authentication on (`true`) or off (`false`). Omitted: auth is enabled automatically unless `api.host` is localhost-only |
 | `env_file` | string | — | Global .env file path, loaded for all processes |
+| `shutdown_timeout` | duration | `10s` | Default stop budget for every process (the SIGTERM→SIGKILL escalation window; see [Stop Timeout](#stop-timeout)). Overridable per process via `stop_timeout`. Must be greater than `2s` and at most `10m` |
 | `processes` | map | required | Process definitions |
 
 ## Process Fields
@@ -70,7 +76,35 @@ processes:
 | `cmd` | string | required | Command to run |
 | `env` | map | — | Environment variables for this process |
 | `env_file` | string | — | Process-specific .env file |
+| `stop_timeout` | duration | inherits `shutdown_timeout` | This process's stop budget, overriding the global `shutdown_timeout` (see [Stop Timeout](#stop-timeout)). Must be greater than `2s` and at most `10m` |
 | `healthcheck` | object | — | Health check configuration |
+
+## Stop Timeout
+
+When prox stops a process — via `prox stop <name>`, `prox restart <name>`, or a
+full `prox stop` / Ctrl-C of the daemon — it first sends `SIGTERM` and waits for
+the process to exit gracefully, then escalates to `SIGKILL`. The **stop budget**
+controls that escalation:
+
+- The effective budget for a process is its own `stop_timeout`, else the global
+  `shutdown_timeout`, else the built-in default of `10s`.
+- The budget is the **SIGTERM→SIGKILL escalation window**. A fixed `2s` at the
+  tail is reserved for the `SIGKILL` phase, so the graceful window is
+  **`budget − 2s`** (e.g. a `10s` budget gives ~8s of graceful drain before
+  `SIGKILL`). The reserve is not configurable.
+- Because of that reserve, the budget must be **greater than `2s`**; values of
+  `2s` or less (including `0s` and negatives) are rejected at load with a
+  field-named error. The upper bound is **`10m`**; `10m` exactly is accepted.
+- The configured value bounds **escalation timing**, not strict total
+  wall-clock — a process that is slow to flush its output can add a few seconds
+  of drain time on top.
+- The budget is honored on every stop path: `prox stop`, `prox restart` (the
+  stop half), and full daemon shutdown, where each process is stopped on its
+  **own** budget concurrently (a large budget on one process no longer forces a
+  shared shorter deadline on the others).
+- The effective budget is reported as `stop_timeout` in the
+  [process detail API](api.md#get-processesname), so you can see the budget
+  governing a long stop.
 
 ## Health Check Fields
 
@@ -100,6 +134,12 @@ Duration fields accept Go duration strings:
 - `5s` - 5 seconds
 - `10m` - 10 minutes
 - `1h30m` - 1 hour 30 minutes
+
+Different duration fields enforce different bounds. Health check durations accept
+any non-negative value (and treat `0` as "use the default"). The stop-budget
+fields `shutdown_timeout` and `stop_timeout` must be greater than `2s` and at
+most `10m` (see [Stop Timeout](#stop-timeout)); a value outside that range —
+including `0s` or a negative — is rejected at load with a field-named error.
 
 ## Runtime State
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -46,8 +46,9 @@ processes:
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `api.port` | int | dynamic | HTTP API port (auto-assigned if not specified or port in use) |
+| `api.port` | int | dynamic | HTTP API port. When unset (or `0`), a free port is auto-assigned; an explicit port is used as-is — if it's already in use the API server fails to start (logged as an error) rather than picking another port |
 | `api.host` | string | `127.0.0.1` | API bind address |
+| `api.auth` | bool | auto | Force authentication on (`true`) or off (`false`). Omitted: auth is enabled automatically unless `api.host` is localhost-only |
 | `env_file` | string | — | Global .env file path, loaded for all processes |
 | `processes` | map | required | Process definitions |
 

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -106,10 +105,11 @@ func (h *Handlers) GetProcess(w http.ResponseWriter, r *http.Request) {
 func (h *Handlers) StartProcess(w http.ResponseWriter, r *http.Request) {
 	name := chi.URLParam(r, "name")
 
-	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
-	defer cancel()
-
-	if err := h.supervisor.StartProcess(ctx, name); err != nil {
+	// No per-handler timeout: the supervisor bounds the operation internally by
+	// the process's configured stop budget, and the lifecycle route group caps
+	// the request at lifecycleRequestTimeout for hang protection. r.Context()
+	// still propagates client disconnect (#35, D2).
+	if err := h.supervisor.StartProcess(r.Context(), name); err != nil {
 		writeError(w, err)
 		return
 	}
@@ -121,10 +121,10 @@ func (h *Handlers) StartProcess(w http.ResponseWriter, r *http.Request) {
 func (h *Handlers) StopProcess(w http.ResponseWriter, r *http.Request) {
 	name := chi.URLParam(r, "name")
 
-	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
-	defer cancel()
-
-	if err := h.supervisor.StopProcess(ctx, name); err != nil {
+	// No per-handler timeout: the supervisor bounds the stop internally by the
+	// process's configured stop budget; the lifecycle route group provides the
+	// hang-protection ceiling. r.Context() still propagates client disconnect.
+	if err := h.supervisor.StopProcess(r.Context(), name); err != nil {
 		writeError(w, err)
 		return
 	}
@@ -136,10 +136,11 @@ func (h *Handlers) StopProcess(w http.ResponseWriter, r *http.Request) {
 func (h *Handlers) RestartProcess(w http.ResponseWriter, r *http.Request) {
 	name := chi.URLParam(r, "name")
 
-	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
-	defer cancel()
-
-	if err := h.supervisor.RestartProcess(ctx, name); err != nil {
+	// No per-handler timeout: the supervisor bounds the stop half internally by
+	// the process's configured stop budget; the lifecycle route group provides
+	// the hang-protection ceiling. r.Context() still propagates client
+	// disconnect.
+	if err := h.supervisor.RestartProcess(r.Context(), name); err != nil {
 		writeError(w, err)
 		return
 	}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -272,6 +272,19 @@ func writeError(w http.ResponseWriter, err error) {
 		status = http.StatusInternalServerError
 		code = domain.ErrCodeProcessGroupNotReaped
 		message = err.Error()
+	case errors.Is(err, domain.ErrConfigReloadFailed):
+		// The config was re-read on an API-driven (re)start and could not be
+		// loaded/validated. The detail is the user's own config path/validation
+		// message, not sensitive, so it is surfaced directly (#33, D3).
+		status = http.StatusUnprocessableEntity
+		code = domain.ErrCodeConfigReloadFailed
+		message = err.Error()
+	case errors.Is(err, domain.ErrProcessNotInConfig):
+		// Target process was removed from the config since `prox up`. The old
+		// process keeps running; the user must run `prox up` to reconcile (#33, D3).
+		status = http.StatusConflict
+		code = domain.ErrCodeProcessNotInConfig
+		message = err.Error()
 	default:
 		// For unknown errors, log the actual error but return a sanitized message
 		// to avoid leaking internal paths or sensitive information

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -426,6 +427,46 @@ func TestProcessControl_Conflict(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, domain.ErrCodeProcessAlreadyRunning, resp.Code)
 	})
+}
+
+// TestWriteError_ReloadSentinels covers the two config-reload error mappings
+// added for #33: ErrConfigReloadFailed -> 422 CONFIG_RELOAD_FAILED and
+// ErrProcessNotInConfig -> 409 PROCESS_NOT_IN_CONFIG, with the underlying detail
+// surfaced in the message.
+func TestWriteError_ReloadSentinels(t *testing.T) {
+	cases := []struct {
+		name       string
+		err        error
+		wantStatus int
+		wantCode   string
+	}{
+		{
+			name:       "config reload failed",
+			err:        fmt.Errorf("%w: parsing yaml: bad", domain.ErrConfigReloadFailed),
+			wantStatus: http.StatusUnprocessableEntity,
+			wantCode:   domain.ErrCodeConfigReloadFailed,
+		},
+		{
+			name:       "process not in config",
+			err:        fmt.Errorf("process %q %w; run 'prox up' to reconcile", "web", domain.ErrProcessNotInConfig),
+			wantStatus: http.StatusConflict,
+			wantCode:   domain.ErrCodeProcessNotInConfig,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			writeError(w, tc.err)
+
+			assert.Equal(t, tc.wantStatus, w.Code)
+
+			var resp ErrorResponse
+			require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+			assert.Equal(t, tc.wantCode, resp.Code)
+			assert.Equal(t, tc.err.Error(), resp.Error, "detail must be surfaced")
+		})
+	}
 }
 
 func TestGetProxyRequests(t *testing.T) {

--- a/internal/api/responses.go
+++ b/internal/api/responses.go
@@ -57,6 +57,11 @@ type ProcessDetailResponse struct {
 	Healthcheck   *HealthcheckInfo  `json:"healthcheck,omitempty"`
 	Cmd           string            `json:"cmd"`
 	Env           map[string]string `json:"env,omitempty"`
+	// StopTimeout is the effective SIGTERM->SIGKILL escalation budget as a
+	// duration string (e.g. "10s"), so users can see the budget governing a
+	// stop/restart. Omitted only when unset (process built outside the
+	// supervisor's normal resolution path).
+	StopTimeout string `json:"stop_timeout,omitempty"`
 }
 
 // HealthcheckInfo represents health check details
@@ -116,6 +121,10 @@ func ToProcessDetailResponse(info domain.ProcessInfo) ProcessDetailResponse {
 		Health:        string(info.Health),
 		Cmd:           info.Cmd,
 		Env:           filterSensitiveEnv(info.Env),
+	}
+
+	if info.StopTimeout > 0 {
+		resp.StopTimeout = info.StopTimeout.String()
 	}
 
 	if info.HealthDetails != nil {

--- a/internal/api/responses_test.go
+++ b/internal/api/responses_test.go
@@ -285,6 +285,7 @@ func TestToProcessDetailResponse(t *testing.T) {
 		RestartCount: 2,
 		Health:       domain.HealthStatusHealthy,
 		Cmd:          "npm start",
+		StopTimeout:  15 * time.Second,
 		Env: map[string]string{
 			"NODE_ENV":    "production",
 			"DB_PASSWORD": "secret123",
@@ -305,6 +306,11 @@ func TestToProcessDetailResponse(t *testing.T) {
 	}
 	if resp.Cmd != "npm start" {
 		t.Errorf("expected Cmd 'npm start', got %q", resp.Cmd)
+	}
+
+	// The effective stop budget is surfaced as a duration string.
+	if resp.StopTimeout != "15s" {
+		t.Errorf("expected StopTimeout '15s', got %q", resp.StopTimeout)
 	}
 
 	// Check that sensitive env vars are redacted
@@ -330,6 +336,23 @@ func TestToProcessDetailResponse(t *testing.T) {
 	}
 	if resp.Healthcheck.ConsecutiveFailures != 0 {
 		t.Errorf("expected ConsecutiveFailures 0, got %d", resp.Healthcheck.ConsecutiveFailures)
+	}
+}
+
+// TestToProcessDetailResponse_StopTimeoutOmittedWhenUnset verifies the
+// stop_timeout field is omitted (omitempty) when the effective budget is zero
+// (a process built outside the supervisor's normal resolution path), rather
+// than serialized as "0s".
+func TestToProcessDetailResponse_StopTimeoutOmittedWhenUnset(t *testing.T) {
+	info := domain.ProcessInfo{
+		Name:  "no-budget",
+		State: domain.ProcessStateStopped,
+		Cmd:   "true",
+	}
+
+	resp := ToProcessDetailResponse(info)
+	if resp.StopTimeout != "" {
+		t.Errorf("expected StopTimeout to be omitted for an unset budget, got %q", resp.StopTimeout)
 	}
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -11,7 +11,20 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
+
+	"github.com/charliek/prox/internal/constants"
 )
+
+// defaultRequestTimeout bounds all non-lifecycle API requests. The lifecycle
+// routes (start/stop/restart) are exempt because the supervisor bounds them
+// internally per-process; they use lifecycleRequestTimeout instead.
+const defaultRequestTimeout = constants.DefaultRequestTimeout
+
+// lifecycleRequestTimeout is the router-level hang-protection ceiling for the
+// start/stop/restart routes. It sits safely above the configured stop-budget
+// cap (constants.MaxStopTimeout) so a legitimately long stop is never cut off
+// by the router; the supervisor is the authoritative bound (#35, D2).
+const lifecycleRequestTimeout = constants.LifecycleTimeoutCeiling
 
 // ServerConfig holds configuration for the API server
 type ServerConfig struct {
@@ -39,7 +52,11 @@ func NewServer(config ServerConfig, handlers *Handlers) *Server {
 	r.Use(middleware.RealIP)
 	r.Use(middleware.Logger)
 	r.Use(middleware.Recoverer)
-	r.Use(middleware.Timeout(30 * time.Second))
+	// NOTE: the request timeout is applied per route group in registerRoutes,
+	// not globally here. Most routes get defaultRequestTimeout (30s); the
+	// lifecycle routes (start/stop/restart) get a much larger ceiling because
+	// the supervisor bounds those operations internally by each process's
+	// configured stop budget (#35, D2).
 
 	// CORS - restricted to localhost only for security
 	r.Use(corsMiddleware())
@@ -148,41 +165,65 @@ func authMiddleware(authEnabled bool, token string) func(http.Handler) http.Hand
 	}
 }
 
-// registerRoutes sets up all API routes
+// registerRoutes sets up all API routes.
+//
+// The request-timeout middleware is applied per route group, not globally, so
+// the lifecycle routes can carry a larger ceiling than everything else:
+//   - Lifecycle group (start/stop/restart): lifecycleRequestTimeout (11m). The
+//     supervisor bounds these operations internally per-process by the
+//     configured stop budget; this router ceiling is hang protection only.
+//   - Default group (everything else, including the SSE streams and /shutdown):
+//     defaultRequestTimeout (30s), preserving the prior behavior exactly. The
+//     SSE streams (/logs/stream, /proxy/requests/stream) watch r.Context() and
+//     were 30s-capped before this restructure; they remain so.
 func (s *Server) registerRoutes() {
-	// Health check at root (no auth required)
-	s.router.Get("/health", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("ok"))
-	})
+	// Health check at root (no auth required). Kept under the default 30s
+	// ceiling to preserve prior behavior (it returns immediately regardless).
+	s.router.With(middleware.Timeout(defaultRequestTimeout)).
+		Get("/health", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+		})
 
 	s.router.Route("/api/v1", func(r chi.Router) {
 		// Apply auth middleware to all API routes (only if auth is enabled)
 		r.Use(authMiddleware(s.config.AuthEnabled, s.config.Token))
 
-		// Supervisor status
-		r.Get("/status", s.handlers.GetStatus)
+		// Lifecycle routes: bounded internally by the supervisor per-process, so
+		// they get the large hang-protection ceiling rather than the 30s default.
+		r.Group(func(r chi.Router) {
+			r.Use(middleware.Timeout(lifecycleRequestTimeout))
 
-		// Processes
-		r.Get("/processes", s.handlers.GetProcesses)
-		r.Get("/processes/{name}", s.handlers.GetProcess)
-		r.Post("/processes/{name}/start", s.handlers.StartProcess)
-		r.Post("/processes/{name}/stop", s.handlers.StopProcess)
-		r.Post("/processes/{name}/restart", s.handlers.RestartProcess)
+			r.Post("/processes/{name}/start", s.handlers.StartProcess)
+			r.Post("/processes/{name}/stop", s.handlers.StopProcess)
+			r.Post("/processes/{name}/restart", s.handlers.RestartProcess)
+		})
 
-		// Logs
-		r.Get("/logs", s.handlers.GetLogs)
-		r.Get("/logs/stream", s.handlers.StreamLogs)
+		// Everything else keeps the default 30s ceiling.
+		r.Group(func(r chi.Router) {
+			r.Use(middleware.Timeout(defaultRequestTimeout))
 
-		// Proxy requests
-		// Note: /proxy/requests/stream must come before /proxy/requests/{id}
-		// to prevent the parameterized route from matching "stream" as an ID
-		r.Get("/proxy/requests", s.handlers.GetProxyRequests)
-		r.Get("/proxy/requests/stream", s.handlers.StreamProxyRequests)
-		r.Get("/proxy/requests/{id}", s.handlers.GetProxyRequest)
+			// Supervisor status
+			r.Get("/status", s.handlers.GetStatus)
 
-		// Shutdown
-		r.Post("/shutdown", s.handlers.Shutdown)
+			// Processes (read-only)
+			r.Get("/processes", s.handlers.GetProcesses)
+			r.Get("/processes/{name}", s.handlers.GetProcess)
+
+			// Logs
+			r.Get("/logs", s.handlers.GetLogs)
+			r.Get("/logs/stream", s.handlers.StreamLogs)
+
+			// Proxy requests
+			// Note: /proxy/requests/stream must come before /proxy/requests/{id}
+			// to prevent the parameterized route from matching "stream" as an ID
+			r.Get("/proxy/requests", s.handlers.GetProxyRequests)
+			r.Get("/proxy/requests/stream", s.handlers.StreamProxyRequests)
+			r.Get("/proxy/requests/{id}", s.handlers.GetProxyRequest)
+
+			// Shutdown (responds immediately, then triggers async teardown)
+			r.Post("/shutdown", s.handlers.Shutdown)
+		})
 	})
 }
 

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -7,10 +7,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/charliek/prox/internal/config"
+	"github.com/charliek/prox/internal/constants"
 	"github.com/charliek/prox/internal/logs"
 	"github.com/charliek/prox/internal/supervisor"
 )
@@ -354,6 +357,102 @@ func TestServerShutdown_NilServer(t *testing.T) {
 
 	err := server.Shutdown(ctx)
 	assert.NoError(t, err)
+}
+
+// TestRequestTimeoutConstants pins the two router-level ceilings: the default
+// 30s for ordinary routes and the much larger lifecycle ceiling, which must sit
+// above the configured stop-budget cap so a legitimately long stop/restart is
+// never truncated by the router (the supervisor is authoritative). (#35, D2)
+func TestRequestTimeoutConstants(t *testing.T) {
+	assert.Equal(t, 30*time.Second, defaultRequestTimeout)
+	assert.Equal(t, constants.MaxStopTimeout+time.Minute, lifecycleRequestTimeout)
+	assert.Greater(t, lifecycleRequestTimeout, defaultRequestTimeout)
+	assert.GreaterOrEqual(t, lifecycleRequestTimeout, constants.MaxStopTimeout,
+		"lifecycle ceiling must cover the maximum configurable stop budget")
+}
+
+// TestRouteGroupTimeoutWiring verifies the per-group timeout mechanism that
+// registerRoutes relies on: a route placed in a group with
+// middleware.Timeout(lifecycleRequestTimeout) sees a context deadline of ~11m,
+// while a route under defaultRequestTimeout sees ~30s. It mirrors the exact
+// group structure of registerRoutes with probe handlers (the real lifecycle
+// handlers cannot report their own deadline), keeping the test instant -- no
+// >30s sleep. Together with TestRequestTimeoutConstants and the routing smoke
+// test, this establishes that lifecycle requests are not cut at the old 30s
+// boundary.
+func TestRouteGroupTimeoutWiring(t *testing.T) {
+	var lifecycleBudget, defaultBudget time.Duration
+
+	probe := func(dst *time.Duration) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			if dl, ok := r.Context().Deadline(); ok {
+				*dst = time.Until(dl)
+			}
+			w.WriteHeader(http.StatusOK)
+		}
+	}
+
+	r := chi.NewRouter()
+	r.Group(func(r chi.Router) {
+		r.Use(middleware.Timeout(lifecycleRequestTimeout))
+		r.Post("/processes/{name}/stop", probe(&lifecycleBudget))
+	})
+	r.Group(func(r chi.Router) {
+		r.Use(middleware.Timeout(defaultRequestTimeout))
+		r.Get("/status", probe(&defaultBudget))
+	})
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest("POST", "/processes/web/stop", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	rec = httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest("GET", "/status", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Lifecycle route must carry the large ceiling, well past the old 30s.
+	assert.Greater(t, lifecycleBudget, 30*time.Second, "lifecycle route deadline must exceed the old 30s boundary")
+	assert.WithinDuration(t, time.Now().Add(lifecycleRequestTimeout), time.Now().Add(lifecycleBudget), 5*time.Second)
+	// Default route keeps the 30s ceiling.
+	assert.LessOrEqual(t, defaultBudget, 30*time.Second)
+	assert.Greater(t, defaultBudget, 25*time.Second)
+}
+
+// TestRegisterRoutes_RoutingSmoke exercises the restructured router end-to-end to
+// confirm the subgroup split did not break routing: lifecycle POSTs, read-only
+// GETs, the SSE routes, /health and /shutdown all resolve to their handlers.
+func TestRegisterRoutes_RoutingSmoke(t *testing.T) {
+	logMgr := logs.NewManager(logs.ManagerConfig{BufferSize: 100})
+	defer logMgr.Close()
+
+	cfg := &config.Config{
+		API:       config.APIConfig{Port: 0, Host: "127.0.0.1"},
+		Processes: map[string]config.ProcessConfig{},
+	}
+	sup := supervisor.New(cfg, logMgr, nil, supervisor.DefaultSupervisorConfig())
+	handlers := NewHandlers(sup, logMgr, "test.yaml", nil)
+	server := NewServer(ServerConfig{Host: "127.0.0.1", Port: 0}, handlers)
+
+	cases := []struct {
+		method, path string
+		wantStatus   int
+	}{
+		{"GET", "/health", http.StatusOK},
+		{"GET", "/api/v1/status", http.StatusOK},
+		{"GET", "/api/v1/processes", http.StatusOK},
+		// Lifecycle routes resolve to their handlers; a missing process yields a
+		// 404 from the handler (not a routing miss), proving the subgroup wiring.
+		{"POST", "/api/v1/processes/missing/start", http.StatusNotFound},
+		{"POST", "/api/v1/processes/missing/stop", http.StatusNotFound},
+		{"POST", "/api/v1/processes/missing/restart", http.StatusNotFound},
+	}
+	for _, tc := range cases {
+		t.Run(tc.method+" "+tc.path, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			server.router.ServeHTTP(rec, httptest.NewRequest(tc.method, tc.path, nil))
+			assert.Equal(t, tc.wantStatus, rec.Code)
+		})
+	}
 }
 
 func TestIsLocalhostOrigin(t *testing.T) {

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/charliek/prox/internal/api"
+	"github.com/charliek/prox/internal/constants"
 	"github.com/charliek/prox/internal/domain"
 )
 
@@ -44,6 +45,12 @@ type Client struct {
 	baseURL    string
 	token      string
 	httpClient *http.Client
+	// lifecycleClient is used for the start/stop/restart calls, which the
+	// daemon may legitimately hold open for up to a configured stop budget
+	// (capped at constants.MaxStopTimeout). Its timeout sits above that cap so
+	// the client never aborts a valid long stop; the server is authoritative
+	// and Ctrl-C on the CLI is safe (#35, D2).
+	lifecycleClient *http.Client
 }
 
 // NewClient creates a new API client
@@ -56,6 +63,9 @@ func NewClient(baseURL string) *Client {
 		token:   token,
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
+		},
+		lifecycleClient: &http.Client{
+			Timeout: constants.LifecycleTimeoutCeiling,
 		},
 	}
 }
@@ -90,19 +100,19 @@ func (c *Client) GetProcess(name string) (*api.ProcessDetailResponse, error) {
 // StartProcess starts a process
 func (c *Client) StartProcess(name string) error {
 	var resp api.SuccessResponse
-	return c.post("/api/v1/processes/"+url.PathEscape(name)+"/start", &resp)
+	return c.postLifecycle("/api/v1/processes/"+url.PathEscape(name)+"/start", &resp)
 }
 
 // StopProcess stops a process
 func (c *Client) StopProcess(name string) error {
 	var resp api.SuccessResponse
-	return c.post("/api/v1/processes/"+url.PathEscape(name)+"/stop", &resp)
+	return c.postLifecycle("/api/v1/processes/"+url.PathEscape(name)+"/stop", &resp)
 }
 
 // RestartProcess restarts a process
 func (c *Client) RestartProcess(name string) error {
 	var resp api.SuccessResponse
-	return c.post("/api/v1/processes/"+url.PathEscape(name)+"/restart", &resp)
+	return c.postLifecycle("/api/v1/processes/"+url.PathEscape(name)+"/restart", &resp)
 }
 
 // Shutdown shuts down the supervisor
@@ -219,6 +229,10 @@ func httpStatusError(statusCode int, errResp *api.ErrorResponse) error {
 }
 
 func (c *Client) doRequest(method, path string, v interface{}) error {
+	return c.doRequestWith(c.httpClient, method, path, v)
+}
+
+func (c *Client) doRequestWith(client *http.Client, method, path string, v interface{}) error {
 	req, err := http.NewRequest(method, c.baseURL+path, nil)
 	if err != nil {
 		return fmt.Errorf("creating request: %w", err)
@@ -228,7 +242,7 @@ func (c *Client) doRequest(method, path string, v interface{}) error {
 	}
 	c.addAuthHeader(req)
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("request failed: %w", err)
 	}
@@ -254,6 +268,13 @@ func (c *Client) get(path string, v interface{}) error {
 
 func (c *Client) post(path string, v interface{}) error {
 	return c.doRequest("POST", path, v)
+}
+
+// postLifecycle issues a POST using the lifecycle client, whose longer timeout
+// tolerates a stop/restart that the daemon holds open up to a configured stop
+// budget (#35, D2).
+func (c *Client) postLifecycle(path string, v interface{}) error {
+	return c.doRequestWith(c.lifecycleClient, "POST", path, v)
 }
 
 // addAuthHeader adds the Authorization header if a token is available

--- a/internal/cli/client_test.go
+++ b/internal/cli/client_test.go
@@ -6,8 +6,10 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/charliek/prox/internal/api"
+	"github.com/charliek/prox/internal/constants"
 	"github.com/charliek/prox/internal/domain"
 )
 
@@ -28,6 +30,91 @@ func TestNewClient_TrimsTrailingSlash(t *testing.T) {
 	if client.baseURL != "http://localhost:5555" {
 		t.Errorf("expected baseURL without trailing slash, got %q", client.baseURL)
 	}
+}
+
+// TestNewClient_LifecycleClientTimeout verifies the two-client split: ordinary
+// calls use the 30s default client, while the lifecycle calls (start/stop/
+// restart) use a dedicated client whose timeout sits above the configured
+// stop-budget cap so a legitimately long stop is never aborted by the CLI
+// (#35, D2).
+func TestNewClient_LifecycleClientTimeout(t *testing.T) {
+	client := NewClient("http://localhost:5555")
+
+	if client.httpClient == nil || client.lifecycleClient == nil {
+		t.Fatal("expected both httpClient and lifecycleClient to be non-nil")
+	}
+	if client.httpClient.Timeout != 30*time.Second {
+		t.Errorf("expected default client timeout 30s, got %v", client.httpClient.Timeout)
+	}
+	wantLifecycle := constants.MaxStopTimeout + time.Minute
+	if client.lifecycleClient.Timeout != wantLifecycle {
+		t.Errorf("expected lifecycle client timeout %v, got %v", wantLifecycle, client.lifecycleClient.Timeout)
+	}
+	if client.lifecycleClient.Timeout <= client.httpClient.Timeout {
+		t.Error("lifecycle client timeout must exceed the default client timeout")
+	}
+}
+
+// TestClient_LifecycleCallsUseLifecycleClient confirms StartProcess/StopProcess/
+// RestartProcess route through the lifecycle client, not the default one, by
+// swapping in a marked client and asserting the ordinary calls do not use it.
+func TestClient_LifecycleCallsUseLifecycleClient(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(api.SuccessResponse{Success: true})
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+
+	// Distinguish the two clients by giving the lifecycle client a sentinel
+	// transport that records whether it was used.
+	used := false
+	client.lifecycleClient = &http.Client{
+		Timeout:   constants.MaxStopTimeout + time.Minute,
+		Transport: recordingTransport{used: &used},
+	}
+
+	if err := client.StopProcess("web"); err != nil {
+		t.Fatalf("StopProcess: %v", err)
+	}
+	if !used {
+		t.Error("StopProcess should use the lifecycle client")
+	}
+
+	used = false
+	if err := client.StartProcess("web"); err != nil {
+		t.Fatalf("StartProcess: %v", err)
+	}
+	if !used {
+		t.Error("StartProcess should use the lifecycle client")
+	}
+
+	used = false
+	if err := client.RestartProcess("web"); err != nil {
+		t.Fatalf("RestartProcess: %v", err)
+	}
+	if !used {
+		t.Error("RestartProcess should use the lifecycle client")
+	}
+
+	// A non-lifecycle call must NOT use the lifecycle client.
+	used = false
+	if _, err := client.GetStatus(); err != nil {
+		t.Fatalf("GetStatus: %v", err)
+	}
+	if used {
+		t.Error("GetStatus should use the default client, not the lifecycle client")
+	}
+}
+
+// recordingTransport marks used=true on every round trip and delegates to the
+// default transport.
+type recordingTransport struct{ used *bool }
+
+func (rt recordingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	*rt.used = true
+	return http.DefaultTransport.RoundTrip(req)
 }
 
 func TestClient_GetStatus(t *testing.T) {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -47,6 +47,7 @@ processes for local development. It supports:
 			"status":  true,
 			"logs":    true,
 			"stop":    true,
+			"start":   true,
 			"restart": true,
 			"down":    true,
 			"attach":  true,

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -279,6 +279,9 @@ func runUp(cmd *cobra.Command, args []string) error {
 	// Create supervisor
 	supConfig := supervisor.DefaultSupervisorConfig()
 	supConfig.ConfigDir = configDir
+	// The absolute config path lets an API-driven (re)start re-read prox.yaml and
+	// apply the target process's current config (#33, D3).
+	supConfig.ConfigPath = absConfigPath
 	// cfg.ShutdownTimeout was already validated by config.Load above, so this
 	// only errors for a hand-built Config bypassing Load/Validate.
 	// ShutdownTimeoutDuration's error is already field-prefixed
@@ -317,8 +320,9 @@ func runUp(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(os.Stderr, "         Any network client can control this supervisor.\n")
 	}
 
-	// Create API handlers and server
-	handlers := api.NewHandlers(sup, logMgr, configPath, shutdownFn)
+	// Create API handlers and server. The handlers get the absolute config path
+	// so GET /status reports the same file the reload path re-reads (#33, D3).
+	handlers := api.NewHandlers(sup, logMgr, absConfigPath, shutdownFn)
 	apiServer := api.NewServer(api.ServerConfig{
 		Host:        cfg.API.Host,
 		Port:        cfg.API.Port,

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -30,8 +30,12 @@ import (
 )
 
 const (
-	// shutdownTimeout is the maximum time to wait for graceful shutdown
-	shutdownTimeout = 10 * time.Second
+	// teardownStageTimeout bounds each fixed daemon-shutdown teardown stage
+	// (proxy deregister/shutdown, API-server shutdown) independently. The
+	// supervisor stage is bounded separately by MaxStopBudget (see the shutdown
+	// path below) so a large configured stop budget is never truncated by proxy
+	// or API teardown time (#35, D2).
+	teardownStageTimeout = 5 * time.Second
 	// logFlushDelay is the time to wait for logs to be printed before closing
 	logFlushDelay = 50 * time.Millisecond
 )
@@ -340,16 +344,18 @@ func runUp(cmd *cobra.Command, args []string) error {
 			return proxyErr
 		}
 	}
-	// Ensure standalone proxy is cleaned up on any subsequent error
-	if proxyService != nil {
-		defer func() {
-			if proxyService != nil {
-				sCtx, sCancel := context.WithTimeout(context.Background(), shutdownTimeout)
-				defer sCancel()
-				_ = proxyService.Shutdown(sCtx)
-			}
-		}()
-	}
+	// Ensure standalone proxy is cleaned up on any subsequent error. This defer
+	// only tears down the proxy listeners (never processes), so it gets the
+	// short proxy stage budget, matching the normal shutdown path. On the
+	// normal shutdown path proxyService is set to nil first, so this becomes a
+	// no-op there.
+	defer func() {
+		if proxyService != nil {
+			sCtx, sCancel := context.WithTimeout(context.Background(), teardownStageTimeout)
+			defer sCancel()
+			_ = proxyService.Shutdown(sCtx)
+		}
+	}()
 
 	// Start supervisor
 	fmt.Printf("Starting prox with config: %s\n", configPath)
@@ -428,9 +434,15 @@ func runUp(cmd *cobra.Command, args []string) error {
 	// Stop signal handler to prevent additional signals during shutdown
 	signal.Stop(sigCh)
 
-	// Graceful shutdown
-	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), shutdownTimeout)
-	defer shutdownCancel()
+	// Graceful shutdown. Each stage gets its own deadline computed at shutdown
+	// time, rather than one shared deadline, so proxy/API teardown time can
+	// never eat into the supervisor's process-stop budget (#35, D2):
+	//   - proxy deregister/shutdown: teardownStageTimeout (fixed, short)
+	//   - API-server shutdown:       teardownStageTimeout (fixed, short;
+	//     force-closes any in-flight lifecycle request, whose process is then
+	//     stopped by sup.Stop immediately below)
+	//   - supervisor stop: MaxStopBudget()+margin, read live so hot-reloaded
+	//     per-process budgets are honored.
 
 	// Deregister from shared daemon or stop standalone proxy
 	if daemonClient != nil {
@@ -442,21 +454,28 @@ func runUp(cmd *cobra.Command, args []string) error {
 		}
 	}
 	if proxyService != nil {
-		if err := proxyService.Shutdown(shutdownCtx); err != nil {
+		proxyCtx, proxyCancel := context.WithTimeout(context.Background(), teardownStageTimeout)
+		if err := proxyService.Shutdown(proxyCtx); err != nil {
 			fmt.Fprintf(os.Stderr, "Error stopping proxy: %v\n", err)
 		}
+		proxyCancel()
 		proxyService = nil
 	}
 
 	// Stop API server
-	if err := apiServer.Shutdown(shutdownCtx); err != nil {
+	apiCtx, apiCancel := context.WithTimeout(context.Background(), teardownStageTimeout)
+	if err := apiServer.Shutdown(apiCtx); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 	}
+	apiCancel()
 
-	// Stop supervisor
-	if err := sup.Stop(shutdownCtx); err != nil {
+	// Stop supervisor with a deadline sized from the live per-process stop
+	// budgets, plus a small margin for the SIGKILL escalation and finalization.
+	supCtx, supCancel := context.WithTimeout(context.Background(), sup.MaxStopBudget()+teardownStageTimeout)
+	if err := sup.Stop(supCtx); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 	}
+	supCancel()
 
 	// Log shutdown complete before closing the log manager
 	sup.SystemLog("shutdown complete")

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -275,6 +275,17 @@ func runUp(cmd *cobra.Command, args []string) error {
 	// Create supervisor
 	supConfig := supervisor.DefaultSupervisorConfig()
 	supConfig.ConfigDir = configDir
+	// cfg.ShutdownTimeout was already validated by config.Load above, so this
+	// only errors for a hand-built Config bypassing Load/Validate.
+	// ShutdownTimeoutDuration's error is already field-prefixed
+	// ("shutdown_timeout: ..."), so it's returned as-is rather than wrapped again.
+	globalShutdownTimeout, err := cfg.ShutdownTimeoutDuration()
+	if err != nil {
+		return err
+	}
+	if globalShutdownTimeout > 0 {
+		supConfig.ShutdownTimeout = globalShutdownTimeout
+	}
 	sup := supervisor.New(cfg, logMgr, nil, supConfig)
 
 	// Create shutdown channel

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,10 @@ type Config struct {
 	Proxy     *ProxyConfig             `yaml:"proxy,omitempty"`
 	Services  map[string]ServiceConfig `yaml:"services,omitempty"`
 	Certs     *CertsConfig             `yaml:"certs,omitempty"`
+	// ShutdownTimeout is the default SIGTERM->SIGKILL escalation budget for
+	// every process that does not set its own stop_timeout. Empty means
+	// "use constants.DefaultShutdownTimeout". See stopBudgetOptions.
+	ShutdownTimeout string `yaml:"shutdown_timeout"`
 }
 
 // ProxyConfig defines the HTTP/HTTPS reverse proxy configuration
@@ -64,6 +68,10 @@ type ProcessConfig struct {
 	Env         map[string]string  `yaml:"env"`
 	EnvFile     string             `yaml:"env_file"`
 	Healthcheck *HealthcheckConfig `yaml:"healthcheck"`
+	// StopTimeout overrides Config.ShutdownTimeout for this process. Empty
+	// means "use the global shutdown_timeout, else the constant default".
+	// See stopBudgetOptions.
+	StopTimeout string `yaml:"stop_timeout"`
 }
 
 // HealthcheckConfig defines health check configuration in YAML
@@ -85,12 +93,13 @@ type rawProxyConfig struct {
 
 // rawConfig is used for initial YAML parsing to handle the flexible process/service format
 type rawConfig struct {
-	API       APIConfig              `yaml:"api"`
-	EnvFile   string                 `yaml:"env_file"`
-	Processes map[string]interface{} `yaml:"processes"`
-	Proxy     *rawProxyConfig        `yaml:"proxy,omitempty"`
-	Services  map[string]interface{} `yaml:"services,omitempty"`
-	Certs     *CertsConfig           `yaml:"certs,omitempty"`
+	API             APIConfig              `yaml:"api"`
+	EnvFile         string                 `yaml:"env_file"`
+	Processes       map[string]interface{} `yaml:"processes"`
+	Proxy           *rawProxyConfig        `yaml:"proxy,omitempty"`
+	Services        map[string]interface{} `yaml:"services,omitempty"`
+	Certs           *CertsConfig           `yaml:"certs,omitempty"`
+	ShutdownTimeout string                 `yaml:"shutdown_timeout"`
 }
 
 // Load reads and parses a configuration file
@@ -124,11 +133,12 @@ func Parse(data []byte) (*Config, error) {
 	}
 
 	config := &Config{
-		API:       raw.API,
-		EnvFile:   raw.EnvFile,
-		Processes: make(map[string]ProcessConfig),
-		Services:  make(map[string]ServiceConfig),
-		Certs:     raw.Certs,
+		API:             raw.API,
+		EnvFile:         raw.EnvFile,
+		Processes:       make(map[string]ProcessConfig),
+		Services:        make(map[string]ServiceConfig),
+		Certs:           raw.Certs,
+		ShutdownTimeout: raw.ShutdownTimeout,
 	}
 	if raw.Proxy != nil {
 		config.Proxy = &ProxyConfig{
@@ -251,11 +261,28 @@ func parseServiceConfig(name string, value interface{}) (ServiceConfig, error) {
 	}
 }
 
-// parseHealthDuration parses one healthcheck duration field. An empty string
-// leaves the value zero so domain.HealthConfig.WithDefaults applies the
-// documented default. A malformed or negative value returns a clear,
-// field-named error (a negative would survive WithDefaults and panic NewTicker).
-func parseHealthDuration(field, s string) (time.Duration, error) {
+// durationFieldOptions configures parseFieldDuration's per-field validation
+// policy. The zero value (all fields false/zero) enforces only "well-formed,
+// non-negative" -- callers opt into the extra behaviors they need.
+type durationFieldOptions struct {
+	// allowZero treats an explicitly-parsed zero duration (e.g. "0s") as
+	// meaning "use the documented default" and returns it as zero without
+	// applying min/max below. Healthcheck fields set this; the stop-budget
+	// fields do not, so an explicit zero falls through to the min check and
+	// is rejected like any other too-small value.
+	allowZero bool
+	// min, when nonzero, rejects any duration <= min. Ignored when zero.
+	min time.Duration
+	// max, when nonzero, rejects any duration > max. Ignored when zero.
+	max time.Duration
+}
+
+// parseFieldDuration parses one duration field under the given policy. An
+// empty string always leaves the value zero (unset) with no error -- what
+// "zero" means (use a default, or absence) is up to the caller. A malformed
+// or negative value always returns a clear, field-named error; min/max are
+// enforced only when set in opts.
+func parseFieldDuration(field, s string, opts durationFieldOptions) (time.Duration, error) {
 	if s == "" {
 		return 0, nil
 	}
@@ -264,12 +291,80 @@ func parseHealthDuration(field, s string) (time.Duration, error) {
 		return 0, fmt.Errorf("%s: invalid duration %q", field, s)
 	}
 	// ParseDuration truncates a tiny negative (e.g. "-0.1ns") to 0, which would
-	// otherwise slip past d < 0 and be silently defaulted by WithDefaults. Check
-	// the input's sign too so any negative value is rejected, not just defaulted.
+	// otherwise slip past d < 0 and be silently accepted as zero. Check the
+	// input's sign too so any negative value is rejected outright.
 	if d < 0 || strings.HasPrefix(s, "-") {
 		return 0, fmt.Errorf("%s: duration must not be negative (%q)", field, s)
 	}
+	if opts.allowZero && d == 0 {
+		return 0, nil
+	}
+	if opts.min > 0 && d <= opts.min {
+		return 0, fmt.Errorf("%s: must be greater than %s (%s is reserved for the SIGKILL escalation): %q",
+			field, trimZeroDuration(opts.min), trimZeroDuration(opts.min), s)
+	}
+	if opts.max > 0 && d > opts.max {
+		return 0, fmt.Errorf("%s: must not exceed %s: %q", field, trimZeroDuration(opts.max), s)
+	}
 	return d, nil
+}
+
+// trimZeroDuration renders a duration without the trailing zero-valued units
+// time.Duration.String always includes (e.g. 10*time.Minute -> "10m0s", not
+// "10m"). Only exercised on the fixed constants used as min/max (KillGrace,
+// MaxStopTimeout) in error messages, so only whole hour/minute/second values
+// need the shorter form; anything else falls back to the standard format.
+func trimZeroDuration(d time.Duration) string {
+	switch {
+	case d >= time.Hour && d%time.Hour == 0:
+		return fmt.Sprintf("%dh", d/time.Hour)
+	case d >= time.Minute && d%time.Minute == 0:
+		return fmt.Sprintf("%dm", d/time.Minute)
+	case d >= time.Second && d%time.Second == 0:
+		return fmt.Sprintf("%ds", d/time.Second)
+	default:
+		return d.String()
+	}
+}
+
+// healthDurationOptions is the validation policy for healthcheck duration
+// fields (interval/timeout/start_period): zero means "use the documented
+// default" and there is no upper cap. This preserves the pre-#35 behavior
+// exactly (issue #31).
+var healthDurationOptions = durationFieldOptions{allowZero: true}
+
+// stopBudgetOptions is the validation policy shared by the top-level
+// shutdown_timeout and per-process stop_timeout fields (#35, D1): no
+// "zero means default" special case -- an explicit zero is just another
+// too-small value -- and a bounded range of (KillGrace, MaxStopTimeout] so
+// every static ceiling that wraps the configured value stays boundable.
+var stopBudgetOptions = durationFieldOptions{
+	min: constants.KillGrace,
+	max: constants.MaxStopTimeout,
+}
+
+// parseHealthDuration parses one healthcheck duration field under
+// healthDurationOptions. See parseFieldDuration.
+func parseHealthDuration(field, s string) (time.Duration, error) {
+	return parseFieldDuration(field, s, healthDurationOptions)
+}
+
+// ShutdownTimeoutDuration parses Config.ShutdownTimeout under
+// stopBudgetOptions. Zero (empty string) means unset -- callers fall back to
+// constants.DefaultShutdownTimeout. Validate has already confirmed the value
+// is well-formed and in range for any config that went through Load/Parse; a
+// parse error here is only reachable for a Config built directly (e.g. tests)
+// without going through Validate.
+func (c *Config) ShutdownTimeoutDuration() (time.Duration, error) {
+	return parseFieldDuration("shutdown_timeout", c.ShutdownTimeout, stopBudgetOptions)
+}
+
+// StopTimeoutDuration parses ProcessConfig.StopTimeout under
+// stopBudgetOptions. Zero (empty string) means unset -- callers fall back to
+// the global shutdown_timeout, then constants.DefaultShutdownTimeout. See
+// Config.ShutdownTimeoutDuration for the same Validate-already-checked note.
+func (p *ProcessConfig) StopTimeoutDuration() (time.Duration, error) {
+	return parseFieldDuration("stop_timeout", p.StopTimeout, stopBudgetOptions)
 }
 
 // ToDomain converts the YAML healthcheck config to the domain type, parsing the

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -184,6 +184,156 @@ func TestHealthcheckConfig_ToDomain(t *testing.T) {
 	})
 }
 
+// TestShutdownTimeoutDuration_Matrix covers the #35/D1 validation policy for
+// the top-level shutdown_timeout field: empty is unset (zero, no error);
+// malformed/negative/zero/sub-KillGrace values are rejected uniformly; values
+// in (KillGrace, MaxStopTimeout] are accepted, including the boundaries.
+func TestShutdownTimeoutDuration_Matrix(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     string
+		wantDur   time.Duration
+		wantErr   bool
+		errSubstr string
+	}{
+		{name: "omitted is unset", value: "", wantDur: 0},
+		{name: "valid value parses", value: "30s", wantDur: 30 * time.Second},
+		{name: "malformed is rejected", value: "3x", wantErr: true, errSubstr: "invalid duration"},
+		{name: "negative is rejected", value: "-5s", wantErr: true, errSubstr: "negative"},
+		{name: "explicit zero is rejected", value: "0s", wantErr: true, errSubstr: "greater than 2s"},
+		{name: "exactly KillGrace (2s) is rejected", value: "2s", wantErr: true, errSubstr: "greater than 2s"},
+		{name: "just above KillGrace (2.5s) is accepted", value: "2.5s", wantDur: 2500 * time.Millisecond},
+		{name: "exactly MaxStopTimeout (10m) is accepted", value: "10m", wantDur: 10 * time.Minute},
+		{name: "above MaxStopTimeout is rejected", value: "10m1s", wantErr: true, errSubstr: "must not exceed 10m"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{ShutdownTimeout: tt.value}
+			got, err := cfg.ShutdownTimeoutDuration()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "shutdown_timeout")
+				assert.Contains(t, err.Error(), tt.errSubstr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantDur, got)
+		})
+	}
+}
+
+// TestStopTimeoutDuration_Matrix mirrors TestShutdownTimeoutDuration_Matrix
+// for the per-process stop_timeout field; same policy, different field name
+// in the error.
+func TestStopTimeoutDuration_Matrix(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     string
+		wantDur   time.Duration
+		wantErr   bool
+		errSubstr string
+	}{
+		{name: "omitted is unset", value: "", wantDur: 0},
+		{name: "valid value parses", value: "45s", wantDur: 45 * time.Second},
+		{name: "malformed is rejected", value: "bogus", wantErr: true, errSubstr: "invalid duration"},
+		{name: "negative is rejected", value: "-1s", wantErr: true, errSubstr: "negative"},
+		{name: "explicit zero is rejected", value: "0s", wantErr: true, errSubstr: "greater than 2s"},
+		{name: "exactly KillGrace (2s) is rejected", value: "2s", wantErr: true, errSubstr: "greater than 2s"},
+		{name: "just above KillGrace (2.5s) is accepted", value: "2.5s", wantDur: 2500 * time.Millisecond},
+		{name: "exactly MaxStopTimeout (10m) is accepted", value: "10m", wantDur: 10 * time.Minute},
+		{name: "above MaxStopTimeout is rejected", value: "10m1s", wantErr: true, errSubstr: "must not exceed 10m"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			proc := &ProcessConfig{Cmd: "true", StopTimeout: tt.value}
+			got, err := proc.StopTimeoutDuration()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "stop_timeout")
+				assert.Contains(t, err.Error(), tt.errSubstr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantDur, got)
+		})
+	}
+}
+
+// TestShutdownTimeoutDuration_ErrorMessageFormat pins the exact error text
+// from the plan (D1): field-named, and states the KillGrace rationale.
+func TestShutdownTimeoutDuration_ErrorMessageFormat(t *testing.T) {
+	cfg := &Config{ShutdownTimeout: "1s"}
+	_, err := cfg.ShutdownTimeoutDuration()
+	require.Error(t, err)
+	assert.Equal(t, `shutdown_timeout: must be greater than 2s (2s is reserved for the SIGKILL escalation): "1s"`, err.Error())
+}
+
+// TestParse_ShutdownAndStopTimeout verifies the new YAML fields round-trip
+// through Parse (both top-level and per-process, expanded form).
+func TestParse_ShutdownAndStopTimeout(t *testing.T) {
+	yamlData := []byte(`
+shutdown_timeout: 30s
+processes:
+  web:
+    cmd: npm run dev
+    stop_timeout: 45s
+  worker: python worker.py
+`)
+	cfg, err := Parse(yamlData)
+	require.NoError(t, err)
+	assert.Equal(t, "30s", cfg.ShutdownTimeout)
+	assert.Equal(t, "45s", cfg.Processes["web"].StopTimeout)
+	assert.Equal(t, "", cfg.Processes["worker"].StopTimeout)
+}
+
+// TestLoad_ValidationError_ShutdownTimeout and its stop_timeout counterpart
+// verify the bad values surface through the full Load path (Parse+Validate),
+// field-named per the #31 pattern.
+func TestLoad_ValidationError_ShutdownTimeout(t *testing.T) {
+	yamlData := []byte(`
+shutdown_timeout: 1s
+processes:
+  web: npm run dev
+`)
+	_, err := Parse(yamlData)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "shutdown_timeout")
+	assert.Contains(t, err.Error(), "greater than 2s")
+}
+
+func TestLoad_ValidationError_StopTimeout(t *testing.T) {
+	yamlData := []byte(`
+processes:
+  web:
+    cmd: npm run dev
+    stop_timeout: 15m
+`)
+	_, err := Parse(yamlData)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "processes.web.stop_timeout")
+	assert.Contains(t, err.Error(), "must not exceed 10m")
+}
+
+// TestHealthcheckConfig_ToDomain_RegressionAfterStopBudgetParser: the parser
+// generalization for #35 must not change healthcheck semantics (non-goal).
+// Explicit zero stays accepted (use-default) and durations well past
+// MaxStopTimeout are still accepted -- healthcheck fields have no cap.
+func TestHealthcheckConfig_ToDomain_RegressionAfterStopBudgetParser(t *testing.T) {
+	t.Run("explicit zero interval still accepted", func(t *testing.T) {
+		hc := &HealthcheckConfig{Cmd: "true", Interval: "0s"}
+		got, err := hc.ToDomain()
+		require.NoError(t, err)
+		assert.Equal(t, time.Duration(0), got.Interval)
+	})
+
+	t.Run("duration beyond MaxStopTimeout still accepted (no cap leak)", func(t *testing.T) {
+		hc := &HealthcheckConfig{Cmd: "true", StartPeriod: "15m"}
+		got, err := hc.ToDomain()
+		require.NoError(t, err)
+		assert.Equal(t, 15*time.Minute, got.StartPeriod)
+	})
+}
+
 func TestParse_ProxyConfig(t *testing.T) {
 	t.Run("parses full proxy config", func(t *testing.T) {
 		yaml := `

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -31,6 +31,13 @@ func Validate(config *Config) error {
 		errs = append(errs, fmt.Sprintf("api.port: must be between 0 and 65535, got %d", config.API.Port))
 	}
 
+	// Validate the default shutdown_timeout (#35, D1): empty is fine (falls
+	// back to constants.DefaultShutdownTimeout); anything else must parse and
+	// fall in (KillGrace, MaxStopTimeout].
+	if _, err := parseFieldDuration("shutdown_timeout", config.ShutdownTimeout, stopBudgetOptions); err != nil {
+		errs = append(errs, err.Error())
+	}
+
 	// Validate processes
 	if len(config.Processes) == 0 {
 		errs = append(errs, "processes: at least one process must be defined")
@@ -39,6 +46,12 @@ func Validate(config *Config) error {
 	for name, proc := range config.Processes {
 		if proc.Cmd == "" {
 			errs = append(errs, fmt.Sprintf("processes.%s.cmd: command is required", name))
+		}
+
+		// Validate stop_timeout under the same policy as shutdown_timeout
+		// (#35, D1); prefixed like the healthcheck field errors below.
+		if _, err := parseFieldDuration("stop_timeout", proc.StopTimeout, stopBudgetOptions); err != nil {
+			errs = append(errs, fmt.Sprintf("processes.%s.%s", name, err))
 		}
 
 		// Validate healthcheck if present

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -239,6 +239,85 @@ func TestValidate(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("shutdown_timeout malformed fails field-named", func(t *testing.T) {
+		cfg := &Config{
+			API:             APIConfig{Port: 5555},
+			ShutdownTimeout: "3x",
+			Processes: map[string]ProcessConfig{
+				"web": {Cmd: "npm run dev"},
+			},
+		}
+		err := Validate(cfg)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, domain.ErrInvalidConfig))
+		assert.Contains(t, err.Error(), "shutdown_timeout")
+		assert.Contains(t, err.Error(), "invalid duration")
+	})
+
+	t.Run("shutdown_timeout at or below KillGrace fails", func(t *testing.T) {
+		cfg := &Config{
+			API:             APIConfig{Port: 5555},
+			ShutdownTimeout: "2s",
+			Processes: map[string]ProcessConfig{
+				"web": {Cmd: "npm run dev"},
+			},
+		}
+		err := Validate(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "shutdown_timeout: must be greater than 2s")
+	})
+
+	t.Run("shutdown_timeout above MaxStopTimeout fails", func(t *testing.T) {
+		cfg := &Config{
+			API:             APIConfig{Port: 5555},
+			ShutdownTimeout: "11m",
+			Processes: map[string]ProcessConfig{
+				"web": {Cmd: "npm run dev"},
+			},
+		}
+		err := Validate(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "shutdown_timeout: must not exceed 10m")
+	})
+
+	t.Run("shutdown_timeout omitted and exactly MaxStopTimeout both pass", func(t *testing.T) {
+		cfg := &Config{
+			API:             APIConfig{Port: 5555},
+			ShutdownTimeout: "10m",
+			Processes: map[string]ProcessConfig{
+				"web": {Cmd: "npm run dev"},
+			},
+		}
+		assert.NoError(t, Validate(cfg))
+
+		cfg.ShutdownTimeout = ""
+		assert.NoError(t, Validate(cfg))
+	})
+
+	t.Run("per-process stop_timeout fails field-named with process prefix", func(t *testing.T) {
+		cfg := &Config{
+			API: APIConfig{Port: 5555},
+			Processes: map[string]ProcessConfig{
+				"web": {Cmd: "npm run dev", StopTimeout: "1s"},
+			},
+		}
+		err := Validate(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "processes.web.stop_timeout: must be greater than 2s")
+	})
+
+	t.Run("per-process stop_timeout omitted and valid values pass", func(t *testing.T) {
+		cfg := &Config{
+			API: APIConfig{Port: 5555},
+			Processes: map[string]ProcessConfig{
+				"web":    {Cmd: "npm run dev"},
+				"api":    {Cmd: "go run ./cmd/server", StopTimeout: "2.5s"},
+				"worker": {Cmd: "python worker.py", StopTimeout: "10m"},
+			},
+		}
+		assert.NoError(t, Validate(cfg))
+	})
+
 	t.Run("healthcheck explicit zero durations pass", func(t *testing.T) {
 		cfg := &Config{
 			API: APIConfig{Port: 5555},

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -49,6 +49,16 @@ const (
 	// value (API route timeout, CLI client timeout, TUI restart timeout)
 	// boundable.
 	MaxStopTimeout = 10 * time.Minute
+
+	// LifecycleTimeoutCeiling is the static hang-protection ceiling for a
+	// lifecycle operation (process start/stop/restart) that the daemon may
+	// legitimately hold open for up to a configured stop budget. It sits one
+	// minute above MaxStopTimeout so a valid long stop is never cut off by the
+	// wrapping layer; the supervisor is the authoritative bound. Shared by the
+	// three consumers named in MaxStopTimeout's comment: the API lifecycle
+	// route timeout, the CLI lifecycle http.Client timeout, and the TUI restart
+	// timeout (#35, D2).
+	LifecycleTimeoutCeiling = MaxStopTimeout + time.Minute
 )
 
 // Log configuration

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -38,7 +38,17 @@ const (
 	// phase runs until (deadline - KillGrace), after which the group is
 	// SIGKILLed and given up to KillGrace more to disappear before Stop reports
 	// the group could not be reaped.
+	//
+	// It also doubles as the configuration-time minimum for shutdown_timeout /
+	// stop_timeout: a configured budget must leave more than KillGrace on the
+	// table for the escalation to mean anything.
 	KillGrace = 2 * time.Second
+
+	// MaxStopTimeout is the configuration-time maximum for shutdown_timeout /
+	// stop_timeout. It keeps the static ceilings that wrap the configured
+	// value (API route timeout, CLI client timeout, TUI restart timeout)
+	// boundable.
+	MaxStopTimeout = 10 * time.Minute
 )
 
 // Log configuration

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -13,6 +13,14 @@ var (
 	ErrInvalidConfig         = errors.New("invalid configuration")
 	ErrEnvReloadFailed       = errors.New("environment reload failed")
 	ErrProcessGroupNotReaped = errors.New("process group could not be terminated")
+	// ErrConfigReloadFailed wraps any failure to re-read/validate prox.yaml on an
+	// API-driven (re)start (missing/unreadable file, YAML syntax, validation
+	// failure). The wrapping detail carries the underlying loader message (#33, D3).
+	ErrConfigReloadFailed = errors.New("config reload failed")
+	// ErrProcessNotInConfig is returned when an API-driven (re)start reloads the
+	// config and the target process is no longer present in it (#33, D3). The
+	// caller must run `prox up` to reconcile added/removed processes.
+	ErrProcessNotInConfig = errors.New("no longer in config")
 )
 
 // Error codes for API responses
@@ -24,6 +32,8 @@ const (
 	ErrCodeShutdownInProgress    = "SHUTDOWN_IN_PROGRESS"
 	ErrCodeEnvReloadFailed       = "ENV_RELOAD_FAILED"
 	ErrCodeProcessGroupNotReaped = "PROCESS_GROUP_NOT_REAPED"
+	ErrCodeConfigReloadFailed    = "CONFIG_RELOAD_FAILED"
+	ErrCodeProcessNotInConfig    = "PROCESS_NOT_IN_CONFIG"
 
 	// Proxy-related error codes (API-only, no sentinel errors as they
 	// are only used for HTTP response formatting in the API layer)
@@ -50,6 +60,10 @@ func ErrorCode(err error) string {
 		return ErrCodeEnvReloadFailed
 	case errors.Is(err, ErrProcessGroupNotReaped):
 		return ErrCodeProcessGroupNotReaped
+	case errors.Is(err, ErrConfigReloadFailed):
+		return ErrCodeConfigReloadFailed
+	case errors.Is(err, ErrProcessNotInConfig):
+		return ErrCodeProcessNotInConfig
 	default:
 		return "INTERNAL_ERROR"
 	}

--- a/internal/domain/process.go
+++ b/internal/domain/process.go
@@ -41,6 +41,11 @@ type ProcessConfig struct {
 	Env         map[string]string
 	EnvFile     string
 	Healthcheck *HealthConfig
+	// StopTimeout is this process's own configured SIGTERM->SIGKILL
+	// escalation budget (config.ProcessConfig.StopTimeout, parsed). Zero
+	// means unset: the effective budget resolution (proc > global > default)
+	// happens in supervisor.createManagedProcess, not here.
+	StopTimeout time.Duration
 }
 
 // ProcessInfo represents the runtime state of a process

--- a/internal/domain/process.go
+++ b/internal/domain/process.go
@@ -59,6 +59,11 @@ type ProcessInfo struct {
 	HealthDetails *HealthState      `json:"healthcheck,omitempty"`
 	Cmd           string            `json:"cmd,omitempty"`
 	Env           map[string]string `json:"env,omitempty"`
+	// StopTimeout is the effective SIGTERM->SIGKILL escalation budget in force
+	// for this process (per-process stop_timeout, else global shutdown_timeout,
+	// else the default). Surfaced so operators can see the budget governing a
+	// stop/restart. Zero only for a process built outside createManagedProcess.
+	StopTimeout time.Duration `json:"-"`
 }
 
 // UptimeSeconds returns the number of seconds the process has been running

--- a/internal/supervisor/fake_runner_test.go
+++ b/internal/supervisor/fake_runner_test.go
@@ -178,12 +178,22 @@ func newUnreapableFake(pid int) *fakeProcess {
 
 // fakeRunner is a ProcessRunner that hands out fakeProcess instances produced
 // by factory, one per Start call (call index passed in). It records every
-// process it produced.
+// process it produced along with the config and env it was launched with, so a
+// reload test can assert what the runner was actually handed (#33, D3).
 type fakeRunner struct {
 	mu      sync.Mutex
 	factory func(call int) *fakeProcess
 	procs   []*fakeProcess
+	configs []domain.ProcessConfig
+	envs    []map[string]string
 	calls   int
+
+	// onStart, when set, is invoked (call index passed in) after the launch is
+	// recorded but before Start returns, while the ManagedProcess still holds
+	// its lock (runner.Start runs inside startWithConfig's critical section).
+	// It lets an interleaving test use the runner as a barrier to force a
+	// deterministic ordering between a winning and a losing (re)start.
+	onStart func(call int)
 }
 
 func newFakeRunner(factory func(call int) *fakeProcess) *fakeRunner {
@@ -192,12 +202,39 @@ func newFakeRunner(factory func(call int) *fakeProcess) *fakeRunner {
 
 func (r *fakeRunner) Start(ctx context.Context, config domain.ProcessConfig, env map[string]string) (Process, error) {
 	r.mu.Lock()
-	defer r.mu.Unlock()
 	call := r.calls
 	r.calls++
 	fp := r.factory(call)
 	r.procs = append(r.procs, fp)
+	r.configs = append(r.configs, config)
+	r.envs = append(r.envs, env)
+	hook := r.onStart
+	r.mu.Unlock()
+
+	if hook != nil {
+		hook(call)
+	}
 	return fp, nil
+}
+
+// lastConfig returns the config the most recent Start was launched with.
+func (r *fakeRunner) lastConfig() domain.ProcessConfig {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.configs) == 0 {
+		return domain.ProcessConfig{}
+	}
+	return r.configs[len(r.configs)-1]
+}
+
+// lastEnv returns the env map the most recent Start was launched with.
+func (r *fakeRunner) lastEnv() map[string]string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.envs) == 0 {
+		return nil
+	}
+	return r.envs[len(r.envs)-1]
 }
 
 // last returns the most recently produced fake process.

--- a/internal/supervisor/process.go
+++ b/internal/supervisor/process.go
@@ -72,10 +72,15 @@ type ManagedProcess struct {
 	// Health checker for the current run.
 	healthChecker *HealthChecker
 
-	// shutdownTimeout overrides constants.DefaultShutdownTimeout for the
-	// no-context-deadline fallback in computeDeadlines. It is a test seam only
-	// (kept small so the no-deadline escalation path runs fast); production
-	// code leaves it zero, which means "use constants.DefaultShutdownTimeout".
+	// shutdownTimeout is this process's effective stop budget: the
+	// no-context-deadline fallback in computeDeadlines. supervisor.
+	// createManagedProcess resolves and sets it (per-process stop_timeout,
+	// else global shutdown_timeout, else constants.DefaultShutdownTimeout)
+	// before the ManagedProcess is published, so production code never sees
+	// zero here. Tests that construct a ManagedProcess directly (bypassing
+	// createManagedProcess) may still set it directly as a seam to shrink the
+	// fallback window; production code and computeDeadlines both go through
+	// the locked StopTimeout() accessor.
 	shutdownTimeout time.Duration
 }
 
@@ -139,6 +144,14 @@ func (p *ManagedProcess) State() domain.ProcessState {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 	return p.state
+}
+
+// StopTimeout returns the effective per-process stop budget used as the
+// no-context-deadline fallback in computeDeadlines.
+func (p *ManagedProcess) StopTimeout() time.Duration {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.shutdownTimeout
 }
 
 // Start starts the process
@@ -243,7 +256,7 @@ func (p *ManagedProcess) computeDeadlines(ctx context.Context) (gracefulDeadline
 
 	dl, ok := ctx.Deadline()
 	if !ok {
-		timeout := p.shutdownTimeout
+		timeout := p.StopTimeout()
 		if timeout <= 0 {
 			timeout = constants.DefaultShutdownTimeout
 		}

--- a/internal/supervisor/process.go
+++ b/internal/supervisor/process.go
@@ -117,6 +117,7 @@ func (p *ManagedProcess) Info() domain.ProcessInfo {
 		Health:       domain.HealthStatusUnknown,
 		Cmd:          p.config.Cmd,
 		Env:          p.env,
+		StopTimeout:  p.shutdownTimeout,
 	}
 
 	// PID is only meaningful while the process is active. Once stopped or

--- a/internal/supervisor/process.go
+++ b/internal/supervisor/process.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"maps"
 	"os/exec"
 	"sync"
 	"syscall"
@@ -42,9 +43,35 @@ func (i *processInstance) closeDone() {
 	i.doneOnce.Do(func() { close(i.done) })
 }
 
+// pendingConfig carries a freshly-reloaded process runtime (domain config, env
+// loader closure, the env map that closure produced, and effective stop budget)
+// to be swapped into a ManagedProcess atomically inside startWithConfig's locked
+// critical section (#33, D3). The supervisor builds it via prepareReload before
+// any stop; a nil pending means "no reload -- keep the stored config".
+type pendingConfig struct {
+	config  domain.ProcessConfig
+	loadEnv func() (map[string]string, error)
+	// env is the exact map prepareReload's preflight already loaded and
+	// validated from disk, BEFORE the stop. startWithConfig applies it as-is for
+	// this run rather than re-invoking loadEnv, so an env file deleted between
+	// the preflight and the launch cannot cause downtime (the fail-before-stop
+	// promise) and the running process gets exactly what was validated. The
+	// loadEnv closure is still stored for any future non-reload start, preserving
+	// the #30 fresh-read-on-every-start semantics.
+	env         map[string]string
+	stopTimeout time.Duration
+}
+
 // ManagedProcess handles the lifecycle of a single process
 type ManagedProcess struct {
 	mu sync.RWMutex
+
+	// name is the process's identity, set once at construction and never
+	// mutated (a rename requires `prox up`, not a restart). It is read lock-free
+	// for log attribution (logf/readOutput) and error messages so a config swap
+	// under mu.Lock cannot race those reads, and so an old run's monitor stays
+	// correctly attributed across a swap (#33, D3).
+	name string
 
 	config     domain.ProcessConfig
 	env        map[string]string
@@ -72,6 +99,13 @@ type ManagedProcess struct {
 	// Health checker for the current run.
 	healthChecker *HealthChecker
 
+	// restartStartBarrier is a test-only seam (nil in production). When set, it
+	// is invoked inside Restart after the stop half completes and before the
+	// replacement's start half runs, so an interleaving test can deterministically
+	// hold a restart open in the unlocked gap between its stop and start and race
+	// a concurrent StartProcess into it. Read once under the lock in Restart.
+	restartStartBarrier func()
+
 	// shutdownTimeout is this process's effective stop budget: the
 	// no-context-deadline fallback in computeDeadlines. supervisor.
 	// createManagedProcess resolves and sets it (per-process stop_timeout,
@@ -87,6 +121,7 @@ type ManagedProcess struct {
 // NewManagedProcess creates a new managed process
 func NewManagedProcess(config domain.ProcessConfig, env map[string]string, runner ProcessRunner, logManager *logs.Manager) *ManagedProcess {
 	return &ManagedProcess{
+		name:       config.Name,
 		config:     config,
 		env:        env,
 		runner:     runner,
@@ -95,14 +130,27 @@ func NewManagedProcess(config domain.ProcessConfig, env map[string]string, runne
 	}
 }
 
-// Name returns the process name
+// Name returns the process name. Immutable, so no lock is taken.
 func (p *ManagedProcess) Name() string {
-	return p.config.Name
+	return p.name
 }
 
-// Config returns the process configuration
+// Config returns a deep copy of the process configuration. It takes the read
+// lock (config is swappable on a reload -- #33, D3) and clones the reference
+// fields (Healthcheck pointer, Env map) so callers cannot observe a torn value
+// or mutate the live config.
 func (p *ManagedProcess) Config() domain.ProcessConfig {
-	return p.config
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	cfg := p.config
+	if p.config.Healthcheck != nil {
+		hc := *p.config.Healthcheck
+		cfg.Healthcheck = &hc
+	}
+	// maps.Clone returns nil for a nil map, preserving the nil-vs-empty distinction.
+	cfg.Env = maps.Clone(p.config.Env)
+	return cfg
 }
 
 // Info returns the current process info
@@ -155,25 +203,73 @@ func (p *ManagedProcess) StopTimeout() time.Duration {
 	return p.shutdownTimeout
 }
 
-// Start starts the process
+// Start starts the process with its currently-stored config.
 func (p *ManagedProcess) Start(ctx context.Context) error {
+	return p.startWithConfig(ctx, nil)
+}
+
+// startWithConfig starts the process, optionally swapping in a freshly-reloaded
+// config first. When pending is non-nil the swap (config, env loader, effective
+// stop budget) happens inside this locked critical section, AFTER both
+// early-return guards (already-running state check, surviving-previous-group
+// check) pass and BEFORE the runner launches -- so a concurrent Start that wins
+// the race starts the old config and the loser returns ErrProcessAlreadyRunning
+// WITHOUT applying the swap. The stored config therefore always matches the
+// running process (#33, D3).
+//
+// If the runner (or the post-swap env reload) fails AFTER the swap was applied,
+// the new config stays in place (state Crashed; the next start uses it) -- "the
+// file is the truth".
+func (p *ManagedProcess) startWithConfig(ctx context.Context, pending *pendingConfig) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
 	// Reject starting over an active run. `stopping` is included so a Start
 	// racing an in-flight Stop is refused rather than launching a duplicate
-	// while the previous group is still being reaped.
+	// while the previous group is still being reaped. The loser exits here
+	// before any swap, keeping the stored config consistent with the winner.
 	if p.state == domain.ProcessStateRunning ||
 		p.state == domain.ProcessStateStarting ||
 		p.state == domain.ProcessStateStopping {
 		return domain.ErrProcessAlreadyRunning
 	}
 
-	// Reload the environment from disk on every Start (covers both `start`
-	// after `stop` and the replacement half of `restart`). This must happen
-	// before any per-instance state is created so a failure here leaves no
-	// dangling instance behind.
-	if p.loadEnv != nil {
+	// Never launch a duplicate over a surviving previous group. If the prior
+	// run's group is still alive (e.g. a prior Stop failed to reap it), refuse
+	// rather than orphan it -- the caller must stop it first. Checked before the
+	// swap so a refusal here also leaves the stored config untouched.
+	if p.current != nil && p.current.proc != nil {
+		if alive, _ := p.current.proc.GroupAlive(); alive {
+			return fmt.Errorf("%w: %s (previous instance still running; stop it first)",
+				domain.ErrProcessGroupNotReaped, p.name)
+		}
+	}
+
+	// Commit point: both guards passed, so this call is the one that launches.
+	// Swap in the reloaded runtime now (config, env loader, effective stop
+	// budget) -- from here on a failure keeps the new config active.
+	if pending != nil {
+		p.config = pending.config
+		p.loadEnv = pending.loadEnv
+		p.shutdownTimeout = pending.stopTimeout
+	}
+
+	// Apply the environment for this run.
+	//
+	//   - Reload path (pending != nil): use the snapshot prepareReload already
+	//     loaded AND validated from disk before the stop. Re-reading here would
+	//     reopen a window where an env file deleted between preflight and launch
+	//     causes downtime, breaking the fail-before-stop promise; it would also
+	//     risk applying something other than what was validated. No error path is
+	//     needed -- the load already succeeded.
+	//   - Non-reload path (up-time start, or ConfigPath unset): read from disk now
+	//     via the stored closure so a plain start still picks up current env-file
+	//     contents (#30 fresh-read-on-every-start). This must happen before any
+	//     per-instance state is created so a failure here leaves no dangling
+	//     instance behind.
+	if pending != nil {
+		p.env = pending.env
+	} else if p.loadEnv != nil {
 		env, err := p.loadEnv()
 		if err != nil {
 			p.state = domain.ProcessStateCrashed
@@ -181,16 +277,6 @@ func (p *ManagedProcess) Start(ctx context.Context) error {
 			return fmt.Errorf("%w: %v", domain.ErrEnvReloadFailed, err)
 		}
 		p.env = env
-	}
-
-	// Never launch a duplicate over a surviving previous group. If the prior
-	// run's group is still alive (e.g. a prior Stop failed to reap it), refuse
-	// rather than orphan it -- the caller must stop it first.
-	if p.current != nil && p.current.proc != nil {
-		if alive, _ := p.current.proc.GroupAlive(); alive {
-			return fmt.Errorf("%w: %s (previous instance still running; stop it first)",
-				domain.ErrProcessGroupNotReaped, p.config.Name)
-		}
 	}
 
 	p.state = domain.ProcessStateStarting
@@ -360,7 +446,7 @@ func (p *ManagedProcess) Stop(ctx context.Context) error {
 			Timestamp: time.Now(),
 			Process:   "system",
 			Stream:    domain.StreamStdout,
-			Line:      fmt.Sprintf("sending SIGKILL to %s (graceful shutdown timed out)", p.config.Name),
+			Line:      fmt.Sprintf("sending SIGKILL to %s (graceful shutdown timed out)", p.name),
 		})
 		if err := inst.proc.Signal(sigkill); err != nil {
 			p.logf(domain.StreamStderr, "SIGKILL failed: %v", err)
@@ -401,7 +487,7 @@ func (p *ManagedProcess) Stop(ctx context.Context) error {
 	p.mu.Unlock()
 
 	if alive {
-		return fmt.Errorf("%w: %s", domain.ErrProcessGroupNotReaped, p.config.Name)
+		return fmt.Errorf("%w: %s", domain.ErrProcessGroupNotReaped, p.name)
 	}
 	return nil
 }
@@ -437,16 +523,28 @@ func waitGroupGone(proc Process, deadline time.Time) bool {
 //
 // If Stop fails (e.g. the old group could not be reaped) Restart aborts before
 // Start, so a surviving group is never shadowed by a replacement.
-func (p *ManagedProcess) Restart(stopCtx, startCtx context.Context) error {
+//
+// pending, when non-nil, carries a freshly-reloaded config swapped in atomically
+// by the replacement's start half (see startWithConfig); nil restarts with the
+// stored config. The stop half runs before the swap, so it uses the OLD stored
+// stop budget -- a raised stop_timeout only governs the next stop (#33, D3).
+func (p *ManagedProcess) Restart(stopCtx, startCtx context.Context, pending *pendingConfig) error {
 	if err := p.Stop(stopCtx); err != nil && err != domain.ErrProcessNotRunning {
 		return err
 	}
 
 	p.mu.Lock()
 	p.restartCount++
+	barrier := p.restartStartBarrier
 	p.mu.Unlock()
 
-	return p.Start(startCtx)
+	// Test-only seam: hold the restart in the unlocked gap between its stop and
+	// its start half so an interleaving test can race a concurrent start in.
+	if barrier != nil {
+		barrier()
+	}
+
+	return p.startWithConfig(startCtx, pending)
 }
 
 // monitor watches a single instance for exit. It owns draining that instance's
@@ -532,7 +630,7 @@ func exitCodeFromWaitErr(err error) int {
 func (p *ManagedProcess) logf(stream domain.Stream, format string, args ...interface{}) {
 	p.logManager.Write(domain.LogEntry{
 		Timestamp: time.Now(),
-		Process:   p.config.Name,
+		Process:   p.name,
 		Stream:    stream,
 		Line:      fmt.Sprintf(format, args...),
 	})
@@ -553,7 +651,7 @@ func (p *ManagedProcess) readOutput(r interface{}, stream domain.Stream) {
 		line := scanner.Text()
 		p.logManager.Write(domain.LogEntry{
 			Timestamp: time.Now(),
-			Process:   p.config.Name,
+			Process:   p.name,
 			Stream:    stream,
 			Line:      line,
 		})

--- a/internal/supervisor/process_stop_test.go
+++ b/internal/supervisor/process_stop_test.go
@@ -158,7 +158,7 @@ func TestManagedProcess_RestartClobberSafety(t *testing.T) {
 	const restarts = 10
 	for i := 0; i < restarts; i++ {
 		stopCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-		err := mp.Restart(stopCtx, context.Background())
+		err := mp.Restart(stopCtx, context.Background(), nil)
 		cancel()
 		require.NoErrorf(t, err, "restart %d", i)
 		require.Equalf(t, domain.ProcessStateRunning, mp.State(), "restart %d should leave the process running", i)

--- a/internal/supervisor/process_stop_test.go
+++ b/internal/supervisor/process_stop_test.go
@@ -280,3 +280,28 @@ func TestManagedProcess_Stop_NoDeadlineFallbackEscalates(t *testing.T) {
 	assert.True(t, fp.sawSignal(sigkill), "stubborn group should be SIGKILLed after the graceful window")
 	assert.Less(t, elapsed, 3*time.Second, "escalation must use the ~1s fallback window, not the 10s default")
 }
+
+// TestManagedProcess_Stop_EscalationUpperBound is the plan §7 escalation-timing
+// bound: a SIGTERM-ignoring process with a 3s stop budget must be SIGKILLed no
+// earlier than ~1s (the graceful window = budget - KillGrace(2s)) and no later
+// than ~3s+ε (the full budget) after the stop begins. It asserts the actual
+// SIGKILL timestamp, not just that a SIGKILL happened.
+func TestManagedProcess_Stop_EscalationUpperBound(t *testing.T) {
+	runner := newFakeRunner(func(call int) *fakeProcess { return newStubbornFake(6500 + call) })
+	mp := newFakeManagedProcess(t, runner)
+	mp.shutdownTimeout = 3 * time.Second // graceful window == 3s - KillGrace(2s) == 1s
+
+	require.NoError(t, mp.Start(context.Background()))
+	fp := runner.last()
+
+	start := time.Now()
+	require.NoError(t, mp.Stop(context.Background()))
+
+	sigs := fp.signalsReceived()
+	killIdx := firstIndexOf(sigs, sigkill)
+	require.GreaterOrEqual(t, killIdx, 0, "stubborn group must be SIGKILLed")
+	killAt := sigs[killIdx].at.Sub(start)
+
+	assert.GreaterOrEqual(t, killAt, 900*time.Millisecond, "SIGKILL must not fire before the ~1s graceful window elapses")
+	assert.LessOrEqual(t, killAt, 3*time.Second+500*time.Millisecond, "SIGKILL must fire within the ~3s budget (+ε)")
+}

--- a/internal/supervisor/process_test.go
+++ b/internal/supervisor/process_test.go
@@ -115,7 +115,7 @@ func TestManagedProcess_Restart(t *testing.T) {
 	restartCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	err = mp.Restart(restartCtx, context.Background())
+	err = mp.Restart(restartCtx, context.Background(), nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, domain.ProcessStateRunning, mp.State())

--- a/internal/supervisor/reload_test.go
+++ b/internal/supervisor/reload_test.go
@@ -1,0 +1,518 @@
+package supervisor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/charliek/prox/internal/config"
+	"github.com/charliek/prox/internal/domain"
+	"github.com/charliek/prox/internal/logs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeConfigFile writes cfgYAML to dir/prox.yaml (0644 so config.Load's
+// permission check passes) and returns the path. Used to seed and later edit
+// the file a reload test drives.
+func writeConfigFile(t *testing.T, dir, cfgYAML string) string {
+	t.Helper()
+	path := filepath.Join(dir, "prox.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(cfgYAML), 0644), "writing config")
+	return path
+}
+
+// newReloadSupervisor writes cfgYAML, loads it, and builds a supervisor wired
+// for config reload (ConfigPath set, ConfigDir = dir) backed by runner. It does
+// not start the supervisor.
+func newReloadSupervisor(t *testing.T, dir, cfgYAML string, runner ProcessRunner) *Supervisor {
+	t.Helper()
+	path := writeConfigFile(t, dir, cfgYAML)
+
+	cfg, err := config.Load(path)
+	require.NoError(t, err, "loading initial config")
+
+	logMgr := logs.NewManager(logs.ManagerConfig{BufferSize: 100})
+	t.Cleanup(func() { logMgr.Close() })
+
+	supCfg := DefaultSupervisorConfig()
+	supCfg.ConfigDir = dir
+	supCfg.ConfigPath = path
+	return New(cfg, logMgr, runner, supCfg)
+}
+
+// getManagedProcess returns the live ManagedProcess for name (lock-held read).
+func getManagedProcess(t *testing.T, sup *Supervisor, name string) *ManagedProcess {
+	t.Helper()
+	sup.mu.RLock()
+	defer sup.mu.RUnlock()
+	mp := sup.processes[name]
+	require.NotNil(t, mp, "process %q should exist", name)
+	return mp
+}
+
+// TestReload_RestartAndStartStartApplyChangedCmd covers the core #33 promise: a
+// cmd edited in prox.yaml takes effect on `restart`, and equally on `stop` +
+// `start` (the reload rule is unified across both API paths -- plan D3). The
+// fake runner records the cmd it was launched with.
+func TestReload_RestartAndStartStartApplyChangedCmd(t *testing.T) {
+	dir := t.TempDir()
+	runner := newFakeRunner(func(call int) *fakeProcess { return newGracefulFake(1000 + call) })
+	sup := newReloadSupervisor(t, dir, "processes:\n  web:\n    cmd: \"echo v1\"\n", runner)
+
+	_, err := sup.Start(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "echo v1", runner.lastConfig().Cmd)
+
+	// restart picks up the edit.
+	writeConfigFile(t, dir, "processes:\n  web:\n    cmd: \"echo v2\"\n")
+	require.NoError(t, sup.RestartProcess(context.Background(), "web"))
+	assert.Equal(t, "echo v2", runner.lastConfig().Cmd, "restart must launch the edited cmd")
+	assert.Equal(t, "echo v2", getManagedProcess(t, sup, "web").Config().Cmd, "stored config must match the launched cmd")
+
+	// stop + start also picks up the (next) edit.
+	require.NoError(t, sup.StopProcess(context.Background(), "web"))
+	writeConfigFile(t, dir, "processes:\n  web:\n    cmd: \"echo v3\"\n")
+	require.NoError(t, sup.StartProcess(context.Background(), "web"))
+	assert.Equal(t, "echo v3", runner.lastConfig().Cmd, "start after stop must launch the edited cmd")
+	assert.Equal(t, "echo v3", getManagedProcess(t, sup, "web").Config().Cmd)
+}
+
+// TestReload_ConsecutiveRestartsPickUpLatestFile: two edit->restart cycles each
+// pick up the latest file, proving reload is per-request (not a one-shot).
+func TestReload_ConsecutiveRestartsPickUpLatestFile(t *testing.T) {
+	dir := t.TempDir()
+	runner := newFakeRunner(func(call int) *fakeProcess { return newGracefulFake(1100 + call) })
+	sup := newReloadSupervisor(t, dir, "processes:\n  web:\n    cmd: \"echo v1\"\n", runner)
+
+	_, err := sup.Start(context.Background())
+	require.NoError(t, err)
+
+	for _, cmd := range []string{"echo v2", "echo v3"} {
+		writeConfigFile(t, dir, "processes:\n  web:\n    cmd: \""+cmd+"\"\n")
+		require.NoError(t, sup.RestartProcess(context.Background(), "web"))
+		assert.Equal(t, cmd, runner.lastConfig().Cmd)
+	}
+}
+
+// TestReload_RestartAppliesChangedHealthcheck: a changed healthcheck in the file
+// is applied on restart (the runner sees the new healthcheck on the launched
+// config).
+func TestReload_RestartAppliesChangedHealthcheck(t *testing.T) {
+	dir := t.TempDir()
+	runner := newFakeRunner(func(call int) *fakeProcess { return newGracefulFake(1200 + call) })
+	sup := newReloadSupervisor(t, dir,
+		"processes:\n  web:\n    cmd: \"echo hi\"\n    healthcheck:\n      cmd: \"true\"\n      interval: 30s\n", runner)
+
+	_, err := sup.Start(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, runner.lastConfig().Healthcheck)
+	require.Equal(t, "true", runner.lastConfig().Healthcheck.Cmd)
+
+	writeConfigFile(t, dir,
+		"processes:\n  web:\n    cmd: \"echo hi\"\n    healthcheck:\n      cmd: \"echo healthy\"\n      interval: 45s\n")
+	require.NoError(t, sup.RestartProcess(context.Background(), "web"))
+
+	hc := runner.lastConfig().Healthcheck
+	require.NotNil(t, hc, "restart must carry the reloaded healthcheck")
+	assert.Equal(t, "echo healthy", hc.Cmd)
+	assert.Equal(t, 45*time.Second, hc.Interval)
+
+	require.NoError(t, sup.Stop(context.Background()))
+}
+
+// TestReload_RestartAppliesChangedStopTimeout: a changed stop_timeout in the file
+// updates the effective stop budget after restart (mp.StopTimeout()).
+func TestReload_RestartAppliesChangedStopTimeout(t *testing.T) {
+	dir := t.TempDir()
+	runner := newFakeRunner(func(call int) *fakeProcess { return newGracefulFake(1300 + call) })
+	sup := newReloadSupervisor(t, dir, "processes:\n  web:\n    cmd: \"echo hi\"\n    stop_timeout: 5s\n", runner)
+
+	_, err := sup.Start(context.Background())
+	require.NoError(t, err)
+	mp := getManagedProcess(t, sup, "web")
+	require.Equal(t, 5*time.Second, mp.StopTimeout())
+
+	writeConfigFile(t, dir, "processes:\n  web:\n    cmd: \"echo hi\"\n    stop_timeout: 8s\n")
+	require.NoError(t, sup.RestartProcess(context.Background(), "web"))
+	assert.Equal(t, 8*time.Second, mp.StopTimeout(), "restart must apply the reloaded stop_timeout")
+}
+
+// TestReload_RestartRebuildsEnvClosureForChangedPath: pointing env_file at a
+// different path in the reloaded file rebuilds the loadEnv closure, so the
+// replacement observes the NEW file's values (the runner records the launched
+// env).
+func TestReload_RestartRebuildsEnvClosureForChangedPath(t *testing.T) {
+	dir := t.TempDir()
+	envA := filepath.Join(dir, "a.env")
+	envB := filepath.Join(dir, "b.env")
+	require.NoError(t, os.WriteFile(envA, []byte("MYVAL=fromA\n"), 0644))
+	require.NoError(t, os.WriteFile(envB, []byte("MYVAL=fromB\n"), 0644))
+
+	runner := newFakeRunner(func(call int) *fakeProcess { return newGracefulFake(1400 + call) })
+	sup := newReloadSupervisor(t, dir, "processes:\n  web:\n    cmd: \"echo hi\"\n    env_file: a.env\n", runner)
+
+	_, err := sup.Start(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "fromA", runner.lastEnv()["MYVAL"])
+
+	writeConfigFile(t, dir, "processes:\n  web:\n    cmd: \"echo hi\"\n    env_file: b.env\n")
+	require.NoError(t, sup.RestartProcess(context.Background(), "web"))
+	assert.Equal(t, "fromB", runner.lastEnv()["MYVAL"], "restart must reload env from the new env_file path")
+}
+
+// TestReload_FailuresLeaveProcessUntouched drives every fail-closed path: broken
+// YAML, a validation failure in an UNRELATED process, a missing file, and the
+// target removed from the file. Each must return the documented sentinel and
+// leave the original process running with its original cmd (no re-launch).
+func TestReload_FailuresLeaveProcessUntouched(t *testing.T) {
+	const goodCmd = "echo v1"
+	base := "processes:\n  web:\n    cmd: \"" + goodCmd + "\"\n  other:\n    cmd: \"echo other\"\n"
+
+	cases := []struct {
+		name     string
+		mutate   func(t *testing.T, dir, path string)
+		wantErr  error
+		wantCode string
+	}{
+		{
+			name:     "broken yaml",
+			mutate:   func(t *testing.T, dir, path string) { writeConfigFile(t, dir, "processes: {: :\n") },
+			wantErr:  domain.ErrConfigReloadFailed,
+			wantCode: domain.ErrCodeConfigReloadFailed,
+		},
+		{
+			name: "unrelated process validation failure",
+			// `other`'s stop_timeout is below KillGrace -> whole-file validation
+			// fails even though `web` (the restart target) is untouched.
+			mutate: func(t *testing.T, dir, path string) {
+				writeConfigFile(t, dir, "processes:\n  web:\n    cmd: \""+goodCmd+"\"\n  other:\n    cmd: \"echo other\"\n    stop_timeout: 1s\n")
+			},
+			wantErr:  domain.ErrConfigReloadFailed,
+			wantCode: domain.ErrCodeConfigReloadFailed,
+		},
+		{
+			name:     "missing file",
+			mutate:   func(t *testing.T, dir, path string) { require.NoError(t, os.Remove(path)) },
+			wantErr:  domain.ErrConfigReloadFailed,
+			wantCode: domain.ErrCodeConfigReloadFailed,
+		},
+		{
+			name: "target removed from config",
+			mutate: func(t *testing.T, dir, path string) {
+				writeConfigFile(t, dir, "processes:\n  other:\n    cmd: \"echo other\"\n")
+			},
+			wantErr:  domain.ErrProcessNotInConfig,
+			wantCode: domain.ErrCodeProcessNotInConfig,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			runner := newFakeRunner(func(call int) *fakeProcess { return newGracefulFake(1500 + call) })
+			sup := newReloadSupervisor(t, dir, base, runner)
+
+			_, err := sup.Start(context.Background())
+			require.NoError(t, err)
+			launchesBefore := runner.count()
+
+			path := filepath.Join(dir, "prox.yaml")
+			tc.mutate(t, dir, path)
+
+			err = sup.RestartProcess(context.Background(), "web")
+			require.Error(t, err)
+			assert.ErrorIs(t, err, tc.wantErr)
+			assert.Equal(t, tc.wantCode, domain.ErrorCode(err), "error must map to the documented code")
+
+			// The target stays running with its original cmd; nothing re-launched.
+			mp := getManagedProcess(t, sup, "web")
+			assert.Equal(t, domain.ProcessStateRunning, mp.State(), "process must stay running after a failed reload")
+			assert.Equal(t, goodCmd, mp.Config().Cmd, "stored config must be unchanged")
+			assert.Equal(t, launchesBefore, runner.count(), "a failed reload must not stop or re-launch the process")
+		})
+	}
+}
+
+// TestReload_PreflightEnvFailureRestartsNothing: a reloaded config that points at
+// a nonexistent env_file must fail the restart BEFORE the stop -- the process is
+// never stopped (env is preflighted in prepareReload). Uses a stubborn fake so a
+// stop, had one happened, would be observable via a SIGTERM.
+func TestReload_PreflightEnvFailureRestartsNothing(t *testing.T) {
+	dir := t.TempDir()
+	runner := newFakeRunner(func(call int) *fakeProcess { return newStubbornFake(1600 + call) })
+	sup := newReloadSupervisor(t, dir, "processes:\n  web:\n    cmd: \"echo v1\"\n", runner)
+
+	_, err := sup.Start(context.Background())
+	require.NoError(t, err)
+	fp := runner.last()
+
+	writeConfigFile(t, dir, "processes:\n  web:\n    cmd: \"echo v1\"\n    env_file: does-not-exist.env\n")
+	err = sup.RestartProcess(context.Background(), "web")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, domain.ErrConfigReloadFailed)
+
+	mp := getManagedProcess(t, sup, "web")
+	assert.Equal(t, domain.ProcessStateRunning, mp.State())
+	assert.Equal(t, 1, runner.count(), "the process must not be re-launched")
+	assert.False(t, fp.sawSignal(sigterm), "the process must not even be signalled (preflight fails before the stop)")
+}
+
+// TestReload_RestartStopHalfUsesOldBudget_NextStopUsesNew is the plan §7 timing
+// contract: raising stop_timeout via a restart does NOT lengthen that restart's
+// own stop half (it uses the pre-swap budget); the new budget governs the next
+// stop.
+//
+// The old (3s) and new (10s) budgets are set far apart so the stop-half SIGKILL
+// timestamp discriminates with a wide, non-flaky margin: it must land within the
+// OLD ~1s graceful window (asserted as a loose ceiling well under the new
+// budget's ~8s window, so slow/-race CI cannot flake it), and the lower bound is
+// the real discriminator that it waited a graceful window at all. The new budget
+// governing the next stop is proven directly via StopTimeout() (StopProcess
+// bounds its stop by exactly that value -- see
+// TestSupervisor_StopProcess_UsesPerProcessBudget); the replacement is a graceful
+// fake so this assertion needs no second multi-second escalation.
+func TestReload_RestartStopHalfUsesOldBudget_NextStopUsesNew(t *testing.T) {
+	dir := t.TempDir()
+	// Instance 0 is stubborn (forces the stop-half SIGKILL we time); the
+	// replacement is graceful so the follow-up stop is instant.
+	runner := newFakeRunner(func(call int) *fakeProcess {
+		if call == 0 {
+			return newStubbornFake(1700)
+		}
+		return newGracefulFake(1700 + call)
+	})
+	// old budget 3s -> graceful window == 3s - KillGrace(2s) == 1s.
+	sup := newReloadSupervisor(t, dir, "processes:\n  web:\n    cmd: \"echo v1\"\n    stop_timeout: 3s\n", runner)
+
+	_, err := sup.Start(context.Background())
+	require.NoError(t, err)
+	oldFP := runner.last() // stubborn instance the restart's stop half will kill
+
+	// Raise the budget to 10s (graceful window would be ~8s if it applied here).
+	writeConfigFile(t, dir, "processes:\n  web:\n    cmd: \"echo v1\"\n    stop_timeout: 10s\n")
+
+	start := time.Now()
+	require.NoError(t, sup.RestartProcess(context.Background(), "web"))
+
+	killIdx := firstIndexOf(oldFP.signalsReceived(), sigkill)
+	require.GreaterOrEqual(t, killIdx, 0, "the restart's stop half should SIGKILL the stubborn old instance")
+	killAt := oldFP.signalsReceived()[killIdx].at.Sub(start)
+	assert.Greater(t, killAt, 700*time.Millisecond, "SIGKILL must wait out the OLD ~1s graceful window (not fire instantly)")
+	assert.Less(t, killAt, 5*time.Second, "stop half must use the OLD 3s budget, not the new 10s one (~8s window)")
+
+	// The new budget is now in force and will bound the next stop.
+	mp := getManagedProcess(t, sup, "web")
+	require.Equal(t, 10*time.Second, mp.StopTimeout(), "the reloaded budget governs subsequent stops")
+
+	// The replacement stops promptly on its own (graceful) -- exercising the
+	// next-stop path without a second multi-second escalation.
+	require.NotSame(t, oldFP, runner.last(), "restart should have launched a fresh instance")
+	require.NoError(t, sup.StopProcess(context.Background(), "web"))
+	assert.Equal(t, domain.ProcessStateStopped, mp.State())
+}
+
+// TestReload_SwapIsAtomicUnderConcurrentStart is the plan D3 deterministic
+// interleaving test. Two (re)starts race to launch a stopped process: both
+// StartProcess and RestartProcess funnel their launch through startWithConfig,
+// which swaps the reloaded config in only inside the locked critical section,
+// after the guards pass and before the runner launches. The runner's onStart
+// barrier makes the ordering deterministic -- the first launcher holds the lock
+// through swap+launch (the winner); the second parks on the lock and, once the
+// winner finishes, sees the process running and returns ErrProcessAlreadyRunning
+// WITHOUT applying its swap. Either way the running process's launched cmd must
+// equal the stored config's cmd.
+func TestReload_SwapIsAtomicUnderConcurrentStart(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		winnerCmd string
+		loserCmd  string
+	}{
+		{name: "restart-config wins", winnerCmd: "cmd-A", loserCmd: "cmd-B"},
+		{name: "start-config wins", winnerCmd: "cmd-B", loserCmd: "cmd-A"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			logMgr := logs.NewManager(logs.ManagerConfig{BufferSize: 100})
+			t.Cleanup(func() { logMgr.Close() })
+
+			gateReached := make(chan struct{})
+			release := make(chan struct{})
+			var once sync.Once
+
+			runner := newFakeRunner(func(call int) *fakeProcess { return newGracefulFake(1800 + call) })
+			runner.onStart = func(call int) {
+				// Only the winner reaches here (the loser never launches). Signal
+				// that the winner holds the lock, then block until released so the
+				// loser is forced to park on the process lock.
+				once.Do(func() { close(gateReached) })
+				<-release
+			}
+
+			mp := NewManagedProcess(domain.ProcessConfig{Name: "web", Cmd: "orig"}, nil, runner, logMgr)
+			t.Cleanup(func() { _ = mp.Stop(context.Background()) })
+
+			winner := &pendingConfig{
+				config:      domain.ProcessConfig{Name: "web", Cmd: tc.winnerCmd},
+				stopTimeout: 4 * time.Second,
+			}
+			loser := &pendingConfig{
+				config:      domain.ProcessConfig{Name: "web", Cmd: tc.loserCmd},
+				stopTimeout: 4 * time.Second,
+			}
+
+			winErr := make(chan error, 1)
+			go func() { winErr <- mp.startWithConfig(context.Background(), winner) }()
+
+			// Wait until the winner holds the lock at the runner barrier, then
+			// launch the loser so it must contend for the (held) lock.
+			<-gateReached
+			loseErr := make(chan error, 1)
+			go func() { loseErr <- mp.startWithConfig(context.Background(), loser) }()
+			time.Sleep(50 * time.Millisecond) // let the loser reach the lock
+
+			close(release)
+
+			require.NoError(t, <-winErr, "the winner's start should succeed")
+			require.ErrorIs(t, <-loseErr, domain.ErrProcessAlreadyRunning, "the loser must be refused")
+
+			// Invariant: running process's launched cmd == stored config's cmd.
+			assert.Equal(t, tc.winnerCmd, runner.lastConfig().Cmd, "the launched cmd must be the winner's")
+			assert.Equal(t, tc.winnerCmd, mp.Config().Cmd, "the stored config must match the running process")
+			assert.Equal(t, 1, runner.count(), "the loser must not launch a second instance")
+		})
+	}
+}
+
+// TestReload_ConcurrentStartVsRestart_ThroughSupervisor drives the real
+// interleaving the unit-level swap test cannot: a concurrent
+// Supervisor.StartProcess racing a Supervisor.RestartProcess through the PUBLIC
+// methods, forcing both winners deterministically with fake-runner /
+// stop barriers (no sleeps). In every outcome the running process's launched cmd
+// must equal the stored Config().Cmd, and the loser must return
+// ErrProcessAlreadyRunning without having applied its own reloaded config.
+func TestReload_ConcurrentStartVsRestart_ThroughSupervisor(t *testing.T) {
+	// (a) StartProcess wins the unlocked gap between the restart's stop and its
+	// start half. The restart is held at the post-stop barrier (process already
+	// Stopped) while a StartProcess launches; the restart's start half then finds
+	// the process running and is refused, without swapping in its own config.
+	t.Run("start wins the post-stop gap", func(t *testing.T) {
+		dir := t.TempDir()
+		// Graceful instances: instance 0 stops cleanly during the restart's stop
+		// half; the StartProcess launches instance 1.
+		runner := newFakeRunner(func(call int) *fakeProcess { return newGracefulFake(2000 + call) })
+		sup := newReloadSupervisor(t, dir, "processes:\n  web:\n    cmd: \"echo v0\"\n", runner)
+
+		_, err := sup.Start(context.Background())
+		require.NoError(t, err)
+		mp := getManagedProcess(t, sup, "web")
+
+		gapReached := make(chan struct{})
+		releaseRestart := make(chan struct{})
+		mp.restartStartBarrier = func() {
+			close(gapReached)
+			<-releaseRestart
+		}
+		t.Cleanup(func() { _ = sup.Stop(context.Background()) })
+
+		// The restart reloads "v-restart"; the start (below) reloads "v-start".
+		writeConfigFile(t, dir, "processes:\n  web:\n    cmd: \"echo v-restart\"\n")
+		restartErr := make(chan error, 1)
+		go func() { restartErr <- sup.RestartProcess(context.Background(), "web") }()
+
+		// Wait until the restart has stopped instance 0 and parked before its
+		// start half; the process is now Stopped and the lock is free.
+		<-gapReached
+
+		// A StartProcess reloads its own config and wins the gap.
+		writeConfigFile(t, dir, "processes:\n  web:\n    cmd: \"echo v-start\"\n")
+		startErr := make(chan error, 1)
+		go func() { startErr <- sup.StartProcess(context.Background(), "web") }()
+		require.NoError(t, <-startErr, "the StartProcess should win the gap")
+
+		// Release the restart; its start half must now be refused.
+		close(releaseRestart)
+		require.ErrorIs(t, <-restartErr, domain.ErrProcessAlreadyRunning,
+			"the restart's start half must be refused once StartProcess won")
+
+		assert.Equal(t, "echo v-start", runner.lastConfig().Cmd, "the running process must be the StartProcess's config")
+		assert.Equal(t, "echo v-start", mp.Config().Cmd, "stored config must match the running process (restart did not swap)")
+	})
+
+	// (b) The restart wins. A concurrent StartProcess arrives while the restart's
+	// stop half is still in flight (process Stopping) and is refused immediately,
+	// without swapping; the restart then completes and launches its own config.
+	t.Run("restart wins over a start during the stop", func(t *testing.T) {
+		dir := t.TempDir()
+
+		termReached := make(chan struct{})
+		releaseTerm := make(chan struct{})
+		// Instance 0 blocks inside its SIGTERM handler, holding the restart in the
+		// Stopping state; the replacement (instance 1) is graceful.
+		runner := newFakeRunner(func(call int) *fakeProcess {
+			if call == 0 {
+				fp := newFakeProcess(2050)
+				fp.onSignal = func(fp *fakeProcess, sig os.Signal) {
+					if sig == sigterm {
+						close(termReached)
+						<-releaseTerm
+						fp.setAlive(false)
+						fp.exitLeader(nil)
+					}
+				}
+				return fp
+			}
+			return newGracefulFake(2050 + call)
+		})
+		sup := newReloadSupervisor(t, dir, "processes:\n  web:\n    cmd: \"echo v0\"\n", runner)
+
+		_, err := sup.Start(context.Background())
+		require.NoError(t, err)
+		mp := getManagedProcess(t, sup, "web")
+		t.Cleanup(func() { _ = sup.Stop(context.Background()) })
+
+		writeConfigFile(t, dir, "processes:\n  web:\n    cmd: \"echo v-restart\"\n")
+		restartErr := make(chan error, 1)
+		go func() { restartErr <- sup.RestartProcess(context.Background(), "web") }()
+
+		// Wait until the restart's stop half has sent SIGTERM and is blocked in
+		// the handler -- the process is Stopping and the lock is free.
+		<-termReached
+
+		// A StartProcess arriving now must be refused (Stopping), without swap.
+		writeConfigFile(t, dir, "processes:\n  web:\n    cmd: \"echo v-start\"\n")
+		require.ErrorIs(t, sup.StartProcess(context.Background(), "web"), domain.ErrProcessAlreadyRunning,
+			"a start during the restart's stop must be refused")
+
+		// Let the stop finish; the restart launches its own reloaded config.
+		close(releaseTerm)
+		require.NoError(t, <-restartErr, "the restart should complete")
+
+		assert.Equal(t, "echo v-restart", runner.lastConfig().Cmd, "the running process must be the restart's config")
+		assert.Equal(t, "echo v-restart", mp.Config().Cmd, "stored config must match (the losing start did not swap)")
+	})
+}
+
+// TestReload_DisabledWhenConfigPathUnset: with no ConfigPath (a Supervisor built
+// directly, as many tests do), restart/start do NOT re-read any file and reuse
+// the stored config -- back-compat is preserved.
+func TestReload_DisabledWhenConfigPathUnset(t *testing.T) {
+	logMgr := logs.NewManager(logs.ManagerConfig{BufferSize: 100})
+	defer logMgr.Close()
+
+	cfg := makeTestConfig(map[string]string{"web": "echo v1"})
+	runner := newFakeRunner(func(call int) *fakeProcess { return newGracefulFake(1900 + call) })
+	sup := New(cfg, logMgr, runner, DefaultSupervisorConfig()) // no ConfigPath
+
+	_, err := sup.Start(context.Background())
+	require.NoError(t, err)
+
+	pending, err := sup.prepareReload("web")
+	require.NoError(t, err)
+	assert.Nil(t, pending, "prepareReload must be a no-op when ConfigPath is unset")
+
+	require.NoError(t, sup.RestartProcess(context.Background(), "web"))
+	assert.Equal(t, "echo v1", runner.lastConfig().Cmd, "restart must reuse the stored config when reload is disabled")
+}

--- a/internal/supervisor/stop_budget_test.go
+++ b/internal/supervisor/stop_budget_test.go
@@ -1,0 +1,172 @@
+package supervisor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/charliek/prox/internal/constants"
+	"github.com/charliek/prox/internal/domain"
+	"github.com/charliek/prox/internal/logs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// startFakeProcessInSupervisor builds a ManagedProcess backed by a fresh fake
+// runner, sets its effective stop budget to the given value (via the promoted
+// shutdownTimeout field), starts it, and registers it on the supervisor. It
+// returns the process and its runner so a test can inspect the fake's recorded
+// signals afterwards.
+func startFakeProcessInSupervisor(t *testing.T, sup *Supervisor, name string, budget time.Duration, factory func(call int) *fakeProcess) (*ManagedProcess, *fakeRunner) {
+	t.Helper()
+	logMgr := logs.NewManager(logs.ManagerConfig{BufferSize: 100})
+	t.Cleanup(func() { logMgr.Close() })
+
+	runner := newFakeRunner(factory)
+	mp := NewManagedProcess(domain.ProcessConfig{Name: name, Cmd: "irrelevant"}, nil, runner, logMgr)
+	mp.shutdownTimeout = budget
+	require.NoError(t, mp.Start(context.Background()))
+
+	sup.mu.Lock()
+	sup.processes[name] = mp
+	sup.mu.Unlock()
+	return mp, runner
+}
+
+// TestSupervisor_MaxStopBudget covers the two contracts of MaxStopBudget: an
+// empty supervisor reports constants.DefaultShutdownTimeout, and a populated one
+// reports the maximum effective budget over its live processes (used to size the
+// daemon's outer shutdown deadline so hot-reloaded budgets are respected).
+func TestSupervisor_MaxStopBudget(t *testing.T) {
+	logMgr := logs.NewManager(logs.ManagerConfig{BufferSize: 100})
+	defer logMgr.Close()
+
+	t.Run("empty supervisor returns the default", func(t *testing.T) {
+		cfg := makeTestConfig(map[string]string{})
+		sup := New(cfg, logMgr, nil, DefaultSupervisorConfig())
+		assert.Equal(t, constants.DefaultShutdownTimeout, sup.MaxStopBudget())
+	})
+
+	t.Run("mixed budgets return the maximum", func(t *testing.T) {
+		cfg := makeTestConfig(map[string]string{})
+		sup := New(cfg, logMgr, nil, DefaultSupervisorConfig())
+
+		mpA := NewManagedProcess(domain.ProcessConfig{Name: "a"}, nil, nil, logMgr)
+		mpA.shutdownTimeout = 5 * time.Second
+		mpB := NewManagedProcess(domain.ProcessConfig{Name: "b"}, nil, nil, logMgr)
+		mpB.shutdownTimeout = 8 * time.Second
+
+		sup.mu.Lock()
+		sup.processes["a"] = mpA
+		sup.processes["b"] = mpB
+		sup.mu.Unlock()
+
+		assert.Equal(t, 8*time.Second, sup.MaxStopBudget())
+	})
+}
+
+// TestSupervisor_Stop_MixedBudgetsPerProcess proves the bulk Stop path gives each
+// process its own deadline rather than one shared deadline: two stubborn
+// processes with different budgets are SIGKILLed at times matching their own
+// (budget - KillGrace) graceful windows, not at a single common instant.
+func TestSupervisor_Stop_MixedBudgetsPerProcess(t *testing.T) {
+	logMgr := logs.NewManager(logs.ManagerConfig{BufferSize: 100})
+	defer logMgr.Close()
+
+	cfg := makeTestConfig(map[string]string{})
+	sup := New(cfg, logMgr, nil, DefaultSupervisorConfig())
+
+	// Bring the supervisor to the running state (no config processes) so Stop
+	// does not short-circuit; then inject the fakes.
+	_, err := sup.Start(context.Background())
+	require.NoError(t, err)
+
+	// fast: graceful window = 2.5s - 2s = 0.5s -> SIGKILL ~0.5s
+	// slow: graceful window = 4s   - 2s = 2s   -> SIGKILL ~2s
+	_, fastRunner := startFakeProcessInSupervisor(t, sup, "fast", 2500*time.Millisecond,
+		func(call int) *fakeProcess { return newStubbornFake(7000 + call) })
+	_, slowRunner := startFakeProcessInSupervisor(t, sup, "slow", 4*time.Second,
+		func(call int) *fakeProcess { return newStubbornFake(8000 + call) })
+
+	start := time.Now()
+	require.NoError(t, sup.Stop(context.Background()))
+
+	fastFP := fastRunner.last()
+	slowFP := slowRunner.last()
+
+	fastKill := firstIndexOf(fastFP.signalsReceived(), sigkill)
+	slowKill := firstIndexOf(slowFP.signalsReceived(), sigkill)
+	require.GreaterOrEqual(t, fastKill, 0, "fast process should have been SIGKILLed")
+	require.GreaterOrEqual(t, slowKill, 0, "slow process should have been SIGKILLed")
+
+	fastAt := fastFP.signalsReceived()[fastKill].at.Sub(start)
+	slowAt := slowFP.signalsReceived()[slowKill].at.Sub(start)
+
+	// Each escalates on its own budget. If Stop used one shared deadline, both
+	// would escalate together; instead fast lands well before slow.
+	assert.Less(t, fastAt, 1500*time.Millisecond, "fast (2.5s budget) should escalate ~0.5s after stop begins")
+	assert.Greater(t, slowAt, 1500*time.Millisecond, "slow (4s budget) should escalate ~2s after stop begins")
+	assert.Less(t, slowAt, 3500*time.Millisecond, "slow should still escalate within its own budget")
+	assert.Less(t, fastAt, slowAt, "per-process deadlines: fast must escalate before slow")
+}
+
+// TestSupervisor_StopProcess_UsesPerProcessBudget verifies StopProcess bounds the
+// stop by the target's own effective budget (mp.StopTimeout), not the global
+// default: a 3s-budget stubborn process escalates to SIGKILL ~1s after the stop
+// begins (graceful window = 3s - KillGrace(2s) = 1s).
+func TestSupervisor_StopProcess_UsesPerProcessBudget(t *testing.T) {
+	logMgr := logs.NewManager(logs.ManagerConfig{BufferSize: 100})
+	defer logMgr.Close()
+
+	cfg := makeTestConfig(map[string]string{})
+	sup := New(cfg, logMgr, nil, DefaultSupervisorConfig())
+	_, err := sup.Start(context.Background())
+	require.NoError(t, err)
+
+	_, runner := startFakeProcessInSupervisor(t, sup, "svc", 3*time.Second,
+		func(call int) *fakeProcess { return newStubbornFake(9000 + call) })
+
+	start := time.Now()
+	require.NoError(t, sup.StopProcess(context.Background(), "svc"))
+	elapsed := time.Since(start)
+
+	fp := runner.last()
+	killIdx := firstIndexOf(fp.signalsReceived(), sigkill)
+	require.GreaterOrEqual(t, killIdx, 0, "stubborn process should be SIGKILLed")
+	killAt := fp.signalsReceived()[killIdx].at.Sub(start)
+
+	assert.Greater(t, killAt, 700*time.Millisecond, "SIGKILL must wait out the ~1s graceful window")
+	assert.Less(t, elapsed, 3*time.Second, "must use the 3s per-process budget, not the 10s default")
+}
+
+// TestSupervisor_RestartProcess_UsesPerProcessBudget verifies the stop half of a
+// restart is bounded by the target's own effective budget: a 3s-budget stubborn
+// process escalates ~1s into the restart, then a fresh instance is started.
+func TestSupervisor_RestartProcess_UsesPerProcessBudget(t *testing.T) {
+	logMgr := logs.NewManager(logs.ManagerConfig{BufferSize: 100})
+	defer logMgr.Close()
+
+	cfg := makeTestConfig(map[string]string{})
+	sup := New(cfg, logMgr, nil, DefaultSupervisorConfig())
+	_, err := sup.Start(context.Background())
+	require.NoError(t, err)
+
+	mp, runner := startFakeProcessInSupervisor(t, sup, "svc", 3*time.Second,
+		func(call int) *fakeProcess { return newStubbornFake(9500 + call) })
+
+	// Capture the first instance's fake before the restart replaces current.
+	firstFP := runner.last()
+
+	start := time.Now()
+	require.NoError(t, sup.RestartProcess(context.Background(), "svc"))
+	elapsed := time.Since(start)
+
+	killIdx := firstIndexOf(firstFP.signalsReceived(), sigkill)
+	require.GreaterOrEqual(t, killIdx, 0, "stubborn process should be SIGKILLed during the stop half")
+	killAt := firstFP.signalsReceived()[killIdx].at.Sub(start)
+
+	assert.Greater(t, killAt, 700*time.Millisecond, "SIGKILL must wait out the ~1s graceful window")
+	assert.Less(t, elapsed, 3*time.Second, "stop half must use the 3s per-process budget, not the 10s default")
+	assert.Equal(t, domain.ProcessStateRunning, mp.State(), "restart should leave a fresh instance running")
+	assert.Equal(t, 2, runner.count(), "restart should have started a second instance")
+}

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -264,21 +264,27 @@ func (s *Supervisor) Stop(ctx context.Context) error {
 	}
 	s.mu.Unlock()
 
-	// Create timeout context for shutdown
-	shutdownCtx, cancel := context.WithTimeout(ctx, s.supConfig.ShutdownTimeout)
-	defer cancel()
-
-	// Stop all processes concurrently
+	// Stop all processes concurrently. Each process gets its own timeout context
+	// sized from its effective stop budget (StopTimeout), so a per-process
+	// stop_timeout is honored individually. This replaces the single shared
+	// shutdownCtx that previously truncated every process to one common deadline
+	// (#35, D2). The daemon's outer deadline is sized by up.go from
+	// MaxStopBudget() so ctx here rarely bounds anything.
 	var wg sync.WaitGroup
 	for _, mp := range processes {
 		wg.Add(1)
 		go func(mp *ManagedProcess) {
 			defer wg.Done()
+			// Info() already snapshots the effective stop budget (StopTimeout),
+			// so read it once here rather than taking the process lock a second
+			// time via mp.StopTimeout().
 			info := mp.Info()
+			stopCtx, cancel := context.WithTimeout(ctx, info.StopTimeout)
+			defer cancel()
 			if info.PID > 0 {
-				s.SystemLog("sending SIGTERM to %s (pid %d)", mp.Name(), info.PID)
+				s.SystemLog("sending SIGTERM to %s (pid %d)", info.Name, info.PID)
 			}
-			if err := mp.Stop(shutdownCtx); err != nil && err != domain.ErrProcessNotRunning {
+			if err := mp.Stop(stopCtx); err != nil && err != domain.ErrProcessNotRunning {
 				s.logManager.Write(domain.LogEntry{
 					Timestamp: time.Now(),
 					Process:   mp.Name(),
@@ -392,8 +398,10 @@ func (s *Supervisor) StopProcess(ctx context.Context, name string) error {
 		return domain.ErrProcessNotFound
 	}
 
-	// Create timeout context
-	stopCtx, cancel := context.WithTimeout(ctx, s.supConfig.ShutdownTimeout)
+	// Bound the stop by this process's own effective budget (a snapshot of the
+	// currently-effective per-process value; a budget raised concurrently takes
+	// effect from the next request). See mp.StopTimeout (#35, D2).
+	stopCtx, cancel := context.WithTimeout(ctx, mp.StopTimeout())
 	defer cancel()
 
 	err := mp.Stop(stopCtx)
@@ -426,8 +434,10 @@ func (s *Supervisor) RestartProcess(ctx context.Context, name string) error {
 		return domain.ErrShutdownInProgress
 	}
 
-	// Create timeout context to bound the stop half of the restart.
-	restartCtx, cancel := context.WithTimeout(ctx, s.supConfig.ShutdownTimeout)
+	// Bound the stop half of the restart by this process's own effective budget
+	// (snapshot of the currently-effective per-process value). See mp.StopTimeout
+	// (#35, D2).
+	restartCtx, cancel := context.WithTimeout(ctx, mp.StopTimeout())
 	defer cancel()
 
 	// Stop uses restartCtx (bounded by the request/shutdown timeout); Start
@@ -444,6 +454,27 @@ func (s *Supervisor) RestartProcess(ctx context.Context, name string) error {
 		})
 	}
 	return err
+}
+
+// MaxStopBudget returns the maximum effective stop budget (StopTimeout) over
+// all current processes, or constants.DefaultShutdownTimeout when there are no
+// processes. It is used at shutdown time to size the daemon's outer shutdown
+// deadline so that hot-reloaded per-process budgets (plan D3, future work) are
+// respected -- it reads live values rather than a snapshot taken at startup.
+func (s *Supervisor) MaxStopBudget() time.Duration {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	maxBudget := time.Duration(0)
+	for _, mp := range s.processes {
+		if b := mp.StopTimeout(); b > maxBudget {
+			maxBudget = b
+		}
+	}
+	if maxBudget <= 0 {
+		return constants.DefaultShutdownTimeout
+	}
+	return maxBudget
 }
 
 // Status returns supervisor status

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/charliek/prox/internal/config"
+	"github.com/charliek/prox/internal/constants"
 	"github.com/charliek/prox/internal/domain"
 	"github.com/charliek/prox/internal/logs"
 )
@@ -22,7 +23,7 @@ type SupervisorConfig struct {
 // DefaultSupervisorConfig returns default configuration
 func DefaultSupervisorConfig() SupervisorConfig {
 	return SupervisorConfig{
-		ShutdownTimeout: 10 * time.Second,
+		ShutdownTimeout: constants.DefaultShutdownTimeout,
 	}
 }
 
@@ -171,10 +172,16 @@ func (s *Supervisor) createManagedProcess(name string, procConfig config.Process
 		return config.LoadProcessEnv(globalEnvFile, procEnvFile, inlineEnv, configDir)
 	}
 
+	stopTimeout, err := procConfig.StopTimeoutDuration()
+	if err != nil {
+		return nil, fmt.Errorf("process %q: %w", name, err)
+	}
+
 	domainConfig := domain.ProcessConfig{
-		Name:    name,
-		Cmd:     procConfig.Cmd,
-		EnvFile: procConfig.EnvFile,
+		Name:        name,
+		Cmd:         procConfig.Cmd,
+		EnvFile:     procConfig.EnvFile,
+		StopTimeout: stopTimeout,
 	}
 	if procConfig.Healthcheck != nil {
 		hc, err := procConfig.Healthcheck.ToDomain()
@@ -186,6 +193,25 @@ func (s *Supervisor) createManagedProcess(name string, procConfig config.Process
 
 	mp := NewManagedProcess(domainConfig, nil, s.runner, s.logManager)
 	mp.loadEnv = loadEnv
+
+	// Resolve the effective stop budget: this process's own stop_timeout,
+	// else the global shutdown_timeout, else the constant default (#35, D1).
+	// mp is not yet published to s.processes / any other goroutine, so this
+	// direct field set (mirroring the mp.loadEnv assignment above) needs no
+	// lock; production reads go through the locked StopTimeout() accessor.
+	effective := stopTimeout
+	if effective == 0 {
+		global, err := s.config.ShutdownTimeoutDuration()
+		if err != nil {
+			return nil, fmt.Errorf("process %q: %w", name, err)
+		}
+		effective = global
+	}
+	if effective == 0 {
+		effective = constants.DefaultShutdownTimeout
+	}
+	mp.shutdownTimeout = effective
+
 	return mp, nil
 }
 

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -18,6 +18,12 @@ import (
 type SupervisorConfig struct {
 	ShutdownTimeout time.Duration
 	ConfigDir       string // Directory containing the config file (for resolving relative paths)
+	// ConfigPath is the absolute path to prox.yaml. When set, an API-driven
+	// (re)start re-reads and validates the file and applies the target
+	// process's current config before launching it (#33, D3). Empty disables
+	// reload entirely (tests that construct a Supervisor directly), preserving
+	// back-compat: the up-time config is used as-is.
+	ConfigPath string
 }
 
 // DefaultSupervisorConfig returns default configuration
@@ -32,7 +38,13 @@ func DefaultSupervisorConfig() SupervisorConfig {
 type Supervisor struct {
 	mu sync.RWMutex
 
-	// config holds the loaded process configuration
+	// config holds the process configuration as loaded at `up` time. It is an
+	// immutable snapshot: per-process API-driven reloads (#33, D3) re-read the
+	// file into a fresh config used only for that process's swap and deliberately
+	// do NOT update this field. Consequently a whole-supervisor Stop-then-Start
+	// rebuilds every process from the ORIGINAL up-time config, not the latest
+	// file (only reachable in tests today; a full-config hot reload is future
+	// work).
 	config *config.Config
 	// supConfig holds supervisor-specific settings like shutdown timeout
 	supConfig SupervisorConfig
@@ -164,7 +176,32 @@ func (s *Supervisor) startWithFilter(ctx context.Context, filter map[string]bool
 // (b) prevent process creation entirely if the env file is transiently
 // unreadable. A bad env file now fails loudly at Start instead.
 func (s *Supervisor) createManagedProcess(name string, procConfig config.ProcessConfig) (*ManagedProcess, error) {
-	globalEnvFile := s.config.EnvFile
+	domainConfig, loadEnv, effective, err := s.buildProcessRuntime(name, s.config, procConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	mp := NewManagedProcess(domainConfig, nil, s.runner, s.logManager)
+	// mp is not yet published to s.processes / any other goroutine, so these
+	// direct field sets need no lock; production reads go through the locked
+	// StopTimeout() accessor and the lock-held loadEnv read in Start.
+	mp.loadEnv = loadEnv
+	mp.shutdownTimeout = effective
+
+	return mp, nil
+}
+
+// buildProcessRuntime resolves the domain process config, the env-loader
+// closure, and the effective stop budget for a process from the given config
+// (the up-time config at creation, or a freshly reloaded one on an API-driven
+// (re)start -- see prepareReload). The env closure captures cfg's global
+// env_file plus the process's own env_file/inline env, so a path change in a
+// reloaded file takes effect when it is invoked at the top of Start.
+//
+// Effective stop budget: the process's own stop_timeout, else cfg's global
+// shutdown_timeout, else constants.DefaultShutdownTimeout (#35, D1).
+func (s *Supervisor) buildProcessRuntime(name string, cfg *config.Config, procConfig config.ProcessConfig) (domain.ProcessConfig, func() (map[string]string, error), time.Duration, error) {
+	globalEnvFile := cfg.EnvFile
 	procEnvFile := procConfig.EnvFile
 	inlineEnv := procConfig.Env
 	configDir := s.supConfig.ConfigDir
@@ -174,7 +211,7 @@ func (s *Supervisor) createManagedProcess(name string, procConfig config.Process
 
 	stopTimeout, err := procConfig.StopTimeoutDuration()
 	if err != nil {
-		return nil, fmt.Errorf("process %q: %w", name, err)
+		return domain.ProcessConfig{}, nil, 0, fmt.Errorf("process %q: %w", name, err)
 	}
 
 	domainConfig := domain.ProcessConfig{
@@ -186,33 +223,76 @@ func (s *Supervisor) createManagedProcess(name string, procConfig config.Process
 	if procConfig.Healthcheck != nil {
 		hc, err := procConfig.Healthcheck.ToDomain()
 		if err != nil {
-			return nil, fmt.Errorf("process %q healthcheck: %w", name, err)
+			return domain.ProcessConfig{}, nil, 0, fmt.Errorf("process %q healthcheck: %w", name, err)
 		}
 		domainConfig.Healthcheck = hc
 	}
 
-	mp := NewManagedProcess(domainConfig, nil, s.runner, s.logManager)
-	mp.loadEnv = loadEnv
-
-	// Resolve the effective stop budget: this process's own stop_timeout,
-	// else the global shutdown_timeout, else the constant default (#35, D1).
-	// mp is not yet published to s.processes / any other goroutine, so this
-	// direct field set (mirroring the mp.loadEnv assignment above) needs no
-	// lock; production reads go through the locked StopTimeout() accessor.
 	effective := stopTimeout
 	if effective == 0 {
-		global, err := s.config.ShutdownTimeoutDuration()
+		global, err := cfg.ShutdownTimeoutDuration()
 		if err != nil {
-			return nil, fmt.Errorf("process %q: %w", name, err)
+			return domain.ProcessConfig{}, nil, 0, fmt.Errorf("process %q: %w", name, err)
 		}
 		effective = global
 	}
 	if effective == 0 {
 		effective = constants.DefaultShutdownTimeout
 	}
-	mp.shutdownTimeout = effective
 
-	return mp, nil
+	return domainConfig, loadEnv, effective, nil
+}
+
+// prepareReload re-reads and validates the whole config file and resolves the
+// pending runtime (domain config + env loader + effective stop budget) for the
+// named process, to be swapped in atomically inside startWithConfig (#33, D3).
+//
+// It returns:
+//   - (nil, nil) when ConfigPath is unset -- reload is disabled and the caller
+//     (re)starts with the existing stored config (back-compat for tests that
+//     construct a Supervisor directly);
+//   - (nil, ErrConfigReloadFailed) for a missing/unreadable file, YAML syntax
+//     error, validation failure (including an invalid UNRELATED section --
+//     whole-file validation is intentional, fail-closed), or a preflight env
+//     failure;
+//   - (nil, ErrProcessNotInConfig) when the target was removed from the file;
+//   - (pending, nil) otherwise.
+//
+// It touches no ManagedProcess state and performs no stop, so any error here
+// leaves the running process completely untouched. The env loader is preflighted
+// once (result discarded) so a missing new env_file fails before any stop.
+func (s *Supervisor) prepareReload(name string) (*pendingConfig, error) {
+	cfgPath := s.supConfig.ConfigPath
+	if cfgPath == "" {
+		return nil, nil
+	}
+
+	fresh, err := config.Load(cfgPath)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", domain.ErrConfigReloadFailed, err)
+	}
+
+	procConfig, ok := fresh.Processes[name]
+	if !ok {
+		return nil, fmt.Errorf("process %q %w; run 'prox up' to reconcile", name, domain.ErrProcessNotInConfig)
+	}
+
+	domainConfig, loadEnv, effective, err := s.buildProcessRuntime(name, fresh, procConfig)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", domain.ErrConfigReloadFailed, err)
+	}
+
+	// Preflight the env load so a missing/unreadable new env_file fails here,
+	// before any stop -- the running process stays untouched. The resulting map
+	// is carried on the pending config and applied verbatim at launch (see
+	// pendingConfig.env), so the same validated snapshot is used and no re-read
+	// window is reopened after the stop.
+	env, err := loadEnv()
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", domain.ErrConfigReloadFailed, err)
+	}
+
+	return &pendingConfig{config: domainConfig, loadEnv: loadEnv, env: env, stopTimeout: effective}, nil
 }
 
 // startProcessesConcurrently starts all managed processes concurrently and updates the result.
@@ -373,10 +453,22 @@ func (s *Supervisor) StartProcess(ctx context.Context, name string) error {
 		return domain.ErrShutdownInProgress
 	}
 
+	// Re-read the config and prepare the fresh runtime BEFORE launching, so a
+	// `stop`+`start` picks up a changed cmd/env/healthcheck/stop_timeout exactly
+	// like `restart` does (#33, D3). Any reload failure leaves the process
+	// untouched. pending is nil when ConfigPath is unset (reload disabled).
+	pending, err := s.prepareReload(name)
+	if err != nil {
+		return err
+	}
+
 	// Use supervisor context for the process lifecycle.
 	// The passed ctx is only used for the API request timeout, but the process
-	// should continue running after the request completes.
-	err := mp.Start(supCtx)
+	// should continue running after the request completes. The pending config is
+	// swapped in atomically inside the locked critical section (see
+	// startWithConfig), so a concurrent Start that wins the race never leaves the
+	// running process and stored config mismatched.
+	err = mp.startWithConfig(supCtx, pending)
 	if err == nil {
 		s.emit(SupervisorEvent{
 			Type:      EventTypeProcessStarted,
@@ -434,17 +526,28 @@ func (s *Supervisor) RestartProcess(ctx context.Context, name string) error {
 		return domain.ErrShutdownInProgress
 	}
 
+	// Re-read + validate the whole file and preflight the target's fresh env
+	// BEFORE the stop, so an invalid file, a removed process, or a missing new
+	// env_file fails with the running process untouched (#33, D3). pending is nil
+	// when ConfigPath is unset (reload disabled).
+	pending, err := s.prepareReload(name)
+	if err != nil {
+		return err
+	}
+
 	// Bound the stop half of the restart by this process's own effective budget
-	// (snapshot of the currently-effective per-process value). See mp.StopTimeout
-	// (#35, D2).
+	// (snapshot of the currently-effective, pre-swap value: a raised stop_timeout
+	// only governs from the next stop). Computed here, before mp.Restart runs the
+	// stop, so the stop half observes the OLD budget (#35, D2 / #33, D3).
 	restartCtx, cancel := context.WithTimeout(ctx, mp.StopTimeout())
 	defer cancel()
 
-	// Stop uses restartCtx (bounded by the request/shutdown timeout); Start
-	// uses supCtx so the replacement's process lifecycle and health checker
+	// Stop uses restartCtx (bounded by the request/shutdown timeout); the
+	// replacement's Start uses supCtx so its process lifecycle and health checker
 	// survive after this request's context is cancelled/expires (mirrors
-	// StartProcess).
-	err := mp.Restart(restartCtx, supCtx)
+	// StartProcess). The pending config is swapped in atomically inside the
+	// replacement's locked critical section (see startWithConfig).
+	err = mp.Restart(restartCtx, supCtx, pending)
 	if err == nil {
 		s.emit(SupervisorEvent{
 			Type:      EventTypeProcessStarted,

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -236,7 +236,14 @@ func (s *Supervisor) buildProcessRuntime(name string, cfg *config.Config, procCo
 		}
 		effective = global
 	}
+	// Honor a SupervisorConfig-level default before the constant so directly
+	// constructed supervisors (no shutdown_timeout in the file) get the timeout
+	// they configured; up.go sets it from the same parsed config, so this is a
+	// no-op on the normal path.
 	if effective == 0 {
+		effective = s.supConfig.ShutdownTimeout
+	}
+	if effective <= 0 {
 		effective = constants.DefaultShutdownTimeout
 	}
 
@@ -439,10 +446,20 @@ func (s *Supervisor) StartProcess(ctx context.Context, name string) error {
 	s.mu.RLock()
 	mp, ok := s.processes[name]
 	supCtx := s.ctx // Use supervisor context for process lifecycle, not request context
+	state := s.state
 	s.mu.RUnlock()
 
 	if !ok {
 		return domain.ErrProcessNotFound
+	}
+
+	// Refuse to launch once shutdown has begun. An in-flight lifecycle request
+	// can outlive the API server's shutdown window (Shutdown never force-closes
+	// active connections), so without this gate a start could re-launch a child
+	// after Supervisor.Stop finished reaping. Not a complete lease (a stop can
+	// still begin after this check); full serialization is tracked with #32/#36.
+	if state != "running" {
+		return domain.ErrShutdownInProgress
 	}
 
 	// s.ctx is nil until Supervisor.Start() runs. Passing a nil context into
@@ -513,10 +530,17 @@ func (s *Supervisor) RestartProcess(ctx context.Context, name string) error {
 	s.mu.RLock()
 	mp, ok := s.processes[name]
 	supCtx := s.ctx // Use supervisor context for the replacement's lifecycle, not request context
+	state := s.state
 	s.mu.RUnlock()
 
 	if !ok {
 		return domain.ErrProcessNotFound
+	}
+
+	// Refuse to launch a replacement once shutdown has begun (same gate and
+	// caveat as StartProcess).
+	if state != "running" {
+		return domain.ErrShutdownInProgress
 	}
 
 	// s.ctx is nil until Supervisor.Start() runs; the replacement is started on

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -393,6 +393,18 @@ func TestSupervisor_CreateManagedProcess_StopTimeoutResolution(t *testing.T) {
 		assert.Equal(t, constants.DefaultShutdownTimeout, mp.StopTimeout())
 	})
 
+	t.Run("SupervisorConfig.ShutdownTimeout is honored before the constant", func(t *testing.T) {
+		cfg := makeTestConfig(map[string]string{})
+		supConfig := DefaultSupervisorConfig()
+		supConfig.ShutdownTimeout = 25 * time.Second
+		sup := New(cfg, logMgr, nil, supConfig)
+
+		mp, err := sup.createManagedProcess("svc", config.ProcessConfig{Cmd: "true"})
+		require.NoError(t, err)
+		assert.Equal(t, 25*time.Second, mp.StopTimeout(),
+			"a directly-configured SupervisorConfig timeout must not be inert")
+	})
+
 	t.Run("malformed global shutdown_timeout surfaces a process-named error", func(t *testing.T) {
 		cfg := makeTestConfig(map[string]string{})
 		cfg.ShutdownTimeout = "3x"

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/charliek/prox/internal/config"
+	"github.com/charliek/prox/internal/constants"
 	"github.com/charliek/prox/internal/domain"
 	"github.com/charliek/prox/internal/logs"
 	"github.com/stretchr/testify/assert"
@@ -349,6 +350,78 @@ func TestSupervisor_CreateManagedProcess_InvalidHealthcheckDuration(t *testing.T
 	assert.Nil(t, mp)
 	assert.Contains(t, err.Error(), "svc")
 	assert.Contains(t, err.Error(), "interval")
+}
+
+// TestSupervisor_CreateManagedProcess_StopTimeoutResolution covers the
+// #35/D1 effective stop-budget precedence: per-process stop_timeout beats the
+// global shutdown_timeout, which beats constants.DefaultShutdownTimeout. The
+// resolved value lands in the ManagedProcess's promoted shutdownTimeout field
+// (read via StopTimeout()); domain.ProcessConfig.StopTimeout carries only the
+// raw per-process value (0 = unset), never the resolved one.
+func TestSupervisor_CreateManagedProcess_StopTimeoutResolution(t *testing.T) {
+	logMgr := logs.NewManager(logs.ManagerConfig{BufferSize: 100})
+	defer logMgr.Close()
+
+	t.Run("per-process stop_timeout overrides global shutdown_timeout", func(t *testing.T) {
+		cfg := makeTestConfig(map[string]string{})
+		cfg.ShutdownTimeout = "20s"
+		sup := New(cfg, logMgr, nil, DefaultSupervisorConfig())
+
+		mp, err := sup.createManagedProcess("svc", config.ProcessConfig{Cmd: "true", StopTimeout: "45s"})
+		require.NoError(t, err)
+		assert.Equal(t, 45*time.Second, mp.StopTimeout())
+		assert.Equal(t, 45*time.Second, mp.config.StopTimeout)
+	})
+
+	t.Run("global shutdown_timeout used when process has none", func(t *testing.T) {
+		cfg := makeTestConfig(map[string]string{})
+		cfg.ShutdownTimeout = "20s"
+		sup := New(cfg, logMgr, nil, DefaultSupervisorConfig())
+
+		mp, err := sup.createManagedProcess("svc", config.ProcessConfig{Cmd: "true"})
+		require.NoError(t, err)
+		assert.Equal(t, 20*time.Second, mp.StopTimeout())
+		assert.Equal(t, time.Duration(0), mp.config.StopTimeout, "raw per-process value stays unset")
+	})
+
+	t.Run("constant default used when neither is set", func(t *testing.T) {
+		cfg := makeTestConfig(map[string]string{})
+		sup := New(cfg, logMgr, nil, DefaultSupervisorConfig())
+
+		mp, err := sup.createManagedProcess("svc", config.ProcessConfig{Cmd: "true"})
+		require.NoError(t, err)
+		assert.Equal(t, constants.DefaultShutdownTimeout, mp.StopTimeout())
+	})
+
+	t.Run("malformed global shutdown_timeout surfaces a process-named error", func(t *testing.T) {
+		cfg := makeTestConfig(map[string]string{})
+		cfg.ShutdownTimeout = "3x"
+		sup := New(cfg, logMgr, nil, DefaultSupervisorConfig())
+
+		mp, err := sup.createManagedProcess("svc", config.ProcessConfig{Cmd: "true"})
+		require.Error(t, err)
+		assert.Nil(t, mp)
+		assert.Contains(t, err.Error(), "svc")
+		assert.Contains(t, err.Error(), "shutdown_timeout")
+	})
+
+	t.Run("malformed per-process stop_timeout surfaces a process-named error", func(t *testing.T) {
+		cfg := makeTestConfig(map[string]string{})
+		sup := New(cfg, logMgr, nil, DefaultSupervisorConfig())
+
+		mp, err := sup.createManagedProcess("svc", config.ProcessConfig{Cmd: "true", StopTimeout: "1s"})
+		require.Error(t, err)
+		assert.Nil(t, mp)
+		assert.Contains(t, err.Error(), "svc")
+		assert.Contains(t, err.Error(), "stop_timeout")
+	})
+}
+
+// TestDefaultSupervisorConfig_ShutdownTimeout pins DefaultSupervisorConfig's
+// default to constants.DefaultShutdownTimeout instead of its own literal
+// (#35).
+func TestDefaultSupervisorConfig_ShutdownTimeout(t *testing.T) {
+	assert.Equal(t, constants.DefaultShutdownTimeout, DefaultSupervisorConfig().ShutdownTimeout)
 }
 
 // TestSupervisor_RestartProcess_HealthCheckerSurvivesRequestContext is the

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -2,16 +2,19 @@ package tui
 
 import (
 	"context"
-	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/charliek/prox/internal/constants"
 	"github.com/charliek/prox/internal/domain"
 	"github.com/charliek/prox/internal/proxy"
 )
 
-// restartTimeout is the maximum time to wait for a restart operation
-const restartTimeout = 30 * time.Second
+// restartTimeout is the maximum time to wait for a foreground restart from the
+// TUI. It sits above the configured stop-budget cap (constants.MaxStopTimeout)
+// so a legitimately long stop half of a restart is never cut off here; this
+// ceiling is hang protection only, matching the CLI lifecycle client (#35, D2).
+const restartTimeout = constants.LifecycleTimeoutCeiling
 
 // Update handles messages
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,7 +93,8 @@ nav:
   - Guides:
       - Local DNS & Certificates: guides/local-dns.md
       - Shared Proxy Across Projects: guides/shared-proxy.md
-      - Discovery: discovery/shared-proxy-across-projects.md
+  - Design Notes:
+      - Shared Proxy Across Projects: discovery/shared-proxy-across-projects.md
   - Reference:
       - CLI: reference/cli.md
       - Configuration: reference/configuration.md

--- a/skills/prox/SKILL.md
+++ b/skills/prox/SKILL.md
@@ -28,6 +28,8 @@ When a project has a `prox.yaml`, **use prox to manage processes** — do not ru
 | Check what's running | `prox status` |
 | Attach interactive TUI | `prox attach` |
 
+**Editing `prox.yaml`?** `prox restart <name>` (and `prox start <name>` after a `prox stop <name>`) re-reads the file and applies that process's current config — changed `cmd`, `healthcheck`, `stop_timeout`, and `env`/`env_file`. So the edit → restart loop needs no full `prox stop` + `prox up`. Adding/removing/renaming processes or changing `services`/`proxy` still requires `prox up`.
+
 **Always use `-d` (daemon mode)** when starting prox so the CLI returns control immediately. Do not start prox in the foreground — it will block.
 
 **Never kill processes directly** (e.g., `kill <pid>`). Use prox commands so it can track state and handle restarts correctly.

--- a/skills/prox/references/api.md
+++ b/skills/prox/references/api.md
@@ -46,6 +46,8 @@ All errors return JSON:
 | `SHUTDOWN_IN_PROGRESS` | Supervisor is shutting down |
 | `ENV_RELOAD_FAILED` | A process's `env_file` could not be re-read from disk on start |
 | `PROCESS_GROUP_NOT_REAPED` | A process's group survived SIGKILL and could not be confirmed terminated |
+| `CONFIG_RELOAD_FAILED` | `prox.yaml` could not be re-read/validated on an API-driven (re)start (missing/unreadable file, YAML syntax, or validation failure); the running process is left untouched |
+| `PROCESS_NOT_IN_CONFIG` | The target process is no longer present in `prox.yaml` on a (re)start; run `prox up` to reconcile |
 | `PROXY_NOT_ENABLED` | Proxy request inspection is unavailable because the proxy is disabled |
 | `STREAMING_NOT_SUPPORTED` | The server cannot provide an SSE stream for this request |
 | `REQUEST_NOT_FOUND` | Proxy request ID does not exist in the request buffer |
@@ -145,6 +147,8 @@ Get detailed process info.
 
 Start a stopped process.
 
+`prox.yaml` is re-read first and the process is launched with its current config — see the reload behavior documented under [restart](#post-processesnamerestart) below (it applies identically to `start`).
+
 **Response:**
 
 ```json
@@ -168,6 +172,13 @@ Stop a running process.
 ### POST /processes/{name}/restart
 
 Restart a process (stop then start).
+
+**Config reload:** before launching, prox re-reads and validates the whole `prox.yaml` and applies the target process's **current** config. Applied on (re)start: `cmd`, `healthcheck`, `stop_timeout` (the new value governs the next stop; the restart's own stop half uses the pre-edit budget), and environment inputs (inline `env`, per-process and global `env_file`, including changed file paths). NOT applied (require `prox up`): renames, added/removed processes, and `services`/`proxy`/port changes.
+
+The reload is **fail-closed**: an invalid file (even an unrelated process or the proxy section), a missing referenced env file, or a removed target aborts the (re)start with an error and leaves the existing process running unchanged:
+
+- `CONFIG_RELOAD_FAILED` (HTTP 422) — the file could not be read/parsed/validated.
+- `PROCESS_NOT_IN_CONFIG` (HTTP 409) — the target process is no longer in the file; run `prox up` to reconcile.
 
 **Response:**
 

--- a/skills/prox/references/api.md
+++ b/skills/prox/references/api.md
@@ -6,11 +6,17 @@
 http://{host}:{port}/api/v1
 ```
 
-Default: `http://127.0.0.1:5555/api/v1`
+By default, `{port}` is a dynamically assigned free localhost port chosen at startup — discover it with `prox status` (which reports the API address), or pin it by setting `api.port` in `prox.yaml`. The examples below assume `api.port: 5555` is set in `prox.yaml`.
 
 ## Authentication
 
-When prox binds to a non-localhost interface, authentication is required. A bearer token is generated and stored in `~/.prox/token`.
+By default, authentication is enabled automatically unless prox binds to a localhost-only address (`127.0.0.1`, `localhost`, or `::1`); binding to `0.0.0.0` or another non-localhost address turns auth on. When enabled, a bearer token is generated and stored in `~/.prox/token`.
+
+This can be overridden with the `api.auth` field in `prox.yaml`:
+
+- Omitted (default): auto-determine based on `api.host` as described above.
+- `true`: force authentication on, even when bound to localhost.
+- `false`: force authentication off, even when bound to a non-localhost address. prox prints a startup warning in this case, since any network client can then control the supervisor.
 
 Include the token in requests:
 
@@ -38,12 +44,24 @@ All errors return JSON:
 | `PROCESS_NOT_RUNNING` | Process is not running |
 | `INVALID_PATTERN` | Invalid regex pattern |
 | `SHUTDOWN_IN_PROGRESS` | Supervisor is shutting down |
+| `ENV_RELOAD_FAILED` | A process's `env_file` could not be re-read from disk on start |
+| `PROCESS_GROUP_NOT_REAPED` | A process's group survived SIGKILL and could not be confirmed terminated |
 | `PROXY_NOT_ENABLED` | Proxy request inspection is unavailable because the proxy is disabled |
 | `STREAMING_NOT_SUPPORTED` | The server cannot provide an SSE stream for this request |
 | `REQUEST_NOT_FOUND` | Proxy request ID does not exist in the request buffer |
 | `MISSING_REQUEST_ID` | Request detail endpoint was called without an ID |
 
 ## Endpoints
+
+### GET /health
+
+Plain liveness check, served at the server root (not under `/api/v1`). No authentication required.
+
+**Response:** `200 OK` with plain-text body `ok` (not JSON).
+
+```bash
+curl http://localhost:5555/health
+```
 
 ### GET /status
 

--- a/skills/prox/references/api.md
+++ b/skills/prox/references/api.md
@@ -134,9 +134,12 @@ Get detailed process info.
   "cmd": "go run ./cmd/server",
   "env": {
     "PORT": "8080"
-  }
+  },
+  "stop_timeout": "30s"
 }
 ```
+
+`stop_timeout` is the effective SIGTERM→SIGKILL escalation budget in force for this process (its own `stop_timeout`, else the global `shutdown_timeout`, else the `10s` default), as a duration string. It is the budget governing a `POST /processes/{name}/stop` or `POST /processes/{name}/restart`. See [Stop Timeout](configuration.md#stop-timeout).
 
 ### POST /processes/{name}/start
 
@@ -354,3 +357,5 @@ Gracefully shut down supervisor and all processes.
 ```
 
 Connection closes after response as supervisor terminates.
+
+The daemon then tears down in stages, each with its own deadline: the proxy and API server are stopped on short fixed deadlines, then every process is stopped concurrently, each on its own configured stop budget (see [Stop Timeout](configuration.md#stop-timeout)). Graceful timing therefore derives from the configured `shutdown_timeout` / `stop_timeout` values, not a single fixed window.

--- a/skills/prox/references/configuration.md
+++ b/skills/prox/references/configuration.md
@@ -106,6 +106,27 @@ controls that escalation:
   [process detail API](api.md#get-processesname), so you can see the budget
   governing a long stop.
 
+## Config Reload on Restart
+
+Whenever a process is (re)started through the API — `prox restart <name>`, or
+`prox start <name>` after a `prox stop <name>` — prox re-reads `prox.yaml` and
+runs the process with the config the file **now** contains. So editing a
+process and restarting it is enough; a full `prox stop` + `prox up` is not
+needed for the fields below.
+
+- Applied on (re)start: `cmd`, `healthcheck`, `stop_timeout`, and environment
+  inputs (inline `env`, per-process and global `env_file`, including changed
+  file paths). A changed `stop_timeout` governs the **next** stop — the
+  restart's own stop half still uses the pre-edit budget.
+- NOT applied (these require `prox up`): process renames, added or removed
+  processes, and `services` / `proxy` / port changes.
+- The reload is **fail-closed**: the whole file is re-validated, so an invalid
+  edit anywhere in it — even in an unrelated process or the proxy section — or a
+  missing referenced env file aborts the (re)start and the existing process keeps
+  running unchanged. See the [restart API](api.md#post-processesnamerestart)
+  reference for the exact error codes (`CONFIG_RELOAD_FAILED`,
+  `PROCESS_NOT_IN_CONFIG`).
+
 ## Health Check Fields
 
 | Field | Type | Default | Description |

--- a/skills/prox/references/configuration.md
+++ b/skills/prox/references/configuration.md
@@ -22,6 +22,9 @@ api:
 
 env_file: .env
 
+# Default stop budget for every process (SIGTERM->SIGKILL escalation window).
+shutdown_timeout: 10s
+
 processes:
   # Simple form - string command
   web: npm run dev
@@ -30,6 +33,8 @@ processes:
   # Expanded form - full configuration
   api:
     cmd: go run ./cmd/server
+    # Give this process a longer graceful-drain window than the global default.
+    stop_timeout: 30s
     env:
       PORT: "8080"
       DEBUG: "true"
@@ -50,6 +55,7 @@ processes:
 | `api.host` | string | `127.0.0.1` | API bind address |
 | `api.auth` | bool | auto | Force authentication on (`true`) or off (`false`). Omitted: auth is enabled automatically unless `api.host` is localhost-only |
 | `env_file` | string | — | Global .env file path, loaded for all processes |
+| `shutdown_timeout` | duration | `10s` | Default stop budget for every process (the SIGTERM→SIGKILL escalation window; see [Stop Timeout](#stop-timeout)). Overridable per process via `stop_timeout`. Must be greater than `2s` and at most `10m` |
 | `processes` | map | required | Process definitions |
 
 ## Process Fields
@@ -70,7 +76,35 @@ processes:
 | `cmd` | string | required | Command to run |
 | `env` | map | — | Environment variables for this process |
 | `env_file` | string | — | Process-specific .env file |
+| `stop_timeout` | duration | inherits `shutdown_timeout` | This process's stop budget, overriding the global `shutdown_timeout` (see [Stop Timeout](#stop-timeout)). Must be greater than `2s` and at most `10m` |
 | `healthcheck` | object | — | Health check configuration |
+
+## Stop Timeout
+
+When prox stops a process — via `prox stop <name>`, `prox restart <name>`, or a
+full `prox stop` / Ctrl-C of the daemon — it first sends `SIGTERM` and waits for
+the process to exit gracefully, then escalates to `SIGKILL`. The **stop budget**
+controls that escalation:
+
+- The effective budget for a process is its own `stop_timeout`, else the global
+  `shutdown_timeout`, else the built-in default of `10s`.
+- The budget is the **SIGTERM→SIGKILL escalation window**. A fixed `2s` at the
+  tail is reserved for the `SIGKILL` phase, so the graceful window is
+  **`budget − 2s`** (e.g. a `10s` budget gives ~8s of graceful drain before
+  `SIGKILL`). The reserve is not configurable.
+- Because of that reserve, the budget must be **greater than `2s`**; values of
+  `2s` or less (including `0s` and negatives) are rejected at load with a
+  field-named error. The upper bound is **`10m`**; `10m` exactly is accepted.
+- The configured value bounds **escalation timing**, not strict total
+  wall-clock — a process that is slow to flush its output can add a few seconds
+  of drain time on top.
+- The budget is honored on every stop path: `prox stop`, `prox restart` (the
+  stop half), and full daemon shutdown, where each process is stopped on its
+  **own** budget concurrently (a large budget on one process no longer forces a
+  shared shorter deadline on the others).
+- The effective budget is reported as `stop_timeout` in the
+  [process detail API](api.md#get-processesname), so you can see the budget
+  governing a long stop.
 
 ## Health Check Fields
 
@@ -100,6 +134,12 @@ Duration fields accept Go duration strings:
 - `5s` - 5 seconds
 - `10m` - 10 minutes
 - `1h30m` - 1 hour 30 minutes
+
+Different duration fields enforce different bounds. Health check durations accept
+any non-negative value (and treat `0` as "use the default"). The stop-budget
+fields `shutdown_timeout` and `stop_timeout` must be greater than `2s` and at
+most `10m` (see [Stop Timeout](#stop-timeout)); a value outside that range —
+including `0s` or a negative — is rejected at load with a field-named error.
 
 ## Runtime State
 

--- a/skills/prox/references/configuration.md
+++ b/skills/prox/references/configuration.md
@@ -46,8 +46,9 @@ processes:
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `api.port` | int | dynamic | HTTP API port (auto-assigned if not specified or port in use) |
+| `api.port` | int | dynamic | HTTP API port. When unset (or `0`), a free port is auto-assigned; an explicit port is used as-is — if it's already in use the API server fails to start (logged as an error) rather than picking another port |
 | `api.host` | string | `127.0.0.1` | API bind address |
+| `api.auth` | bool | auto | Force authentication on (`true`) or off (`false`). Omitted: auth is enabled automatically unless `api.host` is localhost-only |
 | `env_file` | string | — | Global .env file path, loaded for all processes |
 | `processes` | map | required | Process definitions |
 

--- a/test/integration/restart_test.go
+++ b/test/integration/restart_test.go
@@ -192,6 +192,108 @@ processes:
 	waitForLogContains(t, addr, "echoenv", "MYVAL=v2", 5*time.Second)
 }
 
+// printerConfig renders a config whose single `printer` process echoes
+// "MARKER=<marker>" in a loop, on the given API port. Used by the
+// changed-cmd reload test to edit the launched command out from under a
+// running process.
+func printerConfig(port int, marker string) string {
+	return fmt.Sprintf(`api:
+  port: %d
+  host: 127.0.0.1
+
+processes:
+  printer:
+    cmd: 'while :; do echo "MARKER=%s"; sleep 0.3; done'
+`, port, marker)
+}
+
+// TestRestart_ReloadsChangedCmd (#33): edit the launched command in prox.yaml
+// and restart via the API; the replacement must run the NEW command. A second
+// edit->restart cycle proves reload is per-request (consecutive reloads each
+// pick up the latest file), exercising the real `prox up` + API path end to end.
+func TestRestart_ReloadsChangedCmd(t *testing.T) {
+	skipShort(t)
+
+	binary := buildBinary(t)
+	const port = 15563
+	addr := fmt.Sprintf("http://127.0.0.1:%d", port)
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "prox.yaml")
+	requireNoError(t, os.WriteFile(cfgPath, []byte(printerConfig(port, "v1")), 0644), "writing initial config")
+
+	prox := startProxWithOutput(t, binary, "up", "-c", cfgPath)
+	defer killProx(prox.cmd)
+
+	waitForAPI(t, addr, 10*time.Second)
+	waitForLogContains(t, addr, "printer", "MARKER=v1", 5*time.Second)
+
+	// Two consecutive edit->restart cycles, each picking up the latest file.
+	for _, marker := range []string{"v2", "v3"} {
+		requireNoError(t, os.WriteFile(cfgPath, []byte(printerConfig(port, marker)), 0644), "rewriting config")
+
+		status, errResp := restartProcess(t, addr, "printer")
+		if status != http.StatusOK {
+			t.Fatalf("restart (%s) failed: status=%d code=%s error=%s", marker, status, errResp.Code, errResp.Error)
+		}
+		waitForLogContains(t, addr, "printer", "MARKER="+marker, 5*time.Second)
+	}
+}
+
+// TestRestart_RemovedProcessReturns409 (#33): removing the restart target from
+// the config (while another process remains, so validation passes) must make a
+// restart of the removed process fail with PROCESS_NOT_IN_CONFIG (HTTP 409) and
+// leave the still-configured process running untouched.
+func TestRestart_RemovedProcessReturns409(t *testing.T) {
+	skipShort(t)
+
+	binary := buildBinary(t)
+	const port = 15564
+	addr := fmt.Sprintf("http://127.0.0.1:%d", port)
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "prox.yaml")
+	twoProcs := fmt.Sprintf(`api:
+  port: %d
+  host: 127.0.0.1
+
+processes:
+  alpha:
+    cmd: 'while :; do echo "ALPHA"; sleep 0.3; done'
+  beta:
+    cmd: 'while :; do echo "BETA"; sleep 0.3; done'
+`, port)
+	requireNoError(t, os.WriteFile(cfgPath, []byte(twoProcs), 0644), "writing initial config")
+
+	prox := startProxWithOutput(t, binary, "up", "-c", cfgPath)
+	defer killProx(prox.cmd)
+
+	waitForAPI(t, addr, 10*time.Second)
+	waitForLogContains(t, addr, "alpha", "ALPHA", 5*time.Second)
+
+	// Remove alpha from the file (beta remains so the file still validates).
+	onlyBeta := fmt.Sprintf(`api:
+  port: %d
+  host: 127.0.0.1
+
+processes:
+  beta:
+    cmd: 'while :; do echo "BETA"; sleep 0.3; done'
+`, port)
+	requireNoError(t, os.WriteFile(cfgPath, []byte(onlyBeta), 0644), "rewriting config without alpha")
+
+	status, errResp := restartProcess(t, addr, "alpha")
+	if status != http.StatusConflict {
+		t.Fatalf("expected 409 restarting a removed process, got status=%d code=%s error=%s", status, errResp.Code, errResp.Error)
+	}
+	if errResp.Code != "PROCESS_NOT_IN_CONFIG" {
+		t.Fatalf("expected code PROCESS_NOT_IN_CONFIG, got %q (error=%q)", errResp.Code, errResp.Error)
+	}
+
+	// alpha must still be running with its original command untouched.
+	waitForProcessState(t, addr, "alpha", "running", 3*time.Second)
+}
+
 // TestStop_KillsStubbornGrandchild (A3): the leader exits gracefully on
 // SIGTERM but a backgrounded grandchild ignores it and holds a real TCP port.
 // `stop` must return only once the grandchild is verified gone (escalating to

--- a/test/integration/restart_test.go
+++ b/test/integration/restart_test.go
@@ -271,6 +271,11 @@ processes:
 	waitForAPI(t, addr, 10*time.Second)
 	waitForLogContains(t, addr, "alpha", "ALPHA", 5*time.Second)
 
+	// Snapshot alpha's identity so we can prove the failed restart didn't
+	// stop-and-relaunch it (same PID, same restart count), not merely that
+	// something named alpha ended up running.
+	before := waitForProcessState(t, addr, "alpha", "running", 3*time.Second)
+
 	// Remove alpha from the file (beta remains so the file still validates).
 	onlyBeta := fmt.Sprintf(`api:
   port: %d
@@ -290,8 +295,13 @@ processes:
 		t.Fatalf("expected code PROCESS_NOT_IN_CONFIG, got %q (error=%q)", errResp.Code, errResp.Error)
 	}
 
-	// alpha must still be running with its original command untouched.
-	waitForProcessState(t, addr, "alpha", "running", 3*time.Second)
+	// alpha must still be running, and it must be the SAME instance: identical
+	// PID and restart count, not a stop-and-relaunch.
+	after := waitForProcessState(t, addr, "alpha", "running", 3*time.Second)
+	if after.PID != before.PID || after.Restarts != before.Restarts {
+		t.Fatalf("alpha was disturbed by the failed restart: pid %d->%d restarts %d->%d",
+			before.PID, after.PID, before.Restarts, after.Restarts)
+	}
 }
 
 // TestStop_KillsStubbornGrandchild (A3): the leader exits gracefully on


### PR DESCRIPTION
Closes #35. Closes #33.

Five gated commits (plan 003; each passed lint / test / test-race / build, plus `mkdocs build --strict` for docs commits, a conditional simplify pass, and a capped external correctness review):

## What changed

**C1 — docs accuracy audit fixes.** A full audit of README/docs/skills against the code found one wrong claim (API "defaults to :5555" — it binds a dynamic port; all curl examples failed on a fresh run), an undocumented `api.auth` field, two missing API error codes from #30, stale architecture shutdown/restart sections, and assorted staleness. All fixed; `skills/prox` mirrors re-derived (api.md byte-identical; configuration.md keeps its two deliberate offline adaptations).

**C2+C3 — #35 configurable stop budgets.** New `shutdown_timeout` (global) and `stop_timeout` (per-process) duration fields: the SIGTERM→SIGKILL escalation budget (graceful window = budget − 2s reserve; must be >2s, ≤10m; healthcheck duration semantics untouched). C2 lands the fields inert; C3 makes every ceiling derive from them — per-process deadlines in StopProcess/RestartProcess **and full `prox stop`** (each process now gets its own budget instead of one shared 10s deadline), per-stage daemon shutdown (proxy 5s / API 5s / supervisor MaxStopBudget+5s computed at shutdown time), API lifecycle route group at 11m replacing the hardcoded 30s handler+middleware caps, dedicated 11m CLI lifecycle client, TUI ceiling, and `stop_timeout` surfaced in the process detail API. Behavior with nothing configured is unchanged (10s/2s), except full shutdown deliberately no longer lets proxy/API teardown eat into process stop time (CHANGELOG'd).

**C4 — #33 restart/start config hot-reload.** `prox restart <name>` — and `prox start <name>` — re-read prox.yaml and run what the file says (cmd, healthcheck, stop_timeout, env inputs incl. changed env_file paths). Fail-closed: the whole file is validated and the env load preflighted **before** anything stops — invalid file, missing env file, or removed target returns `CONFIG_RELOAD_FAILED` (422) / `PROCESS_NOT_IN_CONFIG` (409) with the old process untouched. The prepared config swaps in atomically inside the start's locked critical section (deterministic interleaving tests, -race clean); the restart's stop half keeps the pre-edit budget. Renames, added/removed processes, and services/proxy changes still require `prox up` (documented).

**C5 — pre-existing CLI bug found by verification.** `start` was missing from the API-address discovery allowlist, so `prox start` always hit the `:5555` fallback and failed against dynamic-port daemons (the default). One-line fix.

## Verification

- Unit + integration suites incl. new coverage: validation matrix, per-process budgets in bulk stop, escalation upper bounds, reload happy/fail paths, deterministic start-vs-restart interleavings (5× under -race), end-to-end restart-with-changed-cmd and removed-process integration tests.
- Live daemon functional pass (6 scenarios): SIGKILL exactly at budget−2s for a SIGTERM-trapping process; a 35s graceful drain under a 45s budget completing with **no SIGKILL** (proves the old 30s ceilings are gone); edit→restart applying new cmd (incl. consecutive edits); broken-YAML and removed-process restarts failing typed with the process untouched (same PID); full `prox stop` running a 6s-budget and a 45s-budget process concurrently, each honored.
- Known-unexercised: TUI >30s restart (constant unit-asserted only); the 11m middleware boundary not driven to its limit live.

## Review trail / accepted risks

- Plan pressure-tested by a 3-reviewer panel (Codex, GLM 5.2, CodeRabbit) before implementation; major corrections adopted (parser policy scoping, swap atomicity, shutdown-time budget computation, TUI ceiling, extending reload to `start`).
- Per-commit codex adversarial reviews: all findings fixed or dispositioned in the commit messages. Accepted: 404/405 responses no longer pass through a timeout middleware group (synchronous writes); a client disconnect does not abort an in-flight stop (deliberate: finish the reap once SIGTERM is sent); daemon shutdown overlapping an in-flight per-process stop keeps #32's pre-existing secondary-stop semantics.
- Pre-existing issues surfaced and filed separately (not fixed here): SSE streams are 30s-capped by the router timeout middleware; `requests` has the same address-discovery gap `start` had.
- No new dependencies; no privacy/secret impact (config error detail in API responses is localhost+auth only).

Follow-up run planned: #32 (concurrent-stop contract) + #36 (full-stop reap reporting).

<details>
<summary>Plan 003 (full text, incl. § Verified)</summary>

# Plan 003 — Configurable stop timeout (#35) + restart config hot-reload (#33) + docs audit

- **Repo:** prox (single-repo scope; one PR)
- **Branch:** `feature/plan-003-stop-timeout-restart-reload`
- **Issues:** closes #35, closes #33
- **Gates (Makefile; no CLAUDE.md):** `make lint`, `make test`, `make test-race` (new target added in C2), `make build`; docs commits also gate on `uv run mkdocs build --strict`
- **Panel review:** DONE (Codex gpt-5.6-sol, GLM 5.2, CodeRabbit — 2026-07-17). Major corrections adopted: duration-parser policy scoped per-field (healthcheck semantics unchanged); stop budget minimum > KillGrace; daemon shutdown deadline computed at shutdown time from live values with per-stage deadlines; restart swap moved inside Start's locked state-check (atomicity); fixed 11m lifecycle ceiling instead of per-process handler lookups; TUI 30s ceiling added; `client.go:294` claim corrected (SSE dial timeout, out of scope); reload error model enumerated; `stop`+`start` reload asymmetry closed by extending reload to `start`; commit order restructured (docs exposure only after ceilings honored); `make test-race` target added (gate was previously aspirational); mkdocs `--strict` gate; three additional doc-drift findings folded into the audit commit; explicit test matrix added. Rejected/adapted: C4-as-separate-PR (kept in-PR as first commit — the drift fixes touch the same files later commits edit; single-owner repo), `/shutdown` middleware exemption (unnecessary — handler responds immediately).

## 1. Problem / motivation

Two gaps from the #29/#30 stop/restart work, plus a documentation-accuracy workstream requested by the user:

- **#35:** Shutdown timing is hardcoded (~8s graceful before SIGKILL). Slow-draining workers get killed mid-cleanup with no recourse; fast CI teardowns always pay the full window on stuck processes.
- **#33:** `prox restart <name>` only reloads env_file *values*; a changed `cmd`, `healthcheck`, etc. in prox.yaml is silently ignored. The natural edit→restart→observe dev loop — the core workflow prox exists for — requires a full `prox stop` + `prox up`.
- **Docs audit:** verify the documentation set (README, docs/, skills/prox mirrors) is accurate against the code, fix drift, and document the new behavior.

## 2. Current state (verified this session)

### Shutdown timing plumbing
- `constants.DefaultShutdownTimeout = 10s`, `constants.KillGrace = 2s` — `internal/constants/constants.go:33,41`.
- `ManagedProcess.computeDeadlines` (`internal/supervisor/process.go:241-263`): uses the caller ctx's deadline when present; falls back to `p.shutdownTimeout` (today a **test-only seam**, `process.go:75-79`) else the constant. KillGrace is reserved at the tail; when remaining ≤ KillGrace the graceful phase is skipped but the kill phase still gets its full KillGrace, and Stop's finalization gate (`process.go:366-369`) can add up to `outputDrainTimeout+1s` (6s) — so the configured value bounds **escalation timing**, not strict total wall-clock.
- `Supervisor.StopProcess`/`RestartProcess` wrap the request ctx with `WithTimeout(s.supConfig.ShutdownTimeout)` (`internal/supervisor/supervisor.go:370,404`). `Supervisor.Stop` creates **one shared** `shutdownCtx` for all processes (`supervisor.go:242`).
- `SupervisorConfig.ShutdownTimeout` (`supervisor.go:17-27`) is set only by `DefaultSupervisorConfig()` (its own hardcoded `10 * time.Second` literal); `up.go:276-278` never overrides it. **No config field feeds it.**
- **Independent timeout ceilings that cap any configured value today:**
  1. API per-handler `context.WithTimeout(r.Context(), 30*time.Second)` on start/stop/restart — `internal/api/handlers.go:109,124,139`.
  2. chi `middleware.Timeout(30 * time.Second)` installed at router level, outside the `/api/v1` group — `internal/api/server.go:42`; per-route removal requires restructuring `registerRoutes` into subgroups. The SSE routes (`/logs/stream`, `/proxy/requests/stream`) sit under the same middleware — current SSE timeout behavior must be **verified and preserved unchanged** during the restructure (if streams are in fact context-capped at 30s today, that's a pre-existing issue to file, not fix here).
  3. CLI `http.Client{Timeout: 30 * time.Second}` — `internal/cli/client.go:58`. (`client.go:294` is the **SSE** client's dial timeout — separate concern, untouched.) A client-side abort also cancels the server's `r.Context()`, cutting the shutdown short server-side.
  4. TUI foreground restart ceiling `restartTimeout = 30s` — `internal/tui/update.go:14` (used for direct restarts from `prox up --tui`).
  5. `internal/cli/up.go:33`: package-level `const shutdownTimeout = 10 * time.Second` — the **actual outer deadline** for full `prox stop`/Ctrl-C daemon shutdown (`up.go:417-448` wraps proxy dereg/shutdown, API shutdown, and `sup.Stop` **sequentially in one context**), and also the startup-error cleanup defer at `up.go:336`.
- Duration validation pattern from #31: string duration fields + `parseHealthDuration` (`internal/config/config.go:258-273`) called from `Validate` (`internal/config/validate.go:44-61`). **Note:** it accepts explicit zero ("use default") and has no upper cap — documented healthcheck behavior that must not change.

### Restart / config-reload plumbing
- `Supervisor.RestartProcess` (`supervisor.go:386-421`) reuses the `ManagedProcess` built at `up`; **never re-reads prox.yaml**. Config is frozen in `s.config` (`supervisor.go:35`).
- Env reload (#30): `loadEnv` closure built in `createManagedProcess` (`supervisor.go:165-190`) captures the **up-time** env-file paths; invoked at top of `Start` (`process.go:162-170`), failure → `ErrEnvReloadFailed`, state `Crashed`.
- `config.ProcessConfig` = `Cmd, Env, EnvFile, Healthcheck` only (`config.go:62-67`); no ports/cwd. Ports live in top-level `services`/`proxy`, registered **once** with the proxy daemon at `up` (`up.go:569-627`); registry rejects re-registration (`internal/proxyd/registry.go:73-75`). Proxy is genuinely orthogonal to a per-process restart.
- `ManagedProcess.config` is immutable today and read **lock-free** in `Name()` (`process.go:94-96`), `Config()` (`process.go:98-101`, returns reference types), `Stop`'s verdict/log paths (`process.go:349,390`), `logf` (`:521`), `readOutput` (`:542`).
- `ManagedProcess.Restart` (`process.go:426-436`) is Stop → re-lock → Start, **not** one critical section; a concurrent Start can interleave.
- The API handler holds the (possibly relative) config path (`internal/api/handlers.go:30,35-42`, from `up.go:306`); the absolute path exists at `up.go:215`. `config.Load(path)` validates the whole file (`config.go:97-117,196`).
- Error mapping: `writeError` (`handlers.go:235-284`) maps enumerated sentinels only; `domain.ErrInvalidConfig`/`ErrConfigNotFound` currently fall through to a sanitized 500, and YAML syntax errors wrap nothing.
- `config.Validate` requires ≥1 process (`validate.go:35-37`); an individual process can disappear from the file while others remain.
- Existing test that uses the seam: `process_stop_test.go:270` (`mp.shutdownTimeout = 3s`).

### Docs surface (audit findings, verified against code)
Docs set: README/CHANGELOG/ROADMAP/RELEASING, mkdocs site under `docs/` (getting-started, guides, discovery, reference/{cli,configuration,tui,api}, development/{setup,architecture}), and `skills/prox` (SKILL.md + references). `api.md` mirror is byte-identical; the `configuration.md` mirror is **deliberately non-identical** (drops a site cross-link; replaces the DNS section with offline alternatives) — mirror edits must re-apply those adaptations, never blind-copy. mkdocs nav complete.

Ranked findings:
- **W1 (wrong):** "API runs at `http://127.0.0.1:5555` by default" — false; without `api.port` the server binds a **dynamic** free port (`internal/cli/up.go:143-155`, `config.go:146`); 5555 is only the client fallback constant. Affected: `README.md:173`, `docs/getting-started/quick-start.md:196,201,207` (curl examples fail on a fresh run), both copies of `api.md:9` (+all curl examples).
- **W2 (wrong, panel addition):** `docs/reference/configuration.md:49` claims an explicit `api.port` is auto-reassigned "if port in use"; code only assigns dynamically when the configured port is 0.
- **W3 (wrong, panel addition):** `architecture.md` startup order says API before processes; `up.go:343` starts supervisor/processes before the API server.
- **M1 (missing):** `api.auth` (`APIConfig.Auth *bool`, `config.go:57`, honored at `up.go:299,514-515`) documented nowhere — add to both configuration tables **and** the api.md authentication section.
- **M2 (missing):** error codes `ENV_RELOAD_FAILED` and `PROCESS_GROUP_NOT_REAPED` (`internal/domain/errors.go:25-26`) absent from both api.md error tables (`api.md:34-44`).
- **M3 (stale):** `docs/development/architecture.md:64-78` shutdown/restart sections predate #30 (no env reload, no group-kill/reap verification).
- **M4 (missing):** `GET /health` (`internal/api/server.go:154`) undocumented.
- **S1/S2 (stale):** README pins `VERSION=0.1.1` (current 0.1.3); setup.md tree omits `internal/{constants,daemon,domain,version}`.
- **Cosmetic:** architecture.md "1000 lines or 1MB" imprecision; Discovery design record nav-grouped under "Guides".

Doc locations #33/#35 must touch: configuration.md field tables (+mirror re-application), cli.md:164 (stop timing + long-wait/Ctrl-C note) and :211-224 (restart semantics), both api.md copies restart (:147-157), shutdown (:326-338) and error-code table, architecture.md:64-78, SKILL.md:20-33, README.md:142, CHANGELOG.md.

## 3. Design decisions — PINNED (panel-revised)

### D1 (#35): Config fields and resolution
- Top-level `shutdown_timeout` (string duration) on `config.Config`; per-process `stop_timeout` (string duration) on `config.ProcessConfig`.
- Effective per-process stop budget = `stop_timeout` else `shutdown_timeout` else `constants.DefaultShutdownTimeout` (10s). Per-process budgets unchanged when unconfigured.
- **KillGrace stays a fixed 2s internal reserve** (user decision). Contract wording (docs + code comments): the configured value is the **SIGTERM→SIGKILL escalation budget** — graceful window = value − 2s, then SIGKILL with the 2s reserve; total wall-clock can exceed it by up to ~6s in pathological output-drain cases (finalization gate). Tests assert escalation timing and upper bounds, not strict totals.
- **Validation bounds:** must parse, must be **> 2s (KillGrace)** — rejecting zero, negatives, and sub-KillGrace values uniformly (error text: "must be greater than 2s; 2s is reserved for the SIGKILL escalation") — and **≤ 10 minutes** (cap keeps the static ceilings in D2 boundable). Alternatives: accepting `0s` as immediate-kill (rejected — a ≤2s budget can still take ~2s through the kill phase, so "immediate" would be a lie; uniform minimum is honest); no cap (rejected — unbounded ceilings).
- **Parser policy is per-field** (panel: Codex #6 / CodeRabbit H1): generalize `parseHealthDuration` into a helper taking options (`allowZero`, `min`, `max`). Healthcheck fields keep exactly today's semantics (zero allowed = use default, no cap, negatives rejected); only the two new fields get the min/max policy. Healthcheck behavior change is a non-goal.

### D2 (#35): Every ceiling derives from (or safely exceeds) config — no silent truncation
- `domain.ProcessConfig` gains `StopTimeout time.Duration` (0 = unset). `createManagedProcess` resolves the effective budget and stores it by **promoting the test seam** `shutdownTimeout` (`process.go:75-79`) into the real per-process value; reads/writes of it are lock-protected (it becomes swappable via D3). Accessor `StopTimeout()` returns the effective budget.
- `Supervisor.StopProcess`/`RestartProcess`: `WithTimeout(ctx, mp.StopTimeout())` (snapshot = currently-effective value; a concurrently-raised budget takes effect from the next request — documented).
- `Supervisor.Stop`: per-process context per goroutine from that process's budget (fixes the shared deadline at `supervisor.go:242`). New `Supervisor.MaxStopBudget()` returns the max effective budget over **live** `ManagedProcess` values — so hot-reloaded values are respected (panel: Codex #2 / CodeRabbit H2).
- `up.go`: delete the `shutdownTimeout` const; **per-stage deadlines computed at shutdown time**: proxy dereg/shutdown and API-server shutdown each get a short fixed stage deadline (5s each; at its deadline API shutdown *returns leaving in-flight lifecycle requests running* — `http.Server.Shutdown` never force-closes active connections (corrected during C3 codex review); the supervisor stage stops their processes regardless, with concurrent-stop semantics per #32), then `sup.Stop` gets its own fresh context of `MaxStopBudget() + 5s`. The startup-error cleanup defer (`up.go:336`) only tears down the standalone proxy (never processes — corrected during C3 codex review), so it gets the same 5s proxy stage deadline.
- `DefaultSupervisorConfig()` literal → `constants.DefaultShutdownTimeout`. `SupervisorConfig.ShutdownTimeout` carries the configured global default (fed from `cfg` at `up.go:276-278`).
- **API ceilings — fixed, not per-process** (panel: Codex #5): restructure `registerRoutes` so the lifecycle routes (start/stop/restart) sit in a subgroup with `middleware.Timeout(11m)` (validation cap + margin) and **no** per-handler `WithTimeout`; the supervisor bounds the operation exactly per-process internally. All other routes keep 30s. `/shutdown` needs no exemption (responds immediately). SSE routes: verify current behavior and preserve it byte-for-byte through the restructure; if they turn out to be 30s-capped today, file it as a tracker issue, don't fix here.
- CLI: lifecycle calls (start/stop/restart) get a dedicated `http.Client{Timeout: 11m}`; all other calls keep 30s; the SSE client (`client.go:294-329`) is untouched. TUI `restartTimeout` (`internal/tui/update.go:14`) → 11m to match. Rationale for fixed ceilings: the client can't reliably know the daemon's config; the server is authoritative; the ceiling is hang protection only.
- **Observability:** effective stop budget exposed as `stop_timeout` (duration string) in `GET /processes/{name}` (helps users understand long waits and gives the functional verification a probe).
- Behavioral-defaults statement (replaces "byte-for-byte"): with nothing configured, per-process budgets and escalation timing are unchanged (10s/2s); the daemon-level outer deadline changes from a flat shared 10s to per-stage deadlines (≈15s worst case for the supervisor stage alone) — a deliberate fix for latent truncation of `sup.Stop` by proxy/API teardown time, called out in the CHANGELOG.

### D3 (#33): `restart` — and `start` — apply the current file's config (default behavior, no flag — user decision)
- **Reload applies to `start` as well as `restart`** (panel: CodeRabbit M1 — otherwise `stop`+`start` silently ignores a changed cmd, the exact #33 failure mode one command over). Unified rule, documented: *whenever a process (re)starts through the API, prox re-reads prox.yaml and the process runs what the file says.* `prox up`-time `Start` calls are unaffected (they just built from the same file).
- Flow in `Supervisor.RestartProcess`/`StartProcess`: **load + validate the whole file first** (`config.Load` on the absolute path — new `ConfigPath` on `SupervisorConfig`, set from `absConfigPath` at `up.go:215`; `NewHandlers` also switches to the absolute path so `/status` reports what reload uses), then look up the target, convert (`ToDomain`), and **preflight the env load** (dry-run of the new `loadEnv`) so a missing new env_file fails before anything stops. Failure at any of these steps → typed error, old process untouched. Runtime failures after a successful stop (e.g. env file deleted in the race window) leave the process stopped/crashed **with the new config active** for the next start — accepted, documented.
- **Swap atomicity** (panel: Codex #3 / CodeRabbit H3): the prepared config is passed *into* Start and swapped **inside Start's locked critical section, after the already-running/group-alive checks pass and before launch**. A concurrent Start that wins the race starts the old config and the loser returns `ErrProcessAlreadyRunning` with the swap **not** applied — state stays consistent (running process ↔ stored config always match). Deterministic barrier-based interleaving tests required in addition to `-race` (a logical race, not a data race). Full serialization of concurrent stops stays out of scope (#32).
- **Reload error model** (panel: Codex #7 / CodeRabbit M2) — new domain sentinels, codes, statuses, all mapped in `writeError` and added to both api.md error tables:
  - `ErrConfigReloadFailed` (missing/unreadable file, YAML syntax, validation failure — message carries the underlying detail; local-only API) → `CONFIG_RELOAD_FAILED`, HTTP 422.
  - `ErrProcessNotInConfig` (target removed from file) → `PROCESS_NOT_IN_CONFIG`, HTTP 409; message: `process "x" no longer in config; run 'prox up' to reconcile`.
  - Whole-file validation is intentional: an invalid **unrelated** edit (another process, proxy section) also blocks restart — fail-closed, documented with the same "fix the file or run `prox up`" guidance.
- Fields applied on (re)start: `cmd`, `healthcheck`, `stop_timeout`, env inputs (global `env_file`, per-process `env_file`, inline `env` — the `loadEnv` closure is rebuilt, so path changes now take effect). Effective stop budget recomputed as (fresh proc `stop_timeout` else fresh global `shutdown_timeout` else default). The supervisor-wide default for *other* processes changes only via `prox up`. The **stop half** of a restart uses the **old** budget; the new value governs from the next stop (docs phrase it: "timeout changes take effect on the next stop after the restart").
- **Identity & lock audit:** immutable `name` field on `ManagedProcess`; `Name()`, `logf`, `readOutput`, and `Stop`'s lock-free `p.config.Name` reads switch to it (log attribution is name-keyed and name is immutable, so old-run readers stay correctly attributed across a swap). `Config()` becomes lock-held and returns a deep copy (it exposes reference types). Every remaining `p.config` / `p.shutdownTimeout` read audited to be lock-held.
- Out of scope, rejected with clear errors or docs: renames (delete+add via `up`), added/removed processes (require `up`), services/proxy/port changes (no daemon update RPC — future work).

### D4: Docs workstream
- **C1 (first commit) fixes pre-existing drift:** W1 (base-URL/port-discovery rewrite incl. curl examples: discover via `prox status` or set `api.port`), W2, W3, M1 (both tables + api.md auth section), M2, M3, M4, S1 (`VERSION=0.1.3`), S2, both cosmetics (incl. mkdocs nav regroup). Kept in this PR rather than split out (panel: GLM) because later commits edit the same files/sections; it leads the branch so it's independently cherry-pickable.
- Feature docs land in the commit that makes them true (C3 for #35, C4 for #33) — never before the behavior works end-to-end (panel: Codex).
- Mirror rule: `api.md` mirror is a byte-copy; `configuration.md` mirror is **re-derived** — apply the same content edit, then re-verify the two documented adaptations (no site cross-link; offline DNS section) survived.

## 4. Deviations / non-goals
- No cgroup work (#34), no concurrent-stop serialization (#32), no full-`prox stop` failure contract (#36) — follow-up run. (#36 interaction noted: with large budgets the daemon may outlive the CLI's immediate "Shutdown initiated" return by minutes; cli.md stop docs get a note now.)
- No healthcheck validation changes (explicit non-goal; parser options preserve semantics).
- No SSE behavior changes (server or client).
- `KillGrace` not configurable. Unrelated `constants.DefaultShutdownTimeout` use at `internal/proxy/proxy.go:123` untouched.

## 5. Work breakdown (gated commits)

| Commit | Scope | Model | Gate |
|---|---|---|---|
| **C1** | Docs drift fixes per D4 (W1-W3, M1-M4, S1-S2, cosmetics, nav) + mirror re-derivation | sonnet | lint+test+build + mkdocs --strict |
| **C2** | #35 inert plumbing: config fields + per-field parser options + validation (>2s, ≤10m) + `domain.ProcessConfig.StopTimeout` + seam promotion (lock-protected) + `Makefile` `test-race` target + unit tests. No user-facing docs yet (fields undocumented until honored). | sonnet | lint+test+test-race+build |
| **C3** | #35 honored everywhere: supervisor per-process deadlines (3 call sites + `MaxStopBudget`) + up.go per-stage shutdown deadlines (+cleanup defer) + API route restructure w/ 11m lifecycle subgroup (SSE behavior verified & preserved) + CLI lifecycle client + TUI ceiling + `stop_timeout` in process detail response + tests + docs + CHANGELOG | opus | lint+test+test-race+build + mkdocs --strict |
| **C4** | #33: `ConfigPath` plumbing (+absolute path to handlers) + load/validate/preflight + swap-inside-Start + reload on start & restart + error sentinels/codes/writeError + deterministic interleaving tests + `-race` + integration tests + docs + CHANGELOG | opus | lint+test+test-race+build + mkdocs --strict |

## 6. File map (indicative)
- `Makefile` (test-race target)
- `internal/config/config.go` (fields, parser options), `validate.go`, tests
- `internal/domain/process.go` (StopTimeout), `errors.go` (2 sentinels + codes)
- `internal/supervisor/supervisor.go` (SupervisorConfig{ShutdownTimeout wiring, ConfigPath}, createManagedProcess, StopProcess/RestartProcess/StartProcess, Stop per-process ctxs, MaxStopBudget, reload flow), `process.go` (seam promotion, name field, swap-in-Start, Config() copy), tests incl. `process_stop_test.go:270` seam-test update + interleaving tests
- `internal/api/handlers.go` (remove per-handler 30s on lifecycle, writeError entries, process response field), `server.go` (route subgroups), `responses.go`, tests
- `internal/cli/client.go` (lifecycle client), `up.go` (per-stage deadlines, ConfigPath/abs-path wiring, cleanup defer), `internal/tui/update.go` (restartTimeout)
- `test/integration/` (real restart-with-changed-cmd, env-path change, removed-process cases)
- Docs: per §2 list + `CHANGELOG.md`; `mkdocs.yml` (nav)

## 7. Acceptance criteria
**#35**
- Configured budgets honored end-to-end on `prox stop <name>`, `prox restart <name>`, TUI restart, and full `prox stop`/Ctrl-C — including a value > 30s on each path (proves every ceiling derives from/exceeds config).
- Per-process `stop_timeout` overrides global `shutdown_timeout`; bulk `prox stop` gives each process its **own** budget (mixed-budget test), not a shared deadline.
- A budget raised by hot-reload (D3) is respected by a subsequent Ctrl-C/full stop (MaxStopBudget reads live values).
- Rejected at load with field-named errors: malformed, ≤ 2s (incl. 0 and negatives), > 10m; exactly 10m accepted. Healthcheck duration semantics byte-for-byte unchanged (zero still accepted, no cap).
- Unconfigured behavior: per-process budgets/escalation timing unchanged (10s/2s); full-stop verification observes daemon exit via the state file/PID (the CLI returns immediately by design — its return time proves nothing).
- Escalation-timing upper-bound test: a SIGTERM-ignoring process with `stop_timeout: 3s` is SIGKILLed no earlier than ~1s and no later than ~3s+ε after stop begins.

**#33**
- Edit `cmd` → `prox restart <name>` runs the new command (API `cmd` field + observed output); same for `prox stop` + `prox start`.
- Changed env_file *path*, changed healthcheck, changed `stop_timeout` all take effect on restart; consecutive edit→restart cycles each pick up the latest file.
- Invalid YAML / failed validation (including an invalid **unrelated** section) / missing file / target removed → typed error with documented code (`CONFIG_RELOAD_FAILED` 422 / `PROCESS_NOT_IN_CONFIG` 409), old process still running untouched; both api.md error tables list the new codes.
- Concurrent start-vs-restart interleaving: whichever wins, the running process and stored config never mismatch (deterministic test), `-race` clean over supervisor+api packages.
- Stop half of a restart uses the pre-edit budget; the new budget governs the next stop (test).

**Docs**
- All audit findings fixed or explicitly dispositioned; mirrors re-derived with adaptations intact; `mkdocs build --strict` passes.

PR references and closes #33 and #35; CHANGELOG entries for both (incl. the daemon per-stage deadline change and the start-also-reloads rule).

## 8. Verification plan (beyond automated tests)
Automated coverage carries most of this (unit + integration per §5/§7). Functional pass with a real `prox up` in a scratch project (artifacts → `~/.claude/plans/prox/003-stop-timeout-and-restart-reload/`):
1. SIGTERM-trapping process, `stop_timeout: 4s` → `prox stop <name>` escalates ~2s after SIGTERM; system log shows SIGKILL line.
2. Process that exits ~35s after SIGTERM, `stop_timeout: 45s` → stop succeeds with no SIGKILL (proves >30s API+CLI path).
3. Edit `cmd` marker → `prox restart <name>` → new marker in logs and `prox status`/process API.
4. Break the YAML → restart → 422 CONFIG_RELOAD_FAILED, old process still running.
5. Remove the process → restart → 409 PROCESS_NOT_IN_CONFIG, process untouched.
6. Raise `stop_timeout` via restart, then Ctrl-C the daemon → surviving-process budget honored (observe daemon exit via state file/PID).
Shell-driven; no browser tooling. TUI >30s restart is covered by code inspection + unit test only (no interactive TUI harness) — recorded honestly in § Verified.

## 9. Risks / open items / future work
- Long-stop requests hold an HTTP connection up to the budget (≤10m cap + 11m ceilings). UX: user sees a silent wait; docs note the wait and that Ctrl-C on the CLI is safe (server is authoritative). Exposing the budget in the process API mitigates confusion. Accepted.
- During full daemon shutdown an in-flight lifecycle request keeps running past the API stage's 5s deadline (Go never force-closes it); `sup.Stop` then overlaps it with concurrent-stop semantics — the #32 secondary-stop limitation can surface on this path (pre-existing, tracked there). Accepted, documented.
- If SSE routes prove to be 30s-capped today, that's filed as a new tracker issue (pre-existing), not fixed here.
- Follow-up run: #32 (with the interleaving tests from C4 as a foundation) + #36; proxy route hot-reload remains future work.

## § Verified (beyond automated tests)

Functional pass against a real `prox up -d` daemon in a scratch project (transcript:
`~/.claude/plans/prox/003-stop-timeout-and-restart-reload/verification.log`):

1. **Escalation timing** — SIGTERM-trapping process, `stop_timeout: 4s`: SIGKILL exactly 2s
   after SIGTERM (budget − KillGrace), `prox stop` returned in 2.16s. PASS.
2. **>30s ceilings removed** — drainer taking 35s after SIGTERM under `stop_timeout: 45s`
   (applied via restart hot-reload; detail API showed `"stop_timeout":"45s"`): stop drained
   35.1s, exited rc=0, no SIGKILL. Proves API middleware/handler/CLI-client ceilings derive
   from config. PASS.
3. **cmd hot-reload** — edit cmd marker → `prox restart` → new marker in logs; consecutive
   edit→restart cycles each picked up the latest file. PASS.
4. **Fail-closed: broken YAML** — restart → `CONFIG_RELOAD_FAILED` with parse detail; process
   untouched (same PID). PASS.
5. **Fail-closed: removed process** — restart → `PROCESS_NOT_IN_CONFIG` ("run 'prox up' to
   reconcile"); process untouched. PASS.
6. **Per-process budgets on full stop + start-reload** — budget changed via `prox start`
   reload; full `prox stop`: stubborn SIGKILLed at ~4s (6s budget) while the 45s-budget
   drainer got its full 35s graceful drain concurrently; daemon exit observed via PID/state
   file removal. Under the old shared 10s deadline the drainer would have been SIGKILLed at
   ~8s. PASS.

Found and fixed during verification: pre-existing bug — `start` missing from the CLI
address-discovery allowlist (commit C5), so `prox start` failed against dynamic-port daemons.

Known-unexercised paths (honest limits): TUI restart >30s ceiling (unit-asserted constant
only — no interactive TUI harness); the 11m middleware value not driven to its boundary
(structure unit-tested; 35s end-to-end proves the old 30s ceiling is gone); concurrent
start-vs-restart interleavings exercised deterministically in -race unit tests, not live.
Automated coverage: unit + integration suites across config/supervisor/api/cli, `-race` clean,
5× repeat on the interleaving tests.


</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgMgg6eo4LgLTCkfYSARcH


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `prox start`/`prox restart` now re-read and apply the latest `prox.yaml` process configuration.
  * Added configurable `shutdown_timeout` and per-process `stop_timeout`, including `stop_timeout` surfaced in process details.
  * API now uses dynamic localhost port assignment by default and includes a public `GET /health` endpoint.
* **Bug Fixes**
  * Reloads are fail-closed (running processes remain unchanged) with new HTTP error mappings for invalid reloads and missing targets.
  * Lifecycle API routes use higher request-timeout ceilings; shutdown/restart honor per-process deadlines and staged teardown.
* **Documentation**
  * Updated installation/CLI/API/configuration/architecture/quick-start guidance to match the new reload and timeout semantics.
* **Tests / Chores**
  * Expanded reload/stop-timeout coverage and added Makefile targets for linting, cleaning, installation, and race testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->