### PR TITLE
fix: long-lived SSE streams (#42) and prox requests API discovery (#43)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,19 @@ All notable changes to this project will be documented in this file.
 
 ### Fixes
 
+- **SSE streams are no longer cut at 30 seconds** (#42). `GET /api/v1/logs/stream`
+  and `GET /api/v1/proxy/requests/stream` sat in the router's default 30s
+  request-timeout class, so `prox logs -f`, `prox attach`, and proxy-request
+  streams silently terminated after ~30s. The two SSE routes are now exempt from
+  the request timeout: streams are long-lived and end only on client disconnect
+  or daemon shutdown. Shutdown now also closes the shared-proxy-daemon request
+  forwarder's subscriber channels, so an attached request stream no longer pins
+  the API server to its full teardown-stage deadline.
+- **`prox requests` now discovers the daemon's API address** (#43). `requests`
+  was missing from the client-command discovery allowlist, so it always talked
+  to the default `:5555` address and failed against daemons on dynamic API ports
+  (the default) — the same gap `start` had. The allowlist is now pinned by a
+  test so a new client command can't silently miss discovery.
 - `prox start <name>` now discovers the daemon's API address from `.prox/prox.state`
   like the other client commands; previously it always used the default `:5555`
   address and failed against daemons on dynamic API ports (found during #33

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -224,6 +224,8 @@ The `lines` parameter is capped at 10000.
 
 Stream logs via Server-Sent Events (SSE).
 
+The stream is long-lived: it is exempt from the 30s request-timeout class and ends only on client disconnect or daemon shutdown.
+
 **Query Parameters:** Same as `GET /logs` (except `lines`)
 
 **Response:** SSE stream
@@ -337,6 +339,8 @@ curl "http://localhost:5555/api/v1/proxy/requests/a1b2c3d?include=body"
 ### GET /proxy/requests/stream
 
 Stream proxy requests via Server-Sent Events (SSE).
+
+The stream is long-lived: it is exempt from the 30s request-timeout class and ends only on client disconnect or daemon shutdown.
 
 **Query Parameters:** Same as `GET /proxy/requests` (except `limit`)
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -173,10 +173,12 @@ func authMiddleware(authEnabled bool, token string) func(http.Handler) http.Hand
 //     (11m). The supervisor bounds start/stop/restart internally per-process by
 //     the configured stop budget; /shutdown?wait=true blocks for the whole drain.
 //     This router ceiling is hang protection only.
-//   - Default group (everything else, including the SSE streams):
-//     defaultRequestTimeout (30s), preserving the prior behavior exactly. The
-//     SSE streams (/logs/stream, /proxy/requests/stream) watch r.Context() and
-//     were 30s-capped before this restructure; they remain so.
+//   - SSE group (/logs/stream, /proxy/requests/stream): NO timeout middleware.
+//     The streams are long-lived by design (WriteTimeout is 0 for the same
+//     reason); they end when the client disconnects (r.Context() is cancelled
+//     on connection close) or when the daemon shuts down (the log manager
+//     closes subscriber channels at shutdown). (#42)
+//   - Default group (everything else): defaultRequestTimeout (30s).
 func (s *Server) registerRoutes() {
 	// Health check at root (no auth required). Kept under the default 30s
 	// ceiling to preserve prior behavior (it returns immediately regardless).
@@ -207,6 +209,17 @@ func (s *Server) registerRoutes() {
 			r.Post("/shutdown", s.handlers.Shutdown)
 		})
 
+		// SSE streams: no timeout middleware. These are long-lived connections
+		// that end on client disconnect or daemon shutdown, matching the
+		// server's WriteTimeout of 0 (#42).
+		r.Group(func(r chi.Router) {
+			r.Get("/logs/stream", s.handlers.StreamLogs)
+			// Note: /proxy/requests/stream is registered here while
+			// /proxy/requests/{id} lives in the default group below; chi routes
+			// the literal "stream" segment ahead of the {id} parameter.
+			r.Get("/proxy/requests/stream", s.handlers.StreamProxyRequests)
+		})
+
 		// Everything else keeps the default 30s ceiling.
 		r.Group(func(r chi.Router) {
 			r.Use(middleware.Timeout(defaultRequestTimeout))
@@ -220,13 +233,9 @@ func (s *Server) registerRoutes() {
 
 			// Logs
 			r.Get("/logs", s.handlers.GetLogs)
-			r.Get("/logs/stream", s.handlers.StreamLogs)
 
 			// Proxy requests
-			// Note: /proxy/requests/stream must come before /proxy/requests/{id}
-			// to prevent the parameterized route from matching "stream" as an ID
 			r.Get("/proxy/requests", s.handlers.GetProxyRequests)
-			r.Get("/proxy/requests/stream", s.handlers.StreamProxyRequests)
 			r.Get("/proxy/requests/{id}", s.handlers.GetProxyRequest)
 		})
 	})

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1,11 +1,13 @@
 package api
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -389,14 +391,20 @@ func deadlineProbe(dst *time.Duration) http.HandlerFunc {
 // TestRouteGroupTimeoutWiring verifies the per-group timeout mechanism that
 // registerRoutes relies on: a route placed in a group with
 // middleware.Timeout(lifecycleRequestTimeout) sees a context deadline of ~11m,
-// while a route under defaultRequestTimeout sees ~30s. It mirrors the exact
-// group structure of registerRoutes with probe handlers (the real lifecycle
-// handlers cannot report their own deadline), keeping the test instant -- no
-// >30s sleep. Together with TestRequestTimeoutConstants and the routing smoke
-// test, this establishes that lifecycle requests are not cut at the old 30s
-// boundary.
+// a route under defaultRequestTimeout sees ~30s, and the SSE group carries NO
+// deadline at all (#42). It mirrors the exact group structure of registerRoutes
+// with probe handlers (the real lifecycle handlers cannot report their own
+// deadline), keeping the test instant -- no >30s sleep. Together with
+// TestRequestTimeoutConstants and the routing smoke test, this establishes
+// that lifecycle requests are not cut at the old 30s boundary and that the SSE
+// streams are not deadline-bounded at all. It also pins chi's static-over-param
+// precedence: /proxy/requests/stream (SSE group) must win over
+// /proxy/requests/{id} (default group) even though they live in different
+// groups.
 func TestRouteGroupTimeoutWiring(t *testing.T) {
-	var lifecycleBudget, defaultBudget time.Duration
+	var lifecycleBudget, defaultBudget, idBudget time.Duration
+	sseLogsSawDeadline := true
+	sseProxySawDeadline := true
 
 	r := chi.NewRouter()
 	r.Group(func(r chi.Router) {
@@ -404,17 +412,31 @@ func TestRouteGroupTimeoutWiring(t *testing.T) {
 		r.Post("/processes/{name}/stop", deadlineProbe(&lifecycleBudget))
 	})
 	r.Group(func(r chi.Router) {
+		r.Get("/logs/stream", func(w http.ResponseWriter, r *http.Request) {
+			_, sseLogsSawDeadline = r.Context().Deadline()
+			w.WriteHeader(http.StatusOK)
+		})
+		r.Get("/proxy/requests/stream", func(w http.ResponseWriter, r *http.Request) {
+			_, sseProxySawDeadline = r.Context().Deadline()
+			w.WriteHeader(http.StatusOK)
+		})
+	})
+	r.Group(func(r chi.Router) {
 		r.Use(middleware.Timeout(defaultRequestTimeout))
 		r.Get("/status", deadlineProbe(&defaultBudget))
+		r.Get("/proxy/requests/{id}", deadlineProbe(&idBudget))
 	})
 
-	rec := httptest.NewRecorder()
-	r.ServeHTTP(rec, httptest.NewRequest("POST", "/processes/web/stop", nil))
-	require.Equal(t, http.StatusOK, rec.Code)
-
-	rec = httptest.NewRecorder()
-	r.ServeHTTP(rec, httptest.NewRequest("GET", "/status", nil))
-	require.Equal(t, http.StatusOK, rec.Code)
+	for _, req := range []*http.Request{
+		httptest.NewRequest("POST", "/processes/web/stop", nil),
+		httptest.NewRequest("GET", "/status", nil),
+		httptest.NewRequest("GET", "/logs/stream", nil),
+		httptest.NewRequest("GET", "/proxy/requests/stream", nil),
+	} {
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+		require.Equal(t, http.StatusOK, rec.Code, "%s %s", req.Method, req.URL.Path)
+	}
 
 	// Lifecycle route must carry the large ceiling, well past the old 30s.
 	assert.Greater(t, lifecycleBudget, 30*time.Second, "lifecycle route deadline must exceed the old 30s boundary")
@@ -422,6 +444,86 @@ func TestRouteGroupTimeoutWiring(t *testing.T) {
 	// Default route keeps the 30s ceiling.
 	assert.LessOrEqual(t, defaultBudget, 30*time.Second)
 	assert.Greater(t, defaultBudget, 25*time.Second)
+	// SSE routes carry no deadline at all (#42).
+	assert.False(t, sseLogsSawDeadline, "/logs/stream must have no context deadline")
+	assert.False(t, sseProxySawDeadline, "/proxy/requests/stream must have no context deadline")
+	// GET /proxy/requests/stream resolved to the SSE probe, so the {id} probe
+	// under the timed group must never have run.
+	assert.Zero(t, idBudget, "/proxy/requests/stream must not match /proxy/requests/{id}")
+}
+
+// TestSSEStreamSurvivesTimeoutBoundary runs the real StreamLogs handler inside
+// the SSE (no-timeout) group structure of registerRoutes, next to a sibling
+// group carrying a short stand-in timeout (150ms instead of 30s, keeping the
+// test instant). The sibling is genuinely cut at the injected boundary, while
+// the stream still delivers an entry published well after it -- proving the
+// SSE group escapes the timeout class that would have killed it (#42). Like
+// TestRouteGroupTimeoutWiring, the router here is a reconstruction of
+// registerRoutes' group structure, not the real router.
+func TestSSEStreamSurvivesTimeoutBoundary(t *testing.T) {
+	const injectedTimeout = 150 * time.Millisecond
+
+	logMgr := logs.NewManager(logs.ManagerConfig{BufferSize: 100, SubscriptionBuffer: 10})
+	defer logMgr.Close()
+	handlers := NewHandlers(nil, logMgr, "test.yaml", nil)
+
+	r := chi.NewRouter()
+	r.Group(func(r chi.Router) {
+		r.Get("/logs/stream", handlers.StreamLogs)
+	})
+	r.Group(func(r chi.Router) {
+		r.Use(middleware.Timeout(injectedTimeout))
+		r.Get("/slow", func(w http.ResponseWriter, r *http.Request) {
+			<-r.Context().Done()
+		})
+	})
+
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	// The timed sibling is cut at the injected boundary.
+	resp, err := http.Get(srv.URL + "/slow")
+	require.NoError(t, err)
+	resp.Body.Close()
+	assert.Equal(t, http.StatusGatewayTimeout, resp.StatusCode)
+
+	// The stream outlives that same boundary.
+	stream, err := http.Get(srv.URL + "/logs/stream")
+	require.NoError(t, err)
+	defer stream.Body.Close()
+
+	reader := bufio.NewReader(stream.Body)
+	line, err := reader.ReadString('\n')
+	require.NoError(t, err)
+	require.Contains(t, line, ": connected")
+
+	// Sail well past the injected boundary, then publish.
+	time.Sleep(3 * injectedTimeout)
+	logMgr.Write(domain.LogEntry{
+		Timestamp: time.Now(),
+		Process:   "late",
+		Stream:    domain.StreamStdout,
+		Line:      "still alive",
+	})
+
+	got := make(chan struct{})
+	go func() {
+		for {
+			l, err := reader.ReadString('\n')
+			if err != nil {
+				return
+			}
+			if strings.Contains(l, "still alive") {
+				close(got)
+				return
+			}
+		}
+	}()
+	select {
+	case <-got:
+	case <-time.After(2 * time.Second):
+		t.Fatal("stream did not deliver an entry published after the injected timeout boundary")
+	}
 }
 
 // TestRegisterRoutes_RoutingSmoke exercises the restructured router end-to-end to

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -43,19 +43,28 @@ processes for local development. It supports:
 		}
 
 		// For client commands, try to discover API address if not explicitly set
-		clientCommands := map[string]bool{
-			"status":  true,
-			"logs":    true,
-			"stop":    true,
-			"start":   true,
-			"restart": true,
-			"down":    true,
-			"attach":  true,
-		}
 		if clientCommands[cmd.Name()] && !apiAddrExplicitlySet {
 			apiAddr = discoverAPIAddress()
 		}
 	},
+}
+
+// clientCommands is the discovery allowlist: the commands that talk to the
+// daemon API via apiAddr and therefore need the address discovered from
+// .prox/prox.state (or the config file) when --addr is not given. Every
+// command whose handler calls NewClient with apiAddr MUST be listed here, or
+// it silently talks to the :5555 default and breaks against dynamic-port
+// daemons (the default) — the exact bug 'start' had (#41) and 'requests' had
+// (#43). TestClientCommandsDiscoveryAllowlist pins this contract.
+var clientCommands = map[string]bool{
+	"status":   true,
+	"logs":     true,
+	"stop":     true,
+	"start":    true,
+	"restart":  true,
+	"down":     true,
+	"attach":   true,
+	"requests": true,
 }
 
 // Execute runs the root command.

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -133,3 +133,48 @@ processes:
 		}
 	})
 }
+
+// TestClientCommandsDiscoveryAllowlist pins the discovery allowlist contract:
+// every command whose handler reaches the daemon API through the shared apiAddr
+// global (the NewClient(apiAddr) call sites in this package, plus attach, which
+// falls back to apiAddr when --addr is set) must be in clientCommands, or it
+// silently talks to the :5555 default and breaks against dynamic-port daemons.
+// 'start' (#41) and 'requests' (#43) both shipped with exactly that gap; when
+// adding a new client command, add it to clientCommands AND to this list.
+func TestClientCommandsDiscoveryAllowlist(t *testing.T) {
+	// The enumerated apiAddr-consuming commands. downCmd reuses runStop, and
+	// attachCmd honors apiAddr when explicitly set, so both belong here.
+	apiAddrCommands := []string{
+		"status",   // runStatus
+		"logs",     // runLogs
+		"stop",     // runStop
+		"down",     // RunE: runStop
+		"start",    // runStartProcess
+		"restart",  // runRestart
+		"attach",   // runAttach (apiAddr fallback + state discovery)
+		"requests", // runRequests
+	}
+
+	for _, name := range apiAddrCommands {
+		if !clientCommands[name] {
+			t.Errorf("command %q performs client calls via apiAddr but is missing from the clientCommands discovery allowlist", name)
+		}
+	}
+
+	// Every allowlist entry must be a real registered subcommand, so a renamed
+	// or removed command can't leave a stale entry silently matching nothing.
+	registered := make(map[string]bool)
+	for _, cmd := range rootCmd.Commands() {
+		registered[cmd.Name()] = true
+	}
+	for name := range clientCommands {
+		if !registered[name] {
+			t.Errorf("clientCommands allowlist entry %q is not a registered command", name)
+		}
+	}
+
+	if len(clientCommands) != len(apiAddrCommands) {
+		t.Errorf("clientCommands has %d entries but %d apiAddr-consuming commands are enumerated here; keep the allowlist and this test in sync",
+			len(clientCommands), len(apiAddrCommands))
+	}
+}

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -462,6 +462,7 @@ func runUp(cmd *cobra.Command, args []string) error {
 		apiServer:    apiServer,
 		coordinator:  coordinator,
 		logMgr:       logMgr,
+		reqMgr:       localRequestManager(proxyService, handlers),
 		cwd:          cwd,
 		stageTimeout: teardownStageTimeout,
 	})
@@ -511,6 +512,7 @@ type shutdownDeps struct {
 	apiServer    *api.Server
 	coordinator  *shutdownCoordinator
 	logMgr       *logs.Manager
+	reqMgr       *proxy.RequestManager
 	cwd          string
 	stageTimeout time.Duration
 }
@@ -549,14 +551,21 @@ type shutdownDeps struct {
 //
 // Deviation from the plan's D4 stage order (API shutdown → flush): the log manager
 // is closed BEFORE the API stage. GET /logs/stream (SSE) handlers range over a log
-// subscription channel and would otherwise hold their connection until the 30s
-// route timeout, making apiServer.Shutdown sit out its full 5s stage on every
-// shutdown with a stream attached. Closing the manager closes those subscriber
-// channels so the handlers return at once; the API stage then only waits for any
-// small wait=true JSON write. This is safe because Write-after-Close is a no-op
-// (RingBuffer.Write always succeeds; Broadcast/Send short-circuit on a closed
-// subscription) and non-streaming GET /logs still reads the intact ring buffer, so
-// no handler panics.
+// subscription channel and carry no route timeout at all (#42), so they would
+// otherwise hold their connection indefinitely, making apiServer.Shutdown sit out
+// its full 5s stage on every shutdown with a stream attached. Closing the manager
+// closes those subscriber channels so the handlers return at once; the API stage
+// then only waits for any small wait=true JSON write. This is safe because
+// Write-after-Close is a no-op (RingBuffer.Write always succeeds; Broadcast/Send
+// short-circuit on a closed subscription) and non-streaming GET /logs still reads
+// the intact ring buffer, so no handler panics.
+//
+// The request manager is closed here for the same reason: GET
+// /proxy/requests/stream (SSE) handlers range over a request subscription channel
+// with no route timeout. In standalone-proxy mode the proxy stage already closed
+// it (Close is idempotent — subscriptions are removed as they close); in
+// shared-daemon mode this is the only close of the local forwarding manager,
+// which nothing else tears down.
 func performShutdown(deps shutdownDeps) *domain.ProcessStopError {
 	// Stage 0: refuse new launches for the whole shutdown, including the deregister
 	// stage below (the API still serves there, before Stop's own gate flip).
@@ -647,6 +656,12 @@ func performShutdown(deps shutdownDeps) *domain.ProcessStopError {
 	time.Sleep(logFlushDelay)
 	if deps.logMgr != nil {
 		deps.logMgr.Close()
+	}
+	// Release any /proxy/requests/stream subscribers for the same reason (see the
+	// doc comment); without this, a connected stream pins the API stage to its
+	// full deadline in shared-daemon mode (#42 codex review finding).
+	if deps.reqMgr != nil {
+		deps.reqMgr.Close()
 	}
 
 	// Stage 5: stop the API server, now that the verdict is published, the log

--- a/internal/logs/subscription.go
+++ b/internal/logs/subscription.go
@@ -96,6 +96,10 @@ type SubscriptionManager struct {
 	mu            sync.RWMutex
 	subscriptions map[string]*Subscription
 	bufferSize    int
+	// closed latches after Close: new Subscribe calls get an already-closed
+	// channel so post-shutdown streams end immediately instead of blocking on
+	// a channel nothing will ever close.
+	closed bool
 }
 
 // NewSubscriptionManager creates a new subscription manager
@@ -109,7 +113,9 @@ func NewSubscriptionManager(bufferSize int) *SubscriptionManager {
 	}
 }
 
-// Subscribe creates a new subscription
+// Subscribe creates a new subscription. After Close, the returned channel is
+// already closed, so an SSE handler that races the shutdown-time Close
+// observes end-of-stream immediately.
 func (m *SubscriptionManager) Subscribe(filter domain.LogFilter) (string, <-chan domain.LogEntry, error) {
 	sub, err := newSubscription(filter, m.bufferSize)
 	if err != nil {
@@ -117,6 +123,11 @@ func (m *SubscriptionManager) Subscribe(filter domain.LogFilter) (string, <-chan
 	}
 
 	m.mu.Lock()
+	if m.closed {
+		m.mu.Unlock()
+		sub.Close()
+		return sub.id, sub.ch, nil
+	}
 	m.subscriptions[sub.id] = sub
 	m.mu.Unlock()
 
@@ -154,9 +165,13 @@ func (m *SubscriptionManager) Count() int {
 	return len(m.subscriptions)
 }
 
-// Close closes all subscriptions
+// Close closes all subscriptions. It latches: subsequent Subscribe calls
+// receive an already-closed channel, so a stream request racing a
+// shutdown-time Close cannot re-subscribe and pin the API server open.
+// Idempotent.
 func (m *SubscriptionManager) Close() {
 	m.mu.Lock()
+	m.closed = true
 	subs := make([]*Subscription, 0, len(m.subscriptions))
 	for _, sub := range m.subscriptions {
 		subs = append(subs, sub)

--- a/internal/logs/subscription_test.go
+++ b/internal/logs/subscription_test.go
@@ -159,6 +159,28 @@ func TestSubscriptionManager_Close(t *testing.T) {
 	assert.False(t, ok2)
 }
 
+// TestSubscriptionManager_SubscribeAfterClose pins the shutdown latch: a
+// subscribe that races past Close must get an already-closed channel (so an
+// SSE handler returns immediately) and must not be registered — otherwise a
+// late stream request pins the API server open through shutdown.
+func TestSubscriptionManager_SubscribeAfterClose(t *testing.T) {
+	m := NewSubscriptionManager(10)
+	m.Close()
+
+	id, ch, err := m.Subscribe(domain.LogFilter{})
+	require.NoError(t, err)
+	require.NotNil(t, ch)
+
+	_, ok := <-ch
+	assert.False(t, ok, "post-Close subscription channel must be closed")
+	assert.Equal(t, 0, m.Count(), "post-Close subscription must not be registered")
+
+	// Unsubscribing the unregistered id must be a safe no-op, and Close must
+	// stay idempotent.
+	m.Unsubscribe(id)
+	m.Close()
+}
+
 func TestSubscriptionManager_Concurrent(t *testing.T) {
 	m := NewSubscriptionManager(100)
 

--- a/internal/proxy/requests.go
+++ b/internal/proxy/requests.go
@@ -83,6 +83,9 @@ type RequestManager struct {
 	subMu  sync.RWMutex
 	subs   map[string]*RequestSubscription
 	nextID int
+	// closed latches after Close: new Subscribe calls get an already-closed
+	// channel so post-shutdown streams end immediately.
+	closed bool
 
 	// onEvict is called when a request is evicted from the buffer
 	onEvict EvictionCallback
@@ -187,6 +190,9 @@ func (m *RequestManager) GetByID(id string) (RequestRecord, bool) {
 }
 
 // Subscribe creates a subscription for real-time request updates.
+// After Close, the returned subscription's channel is already closed, so an
+// SSE handler that races the shutdown-time Close observes end-of-stream
+// immediately instead of blocking on a channel nothing will ever close.
 func (m *RequestManager) Subscribe(filter RequestFilter) *RequestSubscription {
 	m.subMu.Lock()
 	defer m.subMu.Unlock()
@@ -196,6 +202,10 @@ func (m *RequestManager) Subscribe(filter RequestFilter) *RequestSubscription {
 		ID:     fmt.Sprintf("sub-%d", m.nextID),
 		Filter: filter,
 		Ch:     make(chan RequestRecord, 100),
+	}
+	if m.closed {
+		close(sub.Ch)
+		return sub
 	}
 	m.subs[sub.ID] = sub
 
@@ -220,11 +230,15 @@ func (m *RequestManager) Count() int {
 	return m.count
 }
 
-// Close closes all subscription channels and cleans up resources.
+// Close closes all subscription channels and cleans up resources. It latches:
+// subsequent Subscribe calls receive an already-closed channel, so a stream
+// request racing a shutdown-time Close cannot re-subscribe and pin the API
+// server open. Idempotent.
 func (m *RequestManager) Close() {
 	m.subMu.Lock()
 	defer m.subMu.Unlock()
 
+	m.closed = true
 	for id, sub := range m.subs {
 		close(sub.Ch)
 		delete(m.subs, id)

--- a/internal/proxy/requests_test.go
+++ b/internal/proxy/requests_test.go
@@ -220,3 +220,25 @@ func TestRequestManager_Record_PreservesExistingID(t *testing.T) {
 	require.Len(t, records, 1)
 	assert.Equal(t, "custom1", records[0].ID, "expected existing ID to be preserved")
 }
+
+// TestRequestManager_SubscribeAfterClose pins the shutdown latch: a subscribe
+// that races past Close must get an already-closed channel (so an SSE handler
+// returns immediately) and must not be registered — otherwise a late
+// /proxy/requests/stream request pins the API server open through shutdown.
+func TestRequestManager_SubscribeAfterClose(t *testing.T) {
+	m := NewRequestManager(10)
+	m.Close()
+
+	sub := m.Subscribe(RequestFilter{})
+	require.NotNil(t, sub)
+
+	_, ok := <-sub.Ch
+	assert.False(t, ok, "post-Close subscription channel must be closed")
+
+	// The dead subscription must not receive records or be tracked.
+	m.Record(RequestRecord{Method: "GET", URL: "/after-close"})
+
+	// Unsubscribing it must be a safe no-op, and Close must stay idempotent.
+	m.Unsubscribe(sub.ID)
+	m.Close()
+}

--- a/skills/prox/references/api.md
+++ b/skills/prox/references/api.md
@@ -224,6 +224,8 @@ The `lines` parameter is capped at 10000.
 
 Stream logs via Server-Sent Events (SSE).
 
+The stream is long-lived: it is exempt from the 30s request-timeout class and ends only on client disconnect or daemon shutdown.
+
 **Query Parameters:** Same as `GET /logs` (except `lines`)
 
 **Response:** SSE stream
@@ -337,6 +339,8 @@ curl "http://localhost:5555/api/v1/proxy/requests/a1b2c3d?include=body"
 ### GET /proxy/requests/stream
 
 Stream proxy requests via Server-Sent Events (SSE).
+
+The stream is long-lived: it is exempt from the 30s request-timeout class and ends only on client disconnect or daemon shutdown.
 
 **Query Parameters:** Same as `GET /proxy/requests` (except `limit`)
 


### PR DESCRIPTION
Closes #42. Closes #43.

Two gated commits fixing the bugs filed out of the plan-003/004 work (PRs #41/#44).

## Commit 1 — SSE streams no longer cut at 30s (#42)

`GET /api/v1/logs/stream` and `GET /api/v1/proxy/requests/stream` sat in the router's default 30s timeout group, so `prox logs -f` / `attach` / request streams silently terminated at ~30s — contradicting the server's own `WriteTimeout: 0 // Disable for SSE` and the CLI SSE client design. The two routes now live in their own chi group with **no timeout middleware**; streams end on client disconnect (`r.Context()` cancels on connection close) or daemon shutdown (subscriber channels close). Deliberately no idle bound.

- Tests: the route-group wiring probe asserts the SSE routes carry no context deadline and pins chi's static-over-param precedence for `/proxy/requests/stream` vs `/proxy/requests/{id}` across groups; a new real-handler test (`TestSSEStreamSurvivesTimeoutBoundary`) proves a stream survives past an injected 150ms timeout boundary that demonstrably 504s a sibling timed route.
- Docs: both stream endpoints documented as long-lived; `skills/prox/references/api.md` mirror kept byte-identical (`diff`-verified).
- **Codex review finding (fixed in the commit)**: in shared-proxy-daemon mode the local forwarding `RequestManager` was never closed at shutdown, so a connected request stream — now unbounded — would pin `apiServer.Shutdown` to its full 5s stage deadline. `performShutdown` now closes the request manager alongside the log manager (idempotent for the standalone path, which already closes it via `proxy.Service.Shutdown`).

## Commit 2 — `prox requests` discovers the daemon API address (#43)

`requests` was missing from the `clientCommands` discovery allowlist in `rootCmd`'s `PersistentPreRun`, so it always hit the `:5555` default and failed against dynamic-port daemons (the default) — the identical gap `start` had before #41. Added it, extracted the map to a package-level var, and added `TestClientCommandsDiscoveryAllowlist` pinning the contract three ways: every `apiAddr`-consuming command is in the allowlist, every allowlist entry is a registered command, and the counts match — so the next client command can't silently miss discovery. Codex review: no findings.

CHANGELOG: Fixes entries for both under Unreleased.

## Live verification (real daemon, built binary)

- **#42**: `prox up -d` with a 1s-tick process; `prox logs -f` delivered continuously for **41s** (21:34:50 → 21:35:31), well past the old ~30s cutoff, one tick per second with no gap. Plain `GET /api/v1/status` unaffected (200 in <1ms; the 30s class for non-SSE routes is pinned by `TestRouteGroupTimeoutWiring` / `TestRequestTimeoutConstants`).
- **#43**: `prox up -d` on dynamic port 51119 with proxy enabled; `prox requests` reached the daemon and returned "No proxy requests recorded" with exit 0 (and against a no-proxy daemon returned the daemon's own `PROXY_NOT_ENABLED` — a real API response, not a `:5555` connection error).

Gates run per commit: `make lint && make test && make test-race && make build`, plus `uv run mkdocs build --strict` for the docs-touching commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgMgg6eo4LgLTCkfYSARcH


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Log and proxy request SSE streams no longer stop at the 30-second request-timeout; they now end only when the client disconnects or the daemon shuts down.
  * Daemon shutdown now reliably closes active streaming subscribers to avoid lingering/open streams.
  * The `prox requests` command now targets the daemon’s discovered API address instead of a fixed default.
* **Documentation**
  * Updated API and command reference docs to clarify that the two SSE streams are long-lived and exempt from the 30-second request timeout, terminating only on disconnect or daemon shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->