### PR TITLE
Stop failure contract: concurrent-stop verdicts (#32) + full-stop reap reporting (#36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,43 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Breaking
+
+- **Foreground `prox up` now exits non-zero when a process group survives
+  shutdown** (#36). Previously foreground `prox up` (Ctrl-C or an API shutdown)
+  always exited `0`, even if a process group could not be reaped and still held
+  its ports. It now exits `1` with a one-line `shutdown incomplete: …` summary
+  (per-survivor detail is written to the log stream). Scripts that asserted a `0`
+  exit from a foreground `prox up` regardless of outcome must be updated. A clean
+  shutdown still exits `0`.
+
 ### Features
+
+- **Full-stop failure contract** (#36). `prox stop` (no arguments) and `prox down`
+  now **wait for the shutdown outcome** instead of firing and forgetting. The
+  daemon reports the process-stop verdict over a new `POST /api/v1/shutdown?wait=true`
+  path, which responds **HTTP 200** with `{success, waited, failures[]}` — 200 even
+  when a group survived, so the structured survivor list (each carrying the stable
+  `PROCESS_GROUP_NOT_REAPED` code) is not discarded. The CLI maps this to exit
+  codes: **0** when everything stopped cleanly (after a brief bounded wait for the
+  daemon's state/PID files to disappear), **1** when a process group survived (each
+  printed as a `process: error` line), and **1** when the connection drops mid-wait
+  and the outcome is unknown. An older daemon that predates the `wait` parameter is
+  detected (the response omits `waited`) and the CLI falls back to the legacy
+  `Shutdown initiated` message with exit `0`. The daemon shutdown stages were
+  reordered so the API server is stopped **last** (after the supervisor stage and
+  the verdict publish), letting it deliver the waited response, with the launch
+  gate closed first so a lifecycle request during the drain cannot orphan a
+  process.
+- **Concurrent stops return the same verdict** (#32). Two `Stop` calls against the
+  same process (or a daemon shutdown overlapping an in-flight per-process stop) now
+  resolve to the **same** result: a secondary waiter joins the primary's stop
+  episode and observes its authoritative verdict — including a
+  `PROCESS_GROUP_NOT_REAPED` failure — instead of returning success early when the
+  leader is reaped. A caller whose own context is canceled first still gets
+  `ctx.Err()`. A reap failure now emits a `process_crashed` event uniformly from
+  both the per-process stop and full-stop paths.
+
 
 - **`restart` and `start` apply the current `prox.yaml`** (#33). An API-driven
   (re)start — `prox restart <name>`, and `prox start <name>` after a
@@ -53,6 +89,16 @@ All notable changes to this project will be documented in this file.
   like the other client commands; previously it always used the default `:5555`
   address and failed against daemons on dynamic API ports (found during #33
   verification).
+- **A second `POST /shutdown` no longer panics the daemon** (#36). The shutdown
+  trigger was a bare `close(shutdownCh)`, so a duplicate or concurrent shutdown
+  request (e.g. a rapid double `prox stop`) closed an already-closed channel and
+  crashed the daemon. Shutdown is now latched through a `sync.Once` coordinator, so
+  repeated triggers are safe no-ops.
+- **`POST /shutdown` now works against a `--tui` daemon** (#36). The TUI event loop
+  never observed the shutdown channel, so an API shutdown (and therefore
+  `prox stop`) was silently inert against `prox up --tui` — the request returned
+  200 but the daemon kept running. The trigger is now routed into the TUI so it
+  quits and runs the normal shutdown sequence.
 - **Healthcheck `interval`/`timeout`/`retries`/`start_period` are now honored**
   (#31). Previously only `healthcheck.cmd` took effect; the timing/retry fields
   were silently dropped and replaced by the built-in defaults (`10s`/`5s`/`3`/

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -64,13 +64,14 @@ This document describes the internal design of prox for contributors.
 
 The daemon tears down in stages, each with its own deadline computed at shutdown
 time rather than one shared budget, so proxy/API teardown time can never eat
-into the supervisor's process-stop budget:
+into the supervisor's process-stop budget. The API server is stopped **last** so
+it outlives the supervisor stage and can still deliver the outcome to a
+`wait=true` caller:
 
-1. Deregister from (or stop) the proxy — a short fixed stage deadline
-2. Stop the API server — a short fixed stage deadline. The server stops
-   accepting new connections and waits up to the stage deadline for in-flight
-   requests; a still-running lifecycle request is not force-closed, and the
-   supervisor stage below stops its process regardless
+1. Close the launch gate — the supervisor refuses any new process launch for the
+   rest of shutdown, so a lifecycle request arriving during the drain cannot
+   start a process that teardown is about to orphan
+2. Deregister from (or stop) the proxy — a short fixed stage deadline
 3. Stop all processes (the supervisor stage), bounded by the maximum per-process
    stop budget currently in force plus a small margin. Each process is stopped
    concurrently on its **own** effective stop budget:
@@ -85,7 +86,26 @@ into the supervisor's process-stop budget:
       group and poll again until the kill deadline passes
    4. Verify the group is actually gone; if it survived SIGKILL, the stop reports
       `PROCESS_GROUP_NOT_REAPED` instead of succeeding
-4. Exit
+4. Publish the aggregate process-stop verdict to any `wait=true` shutdown caller
+   (a latched broadcast: every waiter reads the same stored outcome)
+5. Flush and close the log manager — this releases SSE log subscribers so their
+   handlers return instead of pinning the API server open through the next stage
+6. Stop the API server — a short fixed stage deadline. It stops accepting new
+   connections and waits up to the deadline for in-flight requests (including the
+   `wait=true` response's small JSON write); a still-running request is not
+   force-closed
+7. Cleanup and exit. In the foreground, a surviving process group makes `prox up`
+   exit non-zero with a one-line `shutdown incomplete: …` summary (per-survivor
+   detail is in the log stream)
+
+**Waited shutdown flow.** `POST /api/v1/shutdown?wait=true` (used by `prox stop`
+and `prox down`) triggers the sequence above, then blocks until stage 4 latches
+the verdict. The handler returns HTTP 200 with the verdict — `success: true` on a
+clean stop, or `success: false` plus a `failures` list naming each survivor. The
+CLI then waits briefly for the daemon's state/PID files to disappear (confirming
+the daemon process itself exited) before printing its summary. See
+[POST /shutdown](../reference/api.md#post-shutdown) and
+[`prox stop`](../reference/cli.md#stop).
 
 ### Process Restart
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -359,7 +359,15 @@ curl -N "http://localhost:5555/api/v1/proxy/requests/stream?subdomain=api"
 
 Gracefully shut down supervisor and all processes.
 
-**Response:**
+**Query Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `wait` | boolean | When exactly `true`, block until the process-stop verdict lands and return it (see below). Any other or absent value uses the legacy async behavior. |
+
+This route is in the lifecycle timeout class (the same long hang-protection ceiling as `start`/`stop`/`restart`), because the `wait=true` path can block for the full drain.
+
+**Legacy async response** (default, `wait` absent or not `true`):
 
 ```json
 {
@@ -367,6 +375,34 @@ Gracefully shut down supervisor and all processes.
 }
 ```
 
-Connection closes after response as supervisor terminates.
+The daemon acks immediately, then tears down in the background. The connection closes as the supervisor terminates.
 
-The daemon then tears down in stages, each with its own deadline: the proxy and API server are stopped on short fixed deadlines, then every process is stopped concurrently, each on its own configured stop budget (see [Stop Timeout](configuration.md#stop-timeout)). Graceful timing therefore derives from the configured `shutdown_timeout` / `stop_timeout` values, not a single fixed window.
+**Waited response** (`wait=true`):
+
+```json
+{
+  "success": true,
+  "waited": true,
+  "failures": []
+}
+```
+
+The request blocks until every process has been stopped and its group reaped, then returns the verdict. `success` is `true` only when `failures` is empty. When a process group survives shutdown, the response still uses **HTTP 200** (so the structured body is not discarded) and lists each survivor:
+
+```json
+{
+  "success": false,
+  "waited": true,
+  "failures": [
+    {
+      "process": "web",
+      "error": "process group could not be terminated: web",
+      "code": "PROCESS_GROUP_NOT_REAPED"
+    }
+  ]
+}
+```
+
+The `code` field is a stable machine-readable classifier (`PROCESS_GROUP_NOT_REAPED`). The `waited` field is present only on this path; a daemon that predates the `wait` parameter ignores it and returns the legacy body without `waited`, letting clients detect the older daemon.
+
+The daemon tears down in stages, each with its own deadline: the launch gate is closed, the proxy is deregistered/stopped on a short fixed deadline, then every process is stopped concurrently, each on its own configured stop budget (see [Stop Timeout](configuration.md#stop-timeout)); the verdict is then published to any `wait=true` caller, the logs are flushed and closed, and finally the API server is stopped. Graceful timing therefore derives from the configured `shutdown_timeout` / `stop_timeout` values, not a single fixed window.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -169,6 +169,14 @@ With a process name, stops only that process while keeping prox and other proces
 
 The SIGTERM→SIGKILL timeout is configurable per process via `stop_timeout` (or globally via `shutdown_timeout`; default `10s`) — see [Stop Timeout](configuration.md#stop-timeout). A process with a large budget may make `prox stop` wait a while before returning: the server is authoritative and holds the request open until the process actually stops (up to the configured budget), so a long silent wait is expected rather than a hang. Pressing Ctrl-C on the CLI is safe — it only detaches the client; the daemon keeps stopping the process on its configured budget.
 
+**Full stop waits for the outcome.** `prox stop` (no arguments) and `prox down` block until the daemon reports the process-stop verdict, then wait briefly (up to ~15s) for the daemon's state and PID files to disappear before printing a stopped summary and exiting **0**. Exit codes:
+
+- **0** — all processes (and their process groups) stopped cleanly. A summary line is printed. If the daemon is still finishing its own exit when the bounded wait elapses, a `Warning: the daemon is still finishing shutdown` line is printed to stderr but the exit code stays `0` (the process-stop verdict already succeeded).
+- **1** — one or more process groups survived shutdown. Each survivor is printed as a `process: error` line, followed by a one-line summary; the group still holds whatever ports it bound.
+- **1** — the connection dropped mid-wait: the daemon may still be completing its shutdown and the outcome is unknown. When a daemon log file is present (detached mode), the message points at `.prox/prox.log` for the authoritative result.
+
+Against an older daemon that predates the waited protocol, `prox stop` falls back to the previous fire-and-forget behavior: it prints `Shutdown initiated` and exits `0`.
+
 **Examples:**
 
 ```bash

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -20,6 +20,22 @@ import (
 	"github.com/charliek/prox/internal/supervisor"
 )
 
+// ShutdownController is the narrow view of the daemon shutdown coordinator the
+// shutdown handler needs. The daemon passes its *shutdownCoordinator; a wait=true
+// request Trigger()s the sequence, then blocks on Done() to read the latched
+// Outcome() (the process-stop verdict). Kept as an interface here so the handler
+// package does not depend on the cli package (which owns the coordinator) and so
+// tests can drive the handler with a fake (#36, D4).
+type ShutdownController interface {
+	// Trigger requests shutdown. Idempotent (backed by sync.Once in the daemon).
+	Trigger()
+	// Done is closed once the shutdown sequence has latched its outcome.
+	Done() <-chan struct{}
+	// Outcome is the process-stop verdict; valid only after Done() is observed.
+	// A nil return means a clean stop (no survivors).
+	Outcome() *domain.ProcessStopError
+}
+
 // Handlers contains all HTTP handlers
 type Handlers struct {
 	supervisor     *supervisor.Supervisor
@@ -27,16 +43,17 @@ type Handlers struct {
 	requestManager *proxy.RequestManager
 	captureManager *proxy.CaptureManager
 	configFile     string
-	shutdownFn     func()
+	shutdown       ShutdownController
 }
 
-// NewHandlers creates new HTTP handlers
-func NewHandlers(sup *supervisor.Supervisor, logMgr *logs.Manager, configFile string, shutdownFn func()) *Handlers {
+// NewHandlers creates new HTTP handlers. shutdown may be nil in tests that never
+// exercise POST /shutdown; the handler guards against it.
+func NewHandlers(sup *supervisor.Supervisor, logMgr *logs.Manager, configFile string, shutdown ShutdownController) *Handlers {
 	return &Handlers{
 		supervisor: sup,
 		logManager: logMgr,
 		configFile: configFile,
-		shutdownFn: shutdownFn,
+		shutdown:   shutdown,
 	}
 }
 
@@ -178,17 +195,72 @@ func (h *Handlers) GetLogs(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
-// Shutdown handles POST /api/v1/shutdown
+// Shutdown handles POST /api/v1/shutdown.
+//
+// With ?wait=true (exactly the string "true") the handler triggers the shutdown
+// sequence and blocks until the daemon latches the process-stop verdict, then
+// returns it as a ShutdownResponse. Any other or absent wait value keeps the
+// legacy async behavior: ack 200 immediately, then trigger after a short delay so
+// the response flushes first. The route lives in the lifecycle timeout group
+// (see registerRoutes) because the waited path can block for the whole drain.
 func (h *Handlers) Shutdown(w http.ResponseWriter, r *http.Request) {
-	writeJSON(w, http.StatusOK, SuccessResponse{Success: true})
+	if h.shutdown != nil && r.URL.Query().Get("wait") == "true" {
+		h.shutdownWait(w, r)
+		return
+	}
 
-	// Trigger shutdown asynchronously
-	go func() {
-		time.Sleep(100 * time.Millisecond) // Let response complete
-		if h.shutdownFn != nil {
-			h.shutdownFn()
+	// Legacy async path: ack immediately, then trigger after a short delay so the
+	// response completes first. Trigger is idempotent, so a duplicate POST is
+	// safe. h.shutdown may be nil (unit-test handler that never exercises this
+	// path); guard before triggering, but the ack itself is unconditional so a
+	// nil coordinator still preserves the legacy response shape.
+	writeJSON(w, http.StatusOK, SuccessResponse{Success: true})
+	if h.shutdown != nil {
+		go func() {
+			time.Sleep(100 * time.Millisecond) // Let response complete
+			h.shutdown.Trigger()
+		}()
+	}
+}
+
+// shutdownWait triggers shutdown and blocks until the coordinator latches the
+// process-stop verdict, then writes it. It always responds HTTP 200 — even when a
+// process group survived — because the CLI discards structured bodies on non-2xx
+// responses; the survivor list must ride a 200 to reach the client (#36, D4). If
+// the client disconnects first, shutdown proceeds regardless (already triggered)
+// and nothing is written to the dead connection.
+func (h *Handlers) shutdownWait(w http.ResponseWriter, r *http.Request) {
+	h.shutdown.Trigger()
+
+	select {
+	case <-h.shutdown.Done():
+		outcome := h.shutdown.Outcome()
+		resp := ShutdownResponse{
+			Waited:   true,
+			Failures: shutdownFailures(outcome),
 		}
-	}()
+		resp.Success = len(resp.Failures) == 0
+		writeJSON(w, http.StatusOK, resp)
+	case <-r.Context().Done():
+		// Client gone; nothing to write. Shutdown is already in progress.
+	}
+}
+
+// shutdownFailures flattens a *ProcessStopError into wire failures. Always
+// returns a non-nil slice so the JSON body carries "failures": [] on a clean stop.
+func shutdownFailures(outcome *domain.ProcessStopError) []ShutdownFailureResponse {
+	failures := make([]ShutdownFailureResponse, 0)
+	if outcome == nil {
+		return failures
+	}
+	for _, f := range outcome.Failures {
+		failures = append(failures, ShutdownFailureResponse{
+			Process: f.Name,
+			Error:   f.Err.Error(),
+			Code:    domain.ErrorCode(f.Err),
+		})
+	}
+	return failures
 }
 
 // parseLogParams extracts log filter parameters from request

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -1059,11 +1059,11 @@ func TestGetProxyRequest(t *testing.T) {
 // fakeShutdownController is a hand-driven ShutdownController for the shutdown
 // handler tests: complete() latches the outcome and closes Done().
 type fakeShutdownController struct {
-	mu        sync.Mutex
-	triggered int
-	done      chan struct{}
-	closeOnce sync.Once
-	outcome   *domain.ProcessStopError
+	mu           sync.Mutex
+	triggered    int
+	done         chan struct{}
+	completeOnce sync.Once
+	outcome      *domain.ProcessStopError
 }
 
 func newFakeShutdownController() *fakeShutdownController {
@@ -1086,9 +1086,14 @@ func (f *fakeShutdownController) Done() <-chan struct{} { return f.done }
 
 func (f *fakeShutdownController) Outcome() *domain.ProcessStopError { return f.outcome }
 
+// complete latches the outcome and closes Done() first-call-wins, matching the
+// production coordinator's contract: a later complete cannot overwrite the stored
+// outcome after Done() has closed.
 func (f *fakeShutdownController) complete(outcome *domain.ProcessStopError) {
-	f.outcome = outcome
-	f.closeOnce.Do(func() { close(f.done) })
+	f.completeOnce.Do(func() {
+		f.outcome = outcome
+		close(f.done)
+	})
 }
 
 func TestShutdownHandler_WaitClean(t *testing.T) {

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1053,4 +1054,143 @@ func TestGetProxyRequest(t *testing.T) {
 		assert.Equal(t, []string{"application/json"}, resp.Details.RequestHeaders["Content-Type"])
 		assert.Equal(t, []string{"application/json"}, resp.Details.ResponseHeaders["Content-Type"])
 	})
+}
+
+// fakeShutdownController is a hand-driven ShutdownController for the shutdown
+// handler tests: complete() latches the outcome and closes Done().
+type fakeShutdownController struct {
+	mu        sync.Mutex
+	triggered int
+	done      chan struct{}
+	closeOnce sync.Once
+	outcome   *domain.ProcessStopError
+}
+
+func newFakeShutdownController() *fakeShutdownController {
+	return &fakeShutdownController{done: make(chan struct{})}
+}
+
+func (f *fakeShutdownController) Trigger() {
+	f.mu.Lock()
+	f.triggered++
+	f.mu.Unlock()
+}
+
+func (f *fakeShutdownController) triggerCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.triggered
+}
+
+func (f *fakeShutdownController) Done() <-chan struct{} { return f.done }
+
+func (f *fakeShutdownController) Outcome() *domain.ProcessStopError { return f.outcome }
+
+func (f *fakeShutdownController) complete(outcome *domain.ProcessStopError) {
+	f.outcome = outcome
+	f.closeOnce.Do(func() { close(f.done) })
+}
+
+func TestShutdownHandler_WaitClean(t *testing.T) {
+	fake := newFakeShutdownController()
+	fake.complete(nil) // clean verdict already latched
+	h := NewHandlers(nil, nil, "prox.yaml", fake)
+
+	req := httptest.NewRequest("POST", "/api/v1/shutdown?wait=true", nil)
+	w := httptest.NewRecorder()
+	h.Shutdown(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.GreaterOrEqual(t, fake.triggerCount(), 1)
+
+	var resp ShutdownResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.True(t, resp.Success)
+	assert.True(t, resp.Waited)
+	assert.Empty(t, resp.Failures)
+}
+
+func TestShutdownHandler_WaitFailures(t *testing.T) {
+	fake := newFakeShutdownController()
+	fake.complete(&domain.ProcessStopError{
+		Failures: []domain.ProcessStopFailure{
+			{Name: "web", Err: fmt.Errorf("%w: web", domain.ErrProcessGroupNotReaped)},
+		},
+	})
+	h := NewHandlers(nil, nil, "prox.yaml", fake)
+
+	req := httptest.NewRequest("POST", "/api/v1/shutdown?wait=true", nil)
+	w := httptest.NewRecorder()
+	h.Shutdown(w, req)
+
+	// 200 even with survivors: the CLI drops structured bodies on non-2xx.
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp ShutdownResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.False(t, resp.Success)
+	assert.True(t, resp.Waited)
+	require.Len(t, resp.Failures, 1)
+	assert.Equal(t, "web", resp.Failures[0].Process)
+	assert.Equal(t, domain.ErrCodeProcessGroupNotReaped, resp.Failures[0].Code)
+}
+
+// TestShutdownHandler_WaitClientGone: when the request context is canceled before
+// the verdict lands, the handler returns without writing a body.
+func TestShutdownHandler_WaitClientGone(t *testing.T) {
+	fake := newFakeShutdownController() // never completed
+	h := NewHandlers(nil, nil, "prox.yaml", fake)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequest("POST", "/api/v1/shutdown?wait=true", nil).WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	returned := make(chan struct{})
+	go func() {
+		h.Shutdown(w, req)
+		close(returned)
+	}()
+
+	cancel() // client disconnects
+
+	select {
+	case <-returned:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler did not return after client disconnect")
+	}
+	assert.Equal(t, 1, fake.triggerCount())
+	assert.Empty(t, w.Body.String(), "nothing should be written to a dead connection")
+}
+
+// TestShutdownHandler_LegacyAsync: without wait=true, the handler acks 200
+// immediately and triggers shutdown asynchronously.
+func TestShutdownHandler_LegacyAsync(t *testing.T) {
+	fake := newFakeShutdownController()
+	h := NewHandlers(nil, nil, "prox.yaml", fake)
+
+	req := httptest.NewRequest("POST", "/api/v1/shutdown", nil)
+	w := httptest.NewRecorder()
+	h.Shutdown(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp SuccessResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.True(t, resp.Success)
+
+	// Trigger fires from a background goroutine after a short delay.
+	require.Eventually(t, func() bool { return fake.triggerCount() >= 1 }, 2*time.Second, 10*time.Millisecond)
+}
+
+// TestShutdownHandler_NilControllerAcks: a handler with no coordinator wired
+// still acks (used by tests that never exercise the shutdown path).
+func TestShutdownHandler_NilControllerAcks(t *testing.T) {
+	h := NewHandlers(nil, nil, "prox.yaml", nil)
+	req := httptest.NewRequest("POST", "/api/v1/shutdown?wait=true", nil)
+	w := httptest.NewRecorder()
+	h.Shutdown(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp SuccessResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.True(t, resp.Success)
 }

--- a/internal/api/responses.go
+++ b/internal/api/responses.go
@@ -92,6 +92,28 @@ type SuccessResponse struct {
 	Success bool `json:"success"`
 }
 
+// ShutdownFailureResponse describes one process whose group survived the
+// full-stop shutdown. Code is the stable machine-readable classifier
+// (e.g. PROCESS_GROUP_NOT_REAPED) so tooling can branch without string matching.
+type ShutdownFailureResponse struct {
+	Process string `json:"process"`
+	Error   string `json:"error"`
+	Code    string `json:"code"`
+}
+
+// ShutdownResponse is the body of POST /api/v1/shutdown?wait=true once the
+// process-stop verdict has landed. Success is true only when Failures is empty.
+// Waited is always true on this path; its presence (vs its absence on the legacy
+// async 200, which sends a bare SuccessResponse) is how an older CLI detects that
+// it reached a waited-capable daemon. The endpoint responds HTTP 200 even when
+// Failures is non-empty, because the CLI discards structured bodies on non-2xx
+// responses — the survivor list must ride a 200 to be read (#36, D4).
+type ShutdownResponse struct {
+	Success  bool                      `json:"success"`
+	Waited   bool                      `json:"waited"`
+	Failures []ShutdownFailureResponse `json:"failures"`
+}
+
 // ErrorResponse represents an error response
 type ErrorResponse struct {
 	Error string `json:"error"`

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -169,10 +169,11 @@ func authMiddleware(authEnabled bool, token string) func(http.Handler) http.Hand
 //
 // The request-timeout middleware is applied per route group, not globally, so
 // the lifecycle routes can carry a larger ceiling than everything else:
-//   - Lifecycle group (start/stop/restart): lifecycleRequestTimeout (11m). The
-//     supervisor bounds these operations internally per-process by the
-//     configured stop budget; this router ceiling is hang protection only.
-//   - Default group (everything else, including the SSE streams and /shutdown):
+//   - Lifecycle group (start/stop/restart, /shutdown): lifecycleRequestTimeout
+//     (11m). The supervisor bounds start/stop/restart internally per-process by
+//     the configured stop budget; /shutdown?wait=true blocks for the whole drain.
+//     This router ceiling is hang protection only.
+//   - Default group (everything else, including the SSE streams):
 //     defaultRequestTimeout (30s), preserving the prior behavior exactly. The
 //     SSE streams (/logs/stream, /proxy/requests/stream) watch r.Context() and
 //     were 30s-capped before this restructure; they remain so.
@@ -191,12 +192,19 @@ func (s *Server) registerRoutes() {
 
 		// Lifecycle routes: bounded internally by the supervisor per-process, so
 		// they get the large hang-protection ceiling rather than the 30s default.
+		// /shutdown lives here too: its wait=true path blocks for the whole drain
+		// (supervisor stop + finalization), which can exceed the 30s default (#36,
+		// D4). The legacy async /shutdown returns immediately, so the larger ceiling
+		// is harmless for it.
 		r.Group(func(r chi.Router) {
 			r.Use(middleware.Timeout(lifecycleRequestTimeout))
 
 			r.Post("/processes/{name}/start", s.handlers.StartProcess)
 			r.Post("/processes/{name}/stop", s.handlers.StopProcess)
 			r.Post("/processes/{name}/restart", s.handlers.RestartProcess)
+
+			// Shutdown (wait=true blocks for the drain; legacy default acks async).
+			r.Post("/shutdown", s.handlers.Shutdown)
 		})
 
 		// Everything else keeps the default 30s ceiling.
@@ -220,9 +228,6 @@ func (s *Server) registerRoutes() {
 			r.Get("/proxy/requests", s.handlers.GetProxyRequests)
 			r.Get("/proxy/requests/stream", s.handlers.StreamProxyRequests)
 			r.Get("/proxy/requests/{id}", s.handlers.GetProxyRequest)
-
-			// Shutdown (responds immediately, then triggers async teardown)
-			r.Post("/shutdown", s.handlers.Shutdown)
 		})
 	})
 }

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -14,6 +16,7 @@ import (
 
 	"github.com/charliek/prox/internal/config"
 	"github.com/charliek/prox/internal/constants"
+	"github.com/charliek/prox/internal/domain"
 	"github.com/charliek/prox/internal/logs"
 	"github.com/charliek/prox/internal/supervisor"
 )
@@ -371,6 +374,18 @@ func TestRequestTimeoutConstants(t *testing.T) {
 		"lifecycle ceiling must cover the maximum configurable stop budget")
 }
 
+// deadlineProbe returns a handler that records the remaining time until its
+// request's context deadline into dst, so a test can assert which timeout
+// middleware group a route landed in without exercising the real handler body.
+func deadlineProbe(dst *time.Duration) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if dl, ok := r.Context().Deadline(); ok {
+			*dst = time.Until(dl)
+		}
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
 // TestRouteGroupTimeoutWiring verifies the per-group timeout mechanism that
 // registerRoutes relies on: a route placed in a group with
 // middleware.Timeout(lifecycleRequestTimeout) sees a context deadline of ~11m,
@@ -383,23 +398,14 @@ func TestRequestTimeoutConstants(t *testing.T) {
 func TestRouteGroupTimeoutWiring(t *testing.T) {
 	var lifecycleBudget, defaultBudget time.Duration
 
-	probe := func(dst *time.Duration) http.HandlerFunc {
-		return func(w http.ResponseWriter, r *http.Request) {
-			if dl, ok := r.Context().Deadline(); ok {
-				*dst = time.Until(dl)
-			}
-			w.WriteHeader(http.StatusOK)
-		}
-	}
-
 	r := chi.NewRouter()
 	r.Group(func(r chi.Router) {
 		r.Use(middleware.Timeout(lifecycleRequestTimeout))
-		r.Post("/processes/{name}/stop", probe(&lifecycleBudget))
+		r.Post("/processes/{name}/stop", deadlineProbe(&lifecycleBudget))
 	})
 	r.Group(func(r chi.Router) {
 		r.Use(middleware.Timeout(defaultRequestTimeout))
-		r.Get("/status", probe(&defaultBudget))
+		r.Get("/status", deadlineProbe(&defaultBudget))
 	})
 
 	rec := httptest.NewRecorder()
@@ -445,6 +451,9 @@ func TestRegisterRoutes_RoutingSmoke(t *testing.T) {
 		{"POST", "/api/v1/processes/missing/start", http.StatusNotFound},
 		{"POST", "/api/v1/processes/missing/stop", http.StatusNotFound},
 		{"POST", "/api/v1/processes/missing/restart", http.StatusNotFound},
+		// Legacy async /shutdown (no wait) resolves to its handler and acks 200
+		// even with a nil coordinator wired.
+		{"POST", "/api/v1/shutdown", http.StatusOK},
 	}
 	for _, tc := range cases {
 		t.Run(tc.method+" "+tc.path, func(t *testing.T) {
@@ -453,6 +462,87 @@ func TestRegisterRoutes_RoutingSmoke(t *testing.T) {
 			assert.Equal(t, tc.wantStatus, rec.Code)
 		})
 	}
+}
+
+// TestShutdownRouteInLifecycleGroup verifies POST /shutdown carries the large
+// lifecycle ceiling, not the 30s default: its wait=true path can block for the
+// whole drain, which would otherwise be cut at 30s (#36, D4). The handler reads
+// its request deadline and reports it back so the test can assert the ceiling.
+func TestShutdownRouteInLifecycleGroup(t *testing.T) {
+	logMgr := logs.NewManager(logs.ManagerConfig{BufferSize: 100})
+	defer logMgr.Close()
+
+	cfg := &config.Config{
+		API:       config.APIConfig{Port: 0, Host: "127.0.0.1"},
+		Processes: map[string]config.ProcessConfig{},
+	}
+	sup := supervisor.New(cfg, logMgr, nil, supervisor.DefaultSupervisorConfig())
+	handlers := NewHandlers(sup, logMgr, "test.yaml", nil)
+	server := NewServer(ServerConfig{Host: "127.0.0.1", Port: 0}, handlers)
+
+	// Probe the deadline the router grants /shutdown. NOTE: probeRouter is a
+	// RECONSTRUCTION of registerRoutes' lifecycle group, not the real router — chi
+	// does not expose a per-route middleware chain to introspect, and proving the
+	// timeout CLASS distinction (11m vs 30s) directly would need a >30s test. It
+	// asserts only that a route wired the way registerRoutes wires /shutdown sees
+	// the lifecycle ceiling. The real route path (router + middleware + handler) is
+	// exercised by the sanity ack below, by TestRegisterRoutes_RoutingSmoke, and by
+	// TestShutdownRoute_WaitedResponseThroughRealRouter.
+	var shutdownBudget time.Duration
+	probeRouter := chi.NewRouter()
+	probeRouter.Route("/api/v1", func(r chi.Router) {
+		r.Group(func(r chi.Router) {
+			r.Use(middleware.Timeout(lifecycleRequestTimeout))
+			r.Post("/shutdown", deadlineProbe(&shutdownBudget))
+		})
+	})
+	rec := httptest.NewRecorder()
+	probeRouter.ServeHTTP(rec, httptest.NewRequest("POST", "/api/v1/shutdown", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Greater(t, shutdownBudget, 30*time.Second, "/shutdown must carry the lifecycle ceiling, not the 30s default")
+
+	// Sanity: the real server still routes legacy /shutdown to a 200 ack.
+	rec = httptest.NewRecorder()
+	server.router.ServeHTTP(rec, httptest.NewRequest("POST", "/api/v1/shutdown", nil))
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// TestShutdownRoute_WaitedResponseThroughRealRouter drives POST
+// /shutdown?wait=true through the REAL router + middleware chain (not the probe)
+// against a coordinator already completed with a survivor outcome, and asserts the
+// waited JSON body (HTTP 200, success=false, failures[]) comes back intact. This
+// proves the real route path delivers the waited verdict end to end.
+func TestShutdownRoute_WaitedResponseThroughRealRouter(t *testing.T) {
+	logMgr := logs.NewManager(logs.ManagerConfig{BufferSize: 100})
+	defer logMgr.Close()
+
+	cfg := &config.Config{
+		API:       config.APIConfig{Port: 0, Host: "127.0.0.1"},
+		Processes: map[string]config.ProcessConfig{},
+	}
+	sup := supervisor.New(cfg, logMgr, nil, supervisor.DefaultSupervisorConfig())
+
+	fake := newFakeShutdownController()
+	fake.complete(&domain.ProcessStopError{
+		Failures: []domain.ProcessStopFailure{
+			{Name: "web", Err: fmt.Errorf("%w: web", domain.ErrProcessGroupNotReaped)},
+		},
+	})
+	handlers := NewHandlers(sup, logMgr, "test.yaml", fake)
+	server := NewServer(ServerConfig{Host: "127.0.0.1", Port: 0}, handlers)
+
+	rec := httptest.NewRecorder()
+	server.router.ServeHTTP(rec, httptest.NewRequest("POST", "/api/v1/shutdown?wait=true", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code, "survivors still ride a 200 so the body is not discarded")
+	var resp ShutdownResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.False(t, resp.Success)
+	assert.True(t, resp.Waited)
+	require.Len(t, resp.Failures, 1)
+	assert.Equal(t, "web", resp.Failures[0].Process)
+	assert.Equal(t, domain.ErrCodeProcessGroupNotReaped, resp.Failures[0].Code)
+	assert.GreaterOrEqual(t, fake.triggerCount(), 1)
 }
 
 func TestIsLocalhostOrigin(t *testing.T) {

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -115,10 +115,44 @@ func (c *Client) RestartProcess(name string) error {
 	return c.postLifecycle("/api/v1/processes/"+url.PathEscape(name)+"/restart", &resp)
 }
 
-// Shutdown shuts down the supervisor
-func (c *Client) Shutdown() error {
-	var resp api.SuccessResponse
-	return c.post("/api/v1/shutdown", &resp)
+// ShutdownFailure is one process whose group survived a waited full stop.
+type ShutdownFailure struct {
+	Process string `json:"process"`
+	Error   string `json:"error"`
+	Code    string `json:"code"`
+}
+
+// ShutdownResult decodes a POST /api/v1/shutdown?wait=true response.
+//
+// Waited is a POINTER on purpose: an old daemon predates the wait param, ignores
+// the query, and acks with a bare {"success":true} that has no "waited" field —
+// leaving Waited nil. A nil Waited therefore means "old daemon, fire-and-forget",
+// which is distinct from a false value (never sent on the wire). Callers MUST
+// treat nil as the legacy path rather than as waited==false.
+type ShutdownResult struct {
+	Success  bool              `json:"success"`
+	Waited   *bool             `json:"waited"`
+	Failures []ShutdownFailure `json:"failures"`
+}
+
+// Shutdown requests a full daemon shutdown.
+//
+// With wait=true it posts /api/v1/shutdown?wait=true on the lifecycle client
+// (11m ceiling), blocks until the daemon returns the process-stop verdict, and
+// returns the decoded *ShutdownResult. With wait=false it posts the legacy async
+// shutdown on the plain client and returns a nil result (the daemon acks
+// immediately and tears down in the background).
+func (c *Client) Shutdown(wait bool) (*ShutdownResult, error) {
+	if !wait {
+		var resp api.SuccessResponse
+		return nil, c.post("/api/v1/shutdown", &resp)
+	}
+
+	var result ShutdownResult
+	if err := c.postLifecycle("/api/v1/shutdown?wait=true", &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
 }
 
 // buildLogQueryParams builds URL query parameters from LogParams

--- a/internal/cli/client_test.go
+++ b/internal/cli/client_test.go
@@ -355,6 +355,9 @@ func TestClient_Shutdown_WaitClean(t *testing.T) {
 
 func TestClient_Shutdown_WaitFailures(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("wait"); got != "true" {
+			t.Errorf("expected wait=true, got %q", got)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(api.ShutdownResponse{
 			Success: false,
@@ -387,6 +390,9 @@ func TestClient_Shutdown_WaitFailures(t *testing.T) {
 // pointer, so the CLI can distinguish it from a real waited response.
 func TestClient_Shutdown_WaitOldDaemon(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("wait"); got != "true" {
+			t.Errorf("expected wait=true, got %q", got)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(api.SuccessResponse{Success: true})
 	}))

--- a/internal/cli/client_test.go
+++ b/internal/cli/client_test.go
@@ -297,8 +297,8 @@ func TestClient_RestartProcess(t *testing.T) {
 	}
 }
 
-func TestClient_Shutdown(t *testing.T) {
-	called := false
+func TestClient_Shutdown_AsyncLegacy(t *testing.T) {
+	var gotWait string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/v1/shutdown" {
 			t.Errorf("unexpected path: %s", r.URL.Path)
@@ -306,22 +306,102 @@ func TestClient_Shutdown(t *testing.T) {
 		if r.Method != "POST" {
 			t.Errorf("expected POST, got %s", r.Method)
 		}
-		called = true
+		gotWait = r.URL.Query().Get("wait")
 
-		resp := api.SuccessResponse{Success: true}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp)
+		json.NewEncoder(w).Encode(api.SuccessResponse{Success: true})
 	}))
 	defer server.Close()
 
 	client := NewClient(server.URL)
-	err := client.Shutdown()
-
+	result, err := client.Shutdown(false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !called {
-		t.Error("expected server to be called")
+	if result != nil {
+		t.Errorf("async shutdown should return a nil result, got %+v", result)
+	}
+	if gotWait != "" {
+		t.Errorf("async shutdown must not set wait, got wait=%q", gotWait)
+	}
+}
+
+func TestClient_Shutdown_WaitClean(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("wait"); got != "true" {
+			t.Errorf("expected wait=true, got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(api.ShutdownResponse{
+			Success:  true,
+			Waited:   true,
+			Failures: []api.ShutdownFailureResponse{},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	result, err := client.Shutdown(true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil || result.Waited == nil || !*result.Waited {
+		t.Fatalf("expected Waited=true, got %+v", result)
+	}
+	if len(result.Failures) != 0 {
+		t.Errorf("expected no failures, got %+v", result.Failures)
+	}
+}
+
+func TestClient_Shutdown_WaitFailures(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(api.ShutdownResponse{
+			Success: false,
+			Waited:  true,
+			Failures: []api.ShutdownFailureResponse{
+				{Process: "web", Error: "process group could not be terminated: web", Code: "PROCESS_GROUP_NOT_REAPED"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	result, err := client.Shutdown(true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil || result.Waited == nil || !*result.Waited {
+		t.Fatalf("expected Waited=true, got %+v", result)
+	}
+	if len(result.Failures) != 1 || result.Failures[0].Process != "web" {
+		t.Fatalf("expected one failure for web, got %+v", result.Failures)
+	}
+	if result.Failures[0].Code != "PROCESS_GROUP_NOT_REAPED" {
+		t.Errorf("expected PROCESS_GROUP_NOT_REAPED code, got %q", result.Failures[0].Code)
+	}
+}
+
+// TestClient_Shutdown_WaitOldDaemon: an old daemon ignores wait=true and returns
+// a bare {"success":true}. The absent "waited" field must decode to a nil
+// pointer, so the CLI can distinguish it from a real waited response.
+func TestClient_Shutdown_WaitOldDaemon(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(api.SuccessResponse{Success: true})
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	result, err := client.Shutdown(true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected a decoded result")
+	}
+	if result.Waited != nil {
+		t.Errorf("old-daemon response must leave Waited nil, got %v", *result.Waited)
 	}
 }
 

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -185,6 +185,12 @@ Examples:
 	ValidArgsFunction: completeProcessNames,
 }
 
+// stopStateWaitTimeout bounds how long `prox stop` waits, after a clean
+// process-stop verdict, for the daemon's own exit (state + PID files gone). The
+// verdict already confirms the processes stopped; this only confirms the daemon
+// process finished tearing down. A timeout here is a warning, not an error.
+const stopStateWaitTimeout = 15 * time.Second
+
 func runStop(cmd *cobra.Command, args []string) error {
 	client := NewClient(apiAddr)
 
@@ -198,13 +204,98 @@ func runStop(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	// No args: stop the entire supervisor
-	if err := client.Shutdown(); err != nil {
-		return clientError(err, "Is prox running? Try 'prox up' first.")
+	// No args: stop the entire supervisor and wait for the outcome.
+	cwd, err := os.Getwd()
+	if err != nil {
+		cwd = "" // daemon.LoadState falls back to os.Getwd internally
+	}
+	return runFullStop(client, cwd, stopStateWaitTimeout)
+}
+
+// runFullStop performs a waited full daemon stop and maps the outcome to the CLI
+// exit contract (#36, D4):
+//   - transport failure: the outcome is unknown daemon-side → error (exit 1);
+//   - old daemon (Waited nil): legacy "Shutdown initiated" → exit 0;
+//   - survivors present: print each, return a one-line summary error → exit 1;
+//   - clean verdict: bounded-wait (stateWaitTimeout) for the daemon's state/PID
+//     files to vanish, print a stopped summary → exit 0 (a wait timeout prints a
+//     Warning to stderr but stays exit 0 — the process-stop verdict already
+//     succeeded). stateWaitTimeout is a parameter so tests can inject a short
+//     bound and exercise the poll-timeout branch.
+func runFullStop(client *Client, cwd string, stateWaitTimeout time.Duration) error {
+	result, err := client.Shutdown(true)
+	if err != nil {
+		// Transport failure mid-wait: the daemon may still be completing its
+		// shutdown; we cannot read the verdict from here (#36, D4).
+		return shutdownUnknownOutcomeError(cwd, err)
 	}
 
-	fmt.Println("Shutdown initiated")
+	// Old daemon: it ignored wait=true and acked immediately with no verdict.
+	if result.Waited == nil {
+		fmt.Println("Shutdown initiated")
+		return nil
+	}
+
+	// Survivors: print one line each (loud, systemd/docker-style), then return a
+	// short summary error so cobra exits 1 WITHOUT reprinting the whole list.
+	if len(result.Failures) > 0 {
+		for _, f := range result.Failures {
+			fmt.Fprintf(os.Stderr, "%s: %s\n", f.Process, f.Error)
+		}
+		return fmt.Errorf("shutdown incomplete: %d process group(s) did not terminate", len(result.Failures))
+	}
+
+	// Clean process-stop verdict. Confirm the daemon itself has exited by waiting
+	// (bounded) for the state + PID files to disappear.
+	if waitForDaemonExit(cwd, stateWaitTimeout) {
+		fmt.Println("Stopped prox")
+	} else {
+		// Verdict was clean, so exit stays 0; the daemon just hasn't finished its
+		// own teardown within the bounded wait. Surface it as a stderr warning.
+		fmt.Println("Stopped processes")
+		fmt.Fprintln(os.Stderr, "Warning: the daemon is still finishing shutdown")
+	}
 	return nil
+}
+
+// waitForDaemonExit polls until the daemon's state and PID files are both gone
+// (its exit cleanup ran) or the timeout elapses. An IsNotExist stat on each path
+// means that file is gone. Returns true once both are absent, false on timeout.
+// Existence is checked with os.Stat rather than daemon.LoadState so a poll
+// iteration never pays for a JSON parse of content that isn't needed; once the
+// state file is confirmed gone, later iterations stop re-checking it.
+func waitForDaemonExit(cwd string, timeout time.Duration) bool {
+	statePath := daemon.StatePath(cwd)
+	pidPath := daemon.PIDPath(cwd)
+	deadline := time.Now().Add(timeout)
+	stateGone := false
+	for {
+		if !stateGone {
+			_, stateErr := os.Stat(statePath)
+			stateGone = os.IsNotExist(stateErr)
+		}
+		if stateGone {
+			if _, pidErr := os.Stat(pidPath); os.IsNotExist(pidErr) {
+				return true
+			}
+		}
+		if !time.Now().Before(deadline) {
+			return false
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+// shutdownUnknownOutcomeError wraps a transport failure that struck while waiting
+// for the shutdown verdict. The daemon may still be completing its teardown, so
+// the outcome is unknown; when a daemon log file exists (detached mode) we point
+// the user at it for the authoritative result.
+func shutdownUnknownOutcomeError(cwd string, err error) error {
+	msg := "shutdown may still be completing daemon-side; outcome unknown"
+	if _, statErr := os.Stat(daemon.LogPath(cwd)); statErr == nil {
+		msg = fmt.Sprintf("%s (see %s)", msg, daemon.LogPath(cwd))
+	}
+	return fmt.Errorf("%s: %w", msg, err)
 }
 
 // downCmd represents the down command (alias for stop without arguments)

--- a/internal/cli/commands_test.go
+++ b/internal/cli/commands_test.go
@@ -7,10 +7,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/charliek/prox/internal/api"
+	"github.com/charliek/prox/internal/daemon"
 )
 
 // captureOutput redirects stdout and stderr for testing
@@ -495,5 +497,153 @@ func TestLogPrinter(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("unexpected color: %q", color1)
+	}
+}
+
+// shutdownStub builds an httptest server that answers POST /api/v1/shutdown with
+// the given status + body, so runFullStop's outcome matrix can be driven without
+// a live daemon.
+func shutdownStub(t *testing.T, status int, body interface{}) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/shutdown" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		if body != nil {
+			_ = json.NewEncoder(w).Encode(body)
+		}
+	}))
+}
+
+// runFullStopStub spins up a shutdown stub returning status/body, runs
+// runFullStop against it with a fresh temp cwd, and returns the captured
+// output plus the resulting error. Shared setup for the outcome-matrix tests
+// below that don't need to control the server's lifetime themselves (compare
+// TestRunFullStop_TransportFailure, which closes the server early).
+func runFullStopStub(t *testing.T, status int, body interface{}) (stdout, stderr string, err error) {
+	t.Helper()
+	server := shutdownStub(t, status, body)
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	stdout, stderr = captureOutput(t, func() {
+		// Temp cwd has no state/PID files, so the daemon-exit wait returns at once
+		// regardless of the bound; a short bound keeps the test snappy anyway.
+		err = runFullStop(client, t.TempDir(), 2*time.Second)
+	})
+	return stdout, stderr, err
+}
+
+// TestRunFullStop_CleanVerdict: a waited clean response with no failures, and a
+// cwd with no state/PID files (so the daemon-exit wait returns immediately),
+// yields a nil error (exit 0) and a stopped summary.
+func TestRunFullStop_CleanVerdict(t *testing.T) {
+	stdout, _, err := runFullStopStub(t, http.StatusOK, api.ShutdownResponse{
+		Success: true, Waited: true, Failures: []api.ShutdownFailureResponse{},
+	})
+	if err != nil {
+		t.Fatalf("expected nil error on clean stop, got %v", err)
+	}
+	if !strings.Contains(stdout, "Stopped") {
+		t.Errorf("expected a stopped summary, got %q", stdout)
+	}
+}
+
+// TestRunFullStop_Survivors: a waited response listing survivors prints one line
+// each and returns a non-nil summary error (cobra -> exit 1). The returned error
+// must NOT reprint the whole per-process list.
+func TestRunFullStop_Survivors(t *testing.T) {
+	_, stderr, err := runFullStopStub(t, http.StatusOK, api.ShutdownResponse{
+		Success: false, Waited: true,
+		Failures: []api.ShutdownFailureResponse{
+			{Process: "web", Error: "process group could not be terminated: web", Code: "PROCESS_GROUP_NOT_REAPED"},
+			{Process: "worker", Error: "process group could not be terminated: worker", Code: "PROCESS_GROUP_NOT_REAPED"},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected a non-nil error when process groups survive")
+	}
+	if !strings.Contains(stderr, "web:") || !strings.Contains(stderr, "worker:") {
+		t.Errorf("expected each survivor printed to stderr, got %q", stderr)
+	}
+	// The summary error is a short count, not the whole list re-rendered.
+	if strings.Contains(err.Error(), "worker:") {
+		t.Errorf("summary error should not reprint the per-process list, got %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "2 process") {
+		t.Errorf("expected a survivor count in the summary error, got %q", err.Error())
+	}
+}
+
+// TestRunFullStop_OldDaemon: a bare {"success":true} (no waited field) is the
+// old-daemon fallback -> legacy message, exit 0.
+func TestRunFullStop_OldDaemon(t *testing.T) {
+	stdout, _, err := runFullStopStub(t, http.StatusOK, api.SuccessResponse{Success: true})
+	if err != nil {
+		t.Fatalf("old-daemon fallback should exit 0, got %v", err)
+	}
+	if !strings.Contains(stdout, "Shutdown initiated") {
+		t.Errorf("expected legacy message, got %q", stdout)
+	}
+}
+
+// TestRunFullStop_TransportFailure: a dead server (connection refused) mid-wait
+// yields an unknown-outcome error (exit 1).
+func TestRunFullStop_TransportFailure(t *testing.T) {
+	server := shutdownStub(t, http.StatusOK, api.SuccessResponse{Success: true})
+	url := server.URL
+	server.Close() // now refuses connections
+
+	client := NewClient(url)
+	var err error
+	captureOutput(t, func() {
+		err = runFullStop(client, t.TempDir(), 2*time.Second)
+	})
+	if err == nil {
+		t.Fatal("expected an error on transport failure")
+	}
+	if !strings.Contains(err.Error(), "unknown") {
+		t.Errorf("expected an unknown-outcome message, got %q", err.Error())
+	}
+}
+
+// TestRunFullStop_CleanVerdictPollTimeout: a clean verdict but the daemon's
+// state/PID files never disappear within the bounded wait -> the CLI prints a
+// Warning to stderr yet stays exit 0 (the process-stop verdict already
+// succeeded). The state + PID files are pre-created so the poll actually times
+// out under a short injected bound.
+func TestRunFullStop_CleanVerdictPollTimeout(t *testing.T) {
+	server := shutdownStub(t, http.StatusOK, api.ShutdownResponse{
+		Success: true, Waited: true, Failures: []api.ShutdownFailureResponse{},
+	})
+	defer server.Close()
+
+	cwd := t.TempDir()
+	if err := daemon.EnsureStateDir(cwd); err != nil {
+		t.Fatalf("failed to create state dir: %v", err)
+	}
+	// Leave both files in place so waitForDaemonExit never sees them vanish.
+	if err := os.WriteFile(daemon.StatePath(cwd), []byte("{}"), 0o600); err != nil {
+		t.Fatalf("failed to write state file: %v", err)
+	}
+	if err := os.WriteFile(daemon.PIDPath(cwd), []byte("1"), 0o600); err != nil {
+		t.Fatalf("failed to write pid file: %v", err)
+	}
+
+	client := NewClient(server.URL)
+	var err error
+	stdout, stderr := captureOutput(t, func() {
+		err = runFullStop(client, cwd, 150*time.Millisecond)
+	})
+	if err != nil {
+		t.Fatalf("poll timeout must keep exit 0, got %v", err)
+	}
+	if !strings.Contains(stdout, "Stopped processes") {
+		t.Errorf("expected a stopped summary on stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "Warning:") || !strings.Contains(stderr, "still finishing shutdown") {
+		t.Errorf("expected a Warning about the daemon still finishing, got stderr %q", stderr)
 	}
 }

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -1,0 +1,72 @@
+package cli
+
+import (
+	"sync"
+
+	"github.com/charliek/prox/internal/domain"
+)
+
+// shutdownCoordinator mediates between the two independent sides of a daemon
+// shutdown:
+//
+//   - the trigger side (Ctrl-C, POST /shutdown, or a hand-quit --tui) requests
+//     shutdown via Trigger(); and
+//   - the outcome side (the foreground exit contract today; C5's wait=true
+//     handlers next) reads the process-stop verdict via Done()/Outcome() after
+//     performShutdown latches it with Complete().
+//
+// Both transitions are guarded by sync.Once. Trigger() fixes the latent
+// double-close panic that a second POST /shutdown used to cause (shutdownFn was
+// a bare close(shutdownCh)). Complete() is a latched broadcast: it stores the
+// outcome and closes done exactly once, so any number of waiters -- zero, one,
+// or many concurrent wait=true handlers -- all read the same stored outcome
+// after <-Done(); the shutdown sequence never blocks on a consumer (a Ctrl-C
+// with no waiter is just store + close).
+type shutdownCoordinator struct {
+	triggerOnce sync.Once
+	triggerCh   chan struct{}
+
+	completeOnce sync.Once
+	doneCh       chan struct{}
+	outcome      *domain.ProcessStopError
+}
+
+// newShutdownCoordinator returns a coordinator with fresh, un-fired trigger and
+// done channels.
+func newShutdownCoordinator() *shutdownCoordinator {
+	return &shutdownCoordinator{
+		triggerCh: make(chan struct{}),
+		doneCh:    make(chan struct{}),
+	}
+}
+
+// Trigger requests shutdown. It is idempotent: a second call (a duplicate POST
+// /shutdown, or a signal racing an API trigger) is a no-op rather than a
+// double-close panic.
+func (c *shutdownCoordinator) Trigger() {
+	c.triggerOnce.Do(func() { close(c.triggerCh) })
+}
+
+// TriggerCh is closed once shutdown has been requested. runUp selects on it (in
+// both the non-TUI wait loop and, via a quit goroutine, the TUI path).
+func (c *shutdownCoordinator) TriggerCh() <-chan struct{} { return c.triggerCh }
+
+// Complete latches the shutdown outcome and unblocks every waiter. The first
+// call wins; later calls are no-ops. The store happens-before the close, so a
+// waiter that reads Outcome() after <-Done() observes the stored value without
+// any additional synchronization.
+func (c *shutdownCoordinator) Complete(outcome *domain.ProcessStopError) {
+	c.completeOnce.Do(func() {
+		c.outcome = outcome
+		close(c.doneCh)
+	})
+}
+
+// Done is closed once Complete has latched the outcome.
+func (c *shutdownCoordinator) Done() <-chan struct{} { return c.doneCh }
+
+// Outcome returns the latched process-stop verdict (nil = clean stop). It is
+// ONLY valid after <-Done() has observed the close: called earlier it returns a
+// nil that is indistinguishable from a clean outcome, so every consumer MUST
+// select on Done() (or receive from it) before reading Outcome().
+func (c *shutdownCoordinator) Outcome() *domain.ProcessStopError { return c.outcome }

--- a/internal/cli/coordinator_test.go
+++ b/internal/cli/coordinator_test.go
@@ -30,12 +30,12 @@ func TestShutdownCoordinator_DoubleTriggerNoPanic(t *testing.T) {
 }
 
 // TestShutdownCoordinator_WiredShutdownFnDoublePost simulates the daemon wiring:
-// the API handler is handed shutdownFn := coordinator.Trigger. Two POST
-// /shutdown calls invoke it twice; the daemon must not panic (regression for the
-// bare close(shutdownCh) bug).
+// the API handler is handed the coordinator and calls Trigger() on POST
+// /shutdown. Two POST /shutdown calls invoke it twice; the daemon must not panic
+// (regression for the bare close(shutdownCh) bug).
 func TestShutdownCoordinator_WiredShutdownFnDoublePost(t *testing.T) {
 	c := newShutdownCoordinator()
-	shutdownFn := c.Trigger // exactly what runUp hands api.NewHandlers
+	shutdownFn := c.Trigger // exactly what api.NewHandlers calls via ShutdownController
 
 	assert.NotPanics(t, func() {
 		shutdownFn()

--- a/internal/cli/coordinator_test.go
+++ b/internal/cli/coordinator_test.go
@@ -1,0 +1,135 @@
+package cli
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/charliek/prox/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestShutdownCoordinator_DoubleTriggerNoPanic pins the fix for the latent
+// double-close panic: a second Trigger() (a duplicate POST /shutdown, or a
+// signal racing an API trigger) must be a no-op, not a close-of-closed-channel
+// panic.
+func TestShutdownCoordinator_DoubleTriggerNoPanic(t *testing.T) {
+	c := newShutdownCoordinator()
+	assert.NotPanics(t, func() {
+		c.Trigger()
+		c.Trigger()
+		c.Trigger()
+	})
+
+	select {
+	case <-c.TriggerCh():
+	default:
+		t.Fatal("TriggerCh must be closed after Trigger")
+	}
+}
+
+// TestShutdownCoordinator_WiredShutdownFnDoublePost simulates the daemon wiring:
+// the API handler is handed shutdownFn := coordinator.Trigger. Two POST
+// /shutdown calls invoke it twice; the daemon must not panic (regression for the
+// bare close(shutdownCh) bug).
+func TestShutdownCoordinator_WiredShutdownFnDoublePost(t *testing.T) {
+	c := newShutdownCoordinator()
+	shutdownFn := c.Trigger // exactly what runUp hands api.NewHandlers
+
+	assert.NotPanics(t, func() {
+		shutdownFn()
+		shutdownFn()
+	})
+}
+
+// TestShutdownCoordinator_CompleteBroadcastsSameOutcome: Complete once, then many
+// waiters each read the identical latched outcome after <-Done().
+func TestShutdownCoordinator_CompleteBroadcastsSameOutcome(t *testing.T) {
+	c := newShutdownCoordinator()
+	want := &domain.ProcessStopError{
+		Failures: []domain.ProcessStopFailure{{Name: "web", Err: domain.ErrProcessGroupNotReaped}},
+	}
+
+	const waiters = 8
+	var wg sync.WaitGroup
+	got := make([]*domain.ProcessStopError, waiters)
+	for i := 0; i < waiters; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-c.Done()
+			got[i] = c.Outcome()
+		}(i)
+	}
+
+	c.Complete(want)
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("waiters did not observe Complete")
+	}
+
+	for i := 0; i < waiters; i++ {
+		assert.Same(t, want, got[i], "every waiter must read the same latched outcome")
+	}
+}
+
+// TestShutdownCoordinator_CompleteOnceLatchesFirst: a second Complete is a no-op;
+// the first outcome stays latched.
+func TestShutdownCoordinator_CompleteOnceLatchesFirst(t *testing.T) {
+	c := newShutdownCoordinator()
+	first := &domain.ProcessStopError{
+		Failures: []domain.ProcessStopFailure{{Name: "a", Err: domain.ErrProcessGroupNotReaped}},
+	}
+	second := &domain.ProcessStopError{
+		Failures: []domain.ProcessStopFailure{{Name: "b", Err: domain.ErrProcessGroupNotReaped}},
+	}
+
+	c.Complete(first)
+	c.Complete(second)
+
+	<-c.Done()
+	assert.Same(t, first, c.Outcome(), "the first Complete must win")
+}
+
+// TestShutdownCoordinator_CompleteNoWaitersDoesNotBlock: the shutdown sequence
+// never blocks on a consumer — Complete with zero waiters is store + close.
+func TestShutdownCoordinator_CompleteNoWaitersDoesNotBlock(t *testing.T) {
+	c := newShutdownCoordinator()
+	done := make(chan struct{})
+	go func() {
+		c.Complete(nil) // clean outcome, no waiters
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Complete blocked with no waiters")
+	}
+
+	select {
+	case <-c.Done():
+	default:
+		t.Fatal("Done must be closed after Complete")
+	}
+	require.Nil(t, c.Outcome(), "a clean outcome is nil")
+}
+
+// TestShutdownCoordinator_OutcomeBeforeDone documents the contract: Outcome() is
+// only valid after <-Done(); read before completion it is a nil that a consumer
+// must not mistake for a clean verdict — which is exactly why every consumer
+// gates on Done() first.
+func TestShutdownCoordinator_OutcomeBeforeDone(t *testing.T) {
+	c := newShutdownCoordinator()
+
+	select {
+	case <-c.Done():
+		t.Fatal("Done must not be closed before Complete")
+	default:
+	}
+	assert.Nil(t, c.Outcome(), "Outcome before Done is nil (indistinguishable from clean; do not read it)")
+}

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -340,6 +340,15 @@ func runUp(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	// Forward an external SIGINT/SIGTERM into the shutdown coordinator so BOTH the
+	// TUI and non-TUI daemons honor it. signal.Notify above disables Go's default
+	// signal handler, so without a consumer a --tui daemon would queue an external
+	// SIGTERM forever and never tear down. Routing the signal through Trigger()
+	// gives it the same path as POST /shutdown. The goroutine consumes sigCh
+	// exactly once, then exits on ctx cancellation (defer cancel at runUp return)
+	// so it never leaks.
+	go forwardShutdownSignal(ctx, sigCh, coordinator, sup.SystemLog)
+
 	// Start proxy — either via shared daemon or standalone fallback.
 	var proxyService *proxy.Service
 	var daemonClient *proxyd.Client
@@ -430,18 +439,16 @@ func runUp(cmd *cobra.Command, args []string) error {
 		// Subscribe to logs and print to terminal
 		go printLogs(logMgr)
 
-		// Wait for shutdown signal
-		select {
-		case sig := <-sigCh:
-			fmt.Println() // Print newline after ^C
-			sup.SystemLog("%s received", sig)
-		case <-coordinator.TriggerCh():
-			fmt.Println() // Print newline
-			sup.SystemLog("shutdown requested via API")
-		}
+		// Wait for shutdown. Both a signal (via forwardShutdownSignal above, which
+		// also logs it) and an API/TUI-quit trigger arrive as a coordinator trigger,
+		// so this selects on the one channel.
+		<-coordinator.TriggerCh()
+		fmt.Println() // Print newline (past any echoed ^C)
 	}
 
-	// Stop signal handler to prevent additional signals during shutdown
+	// Stop signal handler to prevent additional signals during shutdown. The
+	// forwarder goroutine, if still blocked on sigCh, exits when ctx is canceled at
+	// runUp return.
 	signal.Stop(sigCh)
 
 	// Run the extracted shutdown sequence (same for the signal and API paths).
@@ -475,6 +482,22 @@ func runUp(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("shutdown incomplete: %w", outcome)
 	}
 	return nil
+}
+
+// forwardShutdownSignal blocks until an external SIGINT/SIGTERM arrives on sigCh
+// or ctx is canceled. On a signal it logs the receipt via logf and requests
+// shutdown through the coordinator (the same path as POST /shutdown), so a daemon
+// in either TUI or non-TUI mode honors the signal. It consumes at most one signal
+// and returns on ctx cancellation, so it never outlives runUp.
+func forwardShutdownSignal(ctx context.Context, sigCh <-chan os.Signal, coordinator *shutdownCoordinator, logf func(string, ...interface{})) {
+	select {
+	case sig := <-sigCh:
+		if sig != nil && logf != nil {
+			logf("%s received", sig)
+		}
+		coordinator.Trigger()
+	case <-ctx.Done():
+	}
 }
 
 // shutdownDeps bundles everything performShutdown needs. The supervisor is the
@@ -587,9 +610,17 @@ func performShutdown(deps shutdownDeps) *domain.ProcessStopError {
 	var outcome *domain.ProcessStopError
 	if stopErr != nil {
 		if !errors.As(stopErr, &outcome) {
-			// Non-aggregate error (ctx expiry with nothing recorded, etc.): log it;
-			// there is no typed survivor list to publish.
+			// Invariant: today sup.Stop returns only *ProcessStopError or nil, so this
+			// branch is defensive. But an acknowledged non-aggregate error (e.g. a ctx
+			// expiry, or a future error type) must NOT read as a clean stop: leaving
+			// outcome nil here would Complete(nil), hand waited clients success, and
+			// exit the foreground 0 despite the failure. Synthesize a single-failure
+			// aggregate so the error latches, reaches waited clients, and fails the
+			// foreground exit contract.
 			deps.sup.SystemLog("supervisor stop error: %v", stopErr)
+			outcome = &domain.ProcessStopError{
+				Failures: []domain.ProcessStopFailure{{Name: "supervisor", Err: stopErr}},
+			}
 		}
 	}
 

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -298,11 +298,10 @@ func runUp(cmd *cobra.Command, args []string) error {
 	// Create the shutdown coordinator. Its Trigger()/TriggerCh() replace the raw
 	// shutdownCh (a bare close was a latent double-close panic on a second POST
 	// /shutdown); its Done()/Outcome() latch the process-stop verdict for the
-	// foreground exit contract. For now the API handlers still receive the plain
-	// shutdownFn closure (= coordinator.Trigger) — C5 hands them the coordinator
-	// itself so wait=true handlers can read Done()/Outcome().
+	// foreground exit contract and for POST /shutdown?wait=true. The API handlers
+	// receive the coordinator itself (as api.ShutdownController) so a wait=true
+	// request can Trigger() the sequence and then read Done()/Outcome().
 	coordinator := newShutdownCoordinator()
-	shutdownFn := coordinator.Trigger
 
 	// Determine if authentication is required
 	authEnabled := isAuthRequired(cfg)
@@ -325,7 +324,7 @@ func runUp(cmd *cobra.Command, args []string) error {
 
 	// Create API handlers and server. The handlers get the absolute config path
 	// so GET /status reports the same file the reload path re-reads (#33, D3).
-	handlers := api.NewHandlers(sup, logMgr, absConfigPath, shutdownFn)
+	handlers := api.NewHandlers(sup, logMgr, absConfigPath, coordinator)
 	apiServer := api.NewServer(api.ServerConfig{
 		Host:        cfg.API.Host,
 		Port:        cfg.API.Port,
@@ -567,6 +566,11 @@ func performShutdown(deps shutdownDeps) *domain.ProcessStopError {
 	}
 
 	// Stage 1b: stop the standalone proxy (listeners only, never processes).
+	// Accepted pre-existing behavior (out of scope for #36): proxyService.Shutdown
+	// performs an unbounded os.RemoveAll of on-disk capture bodies before this
+	// function reaches the verdict publish. It is small in practice (capture bodies
+	// are size-capped) and the daemon is exiting anyway, so it is left as-is rather
+	// than bounded here.
 	if deps.proxyService != nil {
 		proxyCtx, proxyCancel := context.WithTimeout(context.Background(), deps.stageTimeout)
 		if err := deps.proxyService.Shutdown(proxyCtx); err != nil {

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -474,12 +474,28 @@ func runUp(cmd *cobra.Command, args []string) error {
 	apiCancel()
 
 	// Stop supervisor with a deadline sized from the live per-process stop
-	// budgets, plus a small margin for the SIGKILL escalation and finalization.
-	supCtx, supCancel := context.WithTimeout(context.Background(), sup.MaxStopBudget()+teardownStageTimeout)
-	if err := sup.Stop(supCtx); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-	}
+	// budgets, plus stopVerdictMargin (so a stop joining an in-flight primary
+	// outlives its finalization window) and a stage margin. StopWaitBound()
+	// folds in the per-process budget + verdict margin so this call site does not
+	// duplicate the constant (#36, D3).
+	supCtx, supCancel := context.WithTimeout(context.Background(), sup.StopWaitBound()+teardownStageTimeout)
+	stopErr := sup.Stop(supCtx)
 	supCancel()
+	if stopErr != nil {
+		// Surface each survivor via the existing SystemLog pattern so operators see
+		// which process leaked a group. C4 wires this outcome into the shutdown
+		// coordinator (the blocking endpoint's failure body and the foreground exit
+		// contract); C3 only captures and logs it and does NOT change runUp's return.
+		var stopFail *domain.ProcessStopError
+		if errors.As(stopErr, &stopFail) {
+			for _, f := range stopFail.Failures {
+				sup.SystemLog("process %s did not stop cleanly: %v", f.Name, f.Err)
+			}
+		} else {
+			sup.SystemLog("supervisor stop error: %v", stopErr)
+		}
+		fmt.Fprintf(os.Stderr, "Error: %v\n", stopErr)
+	}
 
 	// Log shutdown complete before closing the log manager
 	sup.SystemLog("shutdown complete")

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -295,11 +295,14 @@ func runUp(cmd *cobra.Command, args []string) error {
 	}
 	sup := supervisor.New(cfg, logMgr, nil, supConfig)
 
-	// Create shutdown channel
-	shutdownCh := make(chan struct{})
-	shutdownFn := func() {
-		close(shutdownCh)
-	}
+	// Create the shutdown coordinator. Its Trigger()/TriggerCh() replace the raw
+	// shutdownCh (a bare close was a latent double-close panic on a second POST
+	// /shutdown); its Done()/Outcome() latch the process-stop verdict for the
+	// foreground exit contract. For now the API handlers still receive the plain
+	// shutdownFn closure (= coordinator.Trigger) — C5 hands them the coordinator
+	// itself so wait=true handlers can read Done()/Outcome().
+	coordinator := newShutdownCoordinator()
+	shutdownFn := coordinator.Trigger
 
 	// Determine if authentication is required
 	authEnabled := isAuthRequired(cfg)
@@ -415,9 +418,13 @@ func runUp(cmd *cobra.Command, args []string) error {
 
 	// Handle TUI vs terminal output
 	if useTUI {
-		// Run TUI - it blocks until quit
+		// Run TUI - it blocks until quit. Passing the coordinator's trigger channel
+		// lets POST /shutdown quit the program (a goroutine inside tui.Run calls
+		// p.Quit() on trigger), so a TUI daemon honors the API shutdown and runs the
+		// same shutdown sequence + exit contract below. Quitting the TUI by hand
+		// still returns from tui.Run into that same sequence, unchanged.
 		reqMgr := localRequestManager(proxyService, handlers)
-		if err := tui.Run(sup, logMgr, reqMgr); err != nil {
+		if err := tui.Run(sup, logMgr, reqMgr, coordinator.TriggerCh()); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		}
 	} else {
@@ -429,7 +436,7 @@ func runUp(cmd *cobra.Command, args []string) error {
 		case sig := <-sigCh:
 			fmt.Println() // Print newline after ^C
 			sup.SystemLog("%s received", sig)
-		case <-shutdownCh:
+		case <-coordinator.TriggerCh():
 			fmt.Println() // Print newline
 			sup.SystemLog("shutdown requested via API")
 		}
@@ -438,74 +445,186 @@ func runUp(cmd *cobra.Command, args []string) error {
 	// Stop signal handler to prevent additional signals during shutdown
 	signal.Stop(sigCh)
 
-	// Graceful shutdown. Each stage gets its own deadline computed at shutdown
-	// time, rather than one shared deadline, so proxy/API teardown time can
-	// never eat into the supervisor's process-stop budget (#35, D2):
-	//   - proxy deregister/shutdown: teardownStageTimeout (fixed, short)
-	//   - API-server shutdown:       teardownStageTimeout (fixed, short;
-	//     force-closes any in-flight lifecycle request, whose process is then
-	//     stopped by sup.Stop immediately below)
-	//   - supervisor stop: MaxStopBudget()+margin, read live so hot-reloaded
-	//     per-process budgets are honored.
+	// Run the extracted shutdown sequence (same for the signal and API paths).
+	// It tears down proxy + supervisor + API server in order, latches the
+	// process-stop verdict on the coordinator, and flushes+closes the log manager
+	// (before the API stage — see performShutdown).
+	outcome := performShutdown(shutdownDeps{
+		sup:          sup,
+		daemonClient: daemonClient,
+		proxyService: proxyService,
+		apiServer:    apiServer,
+		coordinator:  coordinator,
+		logMgr:       logMgr,
+		cwd:          cwd,
+		stageTimeout: teardownStageTimeout,
+	})
+	// performShutdown already tore the standalone proxy down; nil the local so the
+	// early-error cleanup defer (registered above) stays a no-op.
+	proxyService = nil
 
-	// Deregister from shared daemon or stop standalone proxy
-	if daemonClient != nil {
-		if err := daemonClient.Deregister(proxyd.DeregisterRequest{
-			ProjectDir: cwd,
-			PID:        os.Getpid(),
-		}); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to deregister from proxy daemon: %v\n", err)
+	// Foreground exit contract: a surviving process group makes `prox up` exit
+	// non-zero (cobra maps a non-nil RunE error to exit 1). Intentional split:
+	// per-process detail already went to the log stream via SystemLog inside
+	// performShutdown (the only record in detached mode), so here we return ONE
+	// concise summary line rather than also letting cobra reprint every survivor —
+	// wrapping the aggregate with %w keeps errors.Is/errors.As intact on the
+	// returned error. Ctrl-C and API-triggered shutdowns behave identically.
+	// Breaking change: foreground `prox up` previously always exited 0 (CHANGELOG
+	// in C5).
+	if outcome != nil {
+		return fmt.Errorf("shutdown incomplete: %w", outcome)
+	}
+	return nil
+}
+
+// shutdownDeps bundles everything performShutdown needs. The supervisor is the
+// real concrete type (unit tests drive it through its fake-runner seams); the
+// proxy/API/logMgr deps are nil-able so a helper unit test needs no sockets or
+// daemon.
+type shutdownDeps struct {
+	sup          *supervisor.Supervisor
+	daemonClient *proxyd.Client
+	proxyService *proxy.Service
+	apiServer    *api.Server
+	coordinator  *shutdownCoordinator
+	logMgr       *logs.Manager
+	cwd          string
+	stageTimeout time.Duration
+}
+
+// performShutdown runs the daemon-side shutdown sequence and returns the
+// process-stop verdict (nil = clean). It is called from both the signal and API
+// paths (they already share the wait select) and is extracted from runUp so unit
+// tests can drive it with fakes.
+//
+// Stage order (each stage gets its own deadline so a slow stage never eats
+// another's budget, #35/D2):
+//
+//  0. RefuseLaunches — close the launch gate immediately (see below);
+//  1. proxy deregister (shared daemon) / standalone-proxy shutdown — stageTimeout;
+//  2. sup.Stop — StopWaitBound()+stageTimeout, sized from the live per-process
+//     budgets so hot-reloaded stop_timeouts are honored, and capturing the
+//     aggregate survivor verdict;
+//  3. coordinator.Complete(outcome) — publish the verdict to any waiter;
+//  4. flush + logMgr.Close() — closes SSE log subscribers so they stop holding the
+//     API open (see below);
+//  5. API-server shutdown — stageTimeout.
+//
+// The launch gate is closed FIRST (RefuseLaunches), before the deregister stage,
+// because the API keeps serving through deregister (which can take seconds) and
+// Stop's own gate flip only happens in stage 2 — without this, a StartProcess/
+// RestartProcess arriving during deregister would launch a process shutdown is
+// about to orphan.
+//
+// The API server is shut down AFTER the supervisor stage (not before, as it was
+// pre-C4) so it outlives sup.Stop: a future wait=true response (C5) must still be
+// deliverable when the verdict lands. http.Server.Shutdown never force-closes
+// in-flight requests — it stops accepting new connections, then waits for active
+// handlers to return and leaves anything still running when the deadline passes
+// for the client to see as a dropped connection. Lifecycle launches during this
+// window are refused (the #41 state gate + the C2 launch gate).
+//
+// Deviation from the plan's D4 stage order (API shutdown → flush): the log manager
+// is closed BEFORE the API stage. GET /logs/stream (SSE) handlers range over a log
+// subscription channel and would otherwise hold their connection until the 30s
+// route timeout, making apiServer.Shutdown sit out its full 5s stage on every
+// shutdown with a stream attached. Closing the manager closes those subscriber
+// channels so the handlers return at once; the API stage then only waits for any
+// small wait=true JSON write. This is safe because Write-after-Close is a no-op
+// (RingBuffer.Write always succeeds; Broadcast/Send short-circuit on a closed
+// subscription) and non-streaming GET /logs still reads the intact ring buffer, so
+// no handler panics.
+func performShutdown(deps shutdownDeps) *domain.ProcessStopError {
+	// Stage 0: refuse new launches for the whole shutdown, including the deregister
+	// stage below (the API still serves there, before Stop's own gate flip).
+	if deps.sup != nil {
+		deps.sup.RefuseLaunches()
+	}
+
+	// Stage 1a: deregister from the shared proxy daemon. The proxyd client carries
+	// its own 30s HTTP timeout and takes no ctx, so bound it to the stage here:
+	// run it on a goroutine and proceed once the stage deadline passes, leaving the
+	// call to finish or fail in the background (harmless — the daemon is exiting).
+	if deps.daemonClient != nil {
+		derr := make(chan error, 1) // buffered so an abandoned goroutine never leaks
+		go func() {
+			derr <- deps.daemonClient.Deregister(proxyd.DeregisterRequest{
+				ProjectDir: deps.cwd,
+				PID:        os.Getpid(),
+			})
+		}()
+		timer := time.NewTimer(deps.stageTimeout)
+		select {
+		case err := <-derr:
+			timer.Stop()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: failed to deregister from proxy daemon: %v\n", err)
+			}
+		case <-timer.C:
+			fmt.Fprintf(os.Stderr, "Warning: proxy daemon deregister exceeded %s; abandoning in background\n", deps.stageTimeout)
 		}
 	}
-	if proxyService != nil {
-		proxyCtx, proxyCancel := context.WithTimeout(context.Background(), teardownStageTimeout)
-		if err := proxyService.Shutdown(proxyCtx); err != nil {
+
+	// Stage 1b: stop the standalone proxy (listeners only, never processes).
+	if deps.proxyService != nil {
+		proxyCtx, proxyCancel := context.WithTimeout(context.Background(), deps.stageTimeout)
+		if err := deps.proxyService.Shutdown(proxyCtx); err != nil {
 			fmt.Fprintf(os.Stderr, "Error stopping proxy: %v\n", err)
 		}
 		proxyCancel()
-		proxyService = nil
 	}
 
-	// Stop API server
-	apiCtx, apiCancel := context.WithTimeout(context.Background(), teardownStageTimeout)
-	if err := apiServer.Shutdown(apiCtx); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-	}
-	apiCancel()
-
-	// Stop supervisor with a deadline sized from the live per-process stop
-	// budgets, plus stopVerdictMargin (so a stop joining an in-flight primary
-	// outlives its finalization window) and a stage margin. StopWaitBound()
-	// folds in the per-process budget + verdict margin so this call site does not
-	// duplicate the constant (#36, D3).
-	supCtx, supCancel := context.WithTimeout(context.Background(), sup.StopWaitBound()+teardownStageTimeout)
-	stopErr := sup.Stop(supCtx)
+	// Stage 2: stop the supervisor and capture the aggregate verdict.
+	supCtx, supCancel := context.WithTimeout(context.Background(), deps.sup.StopWaitBound()+deps.stageTimeout)
+	stopErr := deps.sup.Stop(supCtx)
 	supCancel()
+
+	var outcome *domain.ProcessStopError
 	if stopErr != nil {
-		// Surface each survivor via the existing SystemLog pattern so operators see
-		// which process leaked a group. C4 wires this outcome into the shutdown
-		// coordinator (the blocking endpoint's failure body and the foreground exit
-		// contract); C3 only captures and logs it and does NOT change runUp's return.
-		var stopFail *domain.ProcessStopError
-		if errors.As(stopErr, &stopFail) {
-			for _, f := range stopFail.Failures {
-				sup.SystemLog("process %s did not stop cleanly: %v", f.Name, f.Err)
-			}
-		} else {
-			sup.SystemLog("supervisor stop error: %v", stopErr)
+		if !errors.As(stopErr, &outcome) {
+			// Non-aggregate error (ctx expiry with nothing recorded, etc.): log it;
+			// there is no typed survivor list to publish.
+			deps.sup.SystemLog("supervisor stop error: %v", stopErr)
 		}
-		fmt.Fprintf(os.Stderr, "Error: %v\n", stopErr)
 	}
 
-	// Log shutdown complete before closing the log manager
-	sup.SystemLog("shutdown complete")
+	// Stage 3: publish the verdict. A latched broadcast — waiters (zero today, C5's
+	// wait=true handlers next) read the same stored outcome after <-Done().
+	if deps.coordinator != nil {
+		deps.coordinator.Complete(outcome)
+	}
 
-	// Give a moment for the log to be printed
+	// Stage 4: log the final lines, then flush and close the log manager BEFORE the
+	// API stage. Per-survivor detail goes to the log stream here (the only record in
+	// detached mode); runUp returns a one-line summary for the exit code. Closing the
+	// manager closes every SSE subscriber channel so /logs/stream handlers return and
+	// do not pin the API server open through the next stage (see the doc comment).
+	if deps.sup != nil {
+		if outcome != nil {
+			for _, f := range outcome.Failures {
+				deps.sup.SystemLog("process %s did not stop cleanly: %v", f.Name, f.Err)
+			}
+		}
+		deps.sup.SystemLog("shutdown complete")
+	}
+	// Give the terminal log printer a moment to drain the final lines before Close.
 	time.Sleep(logFlushDelay)
+	if deps.logMgr != nil {
+		deps.logMgr.Close()
+	}
 
-	// Close log manager
-	logMgr.Close()
-	return nil
+	// Stage 5: stop the API server, now that the verdict is published, the log
+	// subscribers are released, and any waited response can drain.
+	if deps.apiServer != nil {
+		apiCtx, apiCancel := context.WithTimeout(context.Background(), deps.stageTimeout)
+		if err := deps.apiServer.Shutdown(apiCtx); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		}
+		apiCancel()
+	}
+
+	return outcome
 }
 
 // proxDir returns the prox config directory path (~/.prox)

--- a/internal/cli/up_test.go
+++ b/internal/cli/up_test.go
@@ -347,3 +347,58 @@ func TestPerformShutdown_RefusesLaunchesDuringDeregister(t *testing.T) {
 		t.Fatal("performShutdown did not finish after the deregister stage timed out")
 	}
 }
+
+// TestForwardShutdownSignal_TriggersOnSignal pins the forwarder wiring: a signal
+// delivered on the (fake) signal channel must request shutdown via the
+// coordinator. This is the regression guard for the pre-existing bug where a
+// --tui daemon queued an external SIGTERM forever because only the non-TUI branch
+// consumed sigCh. The full TUI+SIGTERM path stays untestable headless.
+func TestForwardShutdownSignal_TriggersOnSignal(t *testing.T) {
+	coordinator := newShutdownCoordinator()
+	sigCh := make(chan os.Signal, 1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var logged string
+	go forwardShutdownSignal(ctx, sigCh, coordinator, func(format string, args ...interface{}) {
+		logged = fmt.Sprintf(format, args...)
+	})
+
+	sigCh <- syscall.SIGTERM
+
+	select {
+	case <-coordinator.TriggerCh():
+	case <-time.After(2 * time.Second):
+		t.Fatal("forwarder did not trigger shutdown on a signal")
+	}
+	assert.Contains(t, logged, "received")
+}
+
+// TestForwardShutdownSignal_ExitsOnContextCancel confirms the forwarder does not
+// leak: with no signal, canceling ctx returns it (and it must NOT trigger).
+func TestForwardShutdownSignal_ExitsOnContextCancel(t *testing.T) {
+	coordinator := newShutdownCoordinator()
+	sigCh := make(chan os.Signal, 1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		forwardShutdownSignal(ctx, sigCh, coordinator, nil)
+		close(done)
+	}()
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("forwarder did not exit on context cancel")
+	}
+
+	select {
+	case <-coordinator.TriggerCh():
+		t.Fatal("forwarder must not trigger shutdown when it exits on ctx cancel")
+	default:
+	}
+}

--- a/internal/cli/up_test.go
+++ b/internal/cli/up_test.go
@@ -1,0 +1,349 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/charliek/prox/internal/config"
+	"github.com/charliek/prox/internal/domain"
+	"github.com/charliek/prox/internal/logs"
+	"github.com/charliek/prox/internal/proxyd"
+	"github.com/charliek/prox/internal/supervisor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeStopProcess is a minimal supervisor.Process for driving performShutdown
+// through the real Supervisor without spawning OS processes. Two behaviours are
+// modelled, mirroring the supervisor package's own fakes:
+//
+//   - survivor: leader exits on SIGTERM (so the run monitor finishes) but the
+//     process group's first liveness probe reports gone and every later probe
+//     reports alive, yielding a deterministic ErrProcessGroupNotReaped — the
+//     verdict a real leaked grandchild produces.
+//   - clean: the group dies on SIGTERM (liveness flips false, leader exits), so
+//     Stop reaps it with no error.
+type fakeStopProcess struct {
+	pid      int
+	survivor bool
+
+	mu         sync.Mutex
+	waitCh     chan struct{}
+	waitClosed bool
+	aliveCalls int
+	alive      bool
+}
+
+func newFakeStopProcess(pid int, survivor bool) *fakeStopProcess {
+	return &fakeStopProcess{pid: pid, survivor: survivor, waitCh: make(chan struct{}), alive: true}
+}
+
+func (p *fakeStopProcess) PID() int { return p.pid }
+
+func (p *fakeStopProcess) Wait() error {
+	<-p.waitCh
+	return nil
+}
+
+func (p *fakeStopProcess) Signal(sig os.Signal) error {
+	if sig == syscall.SIGTERM {
+		// SIGTERM: the leader always exits so the run monitor completes promptly.
+		p.exitLeader()
+		if !p.survivor {
+			p.mu.Lock()
+			p.alive = false
+			p.mu.Unlock()
+		}
+	}
+	return nil
+}
+
+func (p *fakeStopProcess) exitLeader() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if !p.waitClosed {
+		p.waitClosed = true
+		close(p.waitCh)
+	}
+}
+
+func (p *fakeStopProcess) GroupAlive() (bool, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	call := p.aliveCalls
+	p.aliveCalls++
+	if p.survivor {
+		// Gone to the graceful poll (call 0), alive to the authoritative re-probe.
+		return call >= 1, nil
+	}
+	return p.alive, nil
+}
+
+func (p *fakeStopProcess) Stdout() io.Reader { return strings.NewReader("") }
+func (p *fakeStopProcess) Stderr() io.Reader { return strings.NewReader("") }
+
+// fakeStopRunner hands out a pre-built fakeStopProcess per process name. The
+// fakes map is populated once at construction and never mutated afterward, so
+// concurrent reads from Start need no locking.
+type fakeStopRunner struct {
+	fakes map[string]*fakeStopProcess
+}
+
+func (r *fakeStopRunner) Start(_ context.Context, cfg domain.ProcessConfig, _ map[string]string) (supervisor.Process, error) {
+	fp, ok := r.fakes[cfg.Name]
+	if !ok {
+		panic("fakeStopRunner: no fake for " + cfg.Name)
+	}
+	return fp, nil
+}
+
+// newStartedSupervisor builds and starts a Supervisor over the given named
+// fakes, returning it alongside its log manager (so a test can pass logMgr into
+// performShutdown and observe the flush/close stage). Closing the manager twice
+// is safe, so the returned handle also carries a t.Cleanup close.
+func newStartedSupervisor(t *testing.T, fakes map[string]*fakeStopProcess) (*supervisor.Supervisor, *logs.Manager) {
+	t.Helper()
+	logMgr := logs.NewManager(logs.ManagerConfig{BufferSize: 200})
+	t.Cleanup(func() { logMgr.Close() })
+
+	cfg := &config.Config{
+		API:       config.APIConfig{Port: 5599, Host: "127.0.0.1"},
+		Processes: make(map[string]config.ProcessConfig, len(fakes)),
+	}
+	for name := range fakes {
+		cfg.Processes[name] = config.ProcessConfig{Cmd: "irrelevant", StopTimeout: "3s"}
+	}
+	sup := supervisor.New(cfg, logMgr, &fakeStopRunner{fakes: fakes}, supervisor.DefaultSupervisorConfig())
+	_, err := sup.Start(context.Background())
+	require.NoError(t, err)
+	return sup, logMgr
+}
+
+// TestPerformShutdown_SurvivorNamesProcess: performShutdown over a supervisor
+// with a leaked group returns a *ProcessStopError naming that process (the value
+// runUp returns to make `prox up` exit 1), and latches it on the coordinator.
+func TestPerformShutdown_SurvivorNamesProcess(t *testing.T) {
+	sup, logMgr := newStartedSupervisor(t, map[string]*fakeStopProcess{
+		"web": newFakeStopProcess(4101, true),
+		"api": newFakeStopProcess(4102, false),
+	})
+	coord := newShutdownCoordinator()
+
+	// API-server/proxy deps are nil — the helper unit test needs no sockets.
+	outcome := performShutdown(shutdownDeps{
+		sup:          sup,
+		coordinator:  coord,
+		logMgr:       logMgr,
+		stageTimeout: teardownStageTimeout,
+	})
+
+	require.NotNil(t, outcome, "a surviving group must yield a non-nil outcome")
+	require.Len(t, outcome.Failures, 1)
+	assert.Equal(t, "web", outcome.Failures[0].Name)
+	assert.ErrorIs(t, outcome, domain.ErrProcessGroupNotReaped)
+	assert.Contains(t, outcome.Error(), "web", "the returned error must name the survivor")
+
+	// The verdict is latched for waiters (C5's wait=true handlers).
+	select {
+	case <-coord.Done():
+	default:
+		t.Fatal("performShutdown must Complete the coordinator")
+	}
+	assert.Same(t, outcome, coord.Outcome(), "coordinator must latch the same outcome")
+
+	// Fix 3 (survivor exit contract): runUp wraps the aggregate into one concise,
+	// errors.Is/As-preserving summary line for the exit code. Pin that shape here.
+	wrapped := fmt.Errorf("shutdown incomplete: %w", outcome)
+	assert.ErrorIs(t, wrapped, domain.ErrProcessGroupNotReaped, "wrap must preserve errors.Is")
+	var agg *domain.ProcessStopError
+	assert.ErrorAs(t, wrapped, &agg, "wrap must preserve errors.As")
+	assert.Contains(t, wrapped.Error(), "shutdown incomplete")
+	assert.Contains(t, wrapped.Error(), "web", "the summary line must name the survivor")
+}
+
+// TestPerformShutdown_CleanReturnsNil: a clean stop returns nil and latches a nil
+// (clean) outcome on the coordinator.
+func TestPerformShutdown_CleanReturnsNil(t *testing.T) {
+	sup, logMgr := newStartedSupervisor(t, map[string]*fakeStopProcess{
+		"web": newFakeStopProcess(4201, false),
+		"api": newFakeStopProcess(4202, false),
+	})
+	coord := newShutdownCoordinator()
+
+	outcome := performShutdown(shutdownDeps{
+		sup:          sup,
+		coordinator:  coord,
+		logMgr:       logMgr,
+		stageTimeout: teardownStageTimeout,
+	})
+
+	assert.Nil(t, outcome, "a clean stop must return a nil outcome")
+	select {
+	case <-coord.Done():
+	default:
+		t.Fatal("performShutdown must Complete the coordinator even on a clean stop")
+	}
+	assert.Nil(t, coord.Outcome())
+}
+
+// TestPerformShutdown_NilDepsNoPanic: nil proxy/API/coordinator deps are all
+// tolerated (the helper guards each), so a caller can drive just the supervisor.
+func TestPerformShutdown_NilDepsNoPanic(t *testing.T) {
+	sup, _ := newStartedSupervisor(t, map[string]*fakeStopProcess{
+		"web": newFakeStopProcess(4301, false),
+	})
+
+	var outcome *domain.ProcessStopError
+	require.NotPanics(t, func() {
+		outcome = performShutdown(shutdownDeps{sup: sup, stageTimeout: teardownStageTimeout})
+	})
+	assert.Nil(t, outcome)
+}
+
+// TestPerformShutdown_CompletesWithinBound is a coarse guard that the extracted
+// sequence does not hang for a clean stop.
+func TestPerformShutdown_CompletesWithinBound(t *testing.T) {
+	sup, logMgr := newStartedSupervisor(t, map[string]*fakeStopProcess{
+		"web": newFakeStopProcess(4401, false),
+	})
+	done := make(chan struct{})
+	go func() {
+		performShutdown(shutdownDeps{sup: sup, coordinator: newShutdownCoordinator(), logMgr: logMgr, stageTimeout: teardownStageTimeout})
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(15 * time.Second):
+		t.Fatal("performShutdown did not complete a clean stop in time")
+	}
+}
+
+// TestPerformShutdown_ClosesLogMgrBeforeAPIStage pins Fix 2: performShutdown
+// closes the log manager (releasing SSE subscribers) as part of the sequence, and
+// Write-after-Close is a no-op rather than a panic. A subscriber's channel must be
+// closed once performShutdown returns — the property that lets apiServer.Shutdown
+// return promptly instead of waiting out its stage on a held stream.
+func TestPerformShutdown_ClosesLogMgrBeforeAPIStage(t *testing.T) {
+	sup, logMgr := newStartedSupervisor(t, map[string]*fakeStopProcess{
+		"web": newFakeStopProcess(4501, false),
+	})
+
+	// Stand in for an in-flight SSE /logs/stream handler: it ranges over the
+	// subscription channel and returns when the channel closes.
+	subID, ch, err := logMgr.Subscribe(domain.LogFilter{})
+	require.NoError(t, err)
+	defer logMgr.Unsubscribe(subID)
+
+	streamReturned := make(chan struct{})
+	go func() {
+		defer close(streamReturned)
+		for range ch { //nolint:revive // draining until close is the point
+		}
+	}()
+
+	require.NotPanics(t, func() {
+		performShutdown(shutdownDeps{
+			sup:          sup,
+			coordinator:  newShutdownCoordinator(),
+			logMgr:       logMgr,
+			stageTimeout: teardownStageTimeout,
+		})
+	})
+
+	// The subscriber channel was closed by the flush/close stage, so the stand-in
+	// SSE handler returned (it would otherwise hold the API open).
+	select {
+	case <-streamReturned:
+	case <-time.After(3 * time.Second):
+		t.Fatal("log subscriber was not released by performShutdown's close stage")
+	}
+
+	// Write-after-Close must be safe (SystemLog runs through the closed manager).
+	require.NotPanics(t, func() { sup.SystemLog("post-close write must not panic") })
+}
+
+// TestPerformShutdown_RefusesLaunchesDuringDeregister pins Fix 1: RefuseLaunches
+// runs at the very top of performShutdown, so a launch arriving while an earlier
+// stage (here the deregister stage, parked on a hung daemon socket) is still
+// running is refused via the launch gate — even though supervisor state is still
+// "running" (so the #41 state pre-check does not fire; the refusal comes from the
+// gate). RestartProcess is used because its start half reaches the gate after its
+// stop half moves the process out of the "running" state (a StartProcess on the
+// still-running process would short-circuit on the already-running guard, before
+// the gate); this also exercises the accepted residual — the restart stops its
+// process and is then refused at the start half.
+func TestPerformShutdown_RefusesLaunchesDuringDeregister(t *testing.T) {
+	sup, logMgr := newStartedSupervisor(t, map[string]*fakeStopProcess{
+		"web": newFakeStopProcess(4601, false),
+	})
+
+	// A unix socket that accepts the deregister connection and then hangs (never
+	// responds), so performShutdown parks in its deregister select until the stage
+	// timeout. accepted fires once the connection lands — by then RefuseLaunches has
+	// already run (it is stage 0, before the deregister goroutine starts).
+	// Short base dir: a unix socket path must fit the platform's sun_path limit
+	// (~104 bytes on macOS), which the long default t.TempDir() path overflows.
+	sockDir, err := os.MkdirTemp("/tmp", "px")
+	require.NoError(t, err)
+	defer os.RemoveAll(sockDir)
+	sockPath := filepath.Join(sockDir, "d.sock")
+	ln, err := net.Listen("unix", sockPath)
+	require.NoError(t, err)
+	defer ln.Close()
+
+	stopHold := make(chan struct{})
+	defer close(stopHold)
+	accepted := make(chan struct{}, 1)
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			select {
+			case accepted <- struct{}{}:
+			default:
+			}
+			// Hold the connection open without responding until the test ends.
+			go func(c net.Conn) { <-stopHold; c.Close() }(conn)
+		}
+	}()
+
+	shutdownDone := make(chan struct{})
+	go func() {
+		defer close(shutdownDone)
+		performShutdown(shutdownDeps{
+			sup:          sup,
+			daemonClient: proxyd.NewClient(sockPath),
+			coordinator:  newShutdownCoordinator(),
+			logMgr:       logMgr,
+			stageTimeout: 2 * time.Second, // short so the parked deregister proceeds soon
+		})
+	}()
+
+	// Once the deregister connection is accepted, RefuseLaunches has run: a launch
+	// must be refused by the gate.
+	select {
+	case <-accepted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("deregister did not reach the daemon socket")
+	}
+	restartErr := sup.RestartProcess(context.Background(), "web")
+	assert.ErrorIs(t, restartErr, domain.ErrShutdownInProgress,
+		"a launch during the deregister stage must be refused by the pre-closed gate")
+
+	select {
+	case <-shutdownDone:
+	case <-time.After(15 * time.Second):
+		t.Fatal("performShutdown did not finish after the deregister stage timed out")
+	}
+}

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -1,6 +1,10 @@
 package domain
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
 
 // Domain errors
 var (
@@ -22,6 +26,58 @@ var (
 	// caller must run `prox up` to reconcile added/removed processes.
 	ErrProcessNotInConfig = errors.New("no longer in config")
 )
+
+// ProcessStopFailure names one process whose whole-supervisor stop did not
+// complete cleanly, carrying the error that process's Stop returned. Err wraps a
+// sentinel (e.g. ErrProcessGroupNotReaped) so callers can classify it with
+// errors.Is through the aggregate below (#36, D3).
+type ProcessStopFailure struct {
+	Name string
+	Err  error
+}
+
+// ProcessStopError aggregates the per-process failures from a single
+// Supervisor.Stop. It is returned (as a non-nil *ProcessStopError) only when at
+// least one process failed to stop cleanly; a clean stop -- or a stop with
+// nothing to do -- returns a nil error. Failures are sorted by process name for
+// stable output.
+//
+// It implements Unwrap() []error so errors.Is/errors.As see through the
+// aggregate to each failure's wrapped sentinel: errors.Is(err,
+// ErrProcessGroupNotReaped) is true when any survivor could not be reaped, and
+// errors.As(err, &*ProcessStopError) extracts the typed aggregate for
+// serialization (#36, D3).
+type ProcessStopError struct {
+	Failures []ProcessStopFailure
+}
+
+// Error renders a readable multi-process message naming each survivor and its
+// underlying error.
+func (e *ProcessStopError) Error() string {
+	if len(e.Failures) == 0 {
+		// Defensive: a ProcessStopError is only constructed with failures, but
+		// never render an empty, misleading "0 processes" message.
+		return "process stop failed"
+	}
+	parts := make([]string, len(e.Failures))
+	for i, f := range e.Failures {
+		parts[i] = fmt.Sprintf("%s: %v", f.Name, f.Err)
+	}
+	if len(parts) == 1 {
+		return "process failed to stop cleanly: " + parts[0]
+	}
+	return fmt.Sprintf("%d processes failed to stop cleanly: %s", len(parts), strings.Join(parts, "; "))
+}
+
+// Unwrap exposes each failure's error so errors.Is/errors.As traverse the
+// aggregate (Go 1.20 multi-error unwrap).
+func (e *ProcessStopError) Unwrap() []error {
+	errs := make([]error, len(e.Failures))
+	for i, f := range e.Failures {
+		errs[i] = f.Err
+	}
+	return errs
+}
 
 // Error codes for API responses
 const (

--- a/internal/domain/errors_test.go
+++ b/internal/domain/errors_test.go
@@ -2,9 +2,11 @@ package domain
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestErrorCode(t *testing.T) {
@@ -27,4 +29,46 @@ func TestErrorCode(t *testing.T) {
 			assert.Equal(t, tt.want, ErrorCode(tt.err))
 		})
 	}
+}
+
+func TestProcessStopError_IsAndAs(t *testing.T) {
+	err := &ProcessStopError{Failures: []ProcessStopFailure{
+		{Name: "web", Err: fmt.Errorf("%w: web", ErrProcessGroupNotReaped)},
+	}}
+
+	// errors.Is sees through the aggregate to the wrapped sentinel.
+	assert.ErrorIs(t, error(err), ErrProcessGroupNotReaped)
+
+	// errors.As extracts the typed aggregate for serialization.
+	var got *ProcessStopError
+	require.ErrorAs(t, error(err), &got)
+	assert.Same(t, err, got)
+}
+
+func TestProcessStopError_Message(t *testing.T) {
+	single := &ProcessStopError{Failures: []ProcessStopFailure{
+		{Name: "web", Err: ErrProcessGroupNotReaped},
+	}}
+	assert.Contains(t, single.Error(), "web")
+	assert.Contains(t, single.Error(), ErrProcessGroupNotReaped.Error())
+
+	multi := &ProcessStopError{Failures: []ProcessStopFailure{
+		{Name: "web", Err: ErrProcessGroupNotReaped},
+		{Name: "worker", Err: ErrProcessGroupNotReaped},
+	}}
+	msg := multi.Error()
+	assert.Contains(t, msg, "web")
+	assert.Contains(t, msg, "worker")
+	assert.Contains(t, msg, "2 processes")
+}
+
+func TestProcessStopError_UnwrapMulti(t *testing.T) {
+	e1 := fmt.Errorf("%w: a", ErrProcessGroupNotReaped)
+	e2 := errors.New("ctx canceled")
+	err := &ProcessStopError{Failures: []ProcessStopFailure{{Name: "a", Err: e1}, {Name: "b", Err: e2}}}
+
+	unwrapped := err.Unwrap()
+	require.Len(t, unwrapped, 2)
+	assert.Same(t, e1, unwrapped[0])
+	assert.Same(t, e2, unwrapped[1])
 }

--- a/internal/supervisor/fake_runner_test.go
+++ b/internal/supervisor/fake_runner_test.go
@@ -35,6 +35,14 @@ type fakeProcess struct {
 	waitClosed bool
 	waitErr    error
 
+	// groupAliveCalls counts GroupAlive invocations; groupAliveFn, when set,
+	// overrides the flat alive/aliveErr with a per-call script (call index
+	// passed in). This lets a test model a group that looks gone to Stop's
+	// graceful poll yet alive to the authoritative post-reap verdict re-probe --
+	// the fast, deterministic path to an unreapable verdict (#32).
+	groupAliveCalls int
+	groupAliveFn    func(call int) (bool, error)
+
 	// onSignal, when set, is invoked (synchronously, outside fp.mu) for every
 	// signal received so the test can drive liveness/leader-exit in response.
 	onSignal func(fp *fakeProcess, sig os.Signal)
@@ -83,6 +91,11 @@ func (fp *fakeProcess) Signal(sig os.Signal) error {
 func (fp *fakeProcess) GroupAlive() (bool, error) {
 	fp.mu.Lock()
 	defer fp.mu.Unlock()
+	call := fp.groupAliveCalls
+	fp.groupAliveCalls++
+	if fp.groupAliveFn != nil {
+		return fp.groupAliveFn(call)
+	}
 	return fp.alive, fp.aliveErr
 }
 

--- a/internal/supervisor/launch_gate_test.go
+++ b/internal/supervisor/launch_gate_test.go
@@ -88,6 +88,31 @@ func TestLaunchGate_StartAndRestartRefusedAfterStop(t *testing.T) {
 		"RestartProcess must refuse after shutdown")
 }
 
+// TestLaunchGate_RefuseLaunchesClosesGate pins the pre-shutdown gate flip
+// (#36, D4): RefuseLaunches closes the launch gate WITHOUT moving the supervisor
+// out of "running" (so the #41 state pre-check does not fire and read-only status
+// stays answerable), and a subsequent launch is refused by the gate itself. It is
+// idempotent with the flip Stop performs. A restart is used so the start half
+// reaches the gate after its stop half leaves the running state (a StartProcess on
+// the still-running process would short-circuit on the already-running guard).
+func TestLaunchGate_RefuseLaunchesClosesGate(t *testing.T) {
+	runner := newFakeRunner(func(call int) *fakeProcess { return newGracefulFake(1000 + call) })
+	sup := newPlainSupervisor(t, runner)
+
+	_, err := sup.Start(context.Background())
+	require.NoError(t, err)
+
+	sup.RefuseLaunches()
+	assert.Equal(t, "running", sup.Status().State,
+		"RefuseLaunches must not change supervisor state (read-only API stays answerable)")
+
+	assert.ErrorIs(t, sup.RestartProcess(context.Background(), "web"), domain.ErrShutdownInProgress,
+		"a launch after RefuseLaunches must be refused by the gate")
+
+	// Idempotent with Stop's own flip: a following Stop still completes cleanly.
+	require.NoError(t, sup.Stop(context.Background()))
+}
+
 // TestLaunchGate_RestartRefusedAfterStopBeganNoSwap drives the gate path
 // specifically (past the #41 pre-check): a restart is parked in the unlocked gap
 // between its stop half and its start half while a full Supervisor.Stop flips the

--- a/internal/supervisor/launch_gate_test.go
+++ b/internal/supervisor/launch_gate_test.go
@@ -1,0 +1,216 @@
+package supervisor
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/charliek/prox/internal/config"
+	"github.com/charliek/prox/internal/domain"
+	"github.com/charliek/prox/internal/logs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newPlainSupervisor builds a supervisor over a single "web" process backed by
+// runner, with no config reload wired (ConfigPath unset). It does not start the
+// supervisor.
+func newPlainSupervisor(t *testing.T, runner ProcessRunner) *Supervisor {
+	t.Helper()
+	logMgr := logs.NewManager(logs.ManagerConfig{BufferSize: 100})
+	t.Cleanup(func() { logMgr.Close() })
+	cfg := &config.Config{
+		API: config.APIConfig{Port: 5561, Host: "127.0.0.1"},
+		Processes: map[string]config.ProcessConfig{
+			"web": {Cmd: "irrelevant", StopTimeout: "5s"},
+		},
+	}
+	return New(cfg, logMgr, runner, DefaultSupervisorConfig())
+}
+
+// TestLaunchGate_NilGateAllowsStart: a directly-constructed ManagedProcess has no
+// launchGate installed, so Start must proceed exactly as before (#32/#36, D2
+// back-compat).
+func TestLaunchGate_NilGateAllowsStart(t *testing.T) {
+	runner := newFakeRunner(func(call int) *fakeProcess { return newGracefulFake(1000 + call) })
+	mp := newFakeManagedProcess(t, runner)
+
+	require.Nil(t, mp.launchGate, "direct construction must install no gate")
+	require.NoError(t, mp.Start(context.Background()), "a nil gate must allow the start (back-compat)")
+	assert.Equal(t, domain.ProcessStateRunning, mp.State())
+	assert.Equal(t, 1, runner.count())
+}
+
+// TestLaunchGate_StartRefusedWhenGateClosed: with the gate closed, startWithConfig
+// (via Start, the nil-pending path) refuses with ErrShutdownInProgress, applies no
+// state change, and never reaches the runner. Reopening the gate lets the same
+// process start (#32/#36, D2).
+func TestLaunchGate_StartRefusedWhenGateClosed(t *testing.T) {
+	runner := newFakeRunner(func(call int) *fakeProcess { return newGracefulFake(1000 + call) })
+	mp := newFakeManagedProcess(t, runner)
+
+	var launchable atomic.Bool // zero value: gate closed
+	mp.launchGate = func() error {
+		if !launchable.Load() {
+			return domain.ErrShutdownInProgress
+		}
+		return nil
+	}
+
+	err := mp.Start(context.Background())
+	assert.ErrorIs(t, err, domain.ErrShutdownInProgress, "a closed gate must refuse the start")
+	assert.Equal(t, domain.ProcessStateStopped, mp.State(), "state must be unchanged on refusal")
+	assert.Equal(t, 0, runner.count(), "the runner must never launch on refusal")
+
+	launchable.Store(true)
+	require.NoError(t, mp.Start(context.Background()), "an open gate must allow the start")
+	assert.Equal(t, domain.ProcessStateRunning, mp.State())
+	assert.Equal(t, 1, runner.count())
+}
+
+// TestLaunchGate_StartAndRestartRefusedAfterStop: once a full Supervisor.Stop has
+// completed, both StartProcess and RestartProcess refuse with
+// ErrShutdownInProgress (the observable contract; here the #41 supervisor-state
+// pre-check fires first -- the gate-path-specific refusal is proven separately by
+// TestLaunchGate_RestartRefusedAfterStopBeganNoSwap).
+func TestLaunchGate_StartAndRestartRefusedAfterStop(t *testing.T) {
+	runner := newFakeRunner(func(call int) *fakeProcess { return newGracefulFake(1000 + call) })
+	sup := newPlainSupervisor(t, runner)
+
+	_, err := sup.Start(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, sup.Stop(context.Background()))
+
+	assert.ErrorIs(t, sup.StartProcess(context.Background(), "web"), domain.ErrShutdownInProgress,
+		"StartProcess must refuse after shutdown")
+	assert.ErrorIs(t, sup.RestartProcess(context.Background(), "web"), domain.ErrShutdownInProgress,
+		"RestartProcess must refuse after shutdown")
+}
+
+// TestLaunchGate_RestartRefusedAfterStopBeganNoSwap drives the gate path
+// specifically (past the #41 pre-check): a restart is parked in the unlocked gap
+// between its stop half and its start half while a full Supervisor.Stop flips the
+// gate closed. When released, the start half hits the closed gate and is refused
+// BEFORE the pending-config swap -- so no swap is applied and no replacement
+// launches (#32/#36, D2).
+func TestLaunchGate_RestartRefusedAfterStopBeganNoSwap(t *testing.T) {
+	dir := t.TempDir()
+	runner := newFakeRunner(func(call int) *fakeProcess { return newGracefulFake(1000 + call) })
+	sup := newReloadSupervisor(t, dir, "processes:\n  web:\n    cmd: \"echo v1\"\n", runner)
+
+	_, err := sup.Start(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "echo v1", runner.lastConfig().Cmd)
+
+	mp := getManagedProcess(t, sup, "web")
+
+	// Park the restart between its stop and start halves so we can flip the gate
+	// before the start half runs.
+	reached := make(chan struct{})
+	release := make(chan struct{})
+	mp.restartStartBarrier = func() {
+		close(reached)
+		<-release
+	}
+
+	// Edit the file so a NON-refused restart would swap in v2; the refusal must
+	// leave this un-applied.
+	writeConfigFile(t, dir, "processes:\n  web:\n    cmd: \"echo v2\"\n")
+
+	restartErr := make(chan error, 1)
+	go func() { restartErr <- sup.RestartProcess(context.Background(), "web") }()
+
+	select {
+	case <-reached:
+	case <-time.After(5 * time.Second):
+		t.Fatal("restart did not reach the start-half barrier within timeout")
+	}
+
+	// The process is already stopped (stop half done), so Supervisor.Stop's own
+	// per-process stop returns promptly; Stop flips the gate closed and completes.
+	require.NoError(t, sup.Stop(context.Background()))
+
+	close(release)
+
+	err = recvErr(t, restartErr, "RestartProcess")
+	assert.ErrorIs(t, err, domain.ErrShutdownInProgress, "the gate must refuse the start half after Stop began")
+
+	assert.Equal(t, "echo v1", mp.Config().Cmd, "a refused launch must NOT apply the pending config swap")
+	assert.Equal(t, 1, runner.count(), "no replacement may launch")
+	assert.Equal(t, "echo v1", runner.lastConfig().Cmd, "the runner must never see the v2 config")
+}
+
+// TestLaunchGate_CheckUseWindowReplacementReaped exercises the deliberately-weak
+// D2 invariant: a launcher that read the gate open just before Supervisor.Stop
+// closed it still launches (the check/use window is real), but that replacement is
+// reaped before Stop returns. The runner's onStart hook parks the restart's start
+// half INSIDE runner.Start (past the gate check, p.mu held) while a real
+// Supervisor.Stop flips the gate and queues its own reaping stop behind this
+// launch (#32/#36, D2).
+func TestLaunchGate_CheckUseWindowReplacementReaped(t *testing.T) {
+	runner := newFakeRunner(func(call int) *fakeProcess { return newGracefulFake(1000 + call) })
+	sup := newPlainSupervisor(t, runner)
+
+	_, err := sup.Start(context.Background())
+	require.NoError(t, err)
+
+	mp := getManagedProcess(t, sup, "web")
+
+	stopErr := make(chan error, 1)
+	runner.onStart = func(call int) {
+		// call 1 is the restart's start half (the replacement). onStart runs inside
+		// runner.Start, so the gate has already authorized this launch and p.mu is
+		// held here.
+		if call != 1 {
+			return
+		}
+		// Kick off a full shutdown. It flips the gate closed under s.mu, then blocks
+		// trying to stop "web" on p.mu (held by this very launch).
+		go func() { stopErr <- sup.Stop(context.Background()) }()
+		// Wait until Stop has closed the gate, proving the flip lands while this
+		// launcher is already past the gate check (the check/use window).
+		deadline := time.Now().Add(5 * time.Second)
+		for sup.launchable.Load() {
+			if time.Now().After(deadline) {
+				t.Error("Supervisor.Stop did not close the launch gate within timeout")
+				return
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}
+
+	// The restart's start half launches the replacement in the window.
+	require.NoError(t, sup.RestartProcess(context.Background(), "web"),
+		"the replacement launches -- the gate was open when checked")
+	require.Equal(t, 2, runner.count(), "the replacement must have launched despite the concurrent flip")
+
+	// Supervisor.Stop's stop goroutine, queued on p.mu behind the launch, reaps the
+	// replacement before Stop returns: clean outcome, no live process.
+	require.NoError(t, recvErr(t, stopErr, "Supervisor.Stop"))
+	assert.Equal(t, domain.ProcessStateStopped, mp.State(), "the replacement must be reaped before Stop returns")
+
+	replacement := runner.last()
+	assert.True(t, replacement.sawSignal(sigterm), "the reaping stop must have signalled the replacement")
+}
+
+// TestLaunchGate_LaunchableResetOnStopStartCycle: the gate is open after Start,
+// closed after Stop, and reopened by a fresh Start so the process starts normally
+// (supervisor stop->start cycles happen in tests) (#32/#36, D2).
+func TestLaunchGate_LaunchableResetOnStopStartCycle(t *testing.T) {
+	runner := newFakeRunner(func(call int) *fakeProcess { return newGracefulFake(1000 + call) })
+	sup := newPlainSupervisor(t, runner)
+
+	_, err := sup.Start(context.Background())
+	require.NoError(t, err)
+	require.True(t, sup.launchable.Load(), "gate must be open after Start")
+
+	require.NoError(t, sup.Stop(context.Background()))
+	require.False(t, sup.launchable.Load(), "gate must be closed after Stop")
+
+	res, err := sup.Start(context.Background())
+	require.NoError(t, err)
+	require.True(t, sup.launchable.Load(), "gate must reopen on a re-start")
+	assert.Contains(t, res.Started, "web", "the process must start normally after the cycle")
+	assert.Equal(t, domain.ProcessStateRunning, getManagedProcess(t, sup, "web").State())
+}

--- a/internal/supervisor/process.go
+++ b/internal/supervisor/process.go
@@ -139,6 +139,14 @@ type ManagedProcess struct {
 	// in flight.
 	episode *stopEpisode
 
+	// launchGate, when set, is the supervisor's launch gate closure (#32/#36, D2).
+	// startWithConfig invokes it inside its p.mu critical section, after the state
+	// and surviving-group guards and BEFORE the pending-config swap; a non-nil
+	// error (ErrShutdownInProgress) aborts the launch with no swap applied and the
+	// state unchanged. supervisor.createManagedProcess injects it; nil (direct
+	// NewManagedProcess construction in tests) means "always allow".
+	launchGate func() error
+
 	// stopBarrier is a test-only seam (nil in production). Stop invokes it,
 	// unlocked, at two interleaving-sensitive points identified by phase:
 	//
@@ -289,6 +297,29 @@ func (p *ManagedProcess) startWithConfig(ctx context.Context, pending *pendingCo
 		if alive, _ := p.current.proc.GroupAlive(); alive {
 			return fmt.Errorf("%w: %s (previous instance still running; stop it first)",
 				domain.ErrProcessGroupNotReaped, p.name)
+		}
+	}
+
+	// Launch gate (#32/#36, D2). Called here -- inside the p.mu critical section,
+	// after the state and surviving-group guards, before the pending-config swap
+	// and the runner launch -- so a refusal applies no swap, leaves the state
+	// unchanged, and returns the gate's error (ErrShutdownInProgress). The closure
+	// reads only an atomic (see createManagedProcess); it must NOT take s.mu, whose
+	// s.mu -> p.mu order would AB-BA here.
+	//
+	// Invariant (D2, deliberately weak): a launcher that OBSERVES the gate closed
+	// never launches. A launcher that read the gate open just before Supervisor.Stop
+	// flipped it may still launch while holding p.mu -- but that is harmless: Stop
+	// flips the gate under s.mu before it spawns the per-process stop goroutines, so
+	// this process's stop goroutine, queued on p.mu behind this very launch, reaps
+	// the replacement before Supervisor.Stop returns. No replacement outlives
+	// Supervisor.Stop. The stronger "cannot launch after Stop began" is NOT claimed;
+	// a full launch lease (RWMutex) was considered and rejected -- a new lock class
+	// and ordering rules to exclude a transient the invariant already renders
+	// harmless (no orphan survives daemon exit).
+	if p.launchGate != nil {
+		if err := p.launchGate(); err != nil {
+			return err
 		}
 	}
 

--- a/internal/supervisor/process.go
+++ b/internal/supervisor/process.go
@@ -62,6 +62,32 @@ type pendingConfig struct {
 	stopTimeout time.Duration
 }
 
+// stopEpisode carries the verdict of a single in-flight Stop to any concurrent
+// secondary Stop that joins while the process is Stopping. Exactly one episode
+// is installed at every state->Stopping transition (both the normal entry and
+// the crashed-retry fall-through) and resolved exactly once, via
+// resolveStopEpisodeLocked, IN THE SAME p.mu critical section that commits the
+// terminal state verdict.
+//
+// Invariant: any goroutine that observes the terminal state (Stopped/Crashed)
+// under p.mu also observes the episode resolved -- state commit and episode
+// resolution are one atomic step. A Stop that arrives after the commit is by
+// definition NOT concurrent with the episode; it correctly sees
+// ErrProcessNotRunning (clean case) or starts a legitimate fresh retry episode
+// (surviving-group case). That boundary is expected behavior, not divergence.
+//
+// resolved (guarded by p.mu) makes resolution idempotent so the deferred panic
+// backstop is a no-op once the explicit in-critical-section resolution has run.
+// done is closed AFTER err is written, so a waiter that reads err after <-done
+// needs no lock (the write happens-before the close). Episodes are distinct
+// objects per transition, so a waiter that captured episode N never observes
+// episode N+1's verdict (#32, D1).
+type stopEpisode struct {
+	done     chan struct{}
+	err      error
+	resolved bool
+}
+
 // ManagedProcess handles the lifecycle of a single process
 type ManagedProcess struct {
 	mu sync.RWMutex
@@ -105,6 +131,27 @@ type ManagedProcess struct {
 	// hold a restart open in the unlocked gap between its stop and start and race
 	// a concurrent StartProcess into it. Read once under the lock in Restart.
 	restartStartBarrier func()
+
+	// episode is the in-flight stop's verdict carrier, installed under mu at every
+	// state->Stopping transition and cleared by finishStopEpisode when that stop
+	// resolves. A secondary Stop joining while state==Stopping captures it under
+	// mu and waits on it for the primary's verdict (#32, D1). nil when no stop is
+	// in flight.
+	episode *stopEpisode
+
+	// stopBarrier is a test-only seam (nil in production). Stop invokes it,
+	// unlocked, at two interleaving-sensitive points identified by phase:
+	//
+	//   - "primary-installed": in the primary path just after the stop episode is
+	//     installed and the lock released (before any signalling/verdict work), so
+	//     a test can hold the primary open with its episode published.
+	//   - "secondary-joined": in the Stopping branch just after a secondary
+	//     captured the in-flight episode and released the lock (before it waits on
+	//     the verdict), so a test can confirm the join happened.
+	//
+	// Together they make concurrent-stop interleavings deterministic without
+	// sleeps (#32), mirroring the restartStartBarrier seam pattern.
+	stopBarrier func(phase string)
 
 	// shutdownTimeout is this process's effective stop budget: the
 	// no-context-deadline fallback in computeDeadlines. supervisor.
@@ -365,13 +412,14 @@ func (p *ManagedProcess) computeDeadlines(ctx context.Context) (gracefulDeadline
 // Stop stops the process gracefully, escalating to SIGKILL if the group does
 // not exit within the graceful window, and reports an error only if the group
 // truly survives. See design doc D3.
-func (p *ManagedProcess) Stop(ctx context.Context) error {
+func (p *ManagedProcess) Stop(ctx context.Context) (retErr error) {
 	p.mu.Lock()
 
 	switch p.state {
 	case domain.ProcessStateStopped, domain.ProcessStateCrashed:
 		// Nothing running, unless a group survived a prior stop / unexpected
-		// leader exit -- in which case fall through and reap it (retry path).
+		// leader exit -- in which case fall through and reap it (retry path),
+		// installing a fresh episode below.
 		if p.current == nil || p.current.proc == nil {
 			p.mu.Unlock()
 			return domain.ErrProcessNotRunning
@@ -382,37 +430,78 @@ func (p *ManagedProcess) Stop(ctx context.Context) error {
 		}
 		// Surviving group: fall through to reap it.
 	case domain.ProcessStateStopping:
-		// A stop is already in flight; wait for it (or ctx) on the in-flight
-		// run's done channel.
-		//
-		// Known limitation: inst.done closing means the run's monitor finished
-		// (leader reaped), not that the PRIMARY Stop finished its group polling
-		// and verdict. So a concurrent secondary Stop can return nil slightly
-		// before the primary's verdict, and -- only in the doubly-rare case of
-		// two concurrent Stops on the same process AND a genuinely unreapable
-		// group -- can report success while the primary returns
-		// ErrProcessGroupNotReaped. The common (killable) case is consistent:
-		// both return nil. Serializing concurrent same-process stops (or
-		// propagating the primary's result to waiters) is tracked as future
-		// work; the primary always reaps/reports correctly.
+		// A stop is already in flight. Wait for the PRIMARY's published verdict
+		// via the stop episode -- NOT merely the run monitor's leader-reaped
+		// signal -- so two concurrent Stops on the same process return the same
+		// result when both caller contexts stay live through episode completion
+		// (#32, D1). A caller whose context dies first still gets ctx.Err().
+		ep := p.episode
 		inst := p.current
+		barrier := p.stopBarrier
 		p.mu.Unlock()
-		if inst == nil {
-			return nil
+
+		if ep == nil {
+			// Defensive: a Stopping state should always carry an episode (every
+			// transition installs one), so with the atomic commit+resolution above
+			// this branch is unreachable. If it ever isn't, wait on the run monitor
+			// and then take a fresh authoritative probe -- mirroring the primary's
+			// verdict logic -- rather than blindly reporting success.
+			if inst == nil || inst.proc == nil {
+				return nil
+			}
+			select {
+			case <-inst.done:
+				if alive, _ := inst.proc.GroupAlive(); alive {
+					return fmt.Errorf("%w: %s", domain.ErrProcessGroupNotReaped, p.name)
+				}
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
 		}
+
+		if barrier != nil {
+			barrier("secondary-joined")
+		}
+
 		select {
-		case <-inst.done:
-			return nil
+		case <-ep.done:
+			// The err write happens-before close(ep.done), so no lock is needed.
+			return ep.err
 		case <-ctx.Done():
-			return ctx.Err()
+			// Simultaneous readiness: re-check the episode non-blocking and prefer
+			// a published verdict over ctx.Err(), so a real result is never
+			// dropped when done and ctx fire at once (#32, D1).
+			select {
+			case <-ep.done:
+				return ep.err
+			default:
+				return ctx.Err()
+			}
 		}
 	}
 
+	// Primary path: commit the Stopping transition and install a fresh episode to
+	// carry this call's verdict to any secondary waiter. The episode is resolved
+	// in-line with each terminal-state commit below (early-exit and the final
+	// verdict), inside the SAME p.mu critical section, so the two are observed
+	// atomically. The deferred backstop only fires if a recovered panic skipped
+	// that resolution (#32, D1).
 	p.state = domain.ProcessStateStopping
+	ep := &stopEpisode{done: make(chan struct{})}
+	p.episode = ep
+
 	inst := p.current
 	healthChecker := p.healthChecker
 	p.healthChecker = nil
+	barrier := p.stopBarrier
 	p.mu.Unlock()
+
+	defer func() { p.backstopStopEpisode(ep, inst, retErr) }()
+
+	if barrier != nil {
+		barrier("primary-installed")
+	}
 
 	// Stop the health checker for this run.
 	if healthChecker != nil {
@@ -422,6 +511,7 @@ func (p *ManagedProcess) Stop(ctx context.Context) error {
 	if inst == nil || inst.proc == nil {
 		p.mu.Lock()
 		p.state = domain.ProcessStateStopped
+		p.resolveStopEpisodeLocked(ep, nil)
 		p.mu.Unlock()
 		return nil
 	}
@@ -472,6 +562,11 @@ func (p *ManagedProcess) Stop(ctx context.Context) error {
 	// authoritative.
 	alive, _ := inst.proc.GroupAlive()
 
+	var verdict error
+	if alive {
+		verdict = fmt.Errorf("%w: %s", domain.ErrProcessGroupNotReaped, p.name)
+	}
+
 	p.mu.Lock()
 	if p.current == inst {
 		if alive {
@@ -484,12 +579,59 @@ func (p *ManagedProcess) Stop(ctx context.Context) error {
 	if inst.cancel != nil {
 		inst.cancel()
 	}
+	// Resolve the episode in the SAME critical section that commits the terminal
+	// state, so any goroutine observing the state under p.mu also observes the
+	// published verdict -- no torn window between commit and resolution.
+	p.resolveStopEpisodeLocked(ep, verdict)
 	p.mu.Unlock()
 
-	if alive {
-		return fmt.Errorf("%w: %s", domain.ErrProcessGroupNotReaped, p.name)
+	if barrier != nil {
+		barrier("verdict-committed")
 	}
-	return nil
+
+	return verdict
+}
+
+// resolveStopEpisodeLocked resolves a stop episode exactly once. The caller MUST
+// hold p.mu, and MUST call it in the same critical section that commits the
+// terminal state verdict, so the two are observed atomically (see stopEpisode's
+// invariant). It records the verdict, detaches the episode (only if p.episode
+// still points at ep -- a later Stop may already have installed a newer one),
+// and closes ep.done so waiters observe the result. Idempotent: a second call
+// (e.g. the deferred panic backstop after the explicit resolution) is a no-op.
+// Writing err before closing done gives waiters a lock-free read.
+func (p *ManagedProcess) resolveStopEpisodeLocked(ep *stopEpisode, err error) {
+	if ep.resolved {
+		return
+	}
+	ep.resolved = true
+	ep.err = err
+	if p.episode == ep {
+		p.episode = nil
+	}
+	close(ep.done)
+}
+
+// backstopStopEpisode is the deferred panic backstop for a primary Stop. On every
+// normal exit the episode is already resolved in-line with the state commit, so
+// this is a no-op. It only acts when a (recovered) panic skipped the explicit
+// resolution: it publishes a verdict so waiters never hang and -- if the process
+// is still stranded mid-stop (state Stopping, this run still current) -- moves it
+// to Crashed so the group stays reapable by a retry. Unrecovered panics kill the
+// process anyway; this is belt-and-braces for recovered ones.
+func (p *ManagedProcess) backstopStopEpisode(ep *stopEpisode, inst *processInstance, err error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if ep.resolved {
+		return
+	}
+	if p.state == domain.ProcessStateStopping && p.current == inst {
+		p.state = domain.ProcessStateCrashed
+	}
+	if err == nil {
+		err = fmt.Errorf("%w: %s (stop aborted before verdict)", domain.ErrProcessGroupNotReaped, p.name)
+	}
+	p.resolveStopEpisodeLocked(ep, err)
 }
 
 // waitGroupGone polls proc's group liveness on groupPollInterval until the

--- a/internal/supervisor/process.go
+++ b/internal/supervisor/process.go
@@ -148,7 +148,7 @@ type ManagedProcess struct {
 	launchGate func() error
 
 	// stopBarrier is a test-only seam (nil in production). Stop invokes it,
-	// unlocked, at two interleaving-sensitive points identified by phase:
+	// unlocked, at interleaving-sensitive points identified by phase:
 	//
 	//   - "primary-installed": in the primary path just after the stop episode is
 	//     installed and the lock released (before any signalling/verdict work), so
@@ -156,6 +156,12 @@ type ManagedProcess struct {
 	//   - "secondary-joined": in the Stopping branch just after a secondary
 	//     captured the in-flight episode and released the lock (before it waits on
 	//     the verdict), so a test can confirm the join happened.
+	//   - "finalizing": in the primary path inside the finalization window, after
+	//     the monitor-drain wait and BEFORE the authoritative verdict/state commit,
+	//     so a test can hold a verdict late and prove a concurrent secondary
+	//     waiter outlives exactly this tail (the window stopVerdictMargin covers).
+	//   - "verdict-committed": in the primary path just after the terminal state
+	//     and episode were committed atomically, to probe that boundary.
 	//
 	// Together they make concurrent-stop interleavings deterministic without
 	// sleeps (#32), mirroring the restartStartBarrier seam pattern.
@@ -406,8 +412,14 @@ func (p *ManagedProcess) startWithConfig(ctx context.Context, pending *pendingCo
 // computeDeadlines derives the graceful (SIGTERM) and kill (SIGKILL/verify)
 // deadlines for a Stop from the caller's context.
 //
-//   - If ctx has no deadline, a fallback of shutdownTimeout (or
-//     constants.DefaultShutdownTimeout when unset) is used.
+//   - The per-process stop budget (shutdownTimeout, or
+//     constants.DefaultShutdownTimeout when unset) is the graceful+kill window.
+//     It is the fallback when ctx carries no deadline, AND an upper bound when
+//     ctx carries a LATER one: Supervisor.Stop deliberately grants each goroutine
+//     StopTimeout + stopVerdictMargin so a stop joining an in-flight primary as a
+//     secondary can outlive the primary's finalization window, but that oversized
+//     ctx must not stretch THIS process's own escalation past its stop_timeout
+//     (#35). An EARLIER ctx deadline (e.g. a short API request) is still honored.
 //   - KillGrace is reserved at the tail for the SIGKILL phase, so the graceful
 //     phase ends at (deadline - KillGrace).
 //   - If the budget is already spent (remaining <= 0) or too small to reserve
@@ -419,13 +431,24 @@ func (p *ManagedProcess) startWithConfig(ctx context.Context, pending *pendingCo
 func (p *ManagedProcess) computeDeadlines(ctx context.Context) (gracefulDeadline, killDeadline time.Time) {
 	now := time.Now()
 
+	// Read the per-process budget exactly ONCE and use it for both the
+	// no-deadline fallback and the later-deadline cap below, so there is no
+	// double-read window. The budget in force when this stop began governs
+	// escalation; a caller ctx with a LATER deadline is only an outer bound and
+	// cannot stretch escalation past stop_timeout (#35). A config swap cannot
+	// occur mid-stop -- startWithConfig only swaps while a start is permitted, and
+	// this stop has already set state=Stopping, which blocks startWithConfig -- so
+	// this value is stable for the whole stop; it is exactly the budget the
+	// running (or replacement) process was launched under, the correct governor.
+	budget := p.StopTimeout()
+	if budget <= 0 {
+		budget = constants.DefaultShutdownTimeout
+	}
+	budgetDeadline := now.Add(budget)
+
 	dl, ok := ctx.Deadline()
-	if !ok {
-		timeout := p.StopTimeout()
-		if timeout <= 0 {
-			timeout = constants.DefaultShutdownTimeout
-		}
-		dl = now.Add(timeout)
+	if !ok || dl.After(budgetDeadline) {
+		dl = budgetDeadline
 	}
 
 	// If the budget is already spent (remaining <= 0) or too small to reserve
@@ -587,6 +610,14 @@ func (p *ManagedProcess) Stop(ctx context.Context) (retErr error) {
 	select {
 	case <-inst.done:
 	case <-time.After(outputDrainTimeout + time.Second):
+	}
+
+	// Test seam: park inside the finalization window, AFTER the monitor-drain
+	// wait and BEFORE the authoritative verdict/state commit, so a test can hold a
+	// primary's verdict late and prove a concurrent secondary waiter (sized by
+	// Supervisor.Stop's stopVerdictMargin) outlives exactly this tail (#32/#36).
+	if barrier != nil {
+		barrier("finalizing")
 	}
 
 	// Verdict: a fresh probe now that the leader has been reaped is

--- a/internal/supervisor/stop_episode_test.go
+++ b/internal/supervisor/stop_episode_test.go
@@ -1,0 +1,527 @@
+package supervisor
+
+import (
+	"context"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/charliek/prox/internal/config"
+	"github.com/charliek/prox/internal/domain"
+	"github.com/charliek/prox/internal/logs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stopGate coordinates a concurrent-Stop interleaving deterministically (no
+// sleeps) via the ManagedProcess.stopBarrier seam. The primary Stop parks at
+// parkPhase (default "primary-installed": episode published, state Stopping)
+// until releasePrimary is closed; every secondary reports its join on
+// "secondary-joined". A test waits for the primary to park and for N secondaries
+// to join, then releases the primary so its verdict resolves the shared episode
+// (#32, D1). Setting parkPhase to "verdict-committed" parks the primary AFTER the
+// terminal state and episode were committed atomically, to probe that boundary.
+type stopGate struct {
+	parkPhase      string
+	primaryReached chan struct{}
+	releasePrimary chan struct{}
+	joined         chan struct{}
+}
+
+func newStopGate() *stopGate { return newStopGateAt("primary-installed") }
+
+func newStopGateAt(phase string) *stopGate {
+	return &stopGate{
+		parkPhase:      phase,
+		primaryReached: make(chan struct{}),
+		releasePrimary: make(chan struct{}),
+		joined:         make(chan struct{}, 16),
+	}
+}
+
+func (g *stopGate) barrier(phase string) {
+	switch phase {
+	case g.parkPhase:
+		close(g.primaryReached)
+		<-g.releasePrimary
+	case "secondary-joined":
+		g.joined <- struct{}{}
+	}
+}
+
+// awaitPrimary blocks until the primary Stop has installed its episode and
+// parked at the barrier.
+func (g *stopGate) awaitPrimary(t *testing.T) {
+	t.Helper()
+	select {
+	case <-g.primaryReached:
+	case <-time.After(5 * time.Second):
+		t.Fatal("primary Stop did not install its episode within timeout")
+	}
+}
+
+// awaitJoins blocks until n secondary Stops have captured the in-flight episode.
+func (g *stopGate) awaitJoins(t *testing.T, n int) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		select {
+		case <-g.joined:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("secondary %d did not join the episode within timeout", i)
+		}
+	}
+}
+
+// goStop runs mp.Stop(ctx) on a goroutine and returns a channel carrying its
+// result.
+func goStop(mp *ManagedProcess, ctx context.Context) <-chan error {
+	ch := make(chan error, 1)
+	go func() { ch <- mp.Stop(ctx) }()
+	return ch
+}
+
+// recvErr reads a Stop result with a generous timeout so a hung waiter fails the
+// test loudly instead of blocking forever.
+func recvErr(t *testing.T, ch <-chan error, what string) error {
+	t.Helper()
+	select {
+	case err := <-ch:
+		return err
+	case <-time.After(10 * time.Second):
+		t.Fatalf("%s did not return within timeout", what)
+		return nil
+	}
+}
+
+// newFastUnreapableFake models a surviving grandchild whose verdict is reached
+// without the SIGKILL kill-grace wall wait: the leader exits on SIGTERM (so the
+// run monitor finishes and done closes) while GroupAlive reports the group gone
+// to Stop's graceful poll (call 0) yet alive to the authoritative post-reap
+// verdict re-probe (call 1+). The result is a deterministic, fast
+// ErrProcessGroupNotReaped -- the exact corner the verdict re-probe exists to
+// catch (#32).
+func newFastUnreapableFake(pid int) *fakeProcess {
+	fp := newFakeProcess(pid)
+	fp.onSignal = func(fp *fakeProcess, sig os.Signal) {
+		if sig == sigterm {
+			fp.exitLeader(nil)
+		}
+	}
+	fp.groupAliveFn = func(call int) (bool, error) { return call >= 1, nil }
+	return fp
+}
+
+// TestStopEpisode_ConcurrentCleanSameVerdict: a primary and a secondary Stop of
+// a cleanly-reaped group both return nil. The secondary joins the primary's
+// episode (deterministically, via the barrier) and receives the published
+// verdict rather than short-circuiting to ErrProcessNotRunning.
+func TestStopEpisode_ConcurrentCleanSameVerdict(t *testing.T) {
+	runner := newFakeRunner(func(call int) *fakeProcess { return newGracefulFake(1000 + call) })
+	mp := newFakeManagedProcess(t, runner)
+	require.NoError(t, mp.Start(context.Background()))
+
+	gate := newStopGate()
+	mp.stopBarrier = gate.barrier
+
+	primary := goStop(mp, context.Background())
+	gate.awaitPrimary(t)
+
+	secondary := goStop(mp, context.Background())
+	gate.awaitJoins(t, 1)
+
+	close(gate.releasePrimary)
+
+	require.NoError(t, recvErr(t, primary, "primary Stop"))
+	require.NoError(t, recvErr(t, secondary, "secondary Stop"))
+	assert.Equal(t, domain.ProcessStateStopped, mp.State())
+}
+
+// TestStopEpisode_ConcurrentUnreapableSameVerdict: with a group that survives,
+// both the primary and the secondary Stop return ErrProcessGroupNotReaped. The
+// secondary observes the primary's verdict, not a spurious success (the #32 bug).
+func TestStopEpisode_ConcurrentUnreapableSameVerdict(t *testing.T) {
+	runner := newFakeRunner(func(call int) *fakeProcess { return newFastUnreapableFake(2000 + call) })
+	mp := newFakeManagedProcess(t, runner)
+	require.NoError(t, mp.Start(context.Background()))
+
+	gate := newStopGate()
+	mp.stopBarrier = gate.barrier
+
+	primary := goStop(mp, context.Background())
+	gate.awaitPrimary(t)
+
+	secondary := goStop(mp, context.Background())
+	gate.awaitJoins(t, 1)
+
+	close(gate.releasePrimary)
+
+	perr := recvErr(t, primary, "primary Stop")
+	serr := recvErr(t, secondary, "secondary Stop")
+	assert.ErrorIs(t, perr, domain.ErrProcessGroupNotReaped, "primary must report the surviving group")
+	assert.ErrorIs(t, serr, domain.ErrProcessGroupNotReaped, "secondary must observe the same verdict")
+	assert.Equal(t, domain.ProcessStateCrashed, mp.State())
+}
+
+// TestStopEpisode_ThreeConcurrentWaitersSameVerdict: three secondaries joining
+// one in-flight primary all receive the identical (nil) verdict.
+func TestStopEpisode_ThreeConcurrentWaitersSameVerdict(t *testing.T) {
+	runner := newFakeRunner(func(call int) *fakeProcess { return newGracefulFake(3000 + call) })
+	mp := newFakeManagedProcess(t, runner)
+	require.NoError(t, mp.Start(context.Background()))
+
+	gate := newStopGate()
+	mp.stopBarrier = gate.barrier
+
+	primary := goStop(mp, context.Background())
+	gate.awaitPrimary(t)
+
+	const waiters = 3
+	results := make([]<-chan error, waiters)
+	for i := range results {
+		results[i] = goStop(mp, context.Background())
+	}
+	gate.awaitJoins(t, waiters)
+
+	close(gate.releasePrimary)
+
+	require.NoError(t, recvErr(t, primary, "primary Stop"))
+	for i, ch := range results {
+		require.NoErrorf(t, recvErr(t, ch, "waiter Stop"), "waiter %d must get the same nil verdict", i)
+	}
+	assert.Equal(t, domain.ProcessStateStopped, mp.State())
+}
+
+// TestStopEpisode_CanceledSecondaryGetsCtxErr: a secondary whose context is
+// canceled before the primary's verdict lands returns ctx.Err(), while the
+// primary still delivers its own verdict to completion.
+func TestStopEpisode_CanceledSecondaryGetsCtxErr(t *testing.T) {
+	runner := newFakeRunner(func(call int) *fakeProcess { return newGracefulFake(4000 + call) })
+	mp := newFakeManagedProcess(t, runner)
+	require.NoError(t, mp.Start(context.Background()))
+
+	gate := newStopGate()
+	mp.stopBarrier = gate.barrier
+
+	primary := goStop(mp, context.Background())
+	gate.awaitPrimary(t)
+
+	secCtx, secCancel := context.WithCancel(context.Background())
+	secondary := goStop(mp, secCtx)
+	gate.awaitJoins(t, 1)
+
+	// The primary is still parked, so the episode is unresolved: canceling the
+	// secondary's context must make it return ctx.Err() (not the not-yet-published
+	// verdict).
+	secCancel()
+	serr := recvErr(t, secondary, "secondary Stop")
+	assert.ErrorIs(t, serr, context.Canceled, "canceled secondary must return ctx.Err()")
+
+	// The primary is unaffected and delivers its own verdict.
+	close(gate.releasePrimary)
+	require.NoError(t, recvErr(t, primary, "primary Stop"))
+	assert.Equal(t, domain.ProcessStateStopped, mp.State())
+}
+
+// TestStopEpisode_SimultaneousReadinessPrefersVerdict: when the episode is
+// already resolved AND the caller's context is already canceled, the Stopping
+// branch must prefer the published verdict over ctx.Err(). Looped so the runtime
+// exercises both arms of the outer select.
+func TestStopEpisode_SimultaneousReadinessPrefersVerdict(t *testing.T) {
+	runner := newFakeRunner(func(call int) *fakeProcess { return newGracefulFake(5000 + call) })
+	mp := newFakeManagedProcess(t, runner)
+
+	verdict := domain.ErrProcessGroupNotReaped
+	ep := &stopEpisode{done: make(chan struct{}), err: verdict}
+	close(ep.done)
+
+	mp.mu.Lock()
+	mp.state = domain.ProcessStateStopping
+	mp.episode = ep
+	mp.mu.Unlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already canceled: both ep.done and ctx.Done() are ready
+
+	for i := 0; i < 500; i++ {
+		err := mp.Stop(ctx)
+		require.ErrorIs(t, err, domain.ErrProcessGroupNotReaped,
+			"a ready episode must win over an already-canceled context (iter %d)", i)
+	}
+}
+
+// TestStopEpisode_RetryEpisodeIsolation: a waiter that joined episode 1 (an
+// unreapable group) observes episode 1's error; a fresh retry Stop installs a
+// distinct episode 2 that -- with the group now killable -- resolves nil, and
+// episode 2's waiters observe nil. A late/early waiter never sees the other
+// episode's verdict.
+func TestStopEpisode_RetryEpisodeIsolation(t *testing.T) {
+	var killable atomic.Bool
+	runner := newFakeRunner(func(call int) *fakeProcess {
+		fp := newFakeProcess(6000 + call)
+		fp.onSignal = func(fp *fakeProcess, sig os.Signal) {
+			if sig == sigterm {
+				fp.exitLeader(nil)
+			}
+		}
+		// While unreapable: gone to the graceful poll, alive to the verdict.
+		// Once killable: the group is reapable, so every probe reports gone.
+		fp.groupAliveFn = func(call int) (bool, error) {
+			if killable.Load() {
+				return false, nil
+			}
+			return call >= 1, nil
+		}
+		return fp
+	})
+	mp := newFakeManagedProcess(t, runner)
+	require.NoError(t, mp.Start(context.Background()))
+
+	// --- Episode 1: unreapable -> error, with a waiter joined to it. ---
+	gate1 := newStopGate()
+	mp.stopBarrier = gate1.barrier
+
+	primary1 := goStop(mp, context.Background())
+	gate1.awaitPrimary(t)
+	waiter1 := goStop(mp, context.Background())
+	gate1.awaitJoins(t, 1)
+	close(gate1.releasePrimary)
+
+	assert.ErrorIs(t, recvErr(t, primary1, "episode 1 primary"), domain.ErrProcessGroupNotReaped)
+	assert.ErrorIs(t, recvErr(t, waiter1, "episode 1 waiter"), domain.ErrProcessGroupNotReaped,
+		"a waiter on episode 1 must get episode 1's error")
+	require.Equal(t, domain.ProcessStateCrashed, mp.State())
+
+	// --- Episode 2: retry with a now-killable group -> nil, distinct episode. ---
+	gate2 := newStopGate()
+	mp.stopBarrier = gate2.barrier
+
+	primary2 := goStop(mp, context.Background())
+	gate2.awaitPrimary(t)
+	// The group has become reapable between episodes.
+	killable.Store(true)
+	waiter2a := goStop(mp, context.Background())
+	waiter2b := goStop(mp, context.Background())
+	gate2.awaitJoins(t, 2)
+	close(gate2.releasePrimary)
+
+	require.NoError(t, recvErr(t, primary2, "episode 2 primary"))
+	require.NoError(t, recvErr(t, waiter2a, "episode 2 waiter a"), "episode 2 waiters must get nil")
+	require.NoError(t, recvErr(t, waiter2b, "episode 2 waiter b"), "episode 2 waiters must get nil")
+	assert.Equal(t, domain.ProcessStateStopped, mp.State())
+}
+
+// TestStopEpisode_EarlyExitPathResolvesEpisode: a Stop that enters the primary
+// transition but finds no live instance (the early-exit path) must still resolve
+// its episode -- a waiter joined to it gets nil, never a hang.
+func TestStopEpisode_EarlyExitPathResolvesEpisode(t *testing.T) {
+	runner := newFakeRunner(func(call int) *fakeProcess { return newGracefulFake(7000 + call) })
+	mp := newFakeManagedProcess(t, runner)
+
+	// Construct the early-exit precondition directly: state past the guards but
+	// with no instance to signal.
+	mp.mu.Lock()
+	mp.state = domain.ProcessStateRunning
+	mp.current = nil
+	mp.mu.Unlock()
+
+	gate := newStopGate()
+	mp.stopBarrier = gate.barrier
+
+	primary := goStop(mp, context.Background())
+	gate.awaitPrimary(t)
+	secondary := goStop(mp, context.Background())
+	gate.awaitJoins(t, 1)
+	close(gate.releasePrimary)
+
+	require.NoError(t, recvErr(t, primary, "early-exit primary"))
+	require.NoError(t, recvErr(t, secondary, "early-exit waiter"),
+		"a waiter on the early-exit episode must get the nil verdict")
+	assert.Equal(t, domain.ProcessStateStopped, mp.State())
+
+	mp.mu.RLock()
+	assert.Nil(t, mp.episode, "the resolved episode must be detached")
+	mp.mu.RUnlock()
+}
+
+// TestStopEpisode_PostCommitBoundaryCleanGetsNotRunning: a Stop that enters the
+// window between the primary's atomic state+episode commit and its function
+// return observes the committed terminal state -- for a cleanly-reaped group it
+// correctly gets ErrProcessNotRunning. Deterministic proof the torn window
+// (commit visible before episode resolved) is gone (#32, D1).
+func TestStopEpisode_PostCommitBoundaryCleanGetsNotRunning(t *testing.T) {
+	runner := newFakeRunner(func(call int) *fakeProcess { return newGracefulFake(9000 + call) })
+	mp := newFakeManagedProcess(t, runner)
+	require.NoError(t, mp.Start(context.Background()))
+
+	gate := newStopGateAt("verdict-committed")
+	mp.stopBarrier = gate.barrier
+
+	primary := goStop(mp, context.Background())
+	gate.awaitPrimary(t) // parked AFTER state=Stopped + episode resolved, atomically
+
+	late := goStop(mp, context.Background())
+	assert.ErrorIs(t, recvErr(t, late, "post-commit Stop"), domain.ErrProcessNotRunning,
+		"a Stop after the atomic commit is not concurrent with the episode: clean -> ErrProcessNotRunning")
+
+	close(gate.releasePrimary)
+	require.NoError(t, recvErr(t, primary, "primary Stop"))
+	assert.Equal(t, domain.ProcessStateStopped, mp.State())
+}
+
+// TestStopEpisode_PostCommitUnreapableRetryIsolation: for a surviving group, the
+// episode-N waiter observes episode N's error (published atomically at the
+// commit), and a Stop entering the post-commit window becomes a legitimate fresh
+// retry episode (N+1) with its own verdict -- never observing an unpublished N
+// nor N's object (#32, D1).
+func TestStopEpisode_PostCommitUnreapableRetryIsolation(t *testing.T) {
+	runner := newFakeRunner(func(call int) *fakeProcess { return newFastUnreapableFake(9100 + call) })
+	mp := newFakeManagedProcess(t, runner)
+	// Small budget so the retry's real SIGKILL escalation is bounded by the kill
+	// grace rather than the 10s default graceful window.
+	mp.shutdownTimeout = 200 * time.Millisecond
+	require.NoError(t, mp.Start(context.Background()))
+
+	var installOnce, commitOnce sync.Once
+	installReached := make(chan struct{})
+	releaseInstall := make(chan struct{})
+	commitReached := make(chan struct{})
+	releaseCommit := make(chan struct{})
+	joined := make(chan struct{}, 4)
+	mp.stopBarrier = func(phase string) {
+		switch phase {
+		case "primary-installed":
+			parked := false
+			installOnce.Do(func() { parked = true; close(installReached) })
+			if parked {
+				<-releaseInstall
+			}
+		case "secondary-joined":
+			joined <- struct{}{}
+		case "verdict-committed":
+			parked := false
+			commitOnce.Do(func() { parked = true; close(commitReached) })
+			if parked {
+				<-releaseCommit
+			}
+		}
+	}
+
+	// Episode N: park the primary with its episode installed, join a waiter.
+	primaryN := goStop(mp, context.Background())
+	<-installReached
+	waiterN := goStop(mp, context.Background())
+	<-joined
+
+	// Let episode N run to its unreapable verdict (state+episode committed
+	// atomically), then park just past the commit.
+	close(releaseInstall)
+	<-commitReached
+
+	assert.ErrorIs(t, recvErr(t, waiterN, "episode N waiter"), domain.ErrProcessGroupNotReaped,
+		"episode N waiter must observe episode N's verdict, published atomically at the commit")
+
+	// A Stop entering the post-commit window sees state Crashed + a live group, so
+	// it starts a FRESH retry episode (N+1) and runs to its own verdict.
+	retry := goStop(mp, context.Background())
+	assert.ErrorIs(t, recvErr(t, retry, "retry Stop"), domain.ErrProcessGroupNotReaped,
+		"post-commit Stop must produce its own fresh retry verdict")
+
+	close(releaseCommit)
+	assert.ErrorIs(t, recvErr(t, primaryN, "episode N primary"), domain.ErrProcessGroupNotReaped)
+	assert.Equal(t, domain.ProcessStateCrashed, mp.State())
+}
+
+// TestStopEpisode_NilEpisodeFallbackProbe: the defensive ep==nil branch (a
+// Stopping state with no installed episode) waits for the run monitor and then
+// takes a fresh authoritative probe -- a surviving group yields the reap error, a
+// reaped group yields nil -- rather than blindly reporting success (#32, D1).
+func TestStopEpisode_NilEpisodeFallbackProbe(t *testing.T) {
+	run := func(t *testing.T, groupAlive, wantErr bool) {
+		runner := newFakeRunner(func(call int) *fakeProcess { return newFakeProcess(9200 + call) })
+		mp := newFakeManagedProcess(t, runner)
+		require.NoError(t, mp.Start(context.Background()))
+		fp := runner.last()
+
+		// Force the defensive precondition directly: Stopping with no episode.
+		mp.mu.Lock()
+		inst := mp.current
+		mp.state = domain.ProcessStateStopping
+		mp.episode = nil
+		mp.mu.Unlock()
+
+		// Simulate the run monitor having finished (done closed) with the group in
+		// the desired final liveness.
+		fp.setAlive(groupAlive)
+		inst.closeDone()
+
+		err := mp.Stop(context.Background())
+		if wantErr {
+			assert.ErrorIs(t, err, domain.ErrProcessGroupNotReaped, "surviving group must yield the reap error")
+		} else {
+			assert.NoError(t, err, "reaped group must yield nil")
+		}
+
+		// Release the still-blocked monitor goroutine so it does not leak.
+		fp.exitLeader(nil)
+	}
+
+	t.Run("surviving group -> error", func(t *testing.T) { run(t, true, true) })
+	t.Run("reaped group -> nil", func(t *testing.T) { run(t, false, false) })
+}
+
+// TestStopEpisode_StopProcessNoStoppedEventOnSurvivor: through the StopProcess
+// path, an unreapable group makes BOTH the primary and the secondary caller
+// return ErrProcessGroupNotReaped, so StopProcess's existing suppression emits no
+// process_stopped event for either -- the verdicts are now consistent (#32, D1).
+func TestStopEpisode_StopProcessNoStoppedEventOnSurvivor(t *testing.T) {
+	logMgr := logs.NewManager(logs.ManagerConfig{BufferSize: 100})
+	t.Cleanup(func() { logMgr.Close() })
+
+	cfg := &config.Config{
+		API: config.APIConfig{Port: 5555, Host: "127.0.0.1"},
+		Processes: map[string]config.ProcessConfig{
+			// A comfortable budget so the secondary's StopProcess context outlives
+			// the (barrier-gated, fast) primary verdict.
+			"svc": {Cmd: "irrelevant", StopTimeout: "5s"},
+		},
+	}
+	runner := newFakeRunner(func(call int) *fakeProcess { return newFastUnreapableFake(8000 + call) })
+	sup := New(cfg, logMgr, runner, DefaultSupervisorConfig())
+
+	events := sup.Subscribe()
+	_, err := sup.Start(context.Background())
+	require.NoError(t, err)
+
+	mp := getManagedProcess(t, sup, "svc")
+	gate := newStopGate()
+	mp.stopBarrier = gate.barrier
+
+	stop := func() <-chan error {
+		ch := make(chan error, 1)
+		go func() { ch <- sup.StopProcess(context.Background(), "svc") }()
+		return ch
+	}
+	primary := stop()
+	gate.awaitPrimary(t)
+	secondary := stop()
+	gate.awaitJoins(t, 1)
+	close(gate.releasePrimary)
+
+	assert.ErrorIs(t, recvErr(t, primary, "StopProcess primary"), domain.ErrProcessGroupNotReaped)
+	assert.ErrorIs(t, recvErr(t, secondary, "StopProcess secondary"), domain.ErrProcessGroupNotReaped,
+		"the secondary caller must also return the surviving-group error")
+
+	// Both StopProcess calls have returned, so any process_stopped emit would
+	// already be buffered: drain non-blocking and assert none was emitted.
+	for {
+		select {
+		case e := <-events:
+			assert.NotEqualf(t, EventTypeProcessStopped, e.Type,
+				"no process_stopped event may be emitted for a surviving group (got %v)", e.Type)
+		default:
+			return
+		}
+	}
+}

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -15,6 +15,16 @@ import (
 	"github.com/charliek/prox/internal/logs"
 )
 
+// stopVerdictMargin is the slack added to each per-process stop budget when
+// Supervisor.Stop sizes its goroutine contexts (and the outer bound up.go grants
+// via StopWaitBound). A Supervisor.Stop joining an in-flight primary stop must
+// outlive the primary's finalization window: the primary's verdict can land up
+// to ~budget + outputDrainTimeout + 1s after the primary began (see the
+// finalization gate in process.go). Sizing the secondary at budget +
+// stopVerdictMargin keeps it alive through that tail so it aggregates the real
+// PROCESS_GROUP_NOT_REAPED verdict instead of ctx-expiring first (#36, D3).
+const stopVerdictMargin = outputDrainTimeout + 2*time.Second
+
 // SupervisorConfig holds configuration for the supervisor
 type SupervisorConfig struct {
 	ShutdownTimeout time.Duration
@@ -363,7 +373,31 @@ func (s *Supervisor) startProcessesConcurrently(result *StartResult) {
 	wg.Wait()
 }
 
-// Stop stops all processes and the supervisor
+// stopEvent maps a per-process Stop result to the event that Supervisor.Stop and
+// StopProcess both emit, so the event semantics stay uniform across the two paths
+// by construction (#36, D3): a clean stop (or already-not-running) is
+// process_stopped; a surviving group is process_crashed (state is already
+// Crashed); any other error (ctx expiry/cancellation) is not proof of anything
+// and emits no event (ok == false).
+func stopEvent(err error) (EventType, bool) {
+	switch {
+	case err == nil || errors.Is(err, domain.ErrProcessNotRunning):
+		return EventTypeProcessStopped, true
+	case errors.Is(err, domain.ErrProcessGroupNotReaped):
+		return EventTypeProcessCrashed, true
+	default:
+		return "", false
+	}
+}
+
+// Stop stops all processes and the supervisor.
+//
+// The signature stays the idiomatic Stop(ctx) error, but the concrete failure
+// value is a *domain.ProcessStopError aggregating every process that did not stop
+// cleanly (each failure wraps a sentinel such as ErrProcessGroupNotReaped, so
+// errors.Is/errors.As see through the aggregate). It returns a literal nil --
+// never a typed-nil *ProcessStopError -- when the stop is clean, and likewise nil
+// from the not-running early return (nothing to do) (#36, D3).
 func (s *Supervisor) Stop(ctx context.Context) error {
 	s.mu.Lock()
 	if s.state != "running" {
@@ -383,12 +417,16 @@ func (s *Supervisor) Stop(ctx context.Context) error {
 	s.mu.Unlock()
 
 	// Stop all processes concurrently. Each process gets its own timeout context
-	// sized from its effective stop budget (StopTimeout), so a per-process
-	// stop_timeout is honored individually. This replaces the single shared
-	// shutdownCtx that previously truncated every process to one common deadline
-	// (#35, D2). The daemon's outer deadline is sized by up.go from
-	// MaxStopBudget() so ctx here rarely bounds anything.
-	var wg sync.WaitGroup
+	// sized from its effective stop budget (StopTimeout) plus stopVerdictMargin,
+	// so a per-process stop_timeout is honored individually AND a stop joining an
+	// in-flight primary as a secondary outlives the primary's finalization window
+	// (#35, D2 / #36, D3). The daemon's outer deadline is sized by up.go from
+	// StopWaitBound() so ctx here rarely bounds anything.
+	var (
+		wg       sync.WaitGroup
+		failMu   sync.Mutex
+		failures []domain.ProcessStopFailure
+	)
 	for _, mp := range processes {
 		wg.Add(1)
 		go func(mp *ManagedProcess) {
@@ -397,31 +435,38 @@ func (s *Supervisor) Stop(ctx context.Context) error {
 			// so read it once here rather than taking the process lock a second
 			// time via mp.StopTimeout().
 			info := mp.Info()
-			stopCtx, cancel := context.WithTimeout(ctx, info.StopTimeout)
+			stopCtx, cancel := context.WithTimeout(ctx, info.StopTimeout+stopVerdictMargin)
 			defer cancel()
 			if info.PID > 0 {
 				s.SystemLog("sending SIGTERM to %s (pid %d)", info.Name, info.PID)
 			}
-			if err := mp.Stop(stopCtx); err != nil && err != domain.ErrProcessNotRunning {
+			err := mp.Stop(stopCtx)
+			if evt, ok := stopEvent(err); ok {
+				s.emit(SupervisorEvent{
+					Type:      evt,
+					Process:   mp.Name(),
+					Timestamp: time.Now(),
+					Info:      mp.Info(),
+				})
+			}
+			// A non-clean stop (anything but nil/ErrProcessNotRunning) is logged once
+			// and recorded for the aggregate, whichever class it is. A surviving group
+			// is additionally surfaced prominently (D4); its process_crashed event was
+			// already emitted above (#36, D3).
+			if err != nil && !errors.Is(err, domain.ErrProcessNotRunning) {
 				s.logManager.Write(domain.LogEntry{
 					Timestamp: time.Now(),
 					Process:   mp.Name(),
 					Stream:    domain.StreamStderr,
 					Line:      fmt.Sprintf("Error stopping: %v", err),
 				})
-				// Full-instance stop is best-effort, but surface an
-				// un-reapable group prominently so operators can see which
-				// process leaked (D4). We do not abort the rest of shutdown.
 				if errors.Is(err, domain.ErrProcessGroupNotReaped) {
 					s.SystemLog("could not reap process group for %s", mp.Name())
 				}
+				failMu.Lock()
+				failures = append(failures, domain.ProcessStopFailure{Name: mp.Name(), Err: err})
+				failMu.Unlock()
 			}
-			s.emit(SupervisorEvent{
-				Type:      EventTypeProcessStopped,
-				Process:   mp.Name(),
-				Timestamp: time.Now(),
-				Info:      mp.Info(),
-			})
 		}(mp)
 	}
 	wg.Wait()
@@ -438,7 +483,14 @@ func (s *Supervisor) Stop(ctx context.Context) error {
 		Timestamp: time.Now(),
 	})
 
-	return nil
+	if len(failures) == 0 {
+		// Return a literal nil, never a typed-nil *ProcessStopError (which would be
+		// a non-nil error interface).
+		return nil
+	}
+	// Stable output: sort by process name after the concurrent collection.
+	sort.Slice(failures, func(i, j int) bool { return failures[i].Name < failures[j].Name })
+	return &domain.ProcessStopError{Failures: failures}
 }
 
 // Processes returns info for all processes
@@ -544,10 +596,13 @@ func (s *Supervisor) StopProcess(ctx context.Context, name string) error {
 	stopCtx, cancel := context.WithTimeout(ctx, mp.StopTimeout())
 	defer cancel()
 
+	// Event semantics are uniform with Supervisor.Stop via the shared stopEvent
+	// classifier (#36, D3): process_stopped on a clean/already-not-running stop,
+	// process_crashed on a surviving group, no event on any other error.
 	err := mp.Stop(stopCtx)
-	if err == nil || err == domain.ErrProcessNotRunning {
+	if evt, ok := stopEvent(err); ok {
 		s.emit(SupervisorEvent{
-			Type:      EventTypeProcessStopped,
+			Type:      evt,
 			Process:   name,
 			Timestamp: time.Now(),
 			Info:      mp.Info(),
@@ -633,6 +688,16 @@ func (s *Supervisor) MaxStopBudget() time.Duration {
 		return constants.DefaultShutdownTimeout
 	}
 	return maxBudget
+}
+
+// StopWaitBound returns the deadline a caller should grant Supervisor.Stop: the
+// largest live per-process stop budget plus stopVerdictMargin. The margin lets a
+// per-process stop goroutine that joins an in-flight primary as a secondary
+// outlive the primary's finalization window (see stopVerdictMargin). up.go sizes
+// its supervisor teardown stage from this so it does not duplicate the constant
+// (#36, D3).
+func (s *Supervisor) StopWaitBound() time.Duration {
+	return s.MaxStopBudget() + stopVerdictMargin
 }
 
 // Status returns supervisor status

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/charliek/prox/internal/config"
@@ -59,6 +60,17 @@ type Supervisor struct {
 	startedAt time.Time
 	// state is the current supervisor state: "stopped", "running", or "stopping"
 	state string
+
+	// launchable is the launch gate (#32/#36, D2): true while the supervisor is
+	// running, flipped false at the top of Stop (under s.mu, alongside
+	// state="stopping") before the per-process stop goroutines are created, and
+	// reset true on every entry into "running" so a stop->start cycle reopens the
+	// gate. createManagedProcess injects a launchGate closure that reads this flag
+	// (atomic read only -- see the closure comment) and refuses a launch with
+	// ErrShutdownInProgress once it is false. It is an atomic (not guarded by s.mu)
+	// so the gate can be read inside startWithConfig's p.mu critical section without
+	// taking s.mu, which would AB-BA against the verified s.mu -> p.mu order.
+	launchable atomic.Bool
 
 	// ctx and cancel are used for coordinating graceful shutdown
 	ctx    context.Context
@@ -136,6 +148,9 @@ func (s *Supervisor) startWithFilter(ctx context.Context, filter map[string]bool
 
 	s.ctx, s.cancel = context.WithCancel(ctx)
 	s.state = "running"
+	// Reopen the launch gate. This also covers a stop->start cycle (Stop flipped
+	// it false): the fresh run must accept launches again (#32/#36, D2).
+	s.launchable.Store(true)
 	s.startedAt = time.Now()
 	s.mu.Unlock()
 
@@ -187,6 +202,17 @@ func (s *Supervisor) createManagedProcess(name string, procConfig config.Process
 	// StopTimeout() accessor and the lock-held loadEnv read in Start.
 	mp.loadEnv = loadEnv
 	mp.shutdownTimeout = effective
+	// Inject the launch gate (#32/#36, D2). ATOMIC READ ONLY: startWithConfig
+	// calls this inside its p.mu critical section, so this closure must NOT take
+	// s.mu -- the verified s.mu -> p.mu order would make an s.mu acquisition here
+	// an AB-BA deadlock against callers already holding s.mu while reaching for
+	// p.mu (Processes/Process/MaxStopBudget). Reading the atomic is sufficient.
+	mp.launchGate = func() error {
+		if !s.launchable.Load() {
+			return domain.ErrShutdownInProgress
+		}
+		return nil
+	}
 
 	return mp, nil
 }
@@ -345,6 +371,11 @@ func (s *Supervisor) Stop(ctx context.Context) error {
 		return nil
 	}
 	s.state = "stopping"
+	// Close the launch gate before spawning the per-process stop goroutines, so a
+	// launcher that observes it closed never launches, and a launcher already past
+	// the gate (the check/use window) is reaped by this process's stop goroutine --
+	// which is queued on p.mu behind that very launch -- before Stop returns (D2).
+	s.launchable.Store(false)
 	processes := make([]*ManagedProcess, 0, len(s.processes))
 	for _, mp := range s.processes {
 		processes = append(processes, mp)

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -390,6 +390,23 @@ func stopEvent(err error) (EventType, bool) {
 	}
 }
 
+// RefuseLaunches closes the launch gate ahead of Stop. Daemon shutdown runs an
+// earlier teardown stage (proxyd deregister, up to a few seconds) BEFORE Stop
+// flips the gate itself, and the API keeps serving through that stage; without
+// this a StartProcess/RestartProcess arriving in that window would still launch a
+// process the shutdown is about to orphan. Calling this at the very top of the
+// shutdown sequence closes the gate immediately. It is just s.launchable.Store(
+// false) -- idempotent with the identical flip Stop performs, so calling both is
+// harmless, and it does NOT change supervisor state (still "running") so the
+// read-only API stays fully answerable during the drain.
+//
+// Accepted residual: a restart already past its pre-checks can still stop its
+// current process and is only refused at the start half -- fine, shutdown was
+// about to stop that process anyway (#36, D4).
+func (s *Supervisor) RefuseLaunches() {
+	s.launchable.Store(false)
+}
+
 // Stop stops all processes and the supervisor.
 //
 // The signature stays the idiomatic Stop(ctx) error, but the concrete failure

--- a/internal/supervisor/supervisor_stop_test.go
+++ b/internal/supervisor/supervisor_stop_test.go
@@ -1,0 +1,363 @@
+package supervisor
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/charliek/prox/internal/config"
+	"github.com/charliek/prox/internal/domain"
+	"github.com/charliek/prox/internal/logs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// nameRunner hands out a pre-built fakeProcess per process name, so a
+// multi-process Supervisor.Stop test can assign distinct stop behaviour (clean
+// vs unreapable) to specific names regardless of the concurrent, map-ordered
+// Start sequence (fakeRunner's call-index factory cannot bind behaviour to a
+// name). One start per name is assumed (these tests never restart).
+type nameRunner struct {
+	mu    sync.Mutex
+	fakes map[string]*fakeProcess
+}
+
+func newNameRunner(fakes map[string]*fakeProcess) *nameRunner {
+	return &nameRunner{fakes: fakes}
+}
+
+func (r *nameRunner) Start(_ context.Context, cfg domain.ProcessConfig, _ map[string]string) (Process, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	fp, ok := r.fakes[cfg.Name]
+	if !ok {
+		panic("nameRunner: no fake configured for process " + cfg.Name)
+	}
+	return fp, nil
+}
+
+// newStopSupervisor builds a supervisor over the given named fakes (each keyed by
+// process name), all sharing stopTimeout. It does not start the supervisor.
+func newStopSupervisor(t *testing.T, fakes map[string]*fakeProcess, stopTimeout string) *Supervisor {
+	t.Helper()
+	logMgr := logs.NewManager(logs.ManagerConfig{BufferSize: 200})
+	t.Cleanup(func() { logMgr.Close() })
+	cfg := &config.Config{
+		API:       config.APIConfig{Port: 5556, Host: "127.0.0.1"},
+		Processes: make(map[string]config.ProcessConfig, len(fakes)),
+	}
+	for name := range fakes {
+		cfg.Processes[name] = config.ProcessConfig{Cmd: "irrelevant", StopTimeout: stopTimeout}
+	}
+	return New(cfg, logMgr, newNameRunner(fakes), DefaultSupervisorConfig())
+}
+
+// collectStopEvents drains sub non-blocking and returns the stop/crash events
+// per process name. Callers invoke it only after the operation under test has
+// returned (Supervisor.Stop / StopProcess emit synchronously before returning),
+// so the drain observes a settled set with no race.
+func collectStopEvents(sub <-chan SupervisorEvent) map[string][]EventType {
+	out := make(map[string][]EventType)
+	for {
+		select {
+		case e := <-sub:
+			if e.Type == EventTypeProcessStopped || e.Type == EventTypeProcessCrashed {
+				out[e.Process] = append(out[e.Process], e.Type)
+			}
+		default:
+			return out
+		}
+	}
+}
+
+// TestSupervisorStop_AggregatesSingleSurvivor: three processes (clean,
+// unreapable, clean) -> Stop returns a non-nil *ProcessStopError carrying exactly
+// the one survivor; errors.Is sees ErrProcessGroupNotReaped through the aggregate
+// and errors.As extracts the typed value (#36, D3).
+func TestSupervisorStop_AggregatesSingleSurvivor(t *testing.T) {
+	sup := newStopSupervisor(t, map[string]*fakeProcess{
+		"alpha": newGracefulFake(1001),
+		"beta":  newFastUnreapableFake(1002),
+		"gamma": newGracefulFake(1003),
+	}, "3s")
+
+	_, err := sup.Start(context.Background())
+	require.NoError(t, err)
+
+	err = sup.Stop(context.Background())
+	require.Error(t, err, "a surviving group must make Stop return an error")
+
+	var agg *domain.ProcessStopError
+	require.ErrorAs(t, err, &agg, "the error must be a *ProcessStopError")
+	require.Len(t, agg.Failures, 1, "exactly the one unreapable process must be reported")
+	assert.Equal(t, "beta", agg.Failures[0].Name)
+	assert.ErrorIs(t, err, domain.ErrProcessGroupNotReaped, "errors.Is must see through the aggregate")
+	assert.ErrorIs(t, agg.Failures[0].Err, domain.ErrProcessGroupNotReaped)
+}
+
+// TestSupervisorStop_FailuresSortedByName (ordering stability): several survivors
+// with names supplied out of order are reported sorted by name in the aggregate.
+func TestSupervisorStop_FailuresSortedByName(t *testing.T) {
+	sup := newStopSupervisor(t, map[string]*fakeProcess{
+		"zebra": newFastUnreapableFake(2001),
+		"mango": newGracefulFake(2002),
+		"alpha": newFastUnreapableFake(2003),
+		"delta": newFastUnreapableFake(2004),
+	}, "3s")
+
+	_, err := sup.Start(context.Background())
+	require.NoError(t, err)
+
+	err = sup.Stop(context.Background())
+	require.Error(t, err)
+
+	var agg *domain.ProcessStopError
+	require.ErrorAs(t, err, &agg)
+
+	names := make([]string, len(agg.Failures))
+	for i, f := range agg.Failures {
+		names[i] = f.Name
+	}
+	assert.Equal(t, []string{"alpha", "delta", "zebra"}, names, "failures must be sorted by name")
+}
+
+// TestSupervisorStop_CleanReturnsNil: a fully clean stop returns a literal nil
+// error (not a typed-nil *ProcessStopError).
+func TestSupervisorStop_CleanReturnsNil(t *testing.T) {
+	sup := newStopSupervisor(t, map[string]*fakeProcess{
+		"alpha": newGracefulFake(3001),
+		"beta":  newGracefulFake(3002),
+	}, "3s")
+
+	_, err := sup.Start(context.Background())
+	require.NoError(t, err)
+
+	require.NoError(t, sup.Stop(context.Background()), "a clean stop must return nil")
+}
+
+// TestSupervisorStop_EmptyReturnsNil: a running supervisor with no processes
+// stops cleanly with nil.
+func TestSupervisorStop_EmptyReturnsNil(t *testing.T) {
+	sup := newStopSupervisor(t, map[string]*fakeProcess{}, "3s")
+
+	_, err := sup.Start(context.Background())
+	require.NoError(t, err)
+
+	require.NoError(t, sup.Stop(context.Background()), "an empty stop must return nil")
+}
+
+// TestSupervisorStop_NotRunningReturnsNil: Stop on a never-started (not running)
+// supervisor is a no-op returning nil.
+func TestSupervisorStop_NotRunningReturnsNil(t *testing.T) {
+	sup := newStopSupervisor(t, map[string]*fakeProcess{
+		"alpha": newGracefulFake(4001),
+	}, "3s")
+
+	require.NoError(t, sup.Stop(context.Background()), "a not-running Stop must return nil")
+}
+
+// TestSupervisorStop_CleanEmitsStopped: full-stop of clean processes emits
+// process_stopped (and no process_crashed) for each.
+func TestSupervisorStop_CleanEmitsStopped(t *testing.T) {
+	sup := newStopSupervisor(t, map[string]*fakeProcess{
+		"alpha": newGracefulFake(5001),
+		"beta":  newGracefulFake(5002),
+	}, "3s")
+
+	sub := sup.Subscribe()
+	_, err := sup.Start(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, sup.Stop(context.Background()))
+
+	ev := collectStopEvents(sub)
+	assert.Equal(t, []EventType{EventTypeProcessStopped}, ev["alpha"])
+	assert.Equal(t, []EventType{EventTypeProcessStopped}, ev["beta"])
+}
+
+// TestSupervisorStop_UnreapableEmitsCrashedNotStopped: full-stop with a surviving
+// group emits process_crashed for that process and NO process_stopped for it,
+// while the clean sibling still emits process_stopped (#36, D3).
+func TestSupervisorStop_UnreapableEmitsCrashedNotStopped(t *testing.T) {
+	sup := newStopSupervisor(t, map[string]*fakeProcess{
+		"good": newGracefulFake(6001),
+		"bad":  newFastUnreapableFake(6002),
+	}, "3s")
+
+	sub := sup.Subscribe()
+	_, err := sup.Start(context.Background())
+	require.NoError(t, err)
+
+	err = sup.Stop(context.Background())
+	require.Error(t, err)
+
+	ev := collectStopEvents(sub)
+	assert.Equal(t, []EventType{EventTypeProcessCrashed}, ev["bad"],
+		"a surviving group must emit process_crashed and no process_stopped")
+	assert.Equal(t, []EventType{EventTypeProcessStopped}, ev["good"])
+}
+
+// TestSupervisorStop_StopProcessUnreapableEmitsCrashed: StopProcess on a surviving
+// group now emits process_crashed (previously it emitted nothing) -- uniform with
+// the full-stop path (#36, D3).
+func TestSupervisorStop_StopProcessUnreapableEmitsCrashed(t *testing.T) {
+	sup := newStopSupervisor(t, map[string]*fakeProcess{
+		"svc": newFastUnreapableFake(7001),
+	}, "5s")
+
+	sub := sup.Subscribe()
+	_, err := sup.Start(context.Background())
+	require.NoError(t, err)
+
+	err = sup.StopProcess(context.Background(), "svc")
+	assert.ErrorIs(t, err, domain.ErrProcessGroupNotReaped)
+
+	ev := collectStopEvents(sub)
+	assert.Equal(t, []EventType{EventTypeProcessCrashed}, ev["svc"],
+		"StopProcess on a surviving group must emit process_crashed")
+}
+
+// TestSupervisorStop_CtxExpiredSecondaryNoEventStillReported: a full Supervisor.Stop
+// that joins an in-flight primary as a secondary and whose context is canceled
+// before the primary's verdict lands returns ctx.Err() for that process -- it
+// emits NO event (a ctx error is not proof of anything) but still records the
+// process in the aggregate so the failure is surfaced (#36, D3).
+func TestSupervisorStop_CtxExpiredSecondaryNoEventStillReported(t *testing.T) {
+	sup := newStopSupervisor(t, map[string]*fakeProcess{
+		"svc": newFastUnreapableFake(8001),
+	}, "5s")
+
+	sub := sup.Subscribe()
+	_, err := sup.Start(context.Background())
+	require.NoError(t, err)
+
+	mp := getManagedProcess(t, sup, "svc")
+	gate := newStopGate()
+	mp.stopBarrier = gate.barrier
+
+	// In-flight primary StopProcess: parks with its episode installed (state
+	// Stopping), before any signalling/verdict.
+	primaryCh := make(chan error, 1)
+	go func() { primaryCh <- sup.StopProcess(context.Background(), "svc") }()
+	gate.awaitPrimary(t)
+
+	// Supervisor.Stop joins as the secondary; cancel its context before the
+	// primary is released so the secondary observes ctx.Done, not the verdict.
+	stopCtx, stopCancel := context.WithCancel(context.Background())
+	stopCh := make(chan error, 1)
+	go func() { stopCh <- sup.Stop(stopCtx) }()
+	gate.awaitJoins(t, 1)
+	stopCancel()
+
+	serr := recvErr(t, stopCh, "Supervisor.Stop")
+	require.Error(t, serr, "the canceled secondary must surface as a failure")
+	var agg *domain.ProcessStopError
+	require.ErrorAs(t, serr, &agg)
+	require.Len(t, agg.Failures, 1)
+	assert.Equal(t, "svc", agg.Failures[0].Name)
+	assert.ErrorIs(t, serr, context.Canceled, "the recorded error is the ctx cancellation")
+	assert.NotErrorIs(t, serr, domain.ErrProcessGroupNotReaped,
+		"a ctx cancellation is not a reap-failure verdict")
+
+	// No event may be emitted for the ctx-expired secondary (drain while the
+	// primary is still parked, so any emit would be its own, not present yet).
+	ev := collectStopEvents(sub)
+	assert.Empty(t, ev["svc"], "a ctx-expired secondary must emit no event")
+
+	// Release the parked primary so its goroutine finishes and does not leak.
+	close(gate.releasePrimary)
+	assert.ErrorIs(t, recvErr(t, primaryCh, "primary StopProcess"), domain.ErrProcessGroupNotReaped)
+}
+
+// TestSupervisorStop_SecondaryOutlivesFinalizationWindow (the load-bearing overlap
+// test): an in-flight primary StopProcess on a surviving group is parked at the
+// "finalizing" seam -- INSIDE the finalization window, after the monitor drain and
+// before the authoritative verdict -- exactly the tail stopVerdictMargin exists to
+// cover. A full Supervisor.Stop joins as the secondary (its per-process context is
+// StopTimeout + stopVerdictMargin) and must wait through that parked tail to
+// observe and aggregate the true PROCESS_GROUP_NOT_REAPED.
+//
+// The per-process budget is overridden to a tiny 50ms, so the OLD sizing
+// (StopTimeout alone) would have given the secondary a 50ms context that expires
+// long before the parked verdict lands -- proving the margin is load-bearing and
+// that the test exercises the finalization tail, not merely the pre-signalling
+// window (#32/#36, D3).
+func TestSupervisorStop_SecondaryOutlivesFinalizationWindow(t *testing.T) {
+	// Config carries a valid budget (stop_timeout must exceed the reserved SIGKILL
+	// grace); after Start we override the live per-process budget to 50ms directly
+	// (the shutdownTimeout seam other stop tests use).
+	sup := newStopSupervisor(t, map[string]*fakeProcess{
+		"svc": newFastUnreapableFake(9001),
+	}, "3s")
+
+	_, err := sup.Start(context.Background())
+	require.NoError(t, err)
+
+	mp := getManagedProcess(t, sup, "svc")
+	mp.mu.Lock()
+	mp.shutdownTimeout = 50 * time.Millisecond
+	mp.mu.Unlock()
+
+	// Custom barrier: DO NOT park at "primary-installed" (let the primary flow
+	// through signalling to the finalization gate); record the secondary's join;
+	// park exactly once at "finalizing" so the primary's verdict lands late.
+	var installOnce, finalizeOnce sync.Once
+	installed := make(chan struct{})
+	finalizeReached := make(chan struct{})
+	releaseFinalize := make(chan struct{})
+	joined := make(chan struct{}, 4)
+	mp.stopBarrier = func(phase string) {
+		switch phase {
+		case "primary-installed":
+			installOnce.Do(func() { close(installed) })
+		case "secondary-joined":
+			joined <- struct{}{}
+		case "finalizing":
+			parked := false
+			finalizeOnce.Do(func() { parked = true; close(finalizeReached) })
+			if parked {
+				<-releaseFinalize
+			}
+		}
+	}
+
+	// Primary StopProcess installs the episode (state Stopping) and proceeds
+	// toward the finalization gate.
+	primaryCh := make(chan error, 1)
+	go func() { primaryCh <- sup.StopProcess(context.Background(), "svc") }()
+	<-installed
+
+	// Supervisor.Stop joins as the secondary now that state is Stopping.
+	stopCh := make(chan error, 1)
+	go func() { stopCh <- sup.Stop(context.Background()) }()
+	select {
+	case <-joined:
+	case <-time.After(5 * time.Second):
+		t.Fatal("secondary did not join the episode within timeout")
+	}
+
+	// The primary reaches the finalization gate and parks there with its verdict
+	// pending; the secondary is waiting on the episode.
+	select {
+	case <-finalizeReached:
+	case <-time.After(5 * time.Second):
+		t.Fatal("primary did not reach the finalization gate within timeout")
+	}
+
+	// Hold the parked verdict well past the 50ms old-sizing budget. Under the old
+	// StopTimeout-only sizing the secondary's 50ms context is already done here;
+	// under the new sizing (50ms + stopVerdictMargin ~= 7s) it is still waiting.
+	time.Sleep(200 * time.Millisecond)
+	close(releaseFinalize)
+
+	assert.ErrorIs(t, recvErr(t, primaryCh, "primary StopProcess"), domain.ErrProcessGroupNotReaped)
+
+	serr := recvErr(t, stopCh, "Supervisor.Stop")
+	require.Error(t, serr, "the secondary must aggregate the surviving group's verdict")
+	var agg *domain.ProcessStopError
+	require.ErrorAs(t, serr, &agg)
+	require.Len(t, agg.Failures, 1)
+	assert.Equal(t, "svc", agg.Failures[0].Name)
+	assert.ErrorIs(t, serr, domain.ErrProcessGroupNotReaped,
+		"the secondary outlived the finalization tail and carried the true verdict")
+}

--- a/internal/supervisor/supervisor_stop_test.go
+++ b/internal/supervisor/supervisor_stop_test.go
@@ -361,3 +361,44 @@ func TestSupervisorStop_SecondaryOutlivesFinalizationWindow(t *testing.T) {
 	assert.ErrorIs(t, serr, domain.ErrProcessGroupNotReaped,
 		"the secondary outlived the finalization tail and carried the true verdict")
 }
+
+// TestSupervisorStop_StatusReadableDuringDrain pins the property the C4 stage
+// reorder exists for -- the daemon can answer read-only status while a stop is
+// draining -- at the supervisor level (the full HTTP-level check lands in C5).
+// A process's stop is parked mid-drain (state Stopping, s.mu released, p.mu not
+// held at the "primary-installed" seam); Processes() and Status() must still
+// answer promptly rather than block behind the parked stop. Deterministic via
+// the stopBarrier seam (no sleeps).
+func TestSupervisorStop_StatusReadableDuringDrain(t *testing.T) {
+	sup := newStopSupervisor(t, map[string]*fakeProcess{
+		"web": newGracefulFake(11001),
+	}, "5s")
+
+	_, err := sup.Start(context.Background())
+	require.NoError(t, err)
+
+	mp := getManagedProcess(t, sup, "web")
+	gate := newStopGate()
+	mp.stopBarrier = gate.barrier
+
+	stopCh := make(chan error, 1)
+	go func() { stopCh <- sup.Stop(context.Background()) }()
+	gate.awaitPrimary(t) // parked mid-stop: state Stopping, drain in progress
+
+	readDone := make(chan struct{})
+	go func() {
+		defer close(readDone)
+		procs := sup.Processes()
+		assert.Len(t, procs, 1, "Processes must still answer during the drain")
+		st := sup.Status()
+		assert.NotEmpty(t, st.State, "Status must still answer during the drain")
+	}()
+	select {
+	case <-readDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Processes/Status blocked while a stop was parked mid-drain")
+	}
+
+	close(gate.releasePrimary)
+	require.NoError(t, recvErr(t, stopCh, "Supervisor.Stop"), "the parked clean stop must finish nil")
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -13,12 +13,29 @@ import (
 	"github.com/charliek/prox/internal/supervisor"
 )
 
-// Run starts the TUI application
-func Run(sup *supervisor.Supervisor, logMgr *logs.Manager, reqMgr *proxy.RequestManager) error {
+// Run starts the TUI application.
+//
+// shutdownCh, when it closes, quits the program: this is how an out-of-band
+// shutdown request (POST /shutdown, via the coordinator's trigger channel)
+// reaches a --tui daemon, which otherwise blocks here forever. On quit -- whether
+// triggered this way or by the user pressing q/Ctrl-C -- Run returns and the
+// caller runs the normal shutdown sequence, so both routes are identical.
+func Run(sup *supervisor.Supervisor, logMgr *logs.Manager, reqMgr *proxy.RequestManager, shutdownCh <-chan struct{}) error {
 	model := NewModel(sup, logMgr)
 	p := tea.NewProgram(model, tea.WithAltScreen())
 
 	ctx, cancel := context.WithCancel(context.Background())
+
+	// Quit the program when an external shutdown is requested. The goroutine also
+	// exits when ctx is cancelled (after p.Run returns), so a hand-quit TUI never
+	// leaks it.
+	go func() {
+		select {
+		case <-shutdownCh:
+			p.Quit()
+		case <-ctx.Done():
+		}
+	}()
 
 	// Subscribe to logs before starting the forwarder
 	subID, ch, err := logMgr.Subscribe(domain.LogFilter{})

--- a/skills/prox/references/api.md
+++ b/skills/prox/references/api.md
@@ -359,7 +359,15 @@ curl -N "http://localhost:5555/api/v1/proxy/requests/stream?subdomain=api"
 
 Gracefully shut down supervisor and all processes.
 
-**Response:**
+**Query Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `wait` | boolean | When exactly `true`, block until the process-stop verdict lands and return it (see below). Any other or absent value uses the legacy async behavior. |
+
+This route is in the lifecycle timeout class (the same long hang-protection ceiling as `start`/`stop`/`restart`), because the `wait=true` path can block for the full drain.
+
+**Legacy async response** (default, `wait` absent or not `true`):
 
 ```json
 {
@@ -367,6 +375,34 @@ Gracefully shut down supervisor and all processes.
 }
 ```
 
-Connection closes after response as supervisor terminates.
+The daemon acks immediately, then tears down in the background. The connection closes as the supervisor terminates.
 
-The daemon then tears down in stages, each with its own deadline: the proxy and API server are stopped on short fixed deadlines, then every process is stopped concurrently, each on its own configured stop budget (see [Stop Timeout](configuration.md#stop-timeout)). Graceful timing therefore derives from the configured `shutdown_timeout` / `stop_timeout` values, not a single fixed window.
+**Waited response** (`wait=true`):
+
+```json
+{
+  "success": true,
+  "waited": true,
+  "failures": []
+}
+```
+
+The request blocks until every process has been stopped and its group reaped, then returns the verdict. `success` is `true` only when `failures` is empty. When a process group survives shutdown, the response still uses **HTTP 200** (so the structured body is not discarded) and lists each survivor:
+
+```json
+{
+  "success": false,
+  "waited": true,
+  "failures": [
+    {
+      "process": "web",
+      "error": "process group could not be terminated: web",
+      "code": "PROCESS_GROUP_NOT_REAPED"
+    }
+  ]
+}
+```
+
+The `code` field is a stable machine-readable classifier (`PROCESS_GROUP_NOT_REAPED`). The `waited` field is present only on this path; a daemon that predates the `wait` parameter ignores it and returns the legacy body without `waited`, letting clients detect the older daemon.
+
+The daemon tears down in stages, each with its own deadline: the launch gate is closed, the proxy is deregistered/stopped on a short fixed deadline, then every process is stopped concurrently, each on its own configured stop budget (see [Stop Timeout](configuration.md#stop-timeout)); the verdict is then published to any `wait=true` caller, the logs are flushed and closed, and finally the API server is stopped. Graceful timing therefore derives from the configured `shutdown_timeout` / `stop_timeout` values, not a single fixed window.

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -179,6 +180,53 @@ func postProcessAction(t *testing.T, addr, name, action string) (int, ErrorRespo
 type ErrorResponse struct {
 	Error string `json:"error"`
 	Code  string `json:"code"`
+}
+
+// projectRoot returns the repo root (two dirs up from test/integration), where
+// the daemon and CLI both run so they share one .prox state directory.
+func projectRoot(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	return filepath.Join(wd, "..", "..")
+}
+
+// runProx runs a prox subcommand to completion in the repo root and returns its
+// combined output and exit code. Used to exercise the real CLI (e.g. `prox stop`)
+// rather than poking the API directly.
+func runProx(t *testing.T, binary string, args ...string) (string, int) {
+	t.Helper()
+
+	cmd := exec.Command(binary, args...)
+	cmd.Dir = projectRoot(t)
+	out, err := cmd.CombinedOutput()
+
+	exitCode := 0
+	if err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			exitCode = ee.ExitCode()
+		} else {
+			t.Fatalf("failed to run prox %v: %v", args, err)
+		}
+	}
+	return string(out), exitCode
+}
+
+// waitCmdExit waits for a started command to exit within timeout, killing it and
+// failing the test on timeout.
+func waitCmdExit(t *testing.T, cmd *exec.Cmd, timeout time.Duration) {
+	t.Helper()
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		killProx(cmd)
+		t.Fatalf("process did not exit within %v", timeout)
+	}
 }
 
 // killProx forcefully kills the prox process

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -215,17 +215,24 @@ func runProx(t *testing.T, binary string, args ...string) (string, int) {
 	return string(out), exitCode
 }
 
-// waitCmdExit waits for a started command to exit within timeout, killing it and
-// failing the test on timeout.
-func waitCmdExit(t *testing.T, cmd *exec.Cmd, timeout time.Duration) {
+// waitCmdExit waits for a started command to exit within timeout and returns the
+// exit error from Cmd.Wait (nil on a clean exit). On timeout it kills the process
+// directly (not via killProx, which would call Cmd.Wait a second time and race
+// this goroutine's Wait) and fails the test. Callers at clean-exit sites should
+// assert the returned error is nil.
+func waitCmdExit(t *testing.T, cmd *exec.Cmd, timeout time.Duration) error {
 	t.Helper()
 	done := make(chan error, 1)
 	go func() { done <- cmd.Wait() }()
 	select {
-	case <-done:
+	case err := <-done:
+		return err
 	case <-time.After(timeout):
-		killProx(cmd)
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
 		t.Fatalf("process did not exit within %v", timeout)
+		return nil // unreachable; t.Fatalf stops the test
 	}
 }
 

--- a/test/integration/up_test.go
+++ b/test/integration/up_test.go
@@ -151,8 +151,10 @@ func TestStopCommand_WaitsForCleanExit(t *testing.T) {
 		t.Errorf("expected a stopped summary, got:\n%s", out)
 	}
 
-	// The foreground daemon must have exited as part of the waited stop.
-	waitCmdExit(t, cmd, 10*time.Second)
+	// The foreground daemon must have exited cleanly as part of the waited stop.
+	if err := waitCmdExit(t, cmd, 10*time.Second); err != nil {
+		t.Errorf("foreground prox up should exit 0 on a clean stop, got %v", err)
+	}
 
 	// State + PID files must be cleaned up.
 	root := projectRoot(t)
@@ -184,7 +186,9 @@ func TestStopCommand_AsyncPostReturnsImmediately(t *testing.T) {
 		t.Errorf("async POST /shutdown should return promptly, took %v", elapsed)
 	}
 
-	waitCmdExit(t, cmd, 15*time.Second)
+	if err := waitCmdExit(t, cmd, 15*time.Second); err != nil {
+		t.Errorf("foreground prox up should exit 0 after an async clean stop, got %v", err)
+	}
 }
 
 // TestStopCommand_DoubleStopNoPanic runs `prox stop` twice against the same
@@ -221,7 +225,11 @@ func TestStopCommand_DoubleStopNoPanic(t *testing.T) {
 		t.Fatal("first prox stop did not finish")
 	}
 
-	waitCmdExit(t, prox.cmd, 15*time.Second)
+	// The daemon does a clean stop (reapable processes), so the foreground exits 0
+	// regardless of how many stop clients connected.
+	if err := waitCmdExit(t, prox.cmd, 15*time.Second); err != nil {
+		t.Errorf("daemon should exit 0 on a clean double stop, got %v", err)
+	}
 
 	// The daemon must not have panicked.
 	if daemonOut := prox.Output(); strings.Contains(daemonOut, "panic:") {

--- a/test/integration/up_test.go
+++ b/test/integration/up_test.go
@@ -3,6 +3,8 @@ package integration
 import (
 	"encoding/json"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -125,6 +127,134 @@ func TestUpCommand_GracefulShutdown(t *testing.T) {
 	case <-time.After(15 * time.Second):
 		killProx(cmd)
 		t.Fatal("process did not shut down within timeout")
+	}
+}
+
+// TestStopCommand_WaitsForCleanExit drives the real `prox stop` CLI against a
+// foreground daemon: it must wait for the outcome, exit 0, print a stopped
+// summary, and the daemon's state + PID files must be gone afterward (#36, D4).
+func TestStopCommand_WaitsForCleanExit(t *testing.T) {
+	skipShort(t)
+
+	binary := buildBinary(t)
+	cmd := startProx(t, binary, "up", "-c", configPath("integration"))
+	defer killProx(cmd)
+
+	waitForAPI(t, testAPIAddr, 10*time.Second)
+	time.Sleep(500 * time.Millisecond)
+
+	out, exitCode := runProx(t, binary, "stop", "-c", configPath("integration"))
+	if exitCode != 0 {
+		t.Fatalf("prox stop exited %d, want 0\noutput:\n%s", exitCode, out)
+	}
+	if !strings.Contains(out, "Stopped") {
+		t.Errorf("expected a stopped summary, got:\n%s", out)
+	}
+
+	// The foreground daemon must have exited as part of the waited stop.
+	waitCmdExit(t, cmd, 10*time.Second)
+
+	// State + PID files must be cleaned up.
+	root := projectRoot(t)
+	for _, name := range []string{".prox/prox.state", ".prox/prox.pid"} {
+		if _, err := os.Stat(filepath.Join(root, name)); !os.IsNotExist(err) {
+			t.Errorf("expected %s to be gone after stop, stat err=%v", name, err)
+		}
+	}
+}
+
+// TestStopCommand_AsyncPostReturnsImmediately confirms the legacy async POST
+// /shutdown (no wait param) still returns an immediate 200 while the daemon tears
+// down in the background.
+func TestStopCommand_AsyncPostReturnsImmediately(t *testing.T) {
+	skipShort(t)
+
+	binary := buildBinary(t)
+	cmd := startProx(t, binary, "up", "-c", configPath("integration"))
+	defer killProx(cmd)
+
+	waitForAPI(t, testAPIAddr, 10*time.Second)
+	time.Sleep(500 * time.Millisecond)
+
+	start := time.Now()
+	if err := stopProx(t, testAPIAddr); err != nil {
+		t.Fatalf("async shutdown POST failed: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 3*time.Second {
+		t.Errorf("async POST /shutdown should return promptly, took %v", elapsed)
+	}
+
+	waitCmdExit(t, cmd, 15*time.Second)
+}
+
+// TestStopCommand_DoubleStopNoPanic runs `prox stop` twice against the same
+// daemon. The daemon must not panic (regression for the double-close bug), and
+// the second invocation must exit sanely (a waited result, a connection-refused
+// unknown-outcome path, or a not-running message) rather than crashing.
+func TestStopCommand_DoubleStopNoPanic(t *testing.T) {
+	skipShort(t)
+
+	binary := buildBinary(t)
+	prox := startProxWithOutput(t, binary, "up", "-c", configPath("integration"))
+	defer killProx(prox.cmd)
+
+	waitForAPI(t, testAPIAddr, 10*time.Second)
+	time.Sleep(500 * time.Millisecond)
+
+	// Fire the first stop in the background; it waits for the drain. Capture its
+	// output and exit code — the first stop should observe the clean verdict.
+	var out1 string
+	var exit1 int
+	firstDone := make(chan struct{})
+	go func() {
+		out1, exit1 = runProx(t, binary, "stop", "-c", configPath("integration"))
+		close(firstDone)
+	}()
+
+	// A moment later, fire a second stop that races/follows the first.
+	time.Sleep(200 * time.Millisecond)
+	out2, exit2 := runProx(t, binary, "stop", "-c", configPath("integration"))
+
+	select {
+	case <-firstDone:
+	case <-time.After(20 * time.Second):
+		t.Fatal("first prox stop did not finish")
+	}
+
+	waitCmdExit(t, prox.cmd, 15*time.Second)
+
+	// The daemon must not have panicked.
+	if daemonOut := prox.Output(); strings.Contains(daemonOut, "panic:") {
+		t.Errorf("daemon panicked during double stop:\n%s", daemonOut)
+	}
+
+	// The first stop reached the live daemon and should have seen the clean verdict:
+	// exit 0 with a stopped summary.
+	if exit1 != 0 {
+		t.Errorf("first prox stop exited %d, want 0\noutput:\n%s", exit1, out1)
+	}
+	if !strings.Contains(out1, "Stopped") {
+		t.Errorf("first prox stop should print a stopped summary, got:\n%s", out1)
+	}
+
+	// The second stop races the shutdown: depending on the window it either joins
+	// the latched clean verdict (exit 0, stopped summary), hits a
+	// connection-refused / unknown-outcome path (exit 1), or finds the daemon
+	// already gone (a not-running style message). Assert it landed on one of those
+	// recognized, non-panicking outcomes rather than only checking for panic text.
+	if strings.Contains(out2, "panic:") {
+		t.Errorf("second prox stop panicked:\n%s", out2)
+	}
+	if exit2 != 0 && exit2 != 1 {
+		t.Errorf("second prox stop exited %d, want 0 or 1\noutput:\n%s", exit2, out2)
+	}
+	recognized := strings.Contains(out2, "Stopped") ||
+		strings.Contains(out2, "Shutdown initiated") ||
+		strings.Contains(out2, "outcome unknown") ||
+		strings.Contains(out2, "not running") ||
+		strings.Contains(out2, "connection refused")
+	if !recognized {
+		t.Errorf("second prox stop produced an unrecognized outcome (exit %d):\n%s", exit2, out2)
 	}
 }
 


### PR DESCRIPTION
Closes #32. Closes #36.

The "stop failure contract" pair — five gated commits (plan 004; each passed lint / test / test-race / build, plus `mkdocs build --strict` for docs commits, a conditional simplify pass, and a capped adversarial codex review). Follow-up to #41.

## What changed

**C1 — #32: episode-scoped stop verdicts.** A concurrent secondary `Stop` used to return when the run's monitor finished (leader reaped) — before the primary's group-escalation verdict, so with an unreapable group the secondary reported success while the primary returned `PROCESS_GROUP_NOT_REAPED`. Every stop now installs a per-episode verdict signal; secondaries return the primary's exact result, resolution is atomic with the terminal-state commit (a codex-found torn window was closed), and post-commit arrivals correctly see `not running` or start a fresh retry episode. Deterministic barrier tests, `-race` clean 5×.

**C2 — launch gate.** Once full shutdown begins, process launches are refused (`SHUTDOWN_IN_PROGRESS`) via an atomic gate read inside the start's locked section — closing the gap deferred from #41 where a restart's start-half could re-launch a child after shutdown finished reaping. The invariant is deliberately modest and documented: no replacement outlives `Supervisor.Stop` (a full launch lease was considered and rejected in panel review).

**C3 — aggregation + uniform events.** `Supervisor.Stop` returns a typed `*domain.ProcessStopError` naming every surviving group (`errors.Is` works through it); per-process stop goroutines are sized to outlive an in-flight primary's finalization window (previously they could record a misleading context error); event emission is now uniform: clean → `process_stopped`, group-not-reaped → `process_crashed` (full stop previously emitted `process_stopped` unconditionally even for survivors).

**C4 — shutdown coordinator.** Replaces the bare shutdown channel: `sync.Once` trigger (**fixes a latent pre-existing panic — a second `POST /shutdown` double-closed the channel**), latched outcome broadcast, per-stage teardown reordered so the API outlives the supervisor stage (gate flip → proxy → stop processes → publish outcome → close log subscriptions → API stage → cleanup), the proxyd deregister call bounded to its stage, and the shutdown sequence extracted into a testable helper. **Also fixes a second pre-existing bug: `POST /shutdown` was inert against `prox up --tui`** (nothing observed the shutdown channel in the TUI branch).

**C5 — the user-facing contract.** `POST /api/v1/shutdown?wait=true` blocks until the verdict and returns `{success, waited, failures[{process, error, code}]}` (200 even on survivors so the body reaches the client; legacy async form unchanged). `prox stop`/`down` wait for the outcome: clean → exit 0 after a bounded state-file wait; survivors → per-process lines + exit 1; old daemon (no `waited` field) → legacy message, exit 0; transport failure → "outcome unknown", exit 1. **Breaking:** foreground `prox up` now exits 1 when a process group survives shutdown (was always 0) — CHANGELOG'd.

## Verification

- Unit/`-race`: episode same-verdict matrices (clean/unreapable/multi-waiter/canceled/simultaneous-readiness/retry-isolation), launch-gate check/use window (replacement reaped before Stop returns), aggregation + event classes, overlap test proven discriminating by mutation, coordinator double-trigger/broadcast, handler+client+CLI outcome matrices, double-stop integration, real-router waited-response test.
- Live daemon pass: clean waited stop (exit 0, state files gone); 8s drainer — `prox stop` blocked 8.35s while `prox status` answered `stopping` mid-drain (the property the stage reorder exists for); foreground Ctrl-C clean exit 0; rapid double `prox stop` — no daemon panic, sane exits.
- Honest gaps: unreapable survivors can't be fabricated live (SIGKILL always wins outside kernel tricks) — unit-covered at every level with fakes; TUI stop not runnable headless (bubbletea needs a TTY) — structural/unit coverage; old-daemon fallback unit-tested on the decode branch.

## Review trail / accepted risks

- Plan pressure-tested by the 3-reviewer panel (Codex, GLM 5.2, CodeRabbit) before implementation; major panel corrections included the episode-resolution atomicity requirements, re-sized secondary waits, the weakened-but-provable launch-gate invariant, the latched-broadcast outcome design, and both pre-existing bugs above.
- Per-commit codex adversarial reviews: every finding fixed or dispositioned in the commit messages. Accepted: the check/use launch window (bounded by the reap guarantee); a client whose connection drops mid-wait sees "outcome unknown" (durable result file noted as future work); pre-existing unbounded capture-body cleanup during proxy shutdown (size-capped, daemon exiting).
- No new dependencies; no privacy/secret impact.

<details>
<summary>Plan 004 (full text, incl. § Verified)</summary>

# Plan 004 — Stop failure contract: concurrent-stop verdicts (#32) + full-stop reap reporting (#36)

- **Repo:** prox (single repo; one PR)
- **Branch:** `feature/plan-004-stop-failure-contract`
- **Issues:** closes #32, closes #36
- **Gates:** `make lint && make test && make test-race && make build`; docs commits also `uv run mkdocs build --strict`
- **Baseline:** main @ `5cd07a9` (PR #41 merged). All file:line refs verified this session.
- **Panel review:** DONE (Codex gpt-5.6-sol, GLM 5.2, CodeRabbit — 2026-07-17). Major corrections adopted: episode resolution centralized in a panic-safe helper covering the early-exit path (all three); secondary wait budgets in `Supervisor.Stop` re-sized to cover the primary's finalization window (CodeRabbit H2); D2's "cannot launch after Stop began" weakened to the provable invariant "no replacement outlives `Supervisor.Stop`" — Codex showed the atomic gate has a check/use window; a full RWMutex lease was considered and rejected since the weaker invariant already excludes the harm (orphan surviving daemon exit) without a new lock class (contradiction between Codex "build a lease" and CodeRabbit "sound as designed" resolved this way, documented in D2); D3 reshaped to idiomatic `Stop(ctx) error` returning typed `*ProcessStopError` with `Unwrap() []error` (Codex; keeps `errors.Is`, minimizes ~12-call-site churn flagged by GLM); shutdown coordinator pinned: `sync.Once` trigger (fixes a latent double-`close(shutdownCh)` panic all three found), latched broadcast result (stored outcome + closed channel; a single channel send would serve one waiter — CodeRabbit H4/GLM); response protocol fully specified (HTTP 200 with `success:false` on survivors since the client drops structured bodies on non-2xx — Codex; `waited *bool` detection — GLM); CLI completion semantics defined as verdict-then-bounded-state-file-wait (Codex's mismatch); true timeout maxima documented and the unbounded proxyd `Deregister` bounded (Codex); **pre-existing bug found by panel: `POST /shutdown` is inert against `prox up --tui` (nothing selects on `shutdownCh` in the TUI branch) — fixed in scope since `wait=true` would otherwise hang**; `runUp` shutdown orchestration extracted into a testable helper; event semantics pinned for every error class and made uniform across StopProcess/full-stop; Ctrl-C exit-code change flagged as breaking in CHANGELOG; jargon replaced with plain invariants; test matrix expanded per all three reviews.

## 1. Problem / motivation

The remaining pair from the #29/#30 stop-lifecycle work:

- **#32:** A secondary concurrent `Stop` on the same process returns when the run's monitor finishes (leader reaped), before the primary Stop's group-polling/escalation verdict. With an unreapable group the secondary reports success while the primary correctly returns `PROCESS_GROUP_NOT_REAPED`. PR #41 deferred two adjacent gaps here: (a) a restart's start-half can still launch its replacement after full shutdown has begun (the #41 state gate is checked before the stop half), and (b) daemon shutdown overlapping an in-flight per-process stop returns early with the same secondary semantics — the daemon can exit while a primary stop is still reaping.
- **#36:** Full `prox stop` has no failure contract: `/api/v1/shutdown` responds 200 before teardown starts, `Supervisor.Stop` logs reap failures and returns nil unconditionally, the CLI exits 0, and foreground `prox up` also exits 0 — even when a process group survived and still holds a port.

## 2. Current state (verified this session, post-#41 main)

### #32 core (internal/supervisor/process.go)
- Secondary-waiter branch: `process.go:384-409` — waits on `inst.done` (the **monitor's** channel) and returns nil; the inline comment at `:388-397` names propagating the primary's result as future work.
- Primary verdict path: finalization gate `:462-469` (bounded by `outputDrainTimeout+1s` = 6s beyond the kill deadline), authoritative probe `:471-473`, state → `Crashed` at `:479`, error at `:490`. So a primary's verdict can land up to ~`budget + 6s` after its stop began — **later than a budget-sized secondary context**.
- Early-exit path **between** the `Stopping` transition and the verdict section: `process.go:422-427` (`inst == nil || inst.proc == nil` → set Stopped, return nil). Any episode signal must resolve here too or waiters hang.
- Retry path `:372-383`: one instance can host multiple stop episodes (crashed + surviving group).
- Lock ordering: `s.mu → p.mu` is established (`Processes`/`Process`/`MaxStopBudget` hold `s.mu` across `mp` accessors, `supervisor.go:413+`); anything inside `startWithConfig`'s `p.mu` section must not take `s.mu`.

### #36 surface
- CLI: `runStop` no-args → `client.Shutdown()` (`internal/cli/commands.go:188-208`) on the **plain 30s httpClient** (`client.go:119-122`, `:64-66`); prints "Shutdown initiated", exits 0 always. `down` shares this exact path (`commands.go:221` → `runStop`).
- Handler `handlers.go:182-192`: 200 immediately, then goroutine + 100ms → `shutdownFn`. `shutdownFn` is a bare `close(shutdownCh)` (`up.go:299-302`) — **a second POST /shutdown panics the daemon today** (latent, unguarded double-close).
- up.go stages (`up.go:441-492`): proxy deregister → standalone-proxy shutdown (5s stage) → **API server shutdown (5s stage)** → `sup.Stop` (`MaxStopBudget()+5s`) → flush → `return nil` always. Foreground exit code is therefore always 0 (`root.go:73-76`).
- **Deregister is NOT bounded by its stage**: `proxyd.Client` has its own 30s HTTP timeout and takes no ctx (`internal/proxyd/client.go:74`, `:31`).
- **TUI mode never observes `shutdownCh`**: the select exists only in the non-TUI branch (`up.go:427-436`); `prox up --tui` blocks in `tui.Run` — `POST /shutdown` is inert against a TUI daemon today (pre-existing bug, silent because the async handler already returned 200).
- A stale comment at `up.go:444-448` still claims the API stage "force-closes" in-flight requests — false (`http.Server.Shutdown` waits, then returns leaving connections open).
- `Supervisor.Stop` (`supervisor.go:341-411`): per-process goroutines with `WithTimeout(ctx, info.StopTimeout)` (`:368-369`) — **too small to outlive a primary's finalization window when joining as a secondary**; errors logged then discarded; `process_stopped` emitted unconditionally (`:388-393`), asymmetric with `StopProcess` (`:517-524`, suppresses on error, emits nothing else); returns nil (`:410`). Early return when state != "running" (`:343-346`).
- State files: `daemon.State{PID,Port,Host,StartedAt,ConfigFile}` (`daemon/state.go:28-34`); `CleanupStateDir` removes only state+pid (`:145-164`); cleanup runs in LIFO defers after `runUp` returns (`up.go:254-262`) — i.e. **after** any waited HTTP response, so "response received" ≠ "state files gone".
- No events wire-up to the API exists (`Subscribe` is test-only). `.prox/prox.log` exists only in detached mode.
- Tests: unreapable coverage only at `ManagedProcess.Stop` unit level (`process_stop_test.go:103+`, `unreapableOnKill` fake `fake_runner_test.go:150-175`); nothing pins `Supervisor.Stop` aggregation, the shutdown handler, or CLI exit codes.

## 3. Design decisions — PINNED (panel-revised)

### D1 (#32): Episode-scoped stop verdict
- `stopEpisode { done chan struct{}; err error }`; `ManagedProcess.episode *stopEpisode` guarded by `p.mu`. Installed at every `state → Stopping` transition (normal and crashed-retry entries). **All resolution goes through one helper** `finishStopEpisode(err)` called (via defer, panic-safe) on every exit path after installation — including the early-exit path at `process.go:422-427` — recording `err`, clearing `p.episode`, closing `done` in the same locked section that commits the state verdict.
- Secondary (state == `Stopping`): capture `p.episode` under lock; wait on `ep.done` vs `ctx.Done()`; **on ctx-done, re-check `ep.done` non-blocking and prefer a published verdict** (simultaneous readiness must not drop a real result). Reading `ep.err` after `<-ep.done` is safe without the lock (write happens-before close).
- Contract wording: two concurrent Stops return the **same verdict provided both caller contexts stay live through episode completion**; a caller whose ctx dies first gets `ctx.Err()` (unchanged semantics).
- A late waiter that captured episode N never observes episode N+1's result (episodes are distinct objects; test pins it).
- Alternative (supervisor-level serialization) rejected: a queued second stop would re-run escalation or return `ErrProcessNotRunning` where the primary returned nil — violating same-result.

### D2 (#32-adjacent): Launch gate — provable invariant, not a lease
- `Supervisor.launchable atomic.Bool`: true when entering "running" (set in `startWithFilter`, **reset true on any later re-start**), false at the top of `Supervisor.Stop` (with `state = "stopping"`). `createManagedProcess` injects `launchGate func() error` returning `ErrShutdownInProgress` when false; `startWithConfig` calls it inside its locked section after the existing guards (atomic read only — `s.mu` there would AB-BA against the verified `s.mu → p.mu` order). Nil gate (direct-construction tests) = allow.
- **Invariant (weakened per panel):** a launcher that observes the gate closed never launches; and **no replacement outlives `Supervisor.Stop`** — if a launcher read `true` just before the flip, it launches while holding `p.mu`, and that process's pending stop goroutine (created after the flip, queued on `p.mu`) reaps the replacement before `Stop` returns. The stronger "cannot launch after Stop began" is NOT claimed (Codex's check/use window is real). Full RWMutex launch lease considered and rejected: new lock class + ordering rules to exclude a transient that the invariant already renders harmless (no orphan survives daemon exit). Documented in code comment.
- Test: barrier **between gate authorization and runner launch** (the exact window), asserting the replacement is reaped before `Supervisor.Stop` returns; plus gate-closed refusal for both StartProcess and RestartProcess; plus `launchable` reset on stop→start cycle.

### D3 (#36): Typed aggregate error + uniform events + correct secondary sizing
- Signature stays idiomatic: `Stop(ctx context.Context) error`. On survivors returns `*domain.ProcessStopError { Failures []ProcessStopFailure }` (`ProcessStopFailure { Name string; Err error }`, sorted by name; each `Err` wraps `ErrProcessGroupNotReaped`); implements `Error()`, `Unwrap() []error` (so `errors.Is(err, ErrProcessGroupNotReaped)` works), and `errors.As` extraction for serialization. Nil when clean; nil (nothing to do) from the not-running early return. Failure collection under a mutex, sorted after `wg.Wait()`. `require.NoError(t, sup.Stop(...))` call sites keep compiling (~12 sites, 1 production).
- **Secondary wait sizing:** the per-process goroutine ctx becomes `WithTimeout(ctx, info.StopTimeout + stopVerdictMargin)` where `stopVerdictMargin = outputDrainTimeout + 2s` (named const) — a secondary joining an in-flight primary now outlives the primary's finalization window (budget + ≤6s). The up.go outer bound becomes `Supervisor.StopWaitBound()` (= `MaxStopBudget() + stopVerdictMargin`) `+ teardownStageTimeout`. (11m CLI/route ceilings still exceed the 10m-cap worst case.) **Amended during C3:** feeding the margin into the ctx naively would stretch every *primary's* SIGKILL-escalation window by the margin (breaking the #35 escalation contract; caught by the pre-existing mixed-budgets test) — so `computeDeadlines` now additionally caps the graceful/kill window at the process's own stop budget when the ctx deadline is *later* than budget (earlier ctx deadlines still win). The oversized ctx thereby extends only the secondary's episode wait, never escalation timing.
- **Event semantics, pinned for every class and uniform across paths:** success or `ErrProcessNotRunning` → `process_stopped`; `errors.Is(err, ErrProcessGroupNotReaped)` → `process_crashed` (state is Crashed) — now emitted by **both** `Supervisor.Stop` and `StopProcess`; any other error (ctx expiry/cancellation) → **no event** (not proof of anything). `supervisor_stop` still fires on completion; the returned error is the machine-readable failure signal.

### D4 (#36): Shutdown coordinator + stage reorder + blocking endpoint + CLI exit contract
- **Coordinator** (new small type in up.go or internal/daemon): `Trigger()` via `sync.Once` closing `shutdownCh` (**fixes the latent double-close panic; explicit test**); `Complete(outcome)` via `sync.Once` storing the result and closing a `done` channel — a **latched broadcast**: every waiter (zero, one, or many concurrent `wait=true` handlers) reads the same stored outcome after `<-done`; the shutdown sequence never blocks on any consumer (Ctrl-C with no waiter is a store + close, nothing more).
- **Stage order becomes:** **gate flip (`Supervisor.RefuseLaunches()`, amended during C4 — codex found a launch window while the deregister stage ran before `sup.Stop`'s own flip)** → proxy deregister/standalone-proxy shutdown → **`sup.Stop`** → publish outcome (`Complete`) → **final logs + `logMgr.Close()` (amended during C4: closing subscriber channels first makes mid-drain SSE handlers return immediately instead of pinning the API stage to its deadline; `Write`-after-`Close` verified a safe no-op)** → API server shutdown (5s stage; waits for the wait-handlers to finish their small JSON writes — in-flight handlers return promptly once `done` closes or `r.Context()` dies; a write that somehow exceeds the stage surfaces to the client as a dropped connection = unknown outcome) → cleanup defers. Foreground exit error is one concise `shutdown incomplete: …` line wrapping the aggregate (per-survivor detail lives in the log stream — avoids double-printing). Rationale: the API must outlive the supervisor stage to deliver the outcome; lifecycle launches during the window are refused (the #41 gate + D2). Alternatives (result file in `.prox/`, SSE events route) rejected as before — noted future work.
- **Deregister bounding:** wrap the proxyd `Deregister` (own 30s internal timeout, no ctx) in a goroutine + select on the 5s stage ctx — proceed after 5s leaving it to finish or fail in the background; log if abandoned. True stage bound restored.
- **TUI fix (pre-existing bug, in scope):** route `shutdownCh` into the TUI branch (goroutine → program quit) so `POST /shutdown` — and therefore `wait=true` — works against `prox up --tui`. Without this the blocking endpoint would hang to its ceiling against TUI daemons.
- **Stale comment** at `up.go:444-448` (claims force-close) rewritten with the reorder.
- **Endpoint protocol** (`POST /api/v1/shutdown`): `?wait=true` → handler `Trigger()`s, then selects `done` / `r.Context().Done()`; on done responds **HTTP 200** `{success: <failures empty>, waited: true, failures: [{process, error, code}]}` — 200 even on survivors because the CLI client discards structured bodies on non-2xx; `code` is the stable `PROCESS_GROUP_NOT_REAPED`. Any other/absent `wait` value → legacy async `200 {success:true}` (back-compat). Route moves to the lifecycle (11m) timeout group. Duplicate/concurrent `wait=true` requests all receive the identical latched outcome.
- **CLI contract** (`prox stop`, and `down` via the shared `runStop`): `Shutdown(wait bool)` switches to `postLifecycle` (11m client). Response decoding uses `Waited *bool` (absence ≠ false — old daemon ignored the param and acked). Outcomes: `waited` present + clean → wait (bounded, 15s) for the state/PID files to disappear, print "stopped" summary, **exit 0**; failures present → print one `process: error` line each, **exit 1**; `waited` absent (old daemon) → legacy "Shutdown initiated", exit 0; transport failure mid-wait → "shutdown may still be completing daemon-side; outcome unknown" (mention `.prox/prox.log` only when the daemon runs detached), **exit 1**. The waited response marks the **process-stop verdict**; full daemon exit is confirmed by the bounded state-file wait (poll-timeout → warn, keep verdict-based exit code).
- **Foreground exit:** the shutdown sequence is extracted from `runUp` into a testable helper returning the outcome; `runUp` returns a survivors-naming error → exit 1 (Ctrl-C and API paths alike), with `logMgr.Close()` still executed before the error return. **Breaking change** (foreground `prox up` previously always exited 0) — CHANGELOG-flagged.

## 4. Deviations / non-goals
- No `.prox` shutdown-result file, no SSE events endpoint (future work).
- No full launch lease (D2 invariant documented instead). A stop beginning mid-restart remains ordinary concurrent-stop behavior, verdict-consistent via D1.
- No change to budgets/escalation timing/#33 reload flow.
- `supervisor_stop` event unchanged.

## 5. Work breakdown (gated commits)

| Commit | Scope | Model | Gate |
|---|---|---|---|
| **C1** | D1: `stopEpisode` + `finishStopEpisode` (all paths incl. early-exit; panic-safe defer), secondary rewrite w/ published-verdict preference. Tests (-race, barrier-deterministic): concurrent same-verdict (clean + unreapable), multiple secondaries, canceled waiter, simultaneous done/ctx readiness, retry-episode isolation (late waiter on ep1 ≠ ep2 result), early-exit path resolves episode | opus | lint+test+test-race+build |
| **C2** | D2: `launchable` (+reset on restart cycle), gate closure in `startWithConfig`. Tests: gate-closed refusal (Start + Restart), the authorize→launch window barrier test asserting replacement reaped before `Stop` returns, nil-gate back-compat | opus | lint+test+test-race+build |
| **C3** | D3: `ProcessStopError`/`Unwrap`, secondary sizing (`stopVerdictMargin`), event uniformity (StopProcess emits `process_crashed` on reap failure; no event on other errors), call-site updates. Tests: mixed clean/unreapable aggregation + ordering, empty outcome, `errors.Is/As`, event assertions per error class, **overlap test** (StopProcess primary on unreapable group; `Supervisor.Stop` joins as secondary; outcome carries the failure; old sizing would have ctx-expired) | opus | lint+test+test-race+build |
| **C4** | D4 daemon side: coordinator (Once trigger + latched broadcast), stage reorder, deregister bounding, TUI `shutdownCh` wiring, shutdown-helper extraction from `runUp`, foreground exit contract, stale-comment rewrite. Tests: double-trigger safety, no-waiter completion, helper-level survivor exit path, deterministic status-readable-during-drain (fake barriers) | opus | lint+test+test-race+build |
| **C5** | D4 API+CLI: `?wait=true` handler + response shape, route group move, `Shutdown(wait)` on `postLifecycle`, CLI outcome/exit handling + state-file wait + old-daemon fallback (`Waited *bool` unit tests) + transport-failure wording; integration: clean full stop exit 0 + waited response + state files gone; async default still works; docs (both api.md copies: shutdown endpoint; cli.md stop/down; architecture.md stages) + CHANGELOG (incl. breaking Ctrl-C exit-code note) | opus | lint+test+test-race+build + mkdocs --strict |

## 6. File map (indicative)
- `internal/supervisor/process.go` (episodes, gate call), `supervisor.go` (launchable, ProcessStopError→domain, sizing, events), `internal/domain/errors.go` (ProcessStopError or supervisor-local — implementer picks the package that avoids import cycles, prefer domain), tests (+`stop_episode_test.go`)
- `internal/cli/up.go` (coordinator, reorder, helper, TUI wiring, deregister bound), `commands.go`, `client.go`, tests
- `internal/api/handlers.go`, `server.go`, `responses.go`, tests
- `test/integration/up_test.go` (+exit-code/waited assertions)
- `docs/reference/api.md` + mirror, `docs/reference/cli.md`, `docs/development/architecture.md`, `CHANGELOG.md`

## 7. Acceptance criteria
**#32**
- Two concurrent `Stop`s return the same verdict (clean and unreapable cases) **when both caller ctxs live through episode completion**; a canceled waiter gets `ctx.Err()`; simultaneous readiness prefers the published verdict. Deterministic, `-race`.
- No `process_stopped` for a surviving group on any path; reap failure emits `process_crashed` on both StopProcess and full-Stop paths; other errors emit nothing.
- `Supervisor.Stop` joining an in-flight primary waits through the primary's finalization window (sizing test) and aggregates the true verdict.
- Launch gate: observed-closed → refused; replacement launched in the check/use window is reaped before `Supervisor.Stop` returns (barrier test). `launchable` resets across stop→start.
- Waiters on a finished episode never see a later episode's result; early-exit path resolves the episode.

**#36**
- Unit level (unreapable groups can't be fabricated live): full stop with a survivor → `Stop` returns `*ProcessStopError` listing it (sorted, wraps `ErrProcessGroupNotReaped`); handler responds 200 `{success:false, waited:true, failures:[...]}`; CLI prints the survivor lines and exits **1**; foreground helper returns the survivors error → `prox up` exits 1.
- Integration/live: clean `prox stop` → waited response, exit 0, state+pid files gone within the bounded wait; `prox status` answers during a slow drain; async (no-wait) POST still returns immediate 200; double `POST /shutdown` does not panic; `prox stop` works against a `--tui` daemon.
- Old-daemon fallback: `waited` absent → legacy message, exit 0 (unit test on the decode branch).
- Transport failure mid-wait → non-zero exit with "may still be completing" wording.

## 8. Verification plan (beyond automated tests)
Live pass (artifacts → `~/.claude/plans/prox/004-stop-failure-contract/`): (1) clean two-process `prox stop` — waited response, exit 0, state files gone; (2) 20s-drainer — `prox stop` blocks ~20s, `prox status` from another shell answers mid-drain; (3) foreground Ctrl-C clean → exit 0; (4) `prox up --tui` + `prox stop` from another shell → TUI exits (the pre-existing inert-shutdown bug fixed); (5) rapid double `prox stop` → no panic, both exit sanely. Unreapable-survivor and old-daemon paths are unit-only — recorded honestly in § Verified.

## 9. Risks / open items / future work
- Foreground exit-code change is breaking for scripts asserting 0 — CHANGELOG'd prominently.
- Multiple `wait=true` waiters all get the outcome via the latch; a client whose connection drops sees unknown-outcome (documented). Durable result file = future work.
- API serves read-only endpoints during the drain window (state "stopping"); lifecycle routes already refuse.
- Abandoned background `Deregister` after its 5s stage: logged, harmless (daemon exiting).
- `ProcessStopError` placement must avoid domain→supervisor import cycles; prefer `internal/domain`.

## § Verified (beyond automated tests)

Live pass against the built binary (transcript: `~/.claude/plans/prox/004-stop-failure-contract/verification.log`):

1. **Clean waited full stop** — `prox stop` printed "Stopped prox", exit 0, state+pid files gone. PASS.
2. **Slow drain + API liveness** — 8s-drainer: `prox stop` blocked 8.35s for the verdict (exit 0) while a concurrent `prox status` answered `Status: stopping` mid-drain — the property the stage reorder exists for, observed live. PASS.
3. **Foreground Ctrl-C clean** — `prox up` + SIGINT → exit 0. PASS.
4. **Rapid double `prox stop`** — no daemon panic (the latent double-close is fixed); first stop got the waited verdict (exit 0); the second raced the fast daemon exit, fell back to the default address after state-file removal, and correctly took the unknown-outcome path (exit 1). Message notes shutdown may still be completing — acceptable race-window UX, noted. PASS.
5. **TUI stop scenario** — not runnable headless (bubbletea requires a real TTY; `script(1)` insufficient). The TUI shutdown wiring is covered structurally + by unit tests only. HONEST GAP for manual confirmation.

Known-unexercised live (unit/-race coverage only, as planned): unreapable-survivor full stop (cannot fabricate a SIGKILL-surviving group without kernel tricks — covered at ManagedProcess/Supervisor/handler/CLI-matrix levels with fakes); old-daemon fallback (needs an old binary; decode-branch unit tests); concurrent-stop verdict equality (deterministic barrier tests, 5× under -race).


</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgMgg6eo4LgLTCkfYSARcH


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `prox stop` now waits for shutdown completion, reports surviving processes, and exits with updated codes.
  * Added `POST /api/v1/shutdown?wait=true` waited responses with structured failure details.
  * Foreground `prox up` now reflects unsuccessful shutdown via non-zero exit.
  * Added configurable, validated stop timeouts with deadline budgeting.
* **Bug Fixes**
  * Improved shutdown reliability: repeated/concurrent shutdown requests no longer panic and coordinate to a single outcome.
  * `POST /shutdown` now properly triggers shutdown for TUI mode daemons.
  * `start`/`restart` now re-read and validate `prox.yaml`, failing closed on reload errors.
* **Documentation**
  * Updated CLI and API docs to describe the waited behavior and legacy fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->