### PR TITLE
Requests/capture overhaul: daemon-mode body capture, gzip integrity, agent ergonomics, TUI polish

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -320,6 +320,7 @@ Body data is available only when capture was enabled with `prox up --capture` or
     },
     "request_body": {
       "size": 27,
+      "captured_size": 27,
       "truncated": false,
       "content_type": "application/json",
       "is_binary": false,
@@ -328,6 +329,21 @@ Body data is available only when capture was enabled with `prox up --capture` or
   }
 }
 ```
+
+**Captured body fields:**
+
+| Field | Description |
+|-------|-------------|
+| `size` | Total encoded bytes observed by the capture wrapper before truncation (not Content-Length, not the decoded size) |
+| `captured_size` | Encoded bytes actually retained; `truncated` is true when `captured_size < size` |
+| `truncated` | Whether the body exceeded the 1MB capture cap and was truncated |
+| `content_type` | Captured `Content-Type` header value |
+| `content_encoding` | Captured `Content-Encoding` header value (e.g. `gzip`); omitted when unencoded |
+| `is_binary` | With `include=body`: whether the **served** (post-decode) bytes are binary. Without it: the stored classification of the **raw wire** bytes (a gzip body reports `true` here even when its decoded form would serve as text) — see decoded-body semantics below |
+| `data` | Body content (only with `include=body`): plain text for text bodies, base64 for binary |
+| `unavailable_reason` | Set (e.g. `evicted`) when `include=body` was requested but the body could no longer be loaded; `data` is absent |
+
+**Decoded-body semantics:** captured bodies store the raw wire bytes and are decoded at serve time. When `content_encoding` is `gzip` or `x-gzip` and the body was not truncated, the decoded bytes are served and `is_binary` reflects the decoded content (readable JSON/text decodes to `is_binary: false`). Unsupported encodings (`deflate`, `br`, `zstd`, chained values like `gzip, br`), truncated bodies, corrupt streams, and payloads whose decoded size would exceed the 10MB cap are served as the raw bytes, base64-encoded, with `is_binary: true` and `content_encoding` preserved. The stored (raw) binary classification and the served `is_binary` may therefore legitimately differ. The on-disk path of a spilled body is never exposed.
 
 **Examples:**
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -266,7 +266,7 @@ Retrieve recent proxy requests (requires proxy to be enabled).
 {
   "requests": [
     {
-      "id": "a1b2c3d",
+      "id": "a1b2c3d4e5f6",
       "timestamp": "2025-01-19T10:32:01.123Z",
       "method": "GET",
       "url": "/api/users",
@@ -316,7 +316,7 @@ Body data is available only when capture was enabled with `prox up --capture` or
 
 ```json
 {
-  "id": "a1b2c3d",
+  "id": "a1b2c3d4e5f6",
   "timestamp": "2025-01-19T10:32:01.123Z",
   "method": "POST",
   "url": "/api/users",
@@ -359,8 +359,8 @@ Body data is available only when capture was enabled with `prox up --capture` or
 **Examples:**
 
 ```bash
-curl http://localhost:5555/api/v1/proxy/requests/a1b2c3d
-curl "http://localhost:5555/api/v1/proxy/requests/a1b2c3d?include=body"
+curl http://localhost:5555/api/v1/proxy/requests/a1b2c3d4e5f6
+curl "http://localhost:5555/api/v1/proxy/requests/a1b2c3d4e5f6?include=body"
 ```
 
 ### GET /proxy/requests/stream
@@ -376,7 +376,7 @@ The stream is long-lived: it is exempt from the 30s request-timeout class and en
 ```
 : connected
 
-data: {"id":"a1b2c3d","timestamp":"2025-01-19T10:32:01.123Z","method":"GET","url":"/api/users","subdomain":"api","hostname":"api.local.dev","status_code":200,"duration_ms":45,"remote_addr":"127.0.0.1"}
+data: {"id":"a1b2c3d4e5f6","timestamp":"2025-01-19T10:32:01.123Z","method":"GET","url":"/api/users","subdomain":"api","hostname":"api.local.dev","status_code":200,"duration_ms":45,"remote_addr":"127.0.0.1"}
 ```
 
 **Example:**

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -256,6 +256,8 @@ Retrieve recent proxy requests (requires proxy to be enabled).
 | `method` | string | all | Filter by HTTP method (GET, POST, etc.) |
 | `min_status` | int | — | Minimum status code |
 | `max_status` | int | — | Maximum status code |
+| `since` | string | — | RFC3339 timestamp; only requests recorded at or after this time |
+| `url_contains` | string | — | Case-insensitive substring match against the request URL (path+query only — never scheme/host) |
 | `limit` | int | 100 | Max requests to return (max 1000) |
 
 **Response:**
@@ -269,6 +271,7 @@ Retrieve recent proxy requests (requires proxy to be enabled).
       "method": "GET",
       "url": "/api/users",
       "subdomain": "api",
+      "hostname": "api.local.dev",
       "status_code": 200,
       "duration_ms": 45,
       "remote_addr": "127.0.0.1"
@@ -278,6 +281,10 @@ Retrieve recent proxy requests (requires proxy to be enabled).
   "total_count": 250
 }
 ```
+
+`hostname` is the request's Host header with the port stripped (e.g.
+`api.local.dev`); it is omitted when not recorded (older records, or a
+daemon-side record that predates this field).
 
 **Example:**
 
@@ -290,6 +297,9 @@ curl "http://localhost:5555/api/v1/proxy/requests?subdomain=api"
 
 # Filter for errors (5xx)
 curl "http://localhost:5555/api/v1/proxy/requests?min_status=500"
+
+# Filter by URL substring (path+query, case-insensitive)
+curl "http://localhost:5555/api/v1/proxy/requests?url_contains=/api/users"
 ```
 
 ### GET /proxy/requests/{id}
@@ -311,6 +321,7 @@ Body data is available only when capture was enabled with `prox up --capture` or
   "method": "POST",
   "url": "/api/users",
   "subdomain": "api",
+  "hostname": "api.local.dev",
   "status_code": 201,
   "duration_ms": 45,
   "remote_addr": "127.0.0.1",
@@ -358,14 +369,14 @@ Stream proxy requests via Server-Sent Events (SSE).
 
 The stream is long-lived: it is exempt from the 30s request-timeout class and ends only on client disconnect or daemon shutdown.
 
-**Query Parameters:** Same as `GET /proxy/requests` (except `limit`)
+**Query Parameters:** Same as `GET /proxy/requests` (except `limit`), including `url_contains`
 
 **Response:** SSE stream
 
 ```
 : connected
 
-data: {"id":"a1b2c3d","timestamp":"2025-01-19T10:32:01.123Z","method":"GET","url":"/api/users","subdomain":"api","status_code":200,"duration_ms":45,"remote_addr":"127.0.0.1"}
+data: {"id":"a1b2c3d","timestamp":"2025-01-19T10:32:01.123Z","method":"GET","url":"/api/users","subdomain":"api","hostname":"api.local.dev","status_code":200,"duration_ms":45,"remote_addr":"127.0.0.1"}
 ```
 
 **Example:**
@@ -373,6 +384,7 @@ data: {"id":"a1b2c3d","timestamp":"2025-01-19T10:32:01.123Z","method":"GET","url
 ```bash
 curl -N http://localhost:5555/api/v1/proxy/requests/stream
 curl -N "http://localhost:5555/api/v1/proxy/requests/stream?subdomain=api"
+curl -N "http://localhost:5555/api/v1/proxy/requests/stream?url_contains=/api"
 ```
 
 ### POST /shutdown

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -276,6 +276,9 @@ prox requests [id] [options]
 | `--subdomain` | Filter by subdomain |
 | `--method` | Filter by HTTP method (GET, POST, etc.) |
 | `--min-status` | Filter by minimum status code (e.g., 400 for errors) |
+| `--max-status` | Filter by maximum status code (combine with `--min-status 400` for client errors only). Must be 100-599; when both `--min-status` and `--max-status` are set, `--min-status` must not exceed `--max-status` |
+| `--since` | Filter to requests since this time — an RFC3339 timestamp or a Go duration (e.g. `5m`, `1h`) evaluated as "ago" from the moment the command runs |
+| `--url` | Filter by URL substring (path+query only, case-insensitive) |
 | `--json` | Output as JSON |
 | `--body` | Include captured request/response bodies when showing one request by ID |
 
@@ -296,6 +299,18 @@ prox requests --method GET
 
 # Show only errors (4xx and 5xx)
 prox requests --min-status 400
+
+# Show only client errors (4xx)
+prox requests --min-status 400 --max-status 499
+
+# Show requests from the last 5 minutes
+prox requests --since 5m
+
+# Filter by URL substring
+prox requests --url /api
+
+# Agent-oriented: recent 4xx traffic to /api in the last 5 minutes
+prox requests --url /api --since 5m --min-status 400 --max-status 499
 
 # JSON output for piping
 prox requests --json | jq .

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -311,7 +311,7 @@ prox requests abc1234 --body
 
 Each request is assigned a short hash ID (7 characters, git-style). These IDs are displayed in the output and can be used to reference specific requests.
 
-Body output requires request capture to be enabled with `prox up --capture` or `proxy.capture.enabled: true`.
+Body output requires request capture to be enabled with `prox up --capture` or `proxy.capture.enabled: true`. Capture applies in both standalone and shared-daemon mode — the enablement is propagated to the daemon at registration, and a daemon captures bodies only for the projects that opted in. When a request has no captured detail, `prox requests <id>` shows `(capture not enabled - use 'prox up --capture' to enable)`; if the body was captured but has since been evicted from the daemon's buffer, it shows `(body no longer available)` instead. See [Request Capture](configuration.md#request-capture) for capture directories and daemon-upgrade notes.
 
 ### proxy
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -316,17 +316,17 @@ prox requests --url /api --since 5m --min-status 400 --max-status 499
 prox requests --json | jq .
 
 # Show details for one request
-prox requests abc1234
+prox requests abc1234def56
 
 # Include captured bodies for one request
-prox requests abc1234 --body
+prox requests abc1234def56 --body
 ```
 
 **Request IDs:**
 
-Each request is assigned a short hash ID (7 characters, git-style). These IDs are displayed in the output and can be used to reference specific requests.
+Each request is assigned a short hash ID (12 characters, git-style). These IDs are displayed in the output and can be used to reference specific requests.
 
-Body output requires request capture to be enabled with `prox up --capture` or `proxy.capture.enabled: true`. Capture applies in both standalone and shared-daemon mode — the enablement is propagated to the daemon at registration, and a daemon captures bodies only for the projects that opted in. When a request has no captured detail, `prox requests <id>` shows `(capture not enabled - use 'prox up --capture' to enable)`; if the body was captured but has since been evicted from the daemon's buffer, it shows `(body no longer available)` instead. See [Request Capture](configuration.md#request-capture) for capture directories and daemon-upgrade notes.
+Body output requires request capture to be enabled with `prox up --capture` or `proxy.capture.enabled: true`. Capture applies in both standalone and shared-daemon mode — the enablement is propagated to the daemon at registration, and a daemon captures bodies only for the projects that opted in. When a request has no captured detail, `prox requests <id>` shows `(capture not enabled - use 'prox up --capture' to enable)`; if the body was captured but has since been evicted from the request buffer, it shows `(body no longer available)` instead. See [Request Capture](configuration.md#request-capture) for capture directories and daemon-upgrade notes.
 
 ### proxy
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -281,7 +281,7 @@ certs:
 | `proxy.http_port` | int | — | Port for the HTTP proxy server |
 | `proxy.https_port` | int | `6789` | Port for the HTTPS proxy server (default when enabled with no ports set) |
 | `proxy.domain` | string | required | Base domain used to derive hostnames for shared proxy routing |
-| `proxy.capture.enabled` | bool | `false` | Capture request and response body metadata for proxied requests |
+| `proxy.capture.enabled` | bool | `false` | Capture request/response headers and bodies for proxied requests |
 | `proxy.capture.max_body_size` | string | `1MB` | Maximum request or response body size to capture |
 
 ### Shared Proxy Daemon

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -324,7 +324,7 @@ services:
 
 ### Request Capture
 
-Request capture records request and response body metadata for the `prox requests <id>` detail view. Bodies up to `proxy.capture.max_body_size` are retained; larger bodies are truncated.
+Request capture records request and response headers and bodies for the `prox requests <id>` detail view. Bodies up to `proxy.capture.max_body_size` are retained; larger bodies are truncated.
 
 ```yaml
 proxy:
@@ -335,7 +335,16 @@ proxy:
     max_body_size: 1MB
 ```
 
-Captured body files are stored under `.prox/capture/` and cleaned up as request records age out of the in-memory request buffer.
+Capture is enabled per project, either with `proxy.capture.enabled: true` in config or with the `prox up --capture` flag.
+
+**Capture works in both standalone and shared-daemon mode.** The enablement (config or `--capture`) is sent to the shared proxy daemon when the project registers, so it applies whether prox runs a standalone proxy or routes through the per-user daemon. Capture is scoped per project: on a shared daemon, only capture-enabled projects have their bodies captured — a capture-disabled project sharing the same daemon has its requests recorded as metadata only (headers and bodies are not retained), and no project can see another project's captured records or bodies.
+
+Captured body files are stored under the capture directory and cleaned up as request records age out of the in-memory request buffer:
+
+- **Standalone proxy** (`prox up --no-proxy` disabled, i.e. an in-process proxy): `.prox/capture/` within the project directory.
+- **Shared daemon**: `~/.prox/capture/` (the per-user daemon's capture directory). The directory is removed when the daemon shuts down.
+
+> **Upgrading a running daemon:** daemon-mode capture requires a daemon built with this feature. A long-running daemon started before the upgrade must be restarted (`prox proxy stop --force`, then `prox up`) to pick up capture support; the daemon version gate makes the mismatch loud rather than silently dropping capture.
 
 ### Prerequisites (HTTPS only)
 

--- a/docs/reference/tui.md
+++ b/docs/reference/tui.md
@@ -89,6 +89,27 @@ Status codes are color-coded: green (2xx), cyan (3xx), yellow (4xx), red (5xx), 
 | Key | Action |
 | --- | ------ |
 | `s` | String filter (on URL/method/subdomain) |
+| `Enter` | Open detail view for the selected request |
+
+## Request Detail View
+
+Press `Enter` on a request to see headers and captured bodies:
+
+```text
+Request Body (35 bytes, application/json)
+  {
+    "user": "alice"
+  }
+```
+
+- The body section title shows the byte count, Content-Type, and (when the
+  body was transfer-encoded, e.g. gzip) Content-Encoding — omitted when not
+  present.
+- Bodies are pretty-printed 2-space indented JSON when the Content-Type
+  contains `json`, or when the raw body is itself valid JSON. Any other text
+  renders unchanged. Binary bodies show `[binary data]`; bodies that could
+  no longer be loaded (e.g. evicted from disk) show `(body no longer
+  available)`.
 
 ## Process Filter Mode
 

--- a/docs/reference/tui.md
+++ b/docs/reference/tui.md
@@ -107,9 +107,11 @@ Request Body (35 bytes, application/json)
   present.
 - Bodies are pretty-printed 2-space indented JSON when the Content-Type
   contains `json`, or when the raw body is itself valid JSON. Any other text
-  renders unchanged. Binary bodies show `[binary data]`; bodies that could
-  no longer be loaded (e.g. evicted from disk) show `(body no longer
-  available)`.
+  renders unchanged except that ASCII control characters (other than tab and
+  newline) and DEL are sanitized to the Unicode replacement character, so a
+  captured body cannot emit ESC/BEL/OSC sequences that manipulate the terminal.
+  Binary bodies show `[binary data]`; bodies that could no longer be loaded
+  (e.g. evicted from disk) show `(body no longer available)`.
 
 ## Process Filter Mode
 

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -503,6 +503,7 @@ func (h *Handlers) convertCapturedBody(body *proxy.CapturedBody, includeData boo
 	decoded, err := proxy.LoadDecodedBody(body, h.captureAllowedDirs())
 	if err != nil {
 		log.Printf("Error loading captured body: %v", err)
+		resp.UnavailableReason = decoded.UnavailableReason
 		return resp
 	}
 

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/go-chi/chi/v5"
 
@@ -462,40 +463,71 @@ func (h *Handlers) convertRequestDetails(details *proxy.RequestDetails, includeB
 	return resp
 }
 
-// convertCapturedBody converts proxy.CapturedBody to CapturedBodyResponse
+// captureAllowedDirs returns the directories a captured body's FilePath is
+// permitted to resolve within: the local capture manager's dir (when present)
+// and the shared daemon capture dir under the user's home. A socket-supplied
+// path outside these is rejected by the loader.
+func (h *Handlers) captureAllowedDirs() []string {
+	var primary string
+	if h.captureManager != nil {
+		primary = h.captureManager.CaptureDir()
+	}
+	return proxy.CaptureAllowedDirs(primary)
+}
+
+// convertCapturedBody converts proxy.CapturedBody to CapturedBodyResponse.
+//
+// Metadata fields are always populated. When includeData is set, the body is
+// loaded and content-decoded via proxy.LoadDecodedBody: is_binary in the
+// response reflects the served (decoded) bytes, binary data is base64-encoded,
+// and a body that could no longer be loaded reports unavailable_reason with no
+// data (HTTP 200 preserved). file_path is never exposed.
 func (h *Handlers) convertCapturedBody(body *proxy.CapturedBody, includeData bool) *CapturedBodyResponse {
 	if body == nil {
 		return nil
 	}
 
 	resp := &CapturedBodyResponse{
-		Size:        body.Size,
-		Truncated:   body.Truncated,
-		ContentType: body.ContentType,
-		IsBinary:    body.IsBinary,
+		Size:            body.Size,
+		CapturedSize:    body.CapturedSize,
+		Truncated:       body.Truncated,
+		ContentType:     body.ContentType,
+		ContentEncoding: body.ContentEncoding,
+		IsBinary:        body.IsBinary,
 	}
 
-	if includeData {
-		// Load body data (may be from disk)
-		var data []byte
-		var err error
+	if !includeData {
+		return resp
+	}
 
-		if h.captureManager != nil {
-			data, err = h.captureManager.LoadBody(body)
-		} else if body.Data != nil {
-			data = body.Data
-		}
+	decoded, err := proxy.LoadDecodedBody(body, h.captureAllowedDirs())
+	if err != nil {
+		log.Printf("Error loading captured body: %v", err)
+		return resp
+	}
 
-		if err != nil {
-			log.Printf("Error loading captured body: %v", err)
-		} else if data != nil {
-			if body.IsBinary {
-				// Encode binary data as base64
-				resp.Data = base64Encode(data)
-			} else {
-				resp.Data = string(data)
-			}
-		}
+	if !decoded.Available {
+		resp.UnavailableReason = decoded.UnavailableReason
+		return resp
+	}
+
+	// Report served (decoded) binary semantics.
+	resp.IsBinary = decoded.IsBinary
+
+	if len(decoded.Data) == 0 {
+		return resp
+	}
+
+	switch {
+	case decoded.IsBinary:
+		resp.Data = base64Encode(decoded.Data)
+	case utf8.Valid(decoded.Data):
+		resp.Data = string(decoded.Data)
+	default:
+		// Defense in depth: never JSON-encode invalid UTF-8 as a string even if
+		// the classifier considered it text.
+		resp.IsBinary = true
+		resp.Data = base64Encode(decoded.Data)
 	}
 
 	return resp

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -596,6 +596,7 @@ func parseProxyRequestParams(r *http.Request) proxy.RequestFilter {
 
 	filter.Subdomain = r.URL.Query().Get("subdomain")
 	filter.Method = r.URL.Query().Get("method")
+	filter.URLContains = r.URL.Query().Get("url_contains")
 
 	if minStatus := r.URL.Query().Get("min_status"); minStatus != "" {
 		if v, err := strconv.Atoi(minStatus); err == nil {

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -581,6 +581,22 @@ func TestGetProxyRequests(t *testing.T) {
 		assert.Equal(t, 500, resp.Requests[0].StatusCode)
 	})
 
+	t.Run("filter by url_contains", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/v1/proxy/requests?url_contains=Orders", nil)
+		w := httptest.NewRecorder()
+
+		handlers.GetProxyRequests(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var resp ProxyRequestsResponse
+		err := json.NewDecoder(w.Body).Decode(&resp)
+		require.NoError(t, err)
+
+		assert.Len(t, resp.Requests, 1)
+		assert.Equal(t, "/api/orders", resp.Requests[0].URL)
+	})
+
 	t.Run("filter by limit", func(t *testing.T) {
 		req := httptest.NewRequest("GET", "/api/v1/proxy/requests?limit=2", nil)
 		w := httptest.NewRecorder()
@@ -778,6 +794,63 @@ func TestStreamProxyRequests(t *testing.T) {
 		assert.Len(t, requestDataLines, 1)
 		assert.Contains(t, requestDataLines[0], "/matched")
 		assert.NotContains(t, body, "/nomatch")
+	})
+
+	t.Run("filters streamed requests by url_contains", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		req := httptest.NewRequest("GET", "/api/v1/proxy/requests/stream?url_contains=Orders", nil)
+		req = req.WithContext(ctx)
+		w := httptest.NewRecorder()
+
+		done := make(chan struct{})
+		go func() {
+			handlers.StreamProxyRequests(w, req)
+			close(done)
+		}()
+
+		time.Sleep(50 * time.Millisecond)
+
+		// Record a request that doesn't match the URL substring filter
+		rm.Record(proxy.RequestRecord{
+			Timestamp:  time.Now(),
+			Method:     "GET",
+			URL:        "/api/products",
+			Subdomain:  "app",
+			StatusCode: 200,
+			Duration:   10 * time.Millisecond,
+			RemoteAddr: "127.0.0.1",
+		})
+
+		// Record a request that matches (case-insensitive substring)
+		rm.Record(proxy.RequestRecord{
+			Timestamp:  time.Now(),
+			Method:     "GET",
+			URL:        "/api/orders/123",
+			Subdomain:  "app",
+			StatusCode: 200,
+			Duration:   10 * time.Millisecond,
+			RemoteAddr: "127.0.0.1",
+		})
+
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+		<-done
+
+		body := w.Body.String()
+		reader := bufio.NewScanner(strings.NewReader(body))
+		var requestDataLines []string
+		for reader.Scan() {
+			line := reader.Text()
+			if strings.HasPrefix(line, "data: ") && strings.Contains(line, `"url":`) {
+				requestDataLines = append(requestDataLines, line)
+			}
+		}
+
+		assert.Len(t, requestDataLines, 1)
+		assert.Contains(t, requestDataLines[0], "/api/orders/123")
+		assert.NotContains(t, body, "/api/products")
 	})
 }
 

--- a/internal/api/proxy_body_test.go
+++ b/internal/api/proxy_body_test.go
@@ -1,0 +1,284 @@
+package api
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/charliek/prox/internal/config"
+	"github.com/charliek/prox/internal/logs"
+	"github.com/charliek/prox/internal/proxy"
+	"github.com/charliek/prox/internal/supervisor"
+)
+
+func gzipBytes(t *testing.T, data []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	_, err := gw.Write(data)
+	require.NoError(t, err)
+	require.NoError(t, gw.Close())
+	return buf.Bytes()
+}
+
+// newBodyTestHandlers builds Handlers with a request manager and an enabled
+// capture manager rooted at a fresh temp dir. Returns the handlers, the manager,
+// and the capture directory (the allowlist root for FilePath bodies).
+func newBodyTestHandlers(t *testing.T) (*Handlers, *proxy.RequestManager, string) {
+	t.Helper()
+	logMgr := logs.NewManager(logs.ManagerConfig{BufferSize: 100})
+	t.Cleanup(logMgr.Close)
+
+	cfg := &config.Config{
+		API:       config.APIConfig{Port: 0},
+		Processes: map[string]config.ProcessConfig{},
+	}
+	sup := supervisor.New(cfg, logMgr, nil, supervisor.DefaultSupervisorConfig())
+	handlers := NewHandlers(sup, logMgr, "prox.yaml", nil)
+
+	rm := proxy.NewRequestManager(100)
+	handlers.SetRequestManager(rm)
+
+	cm, err := proxy.NewCaptureManager(&config.CaptureConfig{Enabled: true}, t.TempDir())
+	require.NoError(t, err)
+	handlers.SetCaptureManager(cm)
+
+	return handlers, rm, cm.CaptureDir()
+}
+
+// getRequestWithBody records a request whose response body is respBody, then
+// GETs it with include=body, returning both the parsed response and the raw JSON.
+func getRequestWithBody(t *testing.T, handlers *Handlers, rm *proxy.RequestManager, id string, respBody *proxy.CapturedBody) (ProxyRequestDetailResponse, string) {
+	t.Helper()
+	rm.Record(proxy.RequestRecord{
+		ID:         id,
+		Timestamp:  time.Now(),
+		Method:     "GET",
+		URL:        "/api/data",
+		Subdomain:  "api",
+		StatusCode: 200,
+		Duration:   10 * time.Millisecond,
+		RemoteAddr: "127.0.0.1",
+		Details: &proxy.RequestDetails{
+			ResponseHeaders: http.Header{"Content-Type": {respBody.ContentType}},
+			ResponseBody:    respBody,
+		},
+	})
+
+	req := httptest.NewRequest("GET", "/api/v1/proxy/requests/"+id+"?include=body", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", id)
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	w := httptest.NewRecorder()
+
+	handlers.GetProxyRequest(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	raw := w.Body.String()
+	var resp ProxyRequestDetailResponse
+	require.NoError(t, json.Unmarshal([]byte(raw), &resp))
+	return resp, raw
+}
+
+func TestConvertCapturedBody_GzipRoundTrip(t *testing.T) {
+	handlers, rm, _ := newBodyTestHandlers(t)
+	payload := []byte(`{"message":"hello, gzip","items":[1,2,3]}`)
+
+	t.Run("gzip decodes to readable JSON", func(t *testing.T) {
+		resp, _ := getRequestWithBody(t, handlers, rm, "gz00001", &proxy.CapturedBody{
+			Size:            int64(len(payload)),
+			CapturedSize:    int64(len(payload)),
+			ContentType:     "application/json",
+			ContentEncoding: "gzip",
+			IsBinary:        true, // stored: raw gzip bytes
+			Data:            gzipBytes(t, payload),
+		})
+		require.NotNil(t, resp.Details.ResponseBody)
+		body := resp.Details.ResponseBody
+		assert.Equal(t, "gzip", body.ContentEncoding)
+		assert.False(t, body.IsBinary) // served: decoded JSON is text
+		assert.Equal(t, string(payload), body.Data)
+	})
+
+	t.Run("x-gzip alias", func(t *testing.T) {
+		resp, _ := getRequestWithBody(t, handlers, rm, "gz00002", &proxy.CapturedBody{
+			ContentType:     "application/json",
+			ContentEncoding: "x-gzip",
+			IsBinary:        true,
+			Data:            gzipBytes(t, payload),
+		})
+		assert.False(t, resp.Details.ResponseBody.IsBinary)
+		assert.Equal(t, string(payload), resp.Details.ResponseBody.Data)
+	})
+
+	t.Run("uppercase GZIP", func(t *testing.T) {
+		resp, _ := getRequestWithBody(t, handlers, rm, "gz00003", &proxy.CapturedBody{
+			ContentType:     "application/json",
+			ContentEncoding: "GZIP",
+			IsBinary:        true,
+			Data:            gzipBytes(t, payload),
+		})
+		assert.False(t, resp.Details.ResponseBody.IsBinary)
+		assert.Equal(t, string(payload), resp.Details.ResponseBody.Data)
+	})
+}
+
+func TestConvertCapturedBody_FallsBackToRaw(t *testing.T) {
+	handlers, rm, _ := newBodyTestHandlers(t)
+	payload := []byte(`{"x":"y"}`)
+
+	t.Run("corrupt gzip stream", func(t *testing.T) {
+		raw := gzipBytes(t, payload)
+		raw[len(raw)-2] ^= 0xff
+		resp, _ := getRequestWithBody(t, handlers, rm, "cor0001", &proxy.CapturedBody{
+			ContentType:     "application/json",
+			ContentEncoding: "gzip",
+			IsBinary:        true,
+			Data:            raw,
+		})
+		body := resp.Details.ResponseBody
+		assert.True(t, body.IsBinary)
+		assert.Equal(t, "gzip", body.ContentEncoding)
+		assert.Equal(t, base64Encode(raw), body.Data)
+	})
+
+	t.Run("truncated gzip is not decoded", func(t *testing.T) {
+		raw := gzipBytes(t, payload)
+		resp, _ := getRequestWithBody(t, handlers, rm, "tru0001", &proxy.CapturedBody{
+			ContentType:     "application/json",
+			ContentEncoding: "gzip",
+			Truncated:       true,
+			IsBinary:        true,
+			Data:            raw,
+		})
+		body := resp.Details.ResponseBody
+		assert.True(t, body.IsBinary)
+		assert.Equal(t, base64Encode(raw), body.Data)
+	})
+
+	t.Run("unsupported encodings preserved and served raw", func(t *testing.T) {
+		for i, enc := range []string{"br", "gzip, br"} {
+			id := "uns000" + string(rune('a'+i))
+			resp, _ := getRequestWithBody(t, handlers, rm, id, &proxy.CapturedBody{
+				ContentType:     "application/json",
+				ContentEncoding: enc,
+				IsBinary:        false,
+				Data:            payload,
+			})
+			body := resp.Details.ResponseBody
+			assert.True(t, body.IsBinary, enc)
+			assert.Equal(t, enc, body.ContentEncoding, enc)
+			assert.Equal(t, base64Encode(payload), body.Data, enc)
+		}
+	})
+
+	t.Run("zip bomb over decode cap served raw", func(t *testing.T) {
+		bomb := bytes.Repeat([]byte{'a'}, 11*1024*1024)
+		raw := gzipBytes(t, bomb)
+		resp, _ := getRequestWithBody(t, handlers, rm, "bomb001", &proxy.CapturedBody{
+			ContentType:     "text/plain",
+			ContentEncoding: "gzip",
+			IsBinary:        true,
+			Data:            raw,
+		})
+		body := resp.Details.ResponseBody
+		assert.True(t, body.IsBinary)
+		assert.Equal(t, base64Encode(raw), body.Data)
+	})
+}
+
+// TestConvertCapturedBody_StoredVsServedBinary pins the divergence: the stored
+// CapturedBody.IsBinary (raw gzip = true) differs from the served is_binary
+// (decoded JSON = false) in the same response cycle.
+func TestConvertCapturedBody_StoredVsServedBinary(t *testing.T) {
+	handlers, rm, _ := newBodyTestHandlers(t)
+	payload := []byte(`{"ok":true}`)
+	stored := &proxy.CapturedBody{
+		ContentType:     "application/json",
+		ContentEncoding: "gzip",
+		IsBinary:        true,
+		Data:            gzipBytes(t, payload),
+	}
+
+	// Without include=body, is_binary reflects the stored (raw) flag.
+	rm.Record(proxy.RequestRecord{
+		ID:         "div0001",
+		Timestamp:  time.Now(),
+		Method:     "GET",
+		URL:        "/data",
+		StatusCode: 200,
+		Details:    &proxy.RequestDetails{ResponseBody: stored},
+	})
+	meta := httptest.NewRequest("GET", "/api/v1/proxy/requests/div0001", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "div0001")
+	meta = meta.WithContext(context.WithValue(meta.Context(), chi.RouteCtxKey, rctx))
+	mw := httptest.NewRecorder()
+	handlers.GetProxyRequest(mw, meta)
+	var metaResp ProxyRequestDetailResponse
+	require.NoError(t, json.NewDecoder(mw.Body).Decode(&metaResp))
+	assert.True(t, metaResp.Details.ResponseBody.IsBinary, "stored raw flag is binary")
+
+	// With include=body, is_binary reflects the served (decoded) bytes.
+	req := httptest.NewRequest("GET", "/api/v1/proxy/requests/div0001?include=body", nil)
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	rw := httptest.NewRecorder()
+	handlers.GetProxyRequest(rw, req)
+	var servedResp ProxyRequestDetailResponse
+	require.NoError(t, json.NewDecoder(rw.Body).Decode(&servedResp))
+	assert.False(t, servedResp.Details.ResponseBody.IsBinary, "served decoded flag is text")
+	assert.Equal(t, string(payload), servedResp.Details.ResponseBody.Data)
+}
+
+func TestConvertCapturedBody_NeverExposesFilePath(t *testing.T) {
+	handlers, rm, captureDir := newBodyTestHandlers(t)
+
+	// Disk-backed body: write a file into the allowed capture dir.
+	payload := []byte(strings.Repeat("x", 100))
+	fp := filepath.Join(captureDir, "big_res.bin")
+	require.NoError(t, os.WriteFile(fp, payload, 0600))
+
+	resp, raw := getRequestWithBody(t, handlers, rm, "fp00001", &proxy.CapturedBody{
+		Size:         int64(len(payload)),
+		CapturedSize: int64(len(payload)),
+		ContentType:  "text/plain",
+		FilePath:     fp,
+	})
+
+	// Disk-backed body loads through the API.
+	assert.Equal(t, string(payload), resp.Details.ResponseBody.Data)
+	// file_path must never appear in the serialized JSON.
+	assert.NotContains(t, raw, "file_path")
+	assert.NotContains(t, raw, fp)
+}
+
+func TestConvertCapturedBody_EvictedFile(t *testing.T) {
+	handlers, rm, captureDir := newBodyTestHandlers(t)
+
+	// FilePath points inside the allowed dir but the file does not exist
+	// (evicted / daemon restarted).
+	fp := filepath.Join(captureDir, "evicted_res.bin")
+	resp, raw := getRequestWithBody(t, handlers, rm, "ev00001", &proxy.CapturedBody{
+		Size:         50,
+		CapturedSize: 50,
+		ContentType:  "application/json",
+		FilePath:     fp,
+	})
+
+	body := resp.Details.ResponseBody
+	assert.Equal(t, "evicted", body.UnavailableReason)
+	assert.Empty(t, body.Data)
+	assert.NotContains(t, raw, "file_path")
+}

--- a/internal/api/responses.go
+++ b/internal/api/responses.go
@@ -209,6 +209,7 @@ type ProxyRequestResponse struct {
 	Method     string `json:"method"`
 	URL        string `json:"url"`
 	Subdomain  string `json:"subdomain"`
+	Hostname   string `json:"hostname,omitempty"` // full hostname, port stripped (e.g. api.local.dev)
 	StatusCode int    `json:"status_code"`
 	DurationMs int64  `json:"duration_ms"`
 	RemoteAddr string `json:"remote_addr"`
@@ -229,6 +230,7 @@ func ToProxyRequestResponse(req proxy.RequestRecord) ProxyRequestResponse {
 		Method:     req.Method,
 		URL:        req.URL,
 		Subdomain:  req.Subdomain,
+		Hostname:   req.Hostname,
 		StatusCode: req.StatusCode,
 		DurationMs: req.Duration.Milliseconds(),
 		RemoteAddr: req.RemoteAddr,

--- a/internal/api/responses.go
+++ b/internal/api/responses.go
@@ -235,13 +235,19 @@ func ToProxyRequestResponse(req proxy.RequestRecord) ProxyRequestResponse {
 	}
 }
 
-// CapturedBodyResponse represents a captured request or response body in API responses
+// CapturedBodyResponse represents a captured request or response body in API responses.
+// It never exposes the on-disk file_path of a spilled body.
 type CapturedBodyResponse struct {
-	Size        int64  `json:"size"`
-	Truncated   bool   `json:"truncated,omitempty"`
-	ContentType string `json:"content_type,omitempty"`
-	IsBinary    bool   `json:"is_binary,omitempty"`
-	Data        string `json:"data,omitempty"` // base64 for binary, plain text otherwise
+	Size            int64  `json:"size"`
+	CapturedSize    int64  `json:"captured_size"` // Bytes retained after truncation
+	Truncated       bool   `json:"truncated,omitempty"`
+	ContentType     string `json:"content_type,omitempty"`
+	ContentEncoding string `json:"content_encoding,omitempty"` // Stored Content-Encoding (e.g. "gzip")
+	IsBinary        bool   `json:"is_binary,omitempty"`        // With include=body: the SERVED (post-decode) bytes; otherwise the stored raw-bytes classification
+	Data            string `json:"data,omitempty"`             // base64 for binary, plain text otherwise
+	// UnavailableReason is set (e.g. "evicted") when include=body was requested
+	// but the body could no longer be loaded; Data is empty in that case.
+	UnavailableReason string `json:"unavailable_reason,omitempty"`
 }
 
 // RequestDetailsResponse represents captured request/response details in API responses

--- a/internal/api/responses_test.go
+++ b/internal/api/responses_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/charliek/prox/internal/domain"
+	"github.com/charliek/prox/internal/proxy"
 )
 
 func TestFilterSensitiveEnv(t *testing.T) {
@@ -379,5 +380,39 @@ func TestToLogEntryResponse(t *testing.T) {
 	// Verify timestamp is in RFC3339Nano format
 	if resp.Timestamp != now.Format(time.RFC3339Nano) {
 		t.Errorf("expected Timestamp %q, got %q", now.Format(time.RFC3339Nano), resp.Timestamp)
+	}
+}
+
+func TestToProxyRequestResponse_MapsHostname(t *testing.T) {
+	now := time.Now()
+	rec := proxy.RequestRecord{
+		ID:         "abc1234",
+		Timestamp:  now,
+		Method:     "GET",
+		URL:        "/api/users",
+		Subdomain:  "api",
+		Hostname:   "api.local.myapp.dev",
+		StatusCode: 200,
+		Duration:   10 * time.Millisecond,
+		RemoteAddr: "127.0.0.1",
+	}
+
+	resp := ToProxyRequestResponse(rec)
+
+	if resp.Hostname != "api.local.myapp.dev" {
+		t.Errorf("expected Hostname %q, got %q", "api.local.myapp.dev", resp.Hostname)
+	}
+}
+
+func TestToProxyRequestResponse_OmitsEmptyHostname(t *testing.T) {
+	rec := proxy.RequestRecord{
+		ID:  "abc1234",
+		URL: "/api/users",
+	}
+
+	resp := ToProxyRequestResponse(rec)
+
+	if resp.Hostname != "" {
+		t.Errorf("expected empty Hostname, got %q", resp.Hostname)
 	}
 }

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -188,6 +188,12 @@ func buildProxyRequestQueryParams(params domain.ProxyRequestParams) url.Values {
 	if params.MaxStatus > 0 {
 		query.Set("max_status", fmt.Sprintf("%d", params.MaxStatus))
 	}
+	if !params.Since.IsZero() {
+		query.Set("since", params.Since.Format(time.RFC3339Nano))
+	}
+	if params.URLContains != "" {
+		query.Set("url_contains", params.URLContains)
+	}
 	if params.Limit > 0 {
 		query.Set("limit", fmt.Sprintf("%d", params.Limit))
 	}

--- a/internal/cli/client_test.go
+++ b/internal/cli/client_test.go
@@ -659,6 +659,7 @@ func TestBuildLogQueryParams(t *testing.T) {
 }
 
 func TestBuildProxyRequestQueryParams(t *testing.T) {
+	sinceFixture := time.Date(2026, 7, 18, 10, 0, 0, 0, time.UTC)
 	tests := []struct {
 		name     string
 		params   domain.ProxyRequestParams
@@ -690,18 +691,22 @@ func TestBuildProxyRequestQueryParams(t *testing.T) {
 		{
 			name: "all params",
 			params: domain.ProxyRequestParams{
-				Subdomain: "api",
-				Method:    "POST",
-				MinStatus: 400,
-				MaxStatus: 599,
-				Limit:     50,
+				Subdomain:   "api",
+				Method:      "POST",
+				MinStatus:   400,
+				MaxStatus:   599,
+				Since:       sinceFixture,
+				URLContains: "/orders",
+				Limit:       50,
 			},
 			expected: map[string]string{
-				"subdomain":  "api",
-				"method":     "POST",
-				"min_status": "400",
-				"max_status": "599",
-				"limit":      "50",
+				"subdomain":    "api",
+				"method":       "POST",
+				"min_status":   "400",
+				"max_status":   "599",
+				"since":        sinceFixture.Format(time.RFC3339Nano),
+				"url_contains": "/orders",
+				"limit":        "50",
 			},
 		},
 		{
@@ -714,6 +719,31 @@ func TestBuildProxyRequestQueryParams(t *testing.T) {
 			expected: map[string]string{
 				"subdomain": "api",
 			},
+		},
+		{
+			name: "url_contains only",
+			params: domain.ProxyRequestParams{
+				URLContains: "/api",
+			},
+			expected: map[string]string{
+				"url_contains": "/api",
+			},
+		},
+		{
+			name: "since only",
+			params: domain.ProxyRequestParams{
+				Since: sinceFixture,
+			},
+			expected: map[string]string{
+				"since": sinceFixture.Format(time.RFC3339Nano),
+			},
+		},
+		{
+			name: "zero since omitted",
+			params: domain.ProxyRequestParams{
+				Since: time.Time{},
+			},
+			expected: map[string]string{},
 		},
 	}
 

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -424,6 +424,9 @@ var (
 	requestsSubdomain string
 	requestsMethod    string
 	requestsMinStatus int
+	requestsMaxStatus int
+	requestsSince     string
+	requestsURL       string
 	requestsLimit     int
 	requestsJSON      bool
 	requestsBody      bool
@@ -444,6 +447,9 @@ Examples:
   prox requests --subdomain api    # Filter by subdomain
   prox requests --method GET       # Filter by HTTP method
   prox requests --min-status 400   # Show errors only (4xx and 5xx)
+  prox requests --min-status 400 --max-status 499   # Show client errors only (4xx)
+  prox requests --since 5m         # Show requests from the last 5 minutes
+  prox requests --url /api         # Filter by URL substring (path+query)
   prox requests --json             # Output as JSON
   prox requests abc1234            # Show details for request abc1234
   prox requests abc1234 --body     # Include captured request/response bodies`,
@@ -464,11 +470,29 @@ func runRequests(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("invalid --min-status value %d: must be between 100 and 599", requestsMinStatus)
 	}
 
+	// Validate max-status is within valid HTTP status code range
+	if requestsMaxStatus != 0 && (requestsMaxStatus < 100 || requestsMaxStatus > 599) {
+		return fmt.Errorf("invalid --max-status value %d: must be between 100 and 599", requestsMaxStatus)
+	}
+
+	// When both bounds are set, min must not exceed max
+	if requestsMinStatus != 0 && requestsMaxStatus != 0 && requestsMinStatus > requestsMaxStatus {
+		return fmt.Errorf("invalid status range: --min-status %d is greater than --max-status %d", requestsMinStatus, requestsMaxStatus)
+	}
+
+	since, err := parseSinceFlag(requestsSince)
+	if err != nil {
+		return err
+	}
+
 	params := domain.ProxyRequestParams{
-		Subdomain: requestsSubdomain,
-		Method:    strings.ToUpper(requestsMethod),
-		MinStatus: requestsMinStatus,
-		Limit:     requestsLimit,
+		Subdomain:   requestsSubdomain,
+		Method:      strings.ToUpper(requestsMethod),
+		MinStatus:   requestsMinStatus,
+		MaxStatus:   requestsMaxStatus,
+		Since:       since,
+		URLContains: requestsURL,
+		Limit:       requestsLimit,
 	}
 
 	if requestsFollow {
@@ -626,6 +650,25 @@ func isTerminal() bool {
 	return (fi.Mode() & os.ModeCharDevice) != 0
 }
 
+// parseSinceFlag parses the --since flag value, accepting either an RFC3339
+// timestamp or a Go duration (e.g. "5m", "1h"). A duration is treated as
+// "ago from now": time.Now() is captured exactly once here so a single
+// invocation (list or stream) uses one consistent cutoff instant rather than
+// re-evaluating "now" per record. Empty input returns the zero time (no
+// filter). A malformed value that matches neither format is a clear error.
+func parseSinceFlag(value string) (time.Time, error) {
+	if value == "" {
+		return time.Time{}, nil
+	}
+	if t, err := time.Parse(time.RFC3339, value); err == nil {
+		return t, nil
+	}
+	if d, err := time.ParseDuration(value); err == nil {
+		return time.Now().Add(-d), nil
+	}
+	return time.Time{}, fmt.Errorf("invalid --since value %q: must be an RFC3339 timestamp or a duration (e.g. 5m, 1h)", value)
+}
+
 func printProxyRequest(req api.ProxyRequestResponse) {
 	ts, _ := time.Parse(time.RFC3339Nano, req.Timestamp)
 	timeStr := ts.Format("15:04:05")
@@ -679,6 +722,9 @@ func init() {
 	requestsCmd.Flags().StringVar(&requestsSubdomain, "subdomain", "", "Filter by subdomain")
 	requestsCmd.Flags().StringVar(&requestsMethod, "method", "", "Filter by HTTP method (GET, POST, etc.)")
 	requestsCmd.Flags().IntVar(&requestsMinStatus, "min-status", 0, "Filter by minimum status code (e.g., 400 for errors)")
+	requestsCmd.Flags().IntVar(&requestsMaxStatus, "max-status", 0, "Filter by maximum status code (combine with --min-status for ranges)")
+	requestsCmd.Flags().StringVar(&requestsSince, "since", "", "Filter to requests since this time (RFC3339 timestamp or duration like 5m, 1h)")
+	requestsCmd.Flags().StringVar(&requestsURL, "url", "", "Filter by URL substring (path+query, case-insensitive)")
 	requestsCmd.Flags().IntVarP(&requestsLimit, "limit", "n", constants.DefaultProxyRequestLimit, "Number of requests to show")
 	requestsCmd.Flags().BoolVar(&requestsJSON, "json", false, "Output as JSON")
 	requestsCmd.Flags().BoolVar(&requestsBody, "body", false, "Include request/response bodies when showing details")

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -563,42 +563,49 @@ func showRequestDetail(client *Client, id string, includeBody, jsonOutput bool) 
 
 		// Print request body
 		if resp.Details.RequestBody != nil {
-			fmt.Printf("\n--- Request Body (%d bytes", resp.Details.RequestBody.Size)
-			if resp.Details.RequestBody.Truncated {
-				fmt.Print(", truncated")
-			}
-			fmt.Println(") ---")
-			if includeBody && resp.Details.RequestBody.Data != "" {
-				if resp.Details.RequestBody.IsBinary {
-					fmt.Println("[binary data, base64 encoded]")
-				}
-				fmt.Println(resp.Details.RequestBody.Data)
-			} else if !includeBody && resp.Details.RequestBody.Size > 0 {
-				fmt.Println("(use --body to show content)")
-			}
+			printCapturedBody("Request Body", resp.Details.RequestBody, includeBody)
 		}
 
 		// Print response body
 		if resp.Details.ResponseBody != nil {
-			fmt.Printf("\n--- Response Body (%d bytes", resp.Details.ResponseBody.Size)
-			if resp.Details.ResponseBody.Truncated {
-				fmt.Print(", truncated")
-			}
-			fmt.Println(") ---")
-			if includeBody && resp.Details.ResponseBody.Data != "" {
-				if resp.Details.ResponseBody.IsBinary {
-					fmt.Println("[binary data, base64 encoded]")
-				}
-				fmt.Println(resp.Details.ResponseBody.Data)
-			} else if !includeBody && resp.Details.ResponseBody.Size > 0 {
-				fmt.Println("(use --body to show content)")
-			}
+			printCapturedBody("Response Body", resp.Details.ResponseBody, includeBody)
 		}
 	} else {
 		fmt.Println("\n(capture not enabled - use 'prox up --capture' to enable)")
 	}
 
 	return nil
+}
+
+// printCapturedBody prints one captured body section: a header line with size,
+// truncation, content type and content encoding, followed by the body content
+// (or a note that it is unavailable / must be requested with --body).
+func printCapturedBody(label string, body *api.CapturedBodyResponse, includeBody bool) {
+	fmt.Printf("\n--- %s (%d bytes", label, body.Size)
+	if body.Truncated {
+		fmt.Print(", truncated")
+	}
+	if body.ContentType != "" {
+		fmt.Printf(", %s", body.ContentType)
+	}
+	if body.ContentEncoding != "" {
+		fmt.Printf(", encoding: %s", body.ContentEncoding)
+	}
+	fmt.Println(") ---")
+
+	if body.UnavailableReason != "" {
+		fmt.Println("(body no longer available)")
+		return
+	}
+
+	if includeBody && body.Data != "" {
+		if body.IsBinary {
+			fmt.Println("[binary data, base64 encoded]")
+		}
+		fmt.Println(body.Data)
+	} else if !includeBody && body.Size > 0 {
+		fmt.Println("(use --body to show content)")
+	}
 }
 
 // printHeaders prints HTTP headers in a readable format

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -451,8 +451,8 @@ Examples:
   prox requests --since 5m         # Show requests from the last 5 minutes
   prox requests --url /api         # Filter by URL substring (path+query)
   prox requests --json             # Output as JSON
-  prox requests abc1234            # Show details for request abc1234
-  prox requests abc1234 --body     # Include captured request/response bodies`,
+  prox requests abc1234def56       # Show details for request abc1234def56
+  prox requests abc1234def56 --body # Include captured request/response bodies`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runRequests,
 }
@@ -607,7 +607,7 @@ func showRequestDetail(client *Client, id string, includeBody, jsonOutput bool) 
 func printCapturedBody(label string, body *api.CapturedBodyResponse, includeBody bool) {
 	fmt.Printf("\n--- %s (%d bytes", label, body.Size)
 	if body.Truncated {
-		fmt.Print(", truncated")
+		fmt.Printf(", %d bytes captured, truncated", body.CapturedSize)
 	}
 	if body.ContentType != "" {
 		fmt.Printf(", %s", body.ContentType)
@@ -664,6 +664,9 @@ func parseSinceFlag(value string) (time.Time, error) {
 		return t, nil
 	}
 	if d, err := time.ParseDuration(value); err == nil {
+		if d < 0 {
+			return time.Time{}, fmt.Errorf("invalid --since value %q: duration must not be negative", value)
+		}
 		return time.Now().Add(-d), nil
 	}
 	return time.Time{}, fmt.Errorf("invalid --since value %q: must be an RFC3339 timestamp or a duration (e.g. 5m, 1h)", value)

--- a/internal/cli/commands_test.go
+++ b/internal/cli/commands_test.go
@@ -391,6 +391,200 @@ func TestRunRequests_MinStatusValidation(t *testing.T) {
 	}
 }
 
+func TestRunRequests_MaxStatusValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		maxStatus   int
+		expectError bool
+	}{
+		{"valid max 100", 100, false},
+		{"valid max 499", 499, false},
+		{"valid max 599", 599, false},
+		{"zero max (treated as no filter)", 0, false},
+		{"invalid max 99", 99, true},
+		{"invalid max 600", 600, true},
+		{"invalid max negative", -1, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			origMaxStatus := requestsMaxStatus
+			origFollow := requestsFollow
+			origJSON := requestsJSON
+			defer func() {
+				requestsMaxStatus = origMaxStatus
+				requestsFollow = origFollow
+				requestsJSON = origJSON
+			}()
+
+			requestsMaxStatus = tt.maxStatus
+			requestsFollow = false
+			requestsJSON = false
+
+			if !tt.expectError {
+				originalApiAddr := apiAddr
+				defer func() { apiAddr = originalApiAddr }()
+
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					json.NewEncoder(w).Encode(api.ProxyRequestsResponse{
+						Requests:      []api.ProxyRequestResponse{},
+						FilteredCount: 0,
+						TotalCount:    0,
+					})
+				}))
+				defer server.Close()
+				apiAddr = server.URL
+			}
+
+			_, _ = captureOutput(t, func() {
+				err := runRequests(requestsCmd, []string{})
+				if tt.expectError {
+					if err == nil {
+						t.Error("expected error for invalid max-status")
+					}
+				} else {
+					if err != nil {
+						t.Errorf("unexpected error: %v", err)
+					}
+				}
+			})
+		})
+	}
+}
+
+func TestRunRequests_StatusRangeValidation(t *testing.T) {
+	origMinStatus := requestsMinStatus
+	origMaxStatus := requestsMaxStatus
+	origFollow := requestsFollow
+	origJSON := requestsJSON
+	defer func() {
+		requestsMinStatus = origMinStatus
+		requestsMaxStatus = origMaxStatus
+		requestsFollow = origFollow
+		requestsJSON = origJSON
+	}()
+
+	requestsMinStatus = 500
+	requestsMaxStatus = 400
+	requestsFollow = false
+	requestsJSON = false
+
+	_, _ = captureOutput(t, func() {
+		err := runRequests(requestsCmd, []string{})
+		if err == nil {
+			t.Error("expected error when --min-status exceeds --max-status")
+		}
+	})
+}
+
+func TestParseSinceFlag(t *testing.T) {
+	t.Run("empty value returns zero time", func(t *testing.T) {
+		got, err := parseSinceFlag("")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !got.IsZero() {
+			t.Errorf("expected zero time, got %v", got)
+		}
+	})
+
+	t.Run("RFC3339 timestamp parsed exactly", func(t *testing.T) {
+		got, err := parseSinceFlag("2026-07-18T10:00:00Z")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := time.Date(2026, 7, 18, 10, 0, 0, 0, time.UTC)
+		if !got.Equal(want) {
+			t.Errorf("expected %v, got %v", want, got)
+		}
+	})
+
+	t.Run("duration sugar resolves relative to now", func(t *testing.T) {
+		before := time.Now()
+		got, err := parseSinceFlag("5m")
+		after := time.Now()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		wantEarliest := before.Add(-5 * time.Minute)
+		wantLatest := after.Add(-5 * time.Minute)
+		if got.Before(wantEarliest) || got.After(wantLatest) {
+			t.Errorf("expected time between %v and %v, got %v", wantEarliest, wantLatest, got)
+		}
+	})
+
+	t.Run("malformed value errors", func(t *testing.T) {
+		_, err := parseSinceFlag("not-a-time")
+		if err == nil {
+			t.Error("expected error for malformed --since value")
+		}
+	})
+}
+
+func TestRunRequests_SinceValidation(t *testing.T) {
+	origSince := requestsSince
+	origFollow := requestsFollow
+	origJSON := requestsJSON
+	defer func() {
+		requestsSince = origSince
+		requestsFollow = origFollow
+		requestsJSON = origJSON
+	}()
+
+	requestsSince = "not-a-valid-since-value"
+	requestsFollow = false
+	requestsJSON = false
+
+	_, _ = captureOutput(t, func() {
+		err := runRequests(requestsCmd, []string{})
+		if err == nil {
+			t.Error("expected error for malformed --since flag")
+		}
+	})
+}
+
+func TestRunRequests_URLFilterPassthrough(t *testing.T) {
+	origURL := requestsURL
+	origFollow := requestsFollow
+	origJSON := requestsJSON
+	defer func() {
+		requestsURL = origURL
+		requestsFollow = origFollow
+		requestsJSON = origJSON
+	}()
+
+	originalApiAddr := apiAddr
+	defer func() { apiAddr = originalApiAddr }()
+
+	var gotQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query().Get("url_contains")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(api.ProxyRequestsResponse{
+			Requests:      []api.ProxyRequestResponse{},
+			FilteredCount: 0,
+			TotalCount:    0,
+		})
+	}))
+	defer server.Close()
+	apiAddr = server.URL
+
+	requestsURL = "/api"
+	requestsFollow = false
+	requestsJSON = false
+
+	_, _ = captureOutput(t, func() {
+		if err := runRequests(requestsCmd, []string{}); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	if gotQuery != "/api" {
+		t.Errorf("expected url_contains=/api to reach the server, got %q", gotQuery)
+	}
+}
+
 func TestDownCmd_NoArgs(t *testing.T) {
 	// Verify downCmd has NoArgs validation
 	if downCmd.Args == nil {

--- a/internal/cli/commands_test.go
+++ b/internal/cli/commands_test.go
@@ -520,6 +520,13 @@ func TestParseSinceFlag(t *testing.T) {
 			t.Error("expected error for malformed --since value")
 		}
 	})
+
+	t.Run("negative duration errors", func(t *testing.T) {
+		_, err := parseSinceFlag("-5m")
+		if err == nil {
+			t.Error("expected error for negative --since duration")
+		}
+	})
 }
 
 func TestRunRequests_SinceValidation(t *testing.T) {

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -840,7 +840,7 @@ func tryDaemonProxy(cfg *config.Config, cwd string, ctx context.Context, handler
 	// daemon proxy requests into this project's TUI and API.
 	localRM := proxy.NewRequestManager(constants.DefaultProxyRequestBufferSize)
 	handlers.SetRequestManager(localRM)
-	go proxyd.ForwardRequests(ctx, proxyd.SocketPath(), resp.Registered, localRM)
+	go proxyd.ForwardRequests(ctx, proxyd.SocketPath(), cwd, localRM)
 
 	return client, true, nil
 }

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -119,6 +119,18 @@ const (
 	// is treated as a decode failure so a highly-compressible payload (zip bomb)
 	// cannot exhaust memory. 10MB.
 	MaxDecodedBodySize = 10 * 1024 * 1024
+
+	// MaxSSEEventSize bounds a single SSE event the forwarder buffers from the
+	// daemon's request stream. It is derived from DefaultCaptureMaxBodySize
+	// rather than hard-coded: the 64KB inline threshold does NOT bound an event,
+	// because on a capture disk-write failure both the request and response body
+	// fall back to inline storage up to the max body size (see capture.go), so a
+	// single record can carry two max-size bodies base64-encoded (~1.4MB each),
+	// and headers are unbounded by the body threshold. The cap is twice the
+	// base64-expanded max body size plus 1MB of slack for headers and JSON
+	// framing (~3.7MB). An event exceeding it is skipped and the stream
+	// continues. base64 std-encoding expands n bytes to ((n+2)/3)*4.
+	MaxSSEEventSize = 2*(((DefaultCaptureMaxBodySize+2)/3)*4) + 1024*1024
 )
 
 // DaemonCaptureDir returns the daemon's shared capture directory

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -1,7 +1,10 @@
 // Package constants provides shared configuration values used across the prox application.
 package constants
 
-import "time"
+import (
+	"path/filepath"
+	"time"
+)
 
 // Configuration file defaults
 const (
@@ -110,7 +113,20 @@ const (
 
 	// CaptureDirectory is the directory name for storing captured body files
 	CaptureDirectory = ".prox/capture"
+
+	// MaxDecodedBodySize caps the number of bytes produced when decoding a
+	// content-encoded (e.g. gzip) captured body at serve time. Exceeding the cap
+	// is treated as a decode failure so a highly-compressible payload (zip bomb)
+	// cannot exhaust memory. 10MB.
+	MaxDecodedBodySize = 10 * 1024 * 1024
 )
+
+// DaemonCaptureDir returns the daemon's shared capture directory
+// (homeDir/.prox/capture) given a home directory. Kept here so both the api and
+// proxyd packages can derive the path without an import cycle.
+func DaemonCaptureDir(homeDir string) string {
+	return filepath.Join(homeDir, CaptureDirectory)
+}
 
 // Proxy timeouts
 const (

--- a/internal/domain/log_params.go
+++ b/internal/domain/log_params.go
@@ -1,5 +1,7 @@
 package domain
 
+import "time"
+
 // LogParams holds parameters for log retrieval and streaming.
 // This type is shared between the TUI and CLI packages.
 //
@@ -24,11 +26,16 @@ type LogParams struct {
 //   - Method: Filter to requests with a specific HTTP method. Empty string means all.
 //   - MinStatus: Filter to requests with status code >= this value. 0 means no minimum.
 //   - MaxStatus: Filter to requests with status code <= this value. 0 means no maximum.
+//   - Since: Filter to requests recorded at or after this time. Zero value means no lower bound.
+//   - URLContains: Filter to requests whose URL (path+query) contains this substring,
+//     case-insensitive. Empty string means no filtering.
 //   - Limit: Maximum number of requests to return. 0 means use server default.
 type ProxyRequestParams struct {
-	Subdomain string
-	Method    string
-	MinStatus int
-	MaxStatus int
-	Limit     int
+	Subdomain   string
+	Method      string
+	MinStatus   int
+	MaxStatus   int
+	Since       time.Time
+	URLContains string
+	Limit       int
 }

--- a/internal/proxy/body.go
+++ b/internal/proxy/body.go
@@ -202,11 +202,13 @@ func gunzipLimited(raw []byte, limit int64) ([]byte, bool) {
 
 // LoadDecodedBody composes LoadCapturedBody + DecodeCapturedBody.
 //
-// A nil body yields an unavailable result. When the raw load fails (a FilePath
-// body whose file was evicted/removed, or an out-of-allowlist path), the record
-// itself is still valid (D7): the result is marked unavailable with reason
-// "evicted" and a nil error, so the caller returns HTTP 200 with no data rather
-// than failing the request.
+// A nil body yields an unavailable result. A missing capture file (the record
+// is still valid, but its FilePath body was evicted/removed) is treated as a
+// benign condition (D7): the result is marked unavailable with reason "evicted"
+// and a nil error, so the caller returns HTTP 200 with no data rather than
+// failing the request. Any other load failure (e.g. an out-of-allowlist path or
+// an I/O error) is marked unavailable with reason "unavailable" and returned
+// together with the underlying error so callers can log it.
 func LoadDecodedBody(body *CapturedBody, allowedDirs []string) (DecodedBody, error) {
 	if body == nil {
 		return DecodedBody{Available: false}, nil
@@ -214,7 +216,10 @@ func LoadDecodedBody(body *CapturedBody, allowedDirs []string) (DecodedBody, err
 
 	raw, err := LoadCapturedBody(body, allowedDirs)
 	if err != nil {
-		return DecodedBody{Available: false, UnavailableReason: "evicted"}, nil
+		if os.IsNotExist(err) {
+			return DecodedBody{Available: false, UnavailableReason: "evicted"}, nil
+		}
+		return DecodedBody{Available: false, UnavailableReason: "unavailable"}, err
 	}
 
 	return DecodeCapturedBody(body, raw), nil

--- a/internal/proxy/body.go
+++ b/internal/proxy/body.go
@@ -1,0 +1,221 @@
+package proxy
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/charliek/prox/internal/constants"
+)
+
+// DecodedBody is the structured result of loading and content-decoding a
+// captured body. It carries decoded (serve-ready) bytes plus the semantics a
+// caller needs to render them safely.
+type DecodedBody struct {
+	// Data is the bytes to serve. For a supported, successful decode these are
+	// the decoded bytes; otherwise they are the raw retained bytes.
+	Data []byte
+	// IsBinary reflects the SERVED bytes (post-decode). It may legitimately
+	// diverge from CapturedBody.IsBinary, which describes the raw wire bytes.
+	IsBinary bool
+	// ContentEncoding is the stored (lowercased/trimmed) content-encoding token,
+	// empty for identity/unencoded bodies.
+	ContentEncoding string
+	// Available is false when the body could not be loaded (e.g. its disk file
+	// was evicted). When false, Data is nil and UnavailableReason explains why.
+	Available bool
+	// UnavailableReason is a short machine-readable reason set only when
+	// Available is false (e.g. "evicted").
+	UnavailableReason string
+}
+
+// LoadCapturedBody returns a captured body's raw retained bytes, reading from
+// disk when the body was spilled to a FilePath.
+//
+//   - A nil body yields (nil, nil).
+//   - An inline body returns a copy of Data (callers must not mutate the record).
+//   - A FilePath body MUST resolve within one of allowedDirs; a path that
+//     escapes every allowed directory is rejected with an error rather than
+//     read. This prevents a socket-supplied path from exfiltrating arbitrary
+//     files through the project API.
+//   - os.ReadFile errors (missing/evicted file) propagate to the caller.
+func LoadCapturedBody(body *CapturedBody, allowedDirs []string) ([]byte, error) {
+	if body == nil {
+		return nil, nil
+	}
+
+	if body.Data != nil {
+		result := make([]byte, len(body.Data))
+		copy(result, body.Data)
+		return result, nil
+	}
+
+	if body.FilePath == "" {
+		return nil, nil
+	}
+
+	resolved, err := resolveWithinAllowedDirs(body.FilePath, allowedDirs)
+	if err != nil {
+		return nil, err
+	}
+
+	return os.ReadFile(resolved)
+}
+
+// resolveWithinAllowedDirs makes path absolute, resolves every symlink in it
+// (the file itself and its directory components), and verifies the RESOLVED
+// path sits inside one of allowedDirs — each of which is symlink-resolved too,
+// so a capture dir reached via a symlinked parent (e.g. macOS /var → /private/
+// var temp dirs) still matches. The symlink resolution closes the bypass where
+// a file inside an allowed dir is a symlink pointing outside it; the remaining
+// check-then-read race is accepted under the same-user trust model. A missing
+// file surfaces as EvalSymlinks' not-exist error (the evicted case upstream).
+func resolveWithinAllowedDirs(path string, allowedDirs []string) (string, error) {
+	absPath, err := filepath.Abs(filepath.Clean(path))
+	if err != nil {
+		return "", fmt.Errorf("resolving captured body path %q: %w", path, err)
+	}
+	resolvedPath, err := filepath.EvalSymlinks(absPath)
+	if err != nil {
+		return "", err
+	}
+
+	for _, dir := range allowedDirs {
+		if dir == "" {
+			continue
+		}
+		absDir, err := filepath.Abs(filepath.Clean(dir))
+		if err != nil {
+			continue
+		}
+		resolvedDir, err := filepath.EvalSymlinks(absDir)
+		if err != nil {
+			continue
+		}
+		rel, err := filepath.Rel(resolvedDir, resolvedPath)
+		if err != nil {
+			continue
+		}
+		if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			continue
+		}
+		if filepath.IsAbs(rel) {
+			continue
+		}
+		return resolvedPath, nil
+	}
+
+	return "", fmt.Errorf("captured body path %q is outside the allowed capture directories", path)
+}
+
+// CaptureAllowedDirs builds the FilePath allowlist passed to LoadCapturedBody:
+// primaryDir (the caller's own capture dir, skipped when empty) plus the shared
+// daemon capture dir under the user's home (skipped when the home dir cannot be
+// resolved). Centralizing keeps the "the daemon capture dir is always allowed"
+// policy in one place rather than duplicated across the api and tui callers.
+func CaptureAllowedDirs(primaryDir string) []string {
+	var dirs []string
+	if primaryDir != "" {
+		dirs = append(dirs, primaryDir)
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		dirs = append(dirs, constants.DaemonCaptureDir(home))
+	}
+	return dirs
+}
+
+// DecodeCapturedBody content-decodes raw (per body.ContentEncoding) and returns
+// serve-ready bytes with post-decode binary semantics.
+//
+// Supported encodings are gzip and x-gzip (case-insensitive, surrounding
+// whitespace tolerated); identity/empty means no decode. Any other token
+// (deflate, br, zstd, chained values like "gzip, br"), a truncated body, a
+// decode failure, or a decoded size exceeding the cap all fall back to serving
+// the raw bytes with IsBinary=true so a JSON string conversion cannot mangle
+// them.
+func DecodeCapturedBody(body *CapturedBody, raw []byte) DecodedBody {
+	token := strings.ToLower(strings.TrimSpace(body.ContentEncoding))
+
+	switch token {
+	case "", "identity":
+		return DecodedBody{
+			Data:      raw,
+			IsBinary:  body.IsBinary,
+			Available: true,
+		}
+	case "gzip", "x-gzip":
+		// A truncated stream is broken; do not attempt to decode it.
+		if body.Truncated {
+			return rawEncoded(raw, token)
+		}
+		decoded, ok := gunzipLimited(raw, constants.MaxDecodedBodySize)
+		if !ok {
+			return rawEncoded(raw, token)
+		}
+		return DecodedBody{
+			Data:            decoded,
+			IsBinary:        isBinaryContent(decoded, body.ContentType),
+			ContentEncoding: token,
+			Available:       true,
+		}
+	default:
+		// Unsupported encoding: serve raw, flagged binary.
+		return rawEncoded(raw, token)
+	}
+}
+
+// rawEncoded returns the raw bytes served as opaque binary, preserving the
+// stored encoding token for reporting.
+func rawEncoded(raw []byte, token string) DecodedBody {
+	return DecodedBody{
+		Data:            raw,
+		IsBinary:        true,
+		ContentEncoding: token,
+		Available:       true,
+	}
+}
+
+// gunzipLimited gzip-decodes raw, capping output at limit bytes. It returns
+// (nil, false) on a header/stream error or when the decoded size would exceed
+// the cap (zip-bomb guard); memory is bounded to limit+1 bytes.
+func gunzipLimited(raw []byte, limit int64) ([]byte, bool) {
+	gr, err := gzip.NewReader(bytes.NewReader(raw))
+	if err != nil {
+		return nil, false
+	}
+	defer gr.Close()
+
+	// Read one byte past the cap so an over-cap payload is detectable.
+	decoded, err := io.ReadAll(io.LimitReader(gr, limit+1))
+	if err != nil {
+		return nil, false
+	}
+	if int64(len(decoded)) > limit {
+		return nil, false
+	}
+	return decoded, true
+}
+
+// LoadDecodedBody composes LoadCapturedBody + DecodeCapturedBody.
+//
+// A nil body yields an unavailable result. When the raw load fails (a FilePath
+// body whose file was evicted/removed, or an out-of-allowlist path), the record
+// itself is still valid (D7): the result is marked unavailable with reason
+// "evicted" and a nil error, so the caller returns HTTP 200 with no data rather
+// than failing the request.
+func LoadDecodedBody(body *CapturedBody, allowedDirs []string) (DecodedBody, error) {
+	if body == nil {
+		return DecodedBody{Available: false}, nil
+	}
+
+	raw, err := LoadCapturedBody(body, allowedDirs)
+	if err != nil {
+		return DecodedBody{Available: false, UnavailableReason: "evicted"}, nil
+	}
+
+	return DecodeCapturedBody(body, raw), nil
+}

--- a/internal/proxy/body_test.go
+++ b/internal/proxy/body_test.go
@@ -217,6 +217,19 @@ func TestLoadDecodedBody(t *testing.T) {
 		assert.Nil(t, got.Data)
 	})
 
+	t.Run("allowlist violation surfaces error with unavailable reason", func(t *testing.T) {
+		allowed := t.TempDir()
+		outside := t.TempDir()
+		fp := filepath.Join(outside, "secret.bin")
+		require.NoError(t, os.WriteFile(fp, []byte("secret"), 0600))
+		body := &CapturedBody{FilePath: fp}
+		got, err := LoadDecodedBody(body, []string{allowed})
+		require.Error(t, err) // out-of-allowlist path is not benign
+		assert.False(t, got.Available)
+		assert.Equal(t, "unavailable", got.UnavailableReason)
+		assert.Nil(t, got.Data)
+	})
+
 	t.Run("disk-backed gzip body loads and decodes", func(t *testing.T) {
 		dir := t.TempDir()
 		payload := []byte(`{"disk":"gzip"}`)

--- a/internal/proxy/body_test.go
+++ b/internal/proxy/body_test.go
@@ -1,0 +1,238 @@
+package proxy
+
+import (
+	"bytes"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// gzipBytes returns the gzip-compressed form of data.
+func gzipBytes(t *testing.T, data []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	_, err := gw.Write(data)
+	require.NoError(t, err)
+	require.NoError(t, gw.Close())
+	return buf.Bytes()
+}
+
+func TestLoadCapturedBody(t *testing.T) {
+	t.Run("nil body returns nil", func(t *testing.T) {
+		data, err := LoadCapturedBody(nil, nil)
+		require.NoError(t, err)
+		assert.Nil(t, data)
+	})
+
+	t.Run("inline data returns a copy", func(t *testing.T) {
+		original := []byte("hello")
+		body := &CapturedBody{Data: original}
+		got, err := LoadCapturedBody(body, nil)
+		require.NoError(t, err)
+		assert.Equal(t, original, got)
+		got[0] = 'X'
+		assert.Equal(t, byte('h'), original[0]) // original untouched
+	})
+
+	t.Run("file inside an allowed dir loads", func(t *testing.T) {
+		dir := t.TempDir()
+		fp := filepath.Join(dir, "body.bin")
+		require.NoError(t, os.WriteFile(fp, []byte("disk content"), 0600))
+
+		body := &CapturedBody{FilePath: fp}
+		got, err := LoadCapturedBody(body, []string{dir})
+		require.NoError(t, err)
+		assert.Equal(t, "disk content", string(got))
+	})
+
+	t.Run("file outside all allowed dirs is rejected", func(t *testing.T) {
+		allowed := t.TempDir()
+		other := t.TempDir()
+		fp := filepath.Join(other, "body.bin")
+		require.NoError(t, os.WriteFile(fp, []byte("secret"), 0600))
+
+		body := &CapturedBody{FilePath: fp}
+		_, err := LoadCapturedBody(body, []string{allowed})
+		require.Error(t, err)
+	})
+
+	t.Run("dot-dot escape is rejected", func(t *testing.T) {
+		allowed := t.TempDir()
+		// A path that lexically climbs out of the allowed dir.
+		escape := filepath.Join(allowed, "..", "outside.bin")
+		body := &CapturedBody{FilePath: escape}
+		_, err := LoadCapturedBody(body, []string{allowed})
+		require.Error(t, err)
+	})
+
+	t.Run("missing file inside an allowed dir propagates os error", func(t *testing.T) {
+		dir := t.TempDir()
+		body := &CapturedBody{FilePath: filepath.Join(dir, "gone.bin")}
+		_, err := LoadCapturedBody(body, []string{dir})
+		require.Error(t, err)
+		assert.True(t, os.IsNotExist(err))
+	})
+
+	t.Run("symlink inside an allowed dir pointing outside is rejected", func(t *testing.T) {
+		allowed := t.TempDir()
+		outside := t.TempDir()
+		secret := filepath.Join(outside, "secret.bin")
+		require.NoError(t, os.WriteFile(secret, []byte("secret"), 0600))
+
+		link := filepath.Join(allowed, "body.bin")
+		require.NoError(t, os.Symlink(secret, link))
+
+		body := &CapturedBody{FilePath: link}
+		_, err := LoadCapturedBody(body, []string{allowed})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "outside the allowed capture directories")
+	})
+
+	t.Run("allowed dir reached via symlinked parent still loads", func(t *testing.T) {
+		realDir := t.TempDir()
+		linkParent := t.TempDir()
+		linkedDir := filepath.Join(linkParent, "capture-link")
+		require.NoError(t, os.Symlink(realDir, linkedDir))
+
+		fp := filepath.Join(linkedDir, "body.bin")
+		require.NoError(t, os.WriteFile(fp, []byte("via symlinked dir"), 0600))
+
+		body := &CapturedBody{FilePath: fp}
+		got, err := LoadCapturedBody(body, []string{linkedDir})
+		require.NoError(t, err)
+		assert.Equal(t, "via symlinked dir", string(got))
+	})
+}
+
+func TestDecodeCapturedBody(t *testing.T) {
+	jsonPayload := []byte(`{"hello":"world","n":42}`)
+
+	t.Run("identity passes through with stored binary flag", func(t *testing.T) {
+		body := &CapturedBody{ContentEncoding: "identity", IsBinary: false, ContentType: "application/json"}
+		got := DecodeCapturedBody(body, jsonPayload)
+		assert.True(t, got.Available)
+		assert.False(t, got.IsBinary)
+		assert.Equal(t, jsonPayload, got.Data)
+	})
+
+	t.Run("empty encoding passes through", func(t *testing.T) {
+		body := &CapturedBody{IsBinary: true}
+		got := DecodeCapturedBody(body, []byte{0x00, 0x01})
+		assert.True(t, got.Available)
+		assert.True(t, got.IsBinary)
+	})
+
+	t.Run("gzip decodes to readable text", func(t *testing.T) {
+		raw := gzipBytes(t, jsonPayload)
+		body := &CapturedBody{
+			ContentEncoding: "gzip",
+			ContentType:     "application/json",
+			IsBinary:        true, // raw gzip bytes are binary
+		}
+		got := DecodeCapturedBody(body, raw)
+		assert.True(t, got.Available)
+		assert.False(t, got.IsBinary) // decoded JSON is text
+		assert.Equal(t, jsonPayload, got.Data)
+		assert.Equal(t, "gzip", got.ContentEncoding)
+	})
+
+	t.Run("x-gzip alias decodes", func(t *testing.T) {
+		raw := gzipBytes(t, jsonPayload)
+		body := &CapturedBody{ContentEncoding: "x-gzip", ContentType: "application/json"}
+		got := DecodeCapturedBody(body, raw)
+		assert.Equal(t, jsonPayload, got.Data)
+		assert.False(t, got.IsBinary)
+		assert.Equal(t, "x-gzip", got.ContentEncoding)
+	})
+
+	t.Run("uppercase GZIP with whitespace decodes", func(t *testing.T) {
+		raw := gzipBytes(t, jsonPayload)
+		body := &CapturedBody{ContentEncoding: "  GZIP  ", ContentType: "application/json"}
+		got := DecodeCapturedBody(body, raw)
+		assert.Equal(t, jsonPayload, got.Data)
+		assert.False(t, got.IsBinary)
+	})
+
+	t.Run("corrupt gzip stream falls back to raw binary", func(t *testing.T) {
+		raw := gzipBytes(t, jsonPayload)
+		raw[len(raw)-3] ^= 0xff // corrupt near the end
+		body := &CapturedBody{ContentEncoding: "gzip", ContentType: "application/json"}
+		got := DecodeCapturedBody(body, raw)
+		assert.True(t, got.Available)
+		assert.True(t, got.IsBinary)
+		assert.Equal(t, raw, got.Data)
+		assert.Equal(t, "gzip", got.ContentEncoding)
+	})
+
+	t.Run("truncated gzip is not decoded", func(t *testing.T) {
+		raw := gzipBytes(t, jsonPayload)
+		body := &CapturedBody{ContentEncoding: "gzip", ContentType: "application/json", Truncated: true}
+		got := DecodeCapturedBody(body, raw)
+		assert.True(t, got.IsBinary)
+		assert.Equal(t, raw, got.Data)
+	})
+
+	t.Run("unsupported encodings fall back to raw binary", func(t *testing.T) {
+		for _, enc := range []string{"br", "deflate", "zstd", "gzip, br"} {
+			body := &CapturedBody{ContentEncoding: enc, ContentType: "application/json"}
+			got := DecodeCapturedBody(body, jsonPayload)
+			assert.True(t, got.Available, enc)
+			assert.True(t, got.IsBinary, enc)
+			assert.Equal(t, jsonPayload, got.Data, enc)
+			assert.Equal(t, enc, got.ContentEncoding, enc)
+		}
+	})
+
+	t.Run("decode cap exceeded (zip bomb) falls back to raw binary", func(t *testing.T) {
+		// Highly compressible payload larger than the 10MB decode cap.
+		bomb := bytes.Repeat([]byte{'a'}, 11*1024*1024)
+		raw := gzipBytes(t, bomb)
+		require.Less(t, len(raw), len(bomb)) // compressed is much smaller
+		body := &CapturedBody{ContentEncoding: "gzip", ContentType: "text/plain"}
+		got := DecodeCapturedBody(body, raw)
+		assert.True(t, got.IsBinary)
+		assert.Equal(t, raw, got.Data) // served raw, not the expanded bomb
+	})
+}
+
+func TestLoadDecodedBody(t *testing.T) {
+	t.Run("nil body is unavailable without reason", func(t *testing.T) {
+		got, err := LoadDecodedBody(nil, nil)
+		require.NoError(t, err)
+		assert.False(t, got.Available)
+	})
+
+	t.Run("evicted file yields unavailable with nil error", func(t *testing.T) {
+		dir := t.TempDir()
+		body := &CapturedBody{FilePath: filepath.Join(dir, "evicted.bin")}
+		got, err := LoadDecodedBody(body, []string{dir})
+		require.NoError(t, err) // record still valid (D7)
+		assert.False(t, got.Available)
+		assert.Equal(t, "evicted", got.UnavailableReason)
+		assert.Nil(t, got.Data)
+	})
+
+	t.Run("disk-backed gzip body loads and decodes", func(t *testing.T) {
+		dir := t.TempDir()
+		payload := []byte(`{"disk":"gzip"}`)
+		fp := filepath.Join(dir, "res.bin")
+		require.NoError(t, os.WriteFile(fp, gzipBytes(t, payload), 0600))
+
+		body := &CapturedBody{
+			FilePath:        fp,
+			ContentEncoding: "gzip",
+			ContentType:     "application/json",
+			IsBinary:        true,
+		}
+		got, err := LoadDecodedBody(body, []string{dir})
+		require.NoError(t, err)
+		assert.True(t, got.Available)
+		assert.False(t, got.IsBinary)
+		assert.Equal(t, payload, got.Data)
+	})
+}

--- a/internal/proxy/capture.go
+++ b/internal/proxy/capture.go
@@ -109,7 +109,8 @@ func (cm *CaptureManager) CaptureRequest(requestID string, r *http.Request) (*Ca
 
 	// We return a placeholder body info; the actual data will be filled after reading completes
 	body := &CapturedBody{
-		ContentType: contentType,
+		ContentType:     contentType,
+		ContentEncoding: r.Header.Get("Content-Encoding"),
 	}
 
 	captured.body = body
@@ -128,10 +129,12 @@ func (cm *CaptureManager) CaptureResponse(requestID string, crw *capturingRespon
 	data := crw.CapturedBody()
 
 	body := &CapturedBody{
-		Size:        int64(len(data)),
-		Truncated:   crw.Truncated(),
-		ContentType: contentType,
-		IsBinary:    isBinaryContent(data, contentType),
+		Size:            crw.TotalSeen(),
+		CapturedSize:    int64(len(data)),
+		Truncated:       crw.Truncated(),
+		ContentType:     contentType,
+		ContentEncoding: crw.Header().Get("Content-Encoding"),
+		IsBinary:        isBinaryContent(data, contentType),
 	}
 
 	// Determine if we should store inline or on disk
@@ -198,6 +201,7 @@ type captureBuffer struct {
 	buf       bytes.Buffer
 	maxSize   int64
 	truncated bool
+	totalSeen int64 // total bytes observed across all writes, counting past truncation
 	requestID string
 	suffix    string
 	cm        *CaptureManager
@@ -208,7 +212,10 @@ func (cb *captureBuffer) Write(p []byte) (n int, err error) {
 	cb.mu.Lock()
 	defer cb.mu.Unlock()
 
-	if cb.truncated {
+	// Count every byte observed, including data discarded after truncation.
+	cb.totalSeen += int64(len(p))
+
+	if cb.truncated || len(p) == 0 {
 		return len(p), nil // Discard but pretend we wrote it
 	}
 
@@ -242,7 +249,8 @@ func (cb *captureBuffer) finalize() error {
 	}
 
 	data := cb.buf.Bytes()
-	cb.body.Size = int64(len(data))
+	cb.body.Size = cb.totalSeen
+	cb.body.CapturedSize = int64(len(data))
 	cb.body.Truncated = cb.truncated
 	cb.body.IsBinary = isBinaryContent(data, cb.body.ContentType)
 
@@ -301,6 +309,7 @@ type capturingResponseWriter struct {
 	maxBodySize int64
 	truncated   bool
 	wroteHeader bool
+	totalSeen   int64 // total bytes observed across all writes, counting past truncation
 }
 
 // newCapturingResponseWriter creates a new capturing response writer.
@@ -321,8 +330,11 @@ func (crw *capturingResponseWriter) WriteHeader(code int) {
 }
 
 func (crw *capturingResponseWriter) Write(p []byte) (int, error) {
+	// Count every byte observed, including data not retained after truncation.
+	crw.totalSeen += int64(len(p))
+
 	// Capture up to maxBodySize
-	if !crw.truncated {
+	if !crw.truncated && len(p) > 0 {
 		remaining := crw.maxBodySize - int64(crw.body.Len())
 		if remaining > 0 {
 			toCapture := p
@@ -352,6 +364,12 @@ func (crw *capturingResponseWriter) CapturedBody() []byte {
 // Truncated returns whether the body was truncated.
 func (crw *capturingResponseWriter) Truncated() bool {
 	return crw.truncated
+}
+
+// TotalSeen returns the total number of bytes observed by Write, counting
+// bytes that were not retained after truncation.
+func (crw *capturingResponseWriter) TotalSeen() int64 {
+	return crw.totalSeen
 }
 
 // Flush implements http.Flusher for streaming responses (SSE).
@@ -394,20 +412,18 @@ func cloneHeaders(h http.Header) http.Header {
 	return clone
 }
 
-// isBinaryContent determines if content appears to be binary based on data and content type.
+// isBinaryContent determines if content appears to be binary based on data and
+// content type.
+//
+// Integrity-first rule (D9): content is never classified as text unless the
+// COMPLETE retained data is valid UTF-8. Known-binary content types are always
+// binary; a text-y Content-Type never short-circuits to text — data validity
+// decides. The full-buffer scan (no 512-byte sampling) is bounded by the 1MB
+// capture cap.
 func isBinaryContent(data []byte, contentType string) bool {
-	// Check content type first
+	// Known-binary content types are binary regardless of the data.
 	if contentType != "" {
 		ct := strings.ToLower(contentType)
-		// Text types
-		if strings.HasPrefix(ct, "text/") ||
-			strings.Contains(ct, "json") ||
-			strings.Contains(ct, "xml") ||
-			strings.Contains(ct, "javascript") ||
-			strings.Contains(ct, "html") {
-			return false
-		}
-		// Known binary types
 		if strings.HasPrefix(ct, "image/") ||
 			strings.HasPrefix(ct, "audio/") ||
 			strings.HasPrefix(ct, "video/") ||
@@ -420,24 +436,19 @@ func isBinaryContent(data []byte, contentType string) bool {
 		}
 	}
 
-	// Check if the data is valid UTF-8 with no control characters (except common ones)
+	// Empty data is not binary.
 	if len(data) == 0 {
 		return false
 	}
 
-	// Sample the first 512 bytes
-	sample := data
-	if len(sample) > 512 {
-		sample = sample[:512]
-	}
-
-	if !utf8.Valid(sample) {
+	// The entire retained buffer must be valid UTF-8 to be considered text.
+	if !utf8.Valid(data) {
 		return true
 	}
 
-	// Check for binary indicators (non-printable characters)
-	for _, b := range sample {
-		// Allow common control characters: tab, newline, carriage return
+	// Scan the entire buffer for non-printable control characters.
+	// Allow common control characters: tab, newline, carriage return.
+	for _, b := range data {
 		if b < 32 && b != '\t' && b != '\n' && b != '\r' {
 			return true
 		}

--- a/internal/proxy/capture.go
+++ b/internal/proxy/capture.go
@@ -32,19 +32,22 @@ type CaptureManager struct {
 
 // NewCaptureManager creates a new capture manager.
 // If cfg is nil or capture is not enabled, returns a manager that does nothing.
+//
+// This constructor treats workDir as a WORK directory: the capture directory is
+// derived as workDir/.prox/capture. Callers that already hold an exact capture
+// directory (e.g. the shared daemon, whose capture dir is ~/.prox/capture) must
+// use NewCaptureManagerAt instead to avoid a doubled ".prox/capture" suffix.
 func NewCaptureManager(cfg *config.CaptureConfig, workDir string) (*CaptureManager, error) {
-	cm := &CaptureManager{
-		workDir:         workDir,
-		maxBodySize:     constants.DefaultCaptureMaxBodySize,
-		inlineThreshold: constants.DefaultCaptureInlineThreshold,
-	}
-
 	if cfg == nil || !cfg.Enabled {
-		cm.enabled = false
-		return cm, nil
+		return &CaptureManager{
+			workDir:         workDir,
+			enabled:         false,
+			maxBodySize:     constants.DefaultCaptureMaxBodySize,
+			inlineThreshold: constants.DefaultCaptureInlineThreshold,
+		}, nil
 	}
 
-	cm.enabled = true
+	maxBodySize := int64(constants.DefaultCaptureMaxBodySize)
 
 	// Parse max body size if configured
 	if cfg.MaxBodySize != "" {
@@ -53,24 +56,56 @@ func NewCaptureManager(cfg *config.CaptureConfig, workDir string) (*CaptureManag
 			return nil, err
 		}
 		if size > 0 {
-			cm.maxBodySize = size
+			maxBodySize = size
 		}
 	}
 
-	// Set up capture directory
-	cm.captureDir = filepath.Join(workDir, constants.CaptureDirectory)
+	captureDir := filepath.Join(workDir, constants.CaptureDirectory)
+	cm, err := NewCaptureManagerAt(captureDir, maxBodySize)
+	if err != nil {
+		return nil, err
+	}
+	cm.workDir = workDir
+	return cm, nil
+}
 
-	// Clean up any existing capture files from previous run
+// NewCaptureManagerAt creates an enabled capture manager rooted at an EXACT
+// capture directory (no ".prox/capture" suffix is appended). It is the shared
+// setup that NewCaptureManager delegates to once it has resolved the capture
+// directory and body-size limit. Any existing files under captureDir are removed
+// (previous-run cleanup) and the directory is created.
+func NewCaptureManagerAt(captureDir string, maxBodySize int64) (*CaptureManager, error) {
+	if maxBodySize <= 0 {
+		maxBodySize = constants.DefaultCaptureMaxBodySize
+	}
+
+	cm := &CaptureManager{
+		enabled:         true,
+		maxBodySize:     maxBodySize,
+		inlineThreshold: constants.DefaultCaptureInlineThreshold,
+		captureDir:      captureDir,
+	}
+
+	// Clean up any existing capture files from a previous run.
 	if err := cm.Cleanup(); err != nil && !os.IsNotExist(err) {
 		return nil, err
 	}
 
-	// Create capture directory
+	// Create capture directory.
 	if err := os.MkdirAll(cm.captureDir, constants.DirPermissionPrivate); err != nil {
 		return nil, err
 	}
 
 	return cm, nil
+}
+
+// CaptureDir returns the directory where captured body files are stored, or the
+// empty string when capture is disabled. Used by consumers building the
+// LoadCapturedBody allowlist.
+func (cm *CaptureManager) CaptureDir() string {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+	return cm.captureDir
 }
 
 // Enabled returns whether capture is enabled.
@@ -117,9 +152,16 @@ func (cm *CaptureManager) CaptureRequest(requestID string, r *http.Request) (*Ca
 	return body, wrappedBody, headers
 }
 
-// CaptureResponse captures the response body from a capturingResponseWriter.
+// WrapResponseWriter wraps w in a CaptureResponseWriter that records up to the
+// manager's configured max body size while forwarding all writes downstream.
+// The returned writer preserves http.Flusher/Hijacker/Pusher/Unwrap behavior.
+func (cm *CaptureManager) WrapResponseWriter(w http.ResponseWriter) *CaptureResponseWriter {
+	return newCaptureResponseWriter(w, cm.maxBodySize)
+}
+
+// FinalizeResponse captures the response body from a CaptureResponseWriter.
 // Should be called after the response has been fully written.
-func (cm *CaptureManager) CaptureResponse(requestID string, crw *capturingResponseWriter) (*CapturedBody, http.Header) {
+func (cm *CaptureManager) FinalizeResponse(requestID string, crw *CaptureResponseWriter) (*CapturedBody, http.Header) {
 	if !cm.enabled {
 		return nil, cloneHeaders(crw.Header())
 	}
@@ -156,23 +198,10 @@ func (cm *CaptureManager) CaptureResponse(requestID string, crw *capturingRespon
 
 // LoadBody loads a captured body's data, reading from disk if necessary.
 // Returns a copy of the data to prevent callers from modifying the original.
+// FilePath bodies are constrained to the manager's own capture directory via
+// LoadCapturedBody's allowlist.
 func (cm *CaptureManager) LoadBody(body *CapturedBody) ([]byte, error) {
-	if body == nil {
-		return nil, nil
-	}
-
-	if body.Data != nil {
-		// Return a copy to prevent callers from modifying the original data
-		result := make([]byte, len(body.Data))
-		copy(result, body.Data)
-		return result, nil
-	}
-
-	if body.FilePath != "" {
-		return os.ReadFile(body.FilePath)
-	}
-
-	return nil, nil
+	return LoadCapturedBody(body, []string{cm.CaptureDir()})
 }
 
 // CleanupRequest removes disk files associated with a specific request.
@@ -297,12 +326,12 @@ func (crc *captureReadCloser) Close() error {
 	return crc.Closer.Close()
 }
 
-// capturingResponseWriter wraps an http.ResponseWriter to capture the response body.
+// CaptureResponseWriter wraps an http.ResponseWriter to capture the response body.
 // It intercepts writes to capture up to maxBodySize bytes while still forwarding
 // all data to the underlying ResponseWriter. It also implements http.Flusher,
 // http.Hijacker, and http.Pusher for compatibility with streaming and WebSocket
 // connections.
-type capturingResponseWriter struct {
+type CaptureResponseWriter struct {
 	http.ResponseWriter
 	statusCode  int
 	body        bytes.Buffer
@@ -312,16 +341,16 @@ type capturingResponseWriter struct {
 	totalSeen   int64 // total bytes observed across all writes, counting past truncation
 }
 
-// newCapturingResponseWriter creates a new capturing response writer.
-func newCapturingResponseWriter(w http.ResponseWriter, maxBodySize int64) *capturingResponseWriter {
-	return &capturingResponseWriter{
+// newCaptureResponseWriter creates a new capturing response writer.
+func newCaptureResponseWriter(w http.ResponseWriter, maxBodySize int64) *CaptureResponseWriter {
+	return &CaptureResponseWriter{
 		ResponseWriter: w,
 		statusCode:     http.StatusOK,
 		maxBodySize:    maxBodySize,
 	}
 }
 
-func (crw *capturingResponseWriter) WriteHeader(code int) {
+func (crw *CaptureResponseWriter) WriteHeader(code int) {
 	if !crw.wroteHeader {
 		crw.statusCode = code
 		crw.wroteHeader = true
@@ -329,7 +358,7 @@ func (crw *capturingResponseWriter) WriteHeader(code int) {
 	crw.ResponseWriter.WriteHeader(code)
 }
 
-func (crw *capturingResponseWriter) Write(p []byte) (int, error) {
+func (crw *CaptureResponseWriter) Write(p []byte) (int, error) {
 	// Count every byte observed, including data not retained after truncation.
 	crw.totalSeen += int64(len(p))
 
@@ -352,35 +381,35 @@ func (crw *capturingResponseWriter) Write(p []byte) (int, error) {
 }
 
 // StatusCode returns the captured status code.
-func (crw *capturingResponseWriter) StatusCode() int {
+func (crw *CaptureResponseWriter) StatusCode() int {
 	return crw.statusCode
 }
 
 // CapturedBody returns the captured response body.
-func (crw *capturingResponseWriter) CapturedBody() []byte {
+func (crw *CaptureResponseWriter) CapturedBody() []byte {
 	return crw.body.Bytes()
 }
 
 // Truncated returns whether the body was truncated.
-func (crw *capturingResponseWriter) Truncated() bool {
+func (crw *CaptureResponseWriter) Truncated() bool {
 	return crw.truncated
 }
 
 // TotalSeen returns the total number of bytes observed by Write, counting
 // bytes that were not retained after truncation.
-func (crw *capturingResponseWriter) TotalSeen() int64 {
+func (crw *CaptureResponseWriter) TotalSeen() int64 {
 	return crw.totalSeen
 }
 
 // Flush implements http.Flusher for streaming responses (SSE).
-func (crw *capturingResponseWriter) Flush() {
+func (crw *CaptureResponseWriter) Flush() {
 	if f, ok := crw.ResponseWriter.(http.Flusher); ok {
 		f.Flush()
 	}
 }
 
 // Hijack implements http.Hijacker for WebSocket support.
-func (crw *capturingResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+func (crw *CaptureResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	if h, ok := crw.ResponseWriter.(http.Hijacker); ok {
 		return h.Hijack()
 	}
@@ -388,7 +417,7 @@ func (crw *capturingResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error
 }
 
 // Push implements http.Pusher for HTTP/2 server push.
-func (crw *capturingResponseWriter) Push(target string, opts *http.PushOptions) error {
+func (crw *CaptureResponseWriter) Push(target string, opts *http.PushOptions) error {
 	if p, ok := crw.ResponseWriter.(http.Pusher); ok {
 		return p.Push(target, opts)
 	}
@@ -396,7 +425,7 @@ func (crw *capturingResponseWriter) Push(target string, opts *http.PushOptions) 
 }
 
 // Unwrap returns the underlying ResponseWriter for Go 1.20+ http.ResponseController compatibility.
-func (crw *capturingResponseWriter) Unwrap() http.ResponseWriter {
+func (crw *CaptureResponseWriter) Unwrap() http.ResponseWriter {
 	return crw.ResponseWriter
 }
 

--- a/internal/proxy/capture.go
+++ b/internal/proxy/capture.go
@@ -230,6 +230,7 @@ type captureBuffer struct {
 	buf       bytes.Buffer
 	maxSize   int64
 	truncated bool
+	finalized bool
 	totalSeen int64 // total bytes observed across all writes, counting past truncation
 	requestID string
 	suffix    string
@@ -240,6 +241,13 @@ type captureBuffer struct {
 func (cb *captureBuffer) Write(p []byte) (n int, err error) {
 	cb.mu.Lock()
 	defer cb.mu.Unlock()
+
+	// Once finalized, the CapturedBody snapshot is frozen: late writes from a
+	// transport goroutine still draining a canceled request must not mutate
+	// state that a recorded (and possibly already-serialized) body points at.
+	if cb.finalized {
+		return len(p), nil
+	}
 
 	// Count every byte observed, including data discarded after truncation.
 	cb.totalSeen += int64(len(p))
@@ -273,9 +281,10 @@ func (cb *captureBuffer) finalize() error {
 	cb.mu.Lock()
 	defer cb.mu.Unlock()
 
-	if cb.body == nil {
+	if cb.body == nil || cb.finalized {
 		return nil
 	}
+	cb.finalized = true
 
 	data := cb.buf.Bytes()
 	cb.body.Size = cb.totalSeen
@@ -326,6 +335,22 @@ func (crc *captureReadCloser) Close() error {
 	return crc.Closer.Close()
 }
 
+// FinalizeRequestBody forces finalization of a request body previously wrapped
+// by CaptureRequest. Idempotent; a non-wrapped body is a no-op. Proxy handlers
+// call this after the reverse proxy returns and BEFORE recording, so the
+// CapturedBody snapshot is complete when the record is published (SSE
+// subscribers serialize records at notify time). Without it, a canceled
+// request's transport goroutine may still be draining the body, and its later
+// Close-triggered finalize would race the serialization; after this call that
+// finalize is a no-op and late writes are discarded.
+func FinalizeRequestBody(rc io.ReadCloser) {
+	if crc, ok := rc.(*captureReadCloser); ok && crc.captured != nil {
+		if err := crc.captured.finalize(); err != nil {
+			log.Printf("Warning: capture finalize failed: %v", err)
+		}
+	}
+}
+
 // CaptureResponseWriter wraps an http.ResponseWriter to capture the response body.
 // It intercepts writes to capture up to maxBodySize bytes while still forwarding
 // all data to the underlying ResponseWriter. It also implements http.Flusher,
@@ -338,6 +363,7 @@ type CaptureResponseWriter struct {
 	maxBodySize int64
 	truncated   bool
 	wroteHeader bool
+	hijacked    bool
 	totalSeen   int64 // total bytes observed across all writes, counting past truncation
 }
 
@@ -411,9 +437,22 @@ func (crw *CaptureResponseWriter) Flush() {
 // Hijack implements http.Hijacker for WebSocket support.
 func (crw *CaptureResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	if h, ok := crw.ResponseWriter.(http.Hijacker); ok {
-		return h.Hijack()
+		conn, rw, err := h.Hijack()
+		if err == nil {
+			crw.hijacked = true
+		}
+		return conn, rw, err
 	}
 	return nil, nil, errors.New("hijacking not supported")
+}
+
+// Hijacked reports whether the connection was taken over (WebSocket upgrade).
+// After a hijack all traffic bypasses this writer, so the captured status/body
+// do not describe the response — callers should record metadata only rather
+// than finalize garbage Details. Single-goroutine access per the
+// http.ResponseWriter contract.
+func (crw *CaptureResponseWriter) Hijacked() bool {
+	return crw.hijacked
 }
 
 // Push implements http.Pusher for HTTP/2 server push.

--- a/internal/proxy/capture_test.go
+++ b/internal/proxy/capture_test.go
@@ -861,6 +861,68 @@ func TestCaptureBuffer_SizeSemantics(t *testing.T) {
 		assert.Equal(t, int64(10), body.CapturedSize)
 		assert.False(t, body.Truncated)
 	})
+
+	t.Run("writes after finalize are discarded and finalize is idempotent", func(t *testing.T) {
+		// A canceled request's transport goroutine can keep draining the body
+		// after the handler finalized and recorded; those late writes must not
+		// mutate the frozen CapturedBody snapshot.
+		body := &CapturedBody{}
+		cb := &captureBuffer{
+			maxSize: 100,
+			body:    body,
+			cm:      &CaptureManager{inlineThreshold: 1024},
+		}
+
+		cb.Write([]byte("early"))
+		require.NoError(t, cb.finalize())
+		assert.Equal(t, int64(5), body.Size)
+		assert.Equal(t, "early", string(body.Data))
+
+		cb.Write([]byte("late-bytes"))
+		require.NoError(t, cb.finalize()) // second finalize: no-op
+		assert.Equal(t, int64(5), body.Size, "late writes must not change the snapshot")
+		assert.Equal(t, "early", string(body.Data))
+	})
+}
+
+func TestFinalizeRequestBody(t *testing.T) {
+	t.Run("forces finalize on a wrapped body before Close", func(t *testing.T) {
+		cm := newEnabledCaptureManager(t)
+		req := httptest.NewRequest("POST", "/test", strings.NewReader("payload"))
+		capturedBody, wrappedBody, _ := cm.CaptureRequest("req-force", req)
+
+		_, err := io.ReadAll(wrappedBody)
+		require.NoError(t, err)
+
+		FinalizeRequestBody(wrappedBody)
+		assert.Equal(t, int64(7), capturedBody.Size, "snapshot complete without Close")
+
+		// The transport's later Close must not re-finalize or error.
+		require.NoError(t, wrappedBody.Close())
+		assert.Equal(t, int64(7), capturedBody.Size)
+	})
+
+	t.Run("non-wrapped body is a no-op", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			FinalizeRequestBody(io.NopCloser(strings.NewReader("x")))
+			FinalizeRequestBody(nil)
+		})
+	})
+}
+
+func TestCaptureResponseWriter_Hijacked(t *testing.T) {
+	t.Run("not hijacked by default", func(t *testing.T) {
+		crw := newCaptureResponseWriter(httptest.NewRecorder(), 1024)
+		assert.False(t, crw.Hijacked())
+	})
+
+	t.Run("failed hijack does not mark hijacked", func(t *testing.T) {
+		// httptest.ResponseRecorder does not implement http.Hijacker.
+		crw := newCaptureResponseWriter(httptest.NewRecorder(), 1024)
+		_, _, err := crw.Hijack()
+		require.Error(t, err)
+		assert.False(t, crw.Hijacked())
+	})
 }
 
 func TestCapturingResponseWriter_SizeSemantics(t *testing.T) {

--- a/internal/proxy/capture_test.go
+++ b/internal/proxy/capture_test.go
@@ -1,6 +1,8 @@
 package proxy
 
 import (
+	"bytes"
+	"compress/gzip"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -177,7 +179,8 @@ func TestCaptureRequest(t *testing.T) {
 		err = wrappedBody.Close()
 		require.NoError(t, err)
 
-		assert.Equal(t, int64(50), capturedBody.Size)
+		assert.Equal(t, int64(100), capturedBody.Size)        // total bytes observed
+		assert.Equal(t, int64(50), capturedBody.CapturedSize) // bytes retained
 		assert.True(t, capturedBody.Truncated)
 	})
 
@@ -272,7 +275,8 @@ func TestCaptureResponse(t *testing.T) {
 		body, _ := cm.CaptureResponse("req-trunc", crw)
 		require.NotNil(t, body)
 		assert.True(t, body.Truncated)
-		assert.Equal(t, int64(20), body.Size) // captured size is truncated size
+		assert.Equal(t, int64(50), body.Size)         // total bytes observed
+		assert.Equal(t, int64(20), body.CapturedSize) // bytes retained
 	})
 }
 
@@ -529,7 +533,8 @@ func TestCaptureBuffer_Finalize(t *testing.T) {
 		cb.finalize()
 
 		assert.True(t, body.Truncated)
-		assert.Equal(t, int64(5), body.Size)
+		assert.Equal(t, int64(11), body.Size)        // total bytes observed
+		assert.Equal(t, int64(5), body.CapturedSize) // bytes retained
 	})
 }
 
@@ -698,23 +703,41 @@ func TestIsBinaryContent(t *testing.T) {
 		assert.False(t, isBinaryContent(withAllowed, ""))
 	})
 
-	t.Run("only samples first 512 bytes", func(t *testing.T) {
-		// Build 600 bytes: 512 valid ASCII + binary after
+	t.Run("scans the entire buffer, not just first 512 bytes", func(t *testing.T) {
+		// Regression for the 512-byte sampling bug (multipart-style):
+		// >512 bytes of valid ASCII followed by invalid-UTF-8 bytes.
 		data := make([]byte, 600)
 		for i := 0; i < 512; i++ {
 			data[i] = 'a'
 		}
 		for i := 512; i < 600; i++ {
-			data[i] = 0x01 // non-printable
+			data[i] = 0xff // invalid UTF-8 past the old sampling window
 		}
-		// Content type empty, so it falls to data inspection
-		assert.False(t, isBinaryContent(data, ""))
+		// Even with a text-y content type, invalid UTF-8 makes this binary.
+		assert.True(t, isBinaryContent(data, "multipart/form-data"))
+		assert.True(t, isBinaryContent(data, ""))
 	})
 
-	t.Run("content type takes precedence over data", func(t *testing.T) {
-		// Binary data but text content type
+	t.Run("text-y content type does not short-circuit invalid UTF-8", func(t *testing.T) {
+		// Invalid UTF-8 must classify binary regardless of a text-y CT.
 		binaryData := []byte{0xff, 0xfe, 0x00}
-		assert.False(t, isBinaryContent(binaryData, "application/json"))
+		assert.True(t, isBinaryContent(binaryData, "application/json"))
+	})
+
+	t.Run("gzip-compressed JSON with json content type is binary", func(t *testing.T) {
+		var buf bytes.Buffer
+		gz := gzip.NewWriter(&buf)
+		_, err := gz.Write([]byte(`{"hello":"world","n":42}`))
+		require.NoError(t, err)
+		require.NoError(t, gz.Close())
+
+		// Compressed bytes are (almost surely) not valid UTF-8 → binary,
+		// even though the declared content type is application/json.
+		assert.True(t, isBinaryContent(buf.Bytes(), "application/json"))
+	})
+
+	t.Run("known-binary content type is binary even with empty data", func(t *testing.T) {
+		assert.True(t, isBinaryContent([]byte{}, "image/png"))
 	})
 }
 
@@ -779,4 +802,166 @@ func TestRequestManager_EvictionCallbackCleanup(t *testing.T) {
 	assert.True(t, os.IsNotExist(err), "request file should be cleaned up on eviction")
 	_, err = os.Stat(resFile)
 	assert.True(t, os.IsNotExist(err), "response file should be cleaned up on eviction")
+}
+
+// --- Size semantics (D11): total observed vs retained ---
+
+func TestCaptureBuffer_SizeSemantics(t *testing.T) {
+	t.Run("counts bytes past the truncation cap", func(t *testing.T) {
+		body := &CapturedBody{}
+		cb := &captureBuffer{
+			maxSize: 10,
+			body:    body,
+			cm:      &CaptureManager{inlineThreshold: 1024},
+		}
+
+		// Three writes of 6 bytes each = 18 total, cap 10.
+		cb.Write([]byte("aaaaaa"))
+		cb.Write([]byte("bbbbbb"))
+		cb.Write([]byte("cccccc"))
+
+		require.NoError(t, cb.finalize())
+		assert.Equal(t, int64(18), body.Size)         // total observed, counting past the cap
+		assert.Equal(t, int64(10), body.CapturedSize) // bytes retained
+		assert.True(t, body.Truncated)
+	})
+
+	t.Run("exact-cap boundary is not truncated", func(t *testing.T) {
+		body := &CapturedBody{}
+		cb := &captureBuffer{
+			maxSize: 10,
+			body:    body,
+			cm:      &CaptureManager{inlineThreshold: 1024},
+		}
+
+		// Writes summing exactly to the cap.
+		cb.Write([]byte("aaaaa"))
+		cb.Write([]byte("bbbbb"))
+
+		require.NoError(t, cb.finalize())
+		assert.Equal(t, int64(10), body.Size)
+		assert.Equal(t, int64(10), body.CapturedSize)
+		assert.Equal(t, body.Size, body.CapturedSize)
+		assert.False(t, body.Truncated)
+	})
+
+	t.Run("zero-length write at exact cap does not mark truncated", func(t *testing.T) {
+		body := &CapturedBody{}
+		cb := &captureBuffer{
+			maxSize: 10,
+			body:    body,
+			cm:      &CaptureManager{inlineThreshold: 1024},
+		}
+
+		cb.Write([]byte("aaaaaaaaaa"))
+		cb.Write([]byte{})
+
+		require.NoError(t, cb.finalize())
+		assert.Equal(t, int64(10), body.Size)
+		assert.Equal(t, int64(10), body.CapturedSize)
+		assert.False(t, body.Truncated)
+	})
+}
+
+func TestCapturingResponseWriter_SizeSemantics(t *testing.T) {
+	t.Run("counts bytes past the truncation cap via CaptureResponse", func(t *testing.T) {
+		cm := newEnabledCaptureManager(t)
+
+		w := httptest.NewRecorder()
+		crw := newCapturingResponseWriter(w, 10)
+		crw.Header().Set("Content-Type", "text/plain")
+
+		crw.Write([]byte("aaaaaa"))
+		crw.Write([]byte("bbbbbb"))
+		crw.Write([]byte("cccccc"))
+
+		body, _ := cm.CaptureResponse("req-total", crw)
+		require.NotNil(t, body)
+		assert.Equal(t, int64(18), body.Size)
+		assert.Equal(t, int64(10), body.CapturedSize)
+		assert.True(t, body.Truncated)
+	})
+
+	t.Run("exact-cap boundary is not truncated via CaptureResponse", func(t *testing.T) {
+		cm := newEnabledCaptureManager(t)
+
+		w := httptest.NewRecorder()
+		crw := newCapturingResponseWriter(w, 10)
+		crw.Header().Set("Content-Type", "text/plain")
+
+		crw.Write([]byte("aaaaa"))
+		crw.Write([]byte("bbbbb"))
+
+		body, _ := cm.CaptureResponse("req-exact", crw)
+		require.NotNil(t, body)
+		assert.Equal(t, int64(10), body.Size)
+		assert.Equal(t, int64(10), body.CapturedSize)
+		assert.Equal(t, body.Size, body.CapturedSize)
+		assert.False(t, body.Truncated)
+	})
+
+	t.Run("zero-length write at exact cap does not mark truncated", func(t *testing.T) {
+		cm := newEnabledCaptureManager(t)
+
+		w := httptest.NewRecorder()
+		crw := newCapturingResponseWriter(w, 10)
+		crw.Header().Set("Content-Type", "text/plain")
+
+		crw.Write([]byte("aaaaaaaaaa"))
+		crw.Write([]byte{})
+
+		body, _ := cm.CaptureResponse("req-zero", crw)
+		require.NotNil(t, body)
+		assert.Equal(t, int64(10), body.Size)
+		assert.Equal(t, int64(10), body.CapturedSize)
+		assert.False(t, body.Truncated)
+	})
+}
+
+// --- ContentEncoding capture (data model only; no decode) ---
+
+func TestContentEncodingCaptured(t *testing.T) {
+	t.Run("request body records Content-Encoding", func(t *testing.T) {
+		cm := newEnabledCaptureManager(t)
+
+		req := httptest.NewRequest("POST", "/test", strings.NewReader("payload"))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Content-Encoding", "gzip")
+
+		capturedBody, wrappedBody, _ := cm.CaptureRequest("req-enc", req)
+		require.NotNil(t, capturedBody)
+
+		_, err := io.ReadAll(wrappedBody)
+		require.NoError(t, err)
+		require.NoError(t, wrappedBody.Close())
+
+		assert.Equal(t, "gzip", capturedBody.ContentEncoding)
+	})
+
+	t.Run("response body records Content-Encoding", func(t *testing.T) {
+		cm := newEnabledCaptureManager(t)
+
+		w := httptest.NewRecorder()
+		crw := newCapturingResponseWriter(w, constants.DefaultCaptureMaxBodySize)
+		crw.Header().Set("Content-Type", "application/json")
+		crw.Header().Set("Content-Encoding", "gzip")
+		crw.Write([]byte("compressed-ish"))
+
+		body, _ := cm.CaptureResponse("res-enc", crw)
+		require.NotNil(t, body)
+		assert.Equal(t, "gzip", body.ContentEncoding)
+	})
+
+	t.Run("absent Content-Encoding stays empty", func(t *testing.T) {
+		cm := newEnabledCaptureManager(t)
+
+		req := httptest.NewRequest("POST", "/test", strings.NewReader("payload"))
+		capturedBody, wrappedBody, _ := cm.CaptureRequest("req-noenc", req)
+		require.NotNil(t, capturedBody)
+		_, err := io.ReadAll(wrappedBody)
+		require.NoError(t, err)
+		require.NoError(t, wrappedBody.Close())
+
+		assert.Empty(t, capturedBody.ContentEncoding)
+	})
 }

--- a/internal/proxy/capture_test.go
+++ b/internal/proxy/capture_test.go
@@ -209,11 +209,11 @@ func TestCaptureResponse(t *testing.T) {
 		require.NoError(t, err)
 
 		w := httptest.NewRecorder()
-		crw := newCapturingResponseWriter(w, 1024)
+		crw := newCaptureResponseWriter(w, 1024)
 		crw.Header().Set("Content-Type", "text/html")
 		crw.Write([]byte("hello"))
 
-		body, headers := cm.CaptureResponse("req1", crw)
+		body, headers := cm.FinalizeResponse("req1", crw)
 		assert.Nil(t, body)
 		assert.Equal(t, "text/html", headers.Get("Content-Type"))
 	})
@@ -222,11 +222,11 @@ func TestCaptureResponse(t *testing.T) {
 		cm := newEnabledCaptureManager(t)
 
 		w := httptest.NewRecorder()
-		crw := newCapturingResponseWriter(w, constants.DefaultCaptureMaxBodySize)
+		crw := newCaptureResponseWriter(w, constants.DefaultCaptureMaxBodySize)
 		crw.Header().Set("Content-Type", "application/json")
 		crw.Write([]byte(`{"ok":true}`))
 
-		body, headers := cm.CaptureResponse("req1", crw)
+		body, headers := cm.FinalizeResponse("req1", crw)
 		require.NotNil(t, body)
 		assert.Equal(t, int64(11), body.Size)
 		assert.False(t, body.Truncated)
@@ -245,13 +245,13 @@ func TestCaptureResponse(t *testing.T) {
 		cm.inlineThreshold = 10
 
 		w := httptest.NewRecorder()
-		crw := newCapturingResponseWriter(w, constants.DefaultCaptureMaxBodySize)
+		crw := newCaptureResponseWriter(w, constants.DefaultCaptureMaxBodySize)
 		crw.Header().Set("Content-Type", "text/plain")
 
 		payload := strings.Repeat("y", 100)
 		crw.Write([]byte(payload))
 
-		body, _ := cm.CaptureResponse("req-disk", crw)
+		body, _ := cm.FinalizeResponse("req-disk", crw)
 		require.NotNil(t, body)
 		assert.Equal(t, int64(100), body.Size)
 		assert.Nil(t, body.Data)
@@ -266,13 +266,13 @@ func TestCaptureResponse(t *testing.T) {
 		cm := newEnabledCaptureManager(t)
 
 		w := httptest.NewRecorder()
-		crw := newCapturingResponseWriter(w, 20)
+		crw := newCaptureResponseWriter(w, 20)
 		crw.Header().Set("Content-Type", "text/plain")
 
 		payload := strings.Repeat("z", 50)
 		crw.Write([]byte(payload))
 
-		body, _ := cm.CaptureResponse("req-trunc", crw)
+		body, _ := cm.FinalizeResponse("req-trunc", crw)
 		require.NotNil(t, body)
 		assert.True(t, body.Truncated)
 		assert.Equal(t, int64(50), body.Size)         // total bytes observed
@@ -305,8 +305,8 @@ func TestLoadBody(t *testing.T) {
 	t.Run("file-backed body reads from disk", func(t *testing.T) {
 		cm := newEnabledCaptureManager(t)
 
-		// Write a test file
-		tmpFile := filepath.Join(t.TempDir(), "test_body.bin")
+		// Write a test file inside the manager's capture dir (the allowlist root).
+		tmpFile := filepath.Join(cm.CaptureDir(), "test_body.bin")
 		err := os.WriteFile(tmpFile, []byte("file content"), 0600)
 		require.NoError(t, err)
 
@@ -566,12 +566,12 @@ func TestCaptureReadCloser(t *testing.T) {
 	})
 }
 
-// --- capturingResponseWriter tests ---
+// --- CaptureResponseWriter tests ---
 
 func TestCapturingResponseWriter(t *testing.T) {
 	t.Run("captures status code on first WriteHeader", func(t *testing.T) {
 		w := httptest.NewRecorder()
-		crw := newCapturingResponseWriter(w, 1024)
+		crw := newCaptureResponseWriter(w, 1024)
 
 		crw.WriteHeader(http.StatusCreated)
 		assert.Equal(t, http.StatusCreated, crw.StatusCode())
@@ -583,13 +583,13 @@ func TestCapturingResponseWriter(t *testing.T) {
 
 	t.Run("defaults to 200 if WriteHeader not called", func(t *testing.T) {
 		w := httptest.NewRecorder()
-		crw := newCapturingResponseWriter(w, 1024)
+		crw := newCaptureResponseWriter(w, 1024)
 		assert.Equal(t, http.StatusOK, crw.StatusCode())
 	})
 
 	t.Run("captures body while forwarding to underlying writer", func(t *testing.T) {
 		w := httptest.NewRecorder()
-		crw := newCapturingResponseWriter(w, 1024)
+		crw := newCaptureResponseWriter(w, 1024)
 
 		n, err := crw.Write([]byte("hello "))
 		require.NoError(t, err)
@@ -605,7 +605,7 @@ func TestCapturingResponseWriter(t *testing.T) {
 
 	t.Run("truncates capture at max size but forwards full data", func(t *testing.T) {
 		w := httptest.NewRecorder()
-		crw := newCapturingResponseWriter(w, 5)
+		crw := newCaptureResponseWriter(w, 5)
 
 		crw.Write([]byte("hello world"))
 
@@ -616,14 +616,14 @@ func TestCapturingResponseWriter(t *testing.T) {
 
 	t.Run("Flush delegates to underlying flusher", func(t *testing.T) {
 		w := httptest.NewRecorder()
-		crw := newCapturingResponseWriter(w, 1024)
+		crw := newCaptureResponseWriter(w, 1024)
 		// Should not panic even if underlying doesn't implement Flusher
 		crw.Flush()
 	})
 
 	t.Run("Hijack returns error when unsupported", func(t *testing.T) {
 		w := httptest.NewRecorder()
-		crw := newCapturingResponseWriter(w, 1024)
+		crw := newCaptureResponseWriter(w, 1024)
 		_, _, err := crw.Hijack()
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "hijacking not supported")
@@ -631,20 +631,20 @@ func TestCapturingResponseWriter(t *testing.T) {
 
 	t.Run("Push returns ErrNotSupported when unsupported", func(t *testing.T) {
 		w := httptest.NewRecorder()
-		crw := newCapturingResponseWriter(w, 1024)
+		crw := newCaptureResponseWriter(w, 1024)
 		err := crw.Push("/resource", nil)
 		assert.ErrorIs(t, err, http.ErrNotSupported)
 	})
 
 	t.Run("Unwrap returns underlying writer", func(t *testing.T) {
 		w := httptest.NewRecorder()
-		crw := newCapturingResponseWriter(w, 1024)
+		crw := newCaptureResponseWriter(w, 1024)
 		assert.Equal(t, w, crw.Unwrap())
 	})
 
 	t.Run("multiple writes with truncation mid-write", func(t *testing.T) {
 		w := httptest.NewRecorder()
-		crw := newCapturingResponseWriter(w, 8)
+		crw := newCaptureResponseWriter(w, 8)
 
 		crw.Write([]byte("abcd"))
 		assert.False(t, crw.Truncated())
@@ -868,14 +868,14 @@ func TestCapturingResponseWriter_SizeSemantics(t *testing.T) {
 		cm := newEnabledCaptureManager(t)
 
 		w := httptest.NewRecorder()
-		crw := newCapturingResponseWriter(w, 10)
+		crw := newCaptureResponseWriter(w, 10)
 		crw.Header().Set("Content-Type", "text/plain")
 
 		crw.Write([]byte("aaaaaa"))
 		crw.Write([]byte("bbbbbb"))
 		crw.Write([]byte("cccccc"))
 
-		body, _ := cm.CaptureResponse("req-total", crw)
+		body, _ := cm.FinalizeResponse("req-total", crw)
 		require.NotNil(t, body)
 		assert.Equal(t, int64(18), body.Size)
 		assert.Equal(t, int64(10), body.CapturedSize)
@@ -886,13 +886,13 @@ func TestCapturingResponseWriter_SizeSemantics(t *testing.T) {
 		cm := newEnabledCaptureManager(t)
 
 		w := httptest.NewRecorder()
-		crw := newCapturingResponseWriter(w, 10)
+		crw := newCaptureResponseWriter(w, 10)
 		crw.Header().Set("Content-Type", "text/plain")
 
 		crw.Write([]byte("aaaaa"))
 		crw.Write([]byte("bbbbb"))
 
-		body, _ := cm.CaptureResponse("req-exact", crw)
+		body, _ := cm.FinalizeResponse("req-exact", crw)
 		require.NotNil(t, body)
 		assert.Equal(t, int64(10), body.Size)
 		assert.Equal(t, int64(10), body.CapturedSize)
@@ -904,13 +904,13 @@ func TestCapturingResponseWriter_SizeSemantics(t *testing.T) {
 		cm := newEnabledCaptureManager(t)
 
 		w := httptest.NewRecorder()
-		crw := newCapturingResponseWriter(w, 10)
+		crw := newCaptureResponseWriter(w, 10)
 		crw.Header().Set("Content-Type", "text/plain")
 
 		crw.Write([]byte("aaaaaaaaaa"))
 		crw.Write([]byte{})
 
-		body, _ := cm.CaptureResponse("req-zero", crw)
+		body, _ := cm.FinalizeResponse("req-zero", crw)
 		require.NotNil(t, body)
 		assert.Equal(t, int64(10), body.Size)
 		assert.Equal(t, int64(10), body.CapturedSize)
@@ -942,12 +942,12 @@ func TestContentEncodingCaptured(t *testing.T) {
 		cm := newEnabledCaptureManager(t)
 
 		w := httptest.NewRecorder()
-		crw := newCapturingResponseWriter(w, constants.DefaultCaptureMaxBodySize)
+		crw := newCaptureResponseWriter(w, constants.DefaultCaptureMaxBodySize)
 		crw.Header().Set("Content-Type", "application/json")
 		crw.Header().Set("Content-Encoding", "gzip")
 		crw.Write([]byte("compressed-ish"))
 
-		body, _ := cm.CaptureResponse("res-enc", crw)
+		body, _ := cm.FinalizeResponse("res-enc", crw)
 		require.NotNil(t, body)
 		assert.Equal(t, "gzip", body.ContentEncoding)
 	})

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -419,13 +419,23 @@ func (s *Service) createRouter() http.Handler {
 	})
 }
 
+// stripHostPort removes a trailing ":port" from a host header value, if
+// present. Shared by extractSubdomain and recordRequest so hostname handling
+// stays consistent. Uses net.SplitHostPort so IPv6 literals survive: a bare
+// "[::1]" has no port and is returned unchanged rather than mangled at its
+// last colon.
+func stripHostPort(host string) string {
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		return h
+	}
+	return host
+}
+
 // extractSubdomain extracts the subdomain from the host header.
 // For example, "app.local.myapp.dev:6789" with domain "local.myapp.dev" returns "app".
 func (s *Service) extractSubdomain(host string) string {
 	// Remove port if present
-	if colonIdx := strings.LastIndex(host, ":"); colonIdx != -1 {
-		host = host[:colonIdx]
-	}
+	host = stripHostPort(host)
 
 	// Check if host ends with our domain with a proper label boundary (dot)
 	// This prevents "evilocal.myapp.dev" from matching domain "local.myapp.dev"
@@ -453,6 +463,7 @@ func (s *Service) recordRequest(r *http.Request, subdomain string, statusCode in
 		Method:     r.Method,
 		URL:        r.URL.String(),
 		Subdomain:  subdomain,
+		Hostname:   stripHostPort(r.Host),
 		StatusCode: statusCode,
 		Duration:   time.Since(startTime),
 		RemoteAddr: getClientIP(r),

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -305,7 +305,7 @@ func (s *Service) createRouter() http.Handler {
 		startTime := time.Now()
 
 		// Generate request ID early for capture
-		requestID := generateRequestID(startTime, r.Method, r.URL.String())
+		requestID := GenerateRequestID(startTime, r.Method, r.URL.String())
 
 		// Extract subdomain from host
 		subdomain := s.extractSubdomain(r.Host)
@@ -363,9 +363,9 @@ func (s *Service) createRouter() http.Handler {
 
 		// Choose response writer based on capture mode
 		var rw http.ResponseWriter
-		var crw *capturingResponseWriter
+		var crw *CaptureResponseWriter
 		if s.captureManager != nil && s.captureManager.Enabled() {
-			crw = newCapturingResponseWriter(w, s.captureManager.maxBodySize)
+			crw = s.captureManager.WrapResponseWriter(w)
 			rw = crw
 		} else {
 			rw = &responseWriter{ResponseWriter: w, statusCode: http.StatusOK}
@@ -394,7 +394,7 @@ func (s *Service) createRouter() http.Handler {
 		var statusCode int
 		if crw != nil {
 			statusCode = crw.StatusCode()
-			resBody, resHeaders := s.captureManager.CaptureResponse(requestID, crw)
+			resBody, resHeaders := s.captureManager.FinalizeResponse(requestID, crw)
 			details = &RequestDetails{
 				RequestHeaders:  reqHeaders,
 				ResponseHeaders: resHeaders,

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -392,8 +392,15 @@ func (s *Service) createRouter() http.Handler {
 		// Build request details if capture is enabled
 		var details *RequestDetails
 		var statusCode int
-		if crw != nil {
+		if crw != nil && crw.Hijacked() {
+			// Post-upgrade traffic bypassed the capture writer; record metadata
+			// only rather than a garbage 200/empty-body capture.
 			statusCode = crw.StatusCode()
+		} else if crw != nil {
+			statusCode = crw.StatusCode()
+			// Freeze the request-body capture before the record is published
+			// (see FinalizeRequestBody).
+			FinalizeRequestBody(r.Body)
 			resBody, resHeaders := s.captureManager.FinalizeResponse(requestID, crw)
 			details = &RequestDetails{
 				RequestHeaders:  reqHeaders,

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -393,9 +393,16 @@ func (s *Service) createRouter() http.Handler {
 		var details *RequestDetails
 		var statusCode int
 		if crw != nil && crw.Hijacked() {
-			// Post-upgrade traffic bypassed the capture writer; record metadata
-			// only rather than a garbage 200/empty-body capture.
-			statusCode = crw.StatusCode()
+			// A successful reverse-proxy upgrade writes the 101 raw to the
+			// hijacked conn, bypassing WriteHeader, so the writer's statusCode
+			// is meaningless here. Record the protocol switch and record
+			// metadata only rather than a garbage 200/empty-body capture.
+			statusCode = http.StatusSwitchingProtocols
+			// The metadata-only record carries no Details, so eviction would
+			// never clean a request-body file spilled to disk before the
+			// upgrade; finalize and clean it up here to avoid orphaning it.
+			FinalizeRequestBody(r.Body)
+			s.captureManager.CleanupRequest(requestID)
 		} else if crw != nil {
 			statusCode = crw.StatusCode()
 			// Freeze the request-body capture before the record is published

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -49,6 +49,27 @@ func TestExtractSubdomain(t *testing.T) {
 	}
 }
 
+func TestStripHostPort(t *testing.T) {
+	tests := []struct {
+		name     string
+		host     string
+		expected string
+	}{
+		{"host with port", "api.local.myapp.dev:6789", "api.local.myapp.dev"},
+		{"host without port", "api.local.myapp.dev", "api.local.myapp.dev"},
+		{"bare hostname with port", "localhost:8080", "localhost"},
+		{"empty host", "", ""},
+		{"ipv6 with port", "[::1]:443", "::1"},
+		{"bare ipv6 without port", "[::1]", "[::1]"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, stripHostPort(tt.host))
+		})
+	}
+}
+
 func TestGetClientIP(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -272,6 +293,41 @@ func TestCreateRouter_XForwardedProto(t *testing.T) {
 
 		assert.Equal(t, "https", receivedProto.Load())
 	})
+}
+
+func TestCreateRouter_StampsHostnameStripsPort(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	workDir := t.TempDir()
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+	backendPort := backend.Listener.Addr().(*net.TCPAddr).Port
+
+	cfg := &config.ProxyConfig{
+		Enabled:  true,
+		HTTPPort: 6788,
+		Domain:   "local.myapp.dev",
+	}
+	services := map[string]config.ServiceConfig{
+		"app": {Port: backendPort, Host: "localhost"},
+	}
+
+	svc, err := NewService(cfg, services, nil, logger, workDir)
+	require.NoError(t, err)
+
+	router := svc.createRouter()
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Host = "app.local.myapp.dev:6788"
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	records := svc.RequestManager().Recent(RequestFilter{})
+	require.Len(t, records, 1)
+	assert.Equal(t, "app.local.myapp.dev", records[0].Hostname)
 }
 
 func TestPortConflictError_ErrorMessage(t *testing.T) {

--- a/internal/proxy/requests.go
+++ b/internal/proxy/requests.go
@@ -48,8 +48,10 @@ type CapturedBody struct {
 	FilePath        string `json:"file_path"`                  // Disk path for large bodies (Data is nil when set)
 }
 
-// generateRequestID creates a short hash ID (7 chars, git-style) from request data.
-func generateRequestID(timestamp time.Time, method, url string) string {
+// GenerateRequestID creates a short hash ID (7 chars, git-style) from request
+// data. Exported so the shared daemon can generate a request ID before proxying
+// (needed for capture file naming).
+func GenerateRequestID(timestamp time.Time, method, url string) string {
 	data := fmt.Sprintf("%d:%s:%s", timestamp.UnixNano(), method, url)
 	hash := sha256.Sum256([]byte(data))
 	return hex.EncodeToString(hash[:])[:7]
@@ -119,7 +121,7 @@ func (m *RequestManager) SetEvictionCallback(fn EvictionCallback) {
 // If the record doesn't have an ID, one is generated.
 func (m *RequestManager) Record(record RequestRecord) {
 	if record.ID == "" {
-		record.ID = generateRequestID(record.Timestamp, record.Method, record.URL)
+		record.ID = GenerateRequestID(record.Timestamp, record.Method, record.URL)
 	}
 
 	var evictedID string

--- a/internal/proxy/requests.go
+++ b/internal/proxy/requests.go
@@ -21,6 +21,11 @@ type RequestRecord struct {
 	Duration   time.Duration `json:"duration"`
 	RemoteAddr string        `json:"remote_addr"`
 
+	// ProjectDir identifies the project that owns the route this request was
+	// proxied for. Set daemon-side so records/purges are scoped to a project
+	// even when two projects own the same hostname on different ports.
+	ProjectDir string `json:"project_dir,omitempty"`
+
 	// Details contains captured headers and bodies (nil when capture is disabled)
 	Details *RequestDetails `json:"details,omitempty"`
 }
@@ -59,13 +64,14 @@ func GenerateRequestID(timestamp time.Time, method, url string) string {
 
 // RequestFilter specifies criteria for filtering requests.
 type RequestFilter struct {
-	Subdomain string
-	Hostnames []string // match if record.Hostname is in this list (empty = match all)
-	Method    string
-	MinStatus int
-	MaxStatus int
-	Since     time.Time
-	Limit     int
+	Subdomain  string
+	Hostnames  []string // match if record.Hostname is in this list (empty = match all)
+	ProjectDir string   // match if record.ProjectDir equals this exactly (empty = match all)
+	Method     string
+	MinStatus  int
+	MaxStatus  int
+	Since      time.Time
+	Limit      int
 }
 
 // RequestSubscription represents a subscription to request updates.
@@ -283,6 +289,9 @@ func (m *RequestManager) matchesFilter(record RequestRecord, filter RequestFilte
 			return false
 		}
 	}
+	if filter.ProjectDir != "" && record.ProjectDir != filter.ProjectDir {
+		return false
+	}
 	if filter.Method != "" && record.Method != filter.Method {
 		return false
 	}
@@ -298,17 +307,15 @@ func (m *RequestManager) matchesFilter(record RequestRecord, filter RequestFilte
 	return true
 }
 
-// PurgeByHostnames removes all records matching any of the given hostnames
-// from the ring buffer and calls the eviction callback for each.
-// It compacts the buffer to preserve the contiguous ring invariant.
-func (m *RequestManager) PurgeByHostnames(hostnames []string) {
-	if len(hostnames) == 0 {
+// PurgeByProject removes all records owned by the given project from the ring
+// buffer and calls the eviction callback for each purged record that carried
+// captured Details (so its on-disk body files get cleaned up). It compacts the
+// buffer to preserve the contiguous ring invariant. Scoping by project (not
+// hostname) ensures two projects sharing a hostname on different ports don't
+// purge each other's records.
+func (m *RequestManager) PurgeByProject(projectDir string) {
+	if projectDir == "" {
 		return
-	}
-
-	hostSet := make(map[string]struct{}, len(hostnames))
-	for _, h := range hostnames {
-		hostSet[h] = struct{}{}
 	}
 
 	var evictIDs []string
@@ -325,7 +332,7 @@ func (m *RequestManager) PurgeByHostnames(hostnames []string) {
 		if rec.ID == "" {
 			continue
 		}
-		if _, match := hostSet[rec.Hostname]; match {
+		if rec.ProjectDir == projectDir {
 			if rec.Details != nil {
 				evictIDs = append(evictIDs, rec.ID)
 			}

--- a/internal/proxy/requests.go
+++ b/internal/proxy/requests.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -73,14 +74,20 @@ func GenerateRequestID(timestamp time.Time, method, url string) string {
 
 // RequestFilter specifies criteria for filtering requests.
 type RequestFilter struct {
-	Subdomain  string
-	Hostnames  []string // match if record.Hostname is in this list (empty = match all)
-	ProjectDir string   // match if record.ProjectDir equals this exactly (empty = match all)
-	Method     string
-	MinStatus  int
-	MaxStatus  int
-	Since      time.Time
-	Limit      int
+	Subdomain string
+	Hostnames []string // match if record.Hostname is in this list (empty = match all)
+
+	// URLContains matches if record.URL contains this substring
+	// (case-insensitive). URL is path+query only (no scheme/host, matching
+	// the TUI 's' filter's reference behavior), since RequestRecord.URL is
+	// populated from r.URL.String() on the server side. Empty = match all.
+	URLContains string
+	ProjectDir  string // match if record.ProjectDir equals this exactly (empty = match all)
+	Method      string
+	MinStatus   int
+	MaxStatus   int
+	Since       time.Time
+	Limit       int
 }
 
 // RequestSubscription represents a subscription to request updates.
@@ -299,6 +306,9 @@ func (m *RequestManager) matchesFilter(record RequestRecord, filter RequestFilte
 		}
 	}
 	if filter.ProjectDir != "" && record.ProjectDir != filter.ProjectDir {
+		return false
+	}
+	if filter.URLContains != "" && !strings.Contains(strings.ToLower(record.URL), strings.ToLower(filter.URLContains)) {
 		return false
 	}
 	if filter.Method != "" && record.Method != filter.Method {

--- a/internal/proxy/requests.go
+++ b/internal/proxy/requests.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -53,11 +54,19 @@ type CapturedBody struct {
 	FilePath        string `json:"file_path"`                  // Disk path for large bodies (Data is nil when set)
 }
 
+// requestIDCounter disambiguates requests that share a timestamp/method/URL.
+// Without it, two simultaneous identical requests would hash to the same ID
+// and their capture files would overwrite (and cross-delete on eviction).
+var requestIDCounter atomic.Uint64
+
 // GenerateRequestID creates a short hash ID (7 chars, git-style) from request
-// data. Exported so the shared daemon can generate a request ID before proxying
+// data plus a per-process counter, so IDs are unique within a process even for
+// simultaneous identical requests. (Truncating the hash to 28 bits leaves a
+// negligible birthday-collision residual across the 1000-record ring.)
+// Exported so the shared daemon can generate a request ID before proxying
 // (needed for capture file naming).
 func GenerateRequestID(timestamp time.Time, method, url string) string {
-	data := fmt.Sprintf("%d:%s:%s", timestamp.UnixNano(), method, url)
+	data := fmt.Sprintf("%d:%d:%s:%s", timestamp.UnixNano(), requestIDCounter.Add(1), method, url)
 	hash := sha256.Sum256([]byte(data))
 	return hex.EncodeToString(hash[:])[:7]
 }

--- a/internal/proxy/requests.go
+++ b/internal/proxy/requests.go
@@ -35,12 +35,17 @@ type RequestDetails struct {
 
 // CapturedBody represents a captured request or response body.
 type CapturedBody struct {
-	Size        int64  `json:"size"`         // Original body size
-	Truncated   bool   `json:"truncated"`    // True if body was truncated due to size limit
-	ContentType string `json:"content_type"` // Content-Type header value
-	IsBinary    bool   `json:"is_binary"`    // True if body appears to be binary data
-	Data        []byte `json:"data"`         // Inline data for small bodies
-	FilePath    string `json:"file_path"`    // Disk path for large bodies (Data is nil when set)
+	// Size is the total bytes observed by the capture wrapper, including
+	// bytes discarded past the truncation cap (not Content-Length, not
+	// decoded size).
+	Size            int64  `json:"size"`
+	CapturedSize    int64  `json:"captured_size"`              // Bytes actually retained after truncation
+	Truncated       bool   `json:"truncated"`                  // True if body was truncated due to size limit
+	ContentType     string `json:"content_type"`               // Content-Type header value
+	ContentEncoding string `json:"content_encoding,omitempty"` // Content-Encoding header value (raw wire bytes; not decoded here)
+	IsBinary        bool   `json:"is_binary"`                  // True if body appears to be binary data
+	Data            []byte `json:"data"`                       // Inline data for small bodies
+	FilePath        string `json:"file_path"`                  // Disk path for large bodies (Data is nil when set)
 }
 
 // generateRequestID creates a short hash ID (7 chars, git-style) from request data.

--- a/internal/proxy/requests.go
+++ b/internal/proxy/requests.go
@@ -12,7 +12,7 @@ import (
 
 // RequestRecord represents a single proxied request.
 type RequestRecord struct {
-	// ID is a 7-character hash generated from timestamp, method, and URL.
+	// ID is a 12-character hash generated from timestamp, method, and URL.
 	ID         string        `json:"id"`
 	Timestamp  time.Time     `json:"timestamp"`
 	Method     string        `json:"method"`
@@ -60,16 +60,17 @@ type CapturedBody struct {
 // and their capture files would overwrite (and cross-delete on eviction).
 var requestIDCounter atomic.Uint64
 
-// GenerateRequestID creates a short hash ID (7 chars, git-style) from request
+// GenerateRequestID creates a short hash ID (12 chars, git-style) from request
 // data plus a per-process counter, so IDs are unique within a process even for
-// simultaneous identical requests. (Truncating the hash to 28 bits leaves a
-// negligible birthday-collision residual across the 1000-record ring.)
-// Exported so the shared daemon can generate a request ID before proxying
-// (needed for capture file naming).
+// simultaneous identical requests. (Truncating the hash to 48 bits keeps the
+// birthday-collision residual across the 1000-record ring negligible, unlike
+// the 28 bits of a 7-char ID whose ~0.2%-per-full-ring collision odds could
+// overwrite capture files.) Exported so the shared daemon can generate a
+// request ID before proxying (needed for capture file naming).
 func GenerateRequestID(timestamp time.Time, method, url string) string {
 	data := fmt.Sprintf("%d:%d:%s:%s", timestamp.UnixNano(), requestIDCounter.Add(1), method, url)
 	hash := sha256.Sum256([]byte(data))
-	return hex.EncodeToString(hash[:])[:7]
+	return hex.EncodeToString(hash[:])[:12]
 }
 
 // RequestFilter specifies criteria for filtering requests.

--- a/internal/proxy/requests_test.go
+++ b/internal/proxy/requests_test.go
@@ -157,26 +157,26 @@ func TestGenerateRequestID(t *testing.T) {
 	timestamp := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
 
 	t.Run("generates 7 character ID", func(t *testing.T) {
-		id := generateRequestID(timestamp, "GET", "/api/users")
+		id := GenerateRequestID(timestamp, "GET", "/api/users")
 		assert.Len(t, id, 7)
 	})
 
 	t.Run("same inputs produce same ID", func(t *testing.T) {
-		id1 := generateRequestID(timestamp, "GET", "/api/users")
-		id2 := generateRequestID(timestamp, "GET", "/api/users")
+		id1 := GenerateRequestID(timestamp, "GET", "/api/users")
+		id2 := GenerateRequestID(timestamp, "GET", "/api/users")
 		assert.Equal(t, id1, id2)
 	})
 
 	t.Run("different inputs produce different IDs", func(t *testing.T) {
-		id1 := generateRequestID(timestamp, "GET", "/api/users")
-		id2 := generateRequestID(timestamp, "POST", "/api/users")
-		id3 := generateRequestID(timestamp.Add(time.Second), "GET", "/api/users")
+		id1 := GenerateRequestID(timestamp, "GET", "/api/users")
+		id2 := GenerateRequestID(timestamp, "POST", "/api/users")
+		id3 := GenerateRequestID(timestamp.Add(time.Second), "GET", "/api/users")
 		assert.NotEqual(t, id1, id2)
 		assert.NotEqual(t, id1, id3)
 	})
 
 	t.Run("ID is valid hex", func(t *testing.T) {
-		id := generateRequestID(timestamp, "GET", "/api/users")
+		id := GenerateRequestID(timestamp, "GET", "/api/users")
 		for _, c := range id {
 			assert.True(t, (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'),
 				"expected hex character, got %c", c)

--- a/internal/proxy/requests_test.go
+++ b/internal/proxy/requests_test.go
@@ -89,6 +89,48 @@ func TestRequestManager_Filter(t *testing.T) {
 	})
 }
 
+func TestRequestManager_FilterByURLContains(t *testing.T) {
+	m := NewRequestManager(100)
+
+	m.Record(RequestRecord{Subdomain: "api", Method: "GET", URL: "/api/Users?id=1"})
+	m.Record(RequestRecord{Subdomain: "api", Method: "GET", URL: "/healthz"})
+	m.Record(RequestRecord{Subdomain: "api", Method: "GET", URL: "/api/orders"})
+
+	t.Run("case-insensitive substring match on path", func(t *testing.T) {
+		records := m.Recent(RequestFilter{URLContains: "users"})
+		assert.Len(t, records, 1)
+		assert.Equal(t, "/api/Users?id=1", records[0].URL)
+	})
+
+	t.Run("matches query string", func(t *testing.T) {
+		records := m.Recent(RequestFilter{URLContains: "id=1"})
+		assert.Len(t, records, 1)
+	})
+
+	t.Run("matches multiple records by common substring", func(t *testing.T) {
+		records := m.Recent(RequestFilter{URLContains: "/api/"})
+		assert.Len(t, records, 2)
+	})
+
+	t.Run("no match returns empty", func(t *testing.T) {
+		records := m.Recent(RequestFilter{URLContains: "nonexistent"})
+		assert.Len(t, records, 0)
+	})
+
+	t.Run("empty filter matches all", func(t *testing.T) {
+		records := m.Recent(RequestFilter{URLContains: ""})
+		assert.Len(t, records, 3)
+	})
+
+	t.Run("does not match against other fields", func(t *testing.T) {
+		// "api" appears in Subdomain but not URL for /healthz - ensure the
+		// filter only inspects URL, not Subdomain or Method.
+		records := m.Recent(RequestFilter{URLContains: "healthz"})
+		assert.Len(t, records, 1)
+		assert.Equal(t, "/healthz", records[0].URL)
+	})
+}
+
 func TestRequestManager_RingBuffer(t *testing.T) {
 	m := NewRequestManager(5)
 

--- a/internal/proxy/requests_test.go
+++ b/internal/proxy/requests_test.go
@@ -242,3 +242,74 @@ func TestRequestManager_SubscribeAfterClose(t *testing.T) {
 	m.Unsubscribe(sub.ID)
 	m.Close()
 }
+
+// TestRequestManager_FilterByProjectDir pins that a subscriber scoped to one
+// project receives only that project's records, even when two projects share a
+// hostname (differing only by owning port, which the daemon collapses to
+// project identity).
+func TestRequestManager_FilterByProjectDir(t *testing.T) {
+	m := NewRequestManager(10)
+
+	subA := m.Subscribe(RequestFilter{ProjectDir: "/projects/a"})
+	require.NotNil(t, subA)
+
+	// Record for project B (same hostname, different project) — must not reach A.
+	m.Record(RequestRecord{Method: "GET", URL: "/b", Hostname: "api.local.dev", ProjectDir: "/projects/b"})
+	// Record for project A — must reach A.
+	m.Record(RequestRecord{Method: "GET", URL: "/a", Hostname: "api.local.dev", ProjectDir: "/projects/a"})
+
+	select {
+	case rec := <-subA.Ch:
+		assert.Equal(t, "/projects/a", rec.ProjectDir)
+		assert.Equal(t, "/a", rec.URL)
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for project A record")
+	}
+
+	// No further records should be waiting for A (B's was filtered out).
+	select {
+	case rec := <-subA.Ch:
+		t.Fatalf("subscriber A received an unexpected record: %+v", rec)
+	default:
+	}
+
+	// Recent scoped to A returns only A's record.
+	recA := m.Recent(RequestFilter{ProjectDir: "/projects/a"})
+	require.Len(t, recA, 1)
+	assert.Equal(t, "/a", recA[0].URL)
+}
+
+// TestRequestManager_PurgeByProject pins that purge is scoped by project: two
+// projects sharing a hostname on different ports don't purge each other's
+// records, and the eviction callback fires only for the purged project's
+// records that carried captured Details.
+func TestRequestManager_PurgeByProject(t *testing.T) {
+	m := NewRequestManager(10)
+
+	var evicted []string
+	m.SetEvictionCallback(func(id string) {
+		evicted = append(evicted, id)
+	})
+
+	details := &RequestDetails{RequestHeaders: map[string][]string{"X": {"y"}}}
+
+	// A: one detailed record (evictable) and one metadata-only record.
+	m.Record(RequestRecord{ID: "a1", Method: "GET", URL: "/a1", Hostname: "api.local.dev", ProjectDir: "/projects/a", Details: details})
+	m.Record(RequestRecord{ID: "a2", Method: "GET", URL: "/a2", Hostname: "api.local.dev", ProjectDir: "/projects/a"})
+	// B: one detailed record — must survive a purge of A.
+	m.Record(RequestRecord{ID: "b1", Method: "GET", URL: "/b1", Hostname: "api.local.dev", ProjectDir: "/projects/b", Details: details})
+
+	m.PurgeByProject("/projects/a")
+
+	// Only B's record remains.
+	remaining := m.Recent(RequestFilter{})
+	require.Len(t, remaining, 1)
+	assert.Equal(t, "b1", remaining[0].ID)
+
+	// Eviction callback fired only for A's detailed record (a2 had no Details).
+	assert.Equal(t, []string{"a1"}, evicted)
+
+	// Purging an empty project dir is a no-op.
+	m.PurgeByProject("")
+	assert.Len(t, m.Recent(RequestFilter{}), 1)
+}

--- a/internal/proxy/requests_test.go
+++ b/internal/proxy/requests_test.go
@@ -198,9 +198,9 @@ func TestRequestManager_Unsubscribe(t *testing.T) {
 func TestGenerateRequestID(t *testing.T) {
 	timestamp := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
 
-	t.Run("generates 7 character ID", func(t *testing.T) {
+	t.Run("generates 12 character ID", func(t *testing.T) {
 		id := GenerateRequestID(timestamp, "GET", "/api/users")
-		assert.Len(t, id, 7)
+		assert.Len(t, id, 12)
 	})
 
 	t.Run("same inputs produce different IDs", func(t *testing.T) {
@@ -243,7 +243,7 @@ func TestRequestManager_Record_GeneratesID(t *testing.T) {
 
 	records := m.Recent(RequestFilter{})
 	require.Len(t, records, 1)
-	assert.Len(t, records[0].ID, 7, "expected ID to be generated")
+	assert.Len(t, records[0].ID, 12, "expected ID to be generated")
 }
 
 func TestRequestManager_Record_PreservesExistingID(t *testing.T) {

--- a/internal/proxy/requests_test.go
+++ b/internal/proxy/requests_test.go
@@ -161,10 +161,12 @@ func TestGenerateRequestID(t *testing.T) {
 		assert.Len(t, id, 7)
 	})
 
-	t.Run("same inputs produce same ID", func(t *testing.T) {
+	t.Run("same inputs produce different IDs", func(t *testing.T) {
+		// The per-process counter disambiguates simultaneous identical
+		// requests so capture files can never overwrite each other.
 		id1 := GenerateRequestID(timestamp, "GET", "/api/users")
 		id2 := GenerateRequestID(timestamp, "GET", "/api/users")
-		assert.Equal(t, id1, id2)
+		assert.NotEqual(t, id1, id2)
 	})
 
 	t.Run("different inputs produce different IDs", func(t *testing.T) {

--- a/internal/proxyd/daemon.go
+++ b/internal/proxyd/daemon.go
@@ -178,9 +178,20 @@ func RunDaemon(ctx context.Context) error {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				stale := registry.CleanStalePIDs()
-				for _, dir := range stale {
-					logger.Warn("cleaned stale project registration", "project", dir)
+				stale := registry.StalePIDs()
+				for _, sp := range stale {
+					removed, hostnames, emptyPorts := server.removeStaleProject(sp.Dir, sp.PID)
+					if !removed {
+						// Re-registered with a live PID between detection and
+						// removal — leave the new registration alone.
+						continue
+					}
+					logger.Warn("cleaned stale project registration",
+						"project", sp.Dir,
+						"pid", sp.PID,
+						"removed_hostnames", hostnames,
+						"closed_ports", emptyPorts,
+					)
 				}
 				if len(stale) > 0 && registry.IsEmpty() {
 					logger.Info("all routes cleaned up, shutting down")
@@ -221,6 +232,10 @@ func RunDaemon(ctx context.Context) error {
 	if err := dynamicProxy.Shutdown(shutdownCtx); err != nil {
 		logger.Error("error shutting down proxy", "error", err)
 	}
+	// Close the request manager before the socket server so active SSE
+	// subscribers observe end-of-stream and release the server, rather than
+	// pinning it open through the shutdown grace period.
+	requestMgr.Close()
 	if err := server.Shutdown(shutdownCtx); err != nil {
 		logger.Error("error shutting down server", "error", err)
 	}

--- a/internal/proxyd/daemon.go
+++ b/internal/proxyd/daemon.go
@@ -150,7 +150,32 @@ func RunDaemon(ctx context.Context) error {
 	registry := NewRegistry()
 	certMgr := NewMultiDomainCertManager(constants.DefaultCertsDir)
 	requestMgr := proxy.NewRequestManager(constants.DefaultProxyRequestBufferSize)
-	dynamicProxy := NewDynamicProxy(registry, certMgr, requestMgr, logger)
+
+	// Create the daemon's capture manager, rooted at ~/.prox/capture. Resolve
+	// the home directory explicitly; on failure log and run without capture
+	// (nil manager, capture disabled) rather than failing the daemon.
+	var captureMgr *proxy.CaptureManager
+	if homeDir, herr := os.UserHomeDir(); herr != nil {
+		logger.Warn("could not resolve home directory; running without request capture", "error", herr)
+	} else if cm, cerr := proxy.NewCaptureManagerAt(constants.DaemonCaptureDir(homeDir), constants.DefaultCaptureMaxBodySize); cerr != nil {
+		logger.Warn("could not initialize capture manager; running without request capture", "error", cerr)
+	} else {
+		captureMgr = cm
+	}
+	// Cleanup runs on return. Because dynamicProxy.Shutdown and server.Shutdown
+	// run inline in the function body below, this deferred Cleanup necessarily
+	// runs AFTER both — in-flight handlers finish writing their capture files
+	// first. Registered immediately after construction so an early startup
+	// error still removes the capture dir. Cleanup is RemoveAll, so it is
+	// idempotent and safe to leave deferred here.
+	if captureMgr != nil {
+		defer func() { _ = captureMgr.Cleanup() }()
+		// Evicting a record from the ring buffer must delete its on-disk body
+		// files; the capture manager's per-request cleanup does exactly that.
+		requestMgr.SetEvictionCallback(captureMgr.CleanupRequest)
+	}
+
+	dynamicProxy := NewDynamicProxy(registry, certMgr, requestMgr, captureMgr, logger)
 
 	// Create and configure the socket server
 	server := NewServer(ServerConfig{

--- a/internal/proxyd/dynamic_proxy.go
+++ b/internal/proxyd/dynamic_proxy.go
@@ -36,16 +36,20 @@ type DynamicProxy struct {
 	transport      *http.Transport
 	certMgr        *MultiDomainCertManager
 	requestManager *proxy.RequestManager
+	captureManager *proxy.CaptureManager
 	logger         *slog.Logger
 }
 
-// NewDynamicProxy creates a new dynamic proxy.
-func NewDynamicProxy(registry *Registry, certMgr *MultiDomainCertManager, requestManager *proxy.RequestManager, logger *slog.Logger) *DynamicProxy {
+// NewDynamicProxy creates a new dynamic proxy. captureManager may be nil, in
+// which case no request/response bodies are captured (metadata-only records);
+// when non-nil, capture is further gated per route via Route.CaptureEnabled.
+func NewDynamicProxy(registry *Registry, certMgr *MultiDomainCertManager, requestManager *proxy.RequestManager, captureManager *proxy.CaptureManager, logger *slog.Logger) *DynamicProxy {
 	return &DynamicProxy{
 		listeners:      make(map[int]*managedListener),
 		registry:       registry,
 		certMgr:        certMgr,
 		requestManager: requestManager,
+		captureManager: captureManager,
 		logger:         logger,
 		transport: &http.Transport{
 			DialContext: (&net.Dialer{
@@ -166,6 +170,17 @@ func (dp *DynamicProxy) handler(port int) http.Handler {
 			return
 		}
 
+		// Capture is gated per project: only when the matched route opted in and
+		// a capture manager is available and enabled.
+		captureEnabled := route.CaptureEnabled && dp.captureManager != nil && dp.captureManager.Enabled()
+
+		// Generate the request ID BEFORE proxying so capture files (written by
+		// FinalizeResponse) are named consistently with the recorded record.
+		requestID := ""
+		if captureEnabled {
+			requestID = proxy.GenerateRequestID(startTime, r.Method, r.URL.String())
+		}
+
 		target := &url.URL{
 			Scheme: "http",
 			Host:   fmt.Sprintf("%s:%d", route.Target.Host, route.Target.Port),
@@ -179,6 +194,15 @@ func (dp *DynamicProxy) handler(port int) http.Handler {
 		// Determine protocol from the listener
 		proto := route.Protocol
 
+		// Capture the request body and headers before the Director mutates them.
+		// CaptureRequest clones the headers, so reqHeaders is unaffected by the
+		// Director's later header sets (mirrors the in-process proxy path).
+		var reqBody *proxy.CapturedBody
+		var reqHeaders http.Header
+		if captureEnabled {
+			reqBody, r.Body, reqHeaders = dp.captureManager.CaptureRequest(requestID, r)
+		}
+
 		originalDirector := rp.Director
 		rp.Director = func(req *http.Request) {
 			originalDirector(req)
@@ -187,8 +211,18 @@ func (dp *DynamicProxy) handler(port int) http.Handler {
 			req.Header.Set("X-Real-IP", getClientIP(r))
 		}
 
-		// Wrap response writer to capture status code
-		rw := &statusResponseWriter{ResponseWriter: w, statusCode: http.StatusOK}
+		// Choose the response writer: a capturing writer when enabled, otherwise
+		// the lightweight status-only writer used for metadata-only records.
+		var rw http.ResponseWriter
+		var crw *proxy.CaptureResponseWriter
+		var srw *statusResponseWriter
+		if captureEnabled {
+			crw = dp.captureManager.WrapResponseWriter(w)
+			rw = crw
+		} else {
+			srw = &statusResponseWriter{ResponseWriter: w, statusCode: http.StatusOK}
+			rw = srw
+		}
 
 		rp.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
 			dp.logger.Error("proxy error",
@@ -196,7 +230,11 @@ func (dp *DynamicProxy) handler(port int) http.Handler {
 				"target", target.String(),
 				"error", err,
 			)
-			rw.statusCode = http.StatusBadGateway
+			if crw != nil {
+				crw.WriteHeader(http.StatusBadGateway)
+			} else {
+				srw.statusCode = http.StatusBadGateway
+			}
 			http.Error(w, "Backend unavailable", http.StatusBadGateway)
 		}
 
@@ -209,16 +247,47 @@ func (dp *DynamicProxy) handler(port int) http.Handler {
 			if idx := strings.Index(hostname, "."); idx != -1 {
 				subdomain = hostname[:idx]
 			}
+
+			// Finalize capture (if enabled) and derive the status code from the
+			// active writer.
+			var details *proxy.RequestDetails
+			var statusCode int
+			switch {
+			case crw != nil && crw.Hijacked():
+				// After a WebSocket upgrade all traffic bypassed the capture
+				// writer; finalizing would record garbage (status 200, empty
+				// body). Record metadata only, like a non-capture route.
+				statusCode = crw.StatusCode()
+			case crw != nil:
+				statusCode = crw.StatusCode()
+				// Freeze the request-body capture before publishing the record:
+				// a canceled request's transport goroutine may still be draining
+				// the wrapped body, and SSE subscribers serialize the record at
+				// notify time.
+				proxy.FinalizeRequestBody(r.Body)
+				resBody, resHeaders := dp.captureManager.FinalizeResponse(requestID, crw)
+				details = &proxy.RequestDetails{
+					RequestHeaders:  reqHeaders,
+					ResponseHeaders: resHeaders,
+					RequestBody:     reqBody,
+					ResponseBody:    resBody,
+				}
+			default:
+				statusCode = srw.statusCode
+			}
+
 			dp.requestManager.Record(proxy.RequestRecord{
+				ID:         requestID, // empty for non-capture routes; Record generates one
 				Timestamp:  startTime,
 				Method:     r.Method,
 				URL:        r.URL.String(),
 				Subdomain:  subdomain,
 				Hostname:   hostname,
 				ProjectDir: route.ProjectDir,
-				StatusCode: rw.statusCode,
+				StatusCode: statusCode,
 				Duration:   time.Since(startTime),
 				RemoteAddr: r.RemoteAddr,
+				Details:    details,
 			})
 		}
 	})

--- a/internal/proxyd/dynamic_proxy.go
+++ b/internal/proxyd/dynamic_proxy.go
@@ -215,6 +215,7 @@ func (dp *DynamicProxy) handler(port int) http.Handler {
 				URL:        r.URL.String(),
 				Subdomain:  subdomain,
 				Hostname:   hostname,
+				ProjectDir: route.ProjectDir,
 				StatusCode: rw.statusCode,
 				Duration:   time.Since(startTime),
 				RemoteAddr: r.RemoteAddr,

--- a/internal/proxyd/dynamic_proxy.go
+++ b/internal/proxyd/dynamic_proxy.go
@@ -256,8 +256,16 @@ func (dp *DynamicProxy) handler(port int) http.Handler {
 			case crw != nil && crw.Hijacked():
 				// After a WebSocket upgrade all traffic bypassed the capture
 				// writer; finalizing would record garbage (status 200, empty
-				// body). Record metadata only, like a non-capture route.
-				statusCode = crw.StatusCode()
+				// body). The successful upgrade writes the 101 raw to the
+				// hijacked conn, so record the protocol switch and keep
+				// metadata only, like a non-capture route.
+				statusCode = http.StatusSwitchingProtocols
+				// The metadata-only record carries no Details, so eviction
+				// would never clean a request-body file spilled to disk before
+				// the upgrade; finalize and clean it up here to avoid orphaning
+				// it.
+				proxy.FinalizeRequestBody(r.Body)
+				dp.captureManager.CleanupRequest(requestID)
 			case crw != nil:
 				statusCode = crw.StatusCode()
 				// Freeze the request-body capture before publishing the record:

--- a/internal/proxyd/dynamic_proxy_test.go
+++ b/internal/proxyd/dynamic_proxy_test.go
@@ -1,0 +1,268 @@
+package proxyd
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/charliek/prox/internal/constants"
+	"github.com/charliek/prox/internal/proxy"
+)
+
+// newTestBackend starts an httptest server running h and returns its host, port,
+// and a cleanup func registered on t.
+func newTestBackend(t *testing.T, h http.HandlerFunc) (host string, port int) {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse backend URL: %v", err)
+	}
+	hostStr, portStr, err := net.SplitHostPort(u.Host)
+	if err != nil {
+		t.Fatalf("split backend host: %v", err)
+	}
+	p, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("parse backend port: %v", err)
+	}
+	return hostStr, p
+}
+
+// newCaptureProxy wires a DynamicProxy against a backend, registering a single
+// http route on port 80 (hostname api.local.dev) with the given capture setting.
+func newCaptureProxy(t *testing.T, captureEnabled bool, backendHost string, backendPort, bufferCap int) (*DynamicProxy, *proxy.RequestManager, *proxy.CaptureManager) {
+	t.Helper()
+
+	reg := NewRegistry()
+	req := RegisterRequest{
+		ProjectDir:     "/projects/a",
+		PID:            1,
+		Version:        "dev",
+		Domain:         "local.dev",
+		Services:       map[string]ServiceTarget{"api": {Host: backendHost, Port: backendPort}},
+		HTTPPort:       80,
+		CaptureEnabled: captureEnabled,
+	}
+	if _, _, err := reg.Register(req); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	cm, err := proxy.NewCaptureManagerAt(t.TempDir(), constants.DefaultCaptureMaxBodySize)
+	if err != nil {
+		t.Fatalf("NewCaptureManagerAt: %v", err)
+	}
+	rm := proxy.NewRequestManager(bufferCap)
+	rm.SetEvictionCallback(cm.CleanupRequest)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	dp := NewDynamicProxy(reg, nil, rm, cm, logger)
+	return dp, rm, cm
+}
+
+// serve drives one request through the proxy handler for port 80.
+func serve(dp *DynamicProxy, method, target, body string, headers map[string]string) *httptest.ResponseRecorder {
+	handler := dp.handler(80)
+	req := httptest.NewRequest(method, target, bytes.NewReader([]byte(body)))
+	req.Host = "api.local.dev"
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestDynamicProxy_CaptureEnabled_RecordsDetailsInline(t *testing.T) {
+	const respBody = `{"ok":true}`
+	host, port := newTestBackend(t, func(w http.ResponseWriter, r *http.Request) {
+		reqBody, _ := io.ReadAll(r.Body)
+		if string(reqBody) != "ping" {
+			t.Errorf("backend saw request body %q, want %q", reqBody, "ping")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Backend", "yes")
+		_, _ = w.Write([]byte(respBody))
+	})
+
+	dp, rm, _ := newCaptureProxy(t, true, host, port, 10)
+
+	rec := serve(dp, "POST", "http://api.local.dev/echo", "ping", map[string]string{"X-Custom": "abc"})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	records := rm.Recent(proxy.RequestFilter{ProjectDir: "/projects/a"})
+	if len(records) != 1 {
+		t.Fatalf("got %d records, want 1", len(records))
+	}
+	rec0 := records[0]
+
+	if rec0.ID == "" {
+		t.Error("record ID is empty; expected a pre-proxy generated ID")
+	}
+	if rec0.ProjectDir != "/projects/a" {
+		t.Errorf("ProjectDir = %q, want /projects/a", rec0.ProjectDir)
+	}
+	if rec0.Details == nil {
+		t.Fatal("Details is nil; expected captured details for a capture-enabled route")
+	}
+
+	d := rec0.Details
+	if d.RequestBody == nil || string(d.RequestBody.Data) != "ping" {
+		t.Errorf("captured request body = %v, want \"ping\"", d.RequestBody)
+	}
+	if d.ResponseBody == nil || string(d.ResponseBody.Data) != respBody {
+		t.Errorf("captured response body = %v, want %q", d.ResponseBody, respBody)
+	}
+	if got := d.RequestHeaders["X-Custom"]; len(got) != 1 || got[0] != "abc" {
+		t.Errorf("captured request header X-Custom = %v, want [abc]", got)
+	}
+	if got := d.ResponseHeaders["X-Backend"]; len(got) != 1 || got[0] != "yes" {
+		t.Errorf("captured response header X-Backend = %v, want [yes]", got)
+	}
+}
+
+func TestDynamicProxy_CaptureDisabled_MetadataOnly(t *testing.T) {
+	host, port := newTestBackend(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("hello"))
+	})
+
+	dp, rm, _ := newCaptureProxy(t, false, host, port, 10)
+
+	rec := serve(dp, "POST", "http://api.local.dev/echo", "ping", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	records := rm.Recent(proxy.RequestFilter{ProjectDir: "/projects/a"})
+	if len(records) != 1 {
+		t.Fatalf("got %d records, want 1", len(records))
+	}
+	rec0 := records[0]
+
+	if rec0.Details != nil {
+		t.Error("Details is non-nil; capture-disabled route must record metadata only")
+	}
+	if rec0.ID == "" {
+		t.Error("record ID is empty; Record should generate one")
+	}
+	if rec0.StatusCode != http.StatusOK {
+		t.Errorf("StatusCode = %d, want 200", rec0.StatusCode)
+	}
+}
+
+func TestDynamicProxy_CaptureDisk_EvictionDeletesFiles(t *testing.T) {
+	// Response larger than the 64KB inline threshold forces a disk spill.
+	big := strings.Repeat("A", constants.DefaultCaptureInlineThreshold+4096)
+	host, port := newTestBackend(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		_, _ = w.Write([]byte(big))
+	})
+
+	// Buffer capacity 1 so the second request evicts the first.
+	dp, rm, cm := newCaptureProxy(t, true, host, port, 1)
+
+	serve(dp, "POST", "http://api.local.dev/one", "a", nil)
+
+	records := rm.Recent(proxy.RequestFilter{ProjectDir: "/projects/a"})
+	if len(records) != 1 {
+		t.Fatalf("got %d records, want 1", len(records))
+	}
+	id1 := records[0].ID
+	if records[0].Details == nil || records[0].Details.ResponseBody == nil {
+		t.Fatal("expected captured response body")
+	}
+	if records[0].Details.ResponseBody.FilePath == "" {
+		t.Fatal("expected disk-backed response body (FilePath set)")
+	}
+
+	resFile := filepath.Join(cm.CaptureDir(), id1+"_res.bin")
+	if _, err := os.Stat(resFile); err != nil {
+		t.Fatalf("expected capture file %s to exist: %v", resFile, err)
+	}
+
+	// Second request evicts the first, firing CleanupRequest for id1.
+	serve(dp, "POST", "http://api.local.dev/two", "b", nil)
+
+	if _, err := os.Stat(resFile); !os.IsNotExist(err) {
+		t.Errorf("capture file %s should have been deleted on eviction, stat err = %v", resFile, err)
+	}
+}
+
+func TestDynamicProxy_ErrorHandler_CaptureRecordsBadGateway(t *testing.T) {
+	// Register a route to a backend port that nothing is listening on.
+	reg := NewRegistry()
+	req := RegisterRequest{
+		ProjectDir:     "/projects/a",
+		PID:            1,
+		Version:        "dev",
+		Domain:         "local.dev",
+		Services:       map[string]ServiceTarget{"api": {Host: "127.0.0.1", Port: 1}},
+		HTTPPort:       80,
+		CaptureEnabled: true,
+	}
+	if _, _, err := reg.Register(req); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	cm, err := proxy.NewCaptureManagerAt(t.TempDir(), constants.DefaultCaptureMaxBodySize)
+	if err != nil {
+		t.Fatalf("NewCaptureManagerAt: %v", err)
+	}
+	rm := proxy.NewRequestManager(10)
+	rm.SetEvictionCallback(cm.CleanupRequest)
+	dp := NewDynamicProxy(reg, nil, rm, cm, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	rec := serve(dp, "GET", "http://api.local.dev/down", "", nil)
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", rec.Code)
+	}
+
+	records := rm.Recent(proxy.RequestFilter{ProjectDir: "/projects/a"})
+	if len(records) != 1 {
+		t.Fatalf("got %d records, want 1", len(records))
+	}
+	if records[0].StatusCode != http.StatusBadGateway {
+		t.Errorf("recorded StatusCode = %d, want 502", records[0].StatusCode)
+	}
+}
+
+// TestDaemonCaptureDir_IsolatedHome pins the daemon capture directory shape
+// under an isolated HOME without standing up the full daemon.
+func TestDaemonCaptureDir_IsolatedHome(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("UserHomeDir: %v", err)
+	}
+	captureDir := constants.DaemonCaptureDir(homeDir)
+
+	want := filepath.Join(tmp, ".prox", "capture")
+	if captureDir != want {
+		t.Fatalf("DaemonCaptureDir = %q, want %q", captureDir, want)
+	}
+
+	cm, err := proxy.NewCaptureManagerAt(captureDir, constants.DefaultCaptureMaxBodySize)
+	if err != nil {
+		t.Fatalf("NewCaptureManagerAt: %v", err)
+	}
+	if cm.CaptureDir() != want {
+		t.Errorf("CaptureDir() = %q, want %q", cm.CaptureDir(), want)
+	}
+	if fi, err := os.Stat(want); err != nil || !fi.IsDir() {
+		t.Errorf("capture dir %s not created (err=%v)", want, err)
+	}
+}

--- a/internal/proxyd/dynamic_proxy_test.go
+++ b/internal/proxyd/dynamic_proxy_test.go
@@ -1,6 +1,7 @@
 package proxyd
 
 import (
+	"bufio"
 	"bytes"
 	"io"
 	"log/slog"
@@ -13,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/charliek/prox/internal/constants"
 	"github.com/charliek/prox/internal/proxy"
@@ -198,6 +200,70 @@ func TestDynamicProxy_CaptureDisk_EvictionDeletesFiles(t *testing.T) {
 
 	if _, err := os.Stat(resFile); !os.IsNotExist(err) {
 		t.Errorf("capture file %s should have been deleted on eviction, stat err = %v", resFile, err)
+	}
+}
+
+// hijackRecorder is an http.ResponseWriter that also implements http.Hijacker,
+// backed by an in-memory net.Pipe, so a reverse-proxy WebSocket upgrade can be
+// driven in a unit test (httptest.ResponseRecorder alone is not a Hijacker).
+type hijackRecorder struct {
+	*httptest.ResponseRecorder
+	conn net.Conn
+}
+
+func (h *hijackRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	rw := bufio.NewReadWriter(bufio.NewReader(h.conn), bufio.NewWriter(h.conn))
+	return h.conn, rw, nil
+}
+
+func TestDynamicProxy_Hijacked_RecordsSwitchingProtocols(t *testing.T) {
+	// Backend accepts the upgrade by hijacking and writing a raw 101.
+	host, port := newTestBackend(t, func(w http.ResponseWriter, r *http.Request) {
+		conn, _, err := w.(http.Hijacker).Hijack()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		_, _ = conn.Write([]byte("HTTP/1.1 101 Switching Protocols\r\n" +
+			"Connection: Upgrade\r\nUpgrade: websocket\r\n\r\n"))
+	})
+
+	dp, rm, _ := newCaptureProxy(t, true, host, port, 10)
+
+	clientEnd, testEnd := net.Pipe()
+	defer clientEnd.Close()
+	defer testEnd.Close()
+	// Drain whatever the proxy writes to the hijacked client conn (the 101) so
+	// its flush does not block on the synchronous pipe.
+	go func() { _, _ = io.Copy(io.Discard, testEnd) }()
+
+	hr := &hijackRecorder{ResponseRecorder: httptest.NewRecorder(), conn: clientEnd}
+	req := httptest.NewRequest("GET", "http://api.local.dev/ws", nil)
+	req.Host = "api.local.dev"
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Upgrade", "websocket")
+
+	done := make(chan struct{})
+	go func() {
+		dp.handler(80).ServeHTTP(hr, req)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("hijacked request did not complete within 5s")
+	}
+
+	records := rm.Recent(proxy.RequestFilter{ProjectDir: "/projects/a"})
+	if len(records) != 1 {
+		t.Fatalf("got %d records, want 1", len(records))
+	}
+	rec0 := records[0]
+	if rec0.StatusCode != http.StatusSwitchingProtocols {
+		t.Errorf("StatusCode = %d, want %d (101 Switching Protocols)", rec0.StatusCode, http.StatusSwitchingProtocols)
+	}
+	if rec0.Details != nil {
+		t.Error("Details should be nil for a hijacked (metadata-only) record")
 	}
 }
 

--- a/internal/proxyd/forwarder.go
+++ b/internal/proxyd/forwarder.go
@@ -2,15 +2,18 @@ package proxyd
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"log"
 	"net"
 	"net/http"
 	"net/url"
-	"strings"
 	"time"
 
+	"github.com/charliek/prox/internal/constants"
 	"github.com/charliek/prox/internal/proxy"
 )
 
@@ -72,24 +75,92 @@ func streamRequests(ctx context.Context, socketPath, projectDir string, localRM 
 		return fmt.Errorf("daemon SSE returned %d", resp.StatusCode)
 	}
 
-	// Read SSE events line by line
-	scanner := bufio.NewScanner(resp.Body)
-	for scanner.Scan() {
-		line := scanner.Text()
+	// Read SSE events line by line. bufio.Scanner is NOT used: its token size is
+	// capped (and even a raised cap would kill the subscription on the first
+	// oversized line). Records can legitimately exceed 64KB — on a capture
+	// disk-write failure both bodies fall back to inline storage up to 1MB each,
+	// and headers are unbounded — so we use a bufio.Reader with an explicit
+	// per-event cap (constants.MaxSSEEventSize). An oversized event is skipped
+	// (drained to its newline) with a logged warning and the stream continues,
+	// rather than tearing down the bridge.
+	reader := bufio.NewReaderSize(resp.Body, constants.ScannerBufferSize)
+	dataPrefix := []byte("data: ")
+	for {
+		line, oversize, readErr := readEventLine(reader, constants.MaxSSEEventSize)
 
-		// SSE format: "data: {json}"
-		if !strings.HasPrefix(line, "data: ") {
-			continue
+		switch {
+		case readErr != nil:
+			// A line returned alongside a read error has no terminating
+			// newline — the SSE event is incomplete (mid-write disconnect).
+			// Discard it rather than recording a possibly-partial event; the
+			// reconnect loop will re-sync on fresh events.
+		case oversize:
+			log.Printf("prox: skipping oversized daemon request event (exceeds %d bytes)", constants.MaxSSEEventSize)
+		case len(line) > 0:
+			// SSE format: "data: {json}". Trim the trailing "\r\n"/"\n".
+			trimmed := bytes.TrimRight(line, "\r\n")
+			if bytes.HasPrefix(trimmed, dataPrefix) {
+				jsonData := trimmed[len(dataPrefix):]
+				var record proxy.RequestRecord
+				if err := json.Unmarshal(jsonData, &record); err == nil {
+					localRM.Record(record)
+				}
+				// Malformed events are skipped silently, as before.
+			}
 		}
 
-		jsonData := strings.TrimPrefix(line, "data: ")
-		var record proxy.RequestRecord
-		if err := json.Unmarshal([]byte(jsonData), &record); err != nil {
-			continue // skip malformed events
+		if readErr != nil {
+			if readErr == io.EOF {
+				return nil
+			}
+			return readErr
 		}
-
-		localRM.Record(record)
 	}
+}
 
-	return scanner.Err()
+// readEventLine reads a single '\n'-terminated line from r, enforcing maxSize.
+// It returns:
+//   - the line (including its trailing newline) when within the cap;
+//   - oversize=true with a nil line when the line exceeds maxSize — the excess is
+//     drained up to (and including) the newline so the reader is positioned at
+//     the start of the next event and the caller can continue the stream;
+//   - a non-nil error (e.g. io.EOF) from the underlying reader, alongside any
+//     partial line read so far.
+//
+// It uses ReadSlice against r's fixed internal buffer, so no single call buffers
+// more than that buffer's size; the accumulated line is bounded by maxSize.
+func readEventLine(r *bufio.Reader, maxSize int) (line []byte, oversize bool, err error) {
+	var buf []byte
+	for {
+		chunk, rerr := r.ReadSlice('\n')
+
+		if !oversize {
+			if len(buf)+len(chunk) > maxSize {
+				// Over the cap: stop accumulating and release what we have; keep
+				// draining until the newline so the next event is aligned.
+				oversize = true
+				buf = nil
+			} else {
+				buf = append(buf, chunk...)
+			}
+		}
+
+		switch rerr {
+		case nil:
+			// Reached the newline: the line is complete.
+			if oversize {
+				return nil, true, nil
+			}
+			return buf, false, nil
+		case bufio.ErrBufferFull:
+			// No newline in this fill; keep reading the same line.
+			continue
+		default:
+			// Underlying error (io.EOF or a transport failure).
+			if oversize {
+				return nil, true, rerr
+			}
+			return buf, false, rerr
+		}
+	}
 }

--- a/internal/proxyd/forwarder.go
+++ b/internal/proxyd/forwarder.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -14,16 +15,18 @@ import (
 )
 
 // ForwardRequests subscribes to the daemon's SSE request stream and forwards
-// matching records into the local RequestManager. This bridges the daemon's
-// proxy request data into the project's TUI and API.
+// this project's records into the local RequestManager. This bridges the
+// daemon's proxy request data into the project's TUI and API.
+//
+// projectDir must be the same value sent as RegisterRequest.ProjectDir so the
+// daemon-side filter (which scopes records by owning project) matches.
 //
 // It runs until ctx is cancelled. On disconnect, it reconnects with backoff.
-func ForwardRequests(ctx context.Context, socketPath string, domains []string, localRM *proxy.RequestManager) {
-	domainsParam := strings.Join(domains, ",")
+func ForwardRequests(ctx context.Context, socketPath string, projectDir string, localRM *proxy.RequestManager) {
 	backoff := 500 * time.Millisecond
 
 	for {
-		err := streamRequests(ctx, socketPath, domainsParam, localRM)
+		err := streamRequests(ctx, socketPath, projectDir, localRM)
 		if ctx.Err() != nil {
 			return // context cancelled, clean shutdown
 		}
@@ -42,7 +45,7 @@ func ForwardRequests(ctx context.Context, socketPath string, domains []string, l
 }
 
 // streamRequests opens an SSE connection to the daemon and processes events.
-func streamRequests(ctx context.Context, socketPath, domainsParam string, localRM *proxy.RequestManager) error {
+func streamRequests(ctx context.Context, socketPath, projectDir string, localRM *proxy.RequestManager) error {
 	// Create HTTP client that dials the Unix socket
 	dialer := &net.Dialer{}
 	client := &http.Client{
@@ -53,8 +56,8 @@ func streamRequests(ctx context.Context, socketPath, domainsParam string, localR
 		},
 	}
 
-	url := fmt.Sprintf("http://proxyd/api/v1/requests/stream?domains=%s", domainsParam)
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	streamURL := fmt.Sprintf("http://proxyd/api/v1/requests/stream?project=%s", url.QueryEscape(projectDir))
+	req, err := http.NewRequestWithContext(ctx, "GET", streamURL, nil)
 	if err != nil {
 		return fmt.Errorf("creating SSE request: %w", err)
 	}

--- a/internal/proxyd/forwarder_test.go
+++ b/internal/proxyd/forwarder_test.go
@@ -1,13 +1,122 @@
 package proxyd
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/charliek/prox/internal/constants"
 	"github.com/charliek/prox/internal/proxy"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// startRawSSEServer starts an HTTP server on a unix socket that serves handler
+// for every request, and returns the socket path. It lets a test control the
+// exact SSE bytes the forwarder reads (framing, oversized lines, etc.).
+func startRawSSEServer(t *testing.T, handler http.HandlerFunc) string {
+	t.Helper()
+
+	// Short temp dir to stay under the Unix socket 104-byte path limit on macOS.
+	tmpDir, err := os.MkdirTemp("/tmp", "prox-fwd-")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(tmpDir) })
+	socketPath := filepath.Join(tmpDir, "s.sock")
+
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen on unix socket: %v", err)
+	}
+	srv := &http.Server{Handler: handler}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+	return socketPath
+}
+
+// TestStreamRequests_LargeInlineBodies pins that a record carrying the
+// disk-fallback worst case — two 1MB inline bodies (~2.7MB base64) — parses
+// successfully under the new per-event cap, and the inline body bytes round-trip
+// through base64 JSON unchanged. This is exactly the event the old 64KB
+// bufio.Scanner token limit would have dropped.
+func TestStreamRequests_LargeInlineBodies(t *testing.T) {
+	big1 := bytes.Repeat([]byte("a"), 1024*1024)
+	big2 := bytes.Repeat([]byte("b"), 1024*1024)
+
+	rec := proxy.RequestRecord{
+		Timestamp:  time.Now(),
+		Method:     "POST",
+		URL:        "/big",
+		ProjectDir: "/p",
+		Details: &proxy.RequestDetails{
+			RequestBody:  &proxy.CapturedBody{ContentType: "application/octet-stream", Data: big1},
+			ResponseBody: &proxy.CapturedBody{ContentType: "application/octet-stream", Data: big2},
+		},
+	}
+	data, err := json.Marshal(rec)
+	require.NoError(t, err)
+	// Sanity: the framed event is large but under the cap.
+	require.Less(t, len(data)+len("data: \n\n"), constants.MaxSSEEventSize)
+	require.Greater(t, len(data), constants.ScannerBufferSize, "event must exceed the reader's buffer to exercise accumulation")
+
+	socketPath := startRawSSEServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprintf(w, "data: %s\n\n", data)
+	})
+
+	localRM := proxy.NewRequestManager(100)
+	// streamRequests returns nil once the server closes the stream (io.EOF).
+	require.NoError(t, streamRequests(context.Background(), socketPath, "/p", localRM))
+
+	require.Equal(t, 1, localRM.Count())
+	got := localRM.Recent(proxy.RequestFilter{})[0]
+	require.NotNil(t, got.Details)
+	require.NotNil(t, got.Details.RequestBody)
+	require.NotNil(t, got.Details.ResponseBody)
+	assert.True(t, bytes.Equal(big1, got.Details.RequestBody.Data), "request body must round-trip")
+	assert.True(t, bytes.Equal(big2, got.Details.ResponseBody.Data), "response body must round-trip")
+}
+
+// TestStreamRequests_OversizeEventSkippedStreamContinues pins that an event
+// exceeding the per-event cap is skipped (not fatal) and the NEXT event is still
+// delivered — the reader drains the oversized line to its newline and continues.
+func TestStreamRequests_OversizeEventSkippedStreamContinues(t *testing.T) {
+	small := proxy.RequestRecord{
+		Timestamp:  time.Now(),
+		Method:     "GET",
+		URL:        "/small",
+		ProjectDir: "/p",
+	}
+	smallData, err := json.Marshal(small)
+	require.NoError(t, err)
+
+	// A single data line whose payload exceeds the cap.
+	oversize := bytes.Repeat([]byte("x"), constants.MaxSSEEventSize+4096)
+
+	socketPath := startRawSSEServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprintf(w, "data: %s\n\n", oversize)
+		fmt.Fprintf(w, "data: %s\n\n", smallData)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	})
+
+	localRM := proxy.NewRequestManager(100)
+	require.NoError(t, streamRequests(context.Background(), socketPath, "/p", localRM))
+
+	require.Equal(t, 1, localRM.Count(), "oversize event skipped, following event delivered")
+	got := localRM.Recent(proxy.RequestFilter{})[0]
+	assert.Equal(t, "/small", got.URL)
+}
 
 // TestForwardRequests_FiltersByProject pins that the forwarder subscribes by
 // project dir (via the ?project= stream param) and the daemon delivers only the

--- a/internal/proxyd/forwarder_test.go
+++ b/internal/proxyd/forwarder_test.go
@@ -1,0 +1,56 @@
+package proxyd
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/charliek/prox/internal/proxy"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestForwardRequests_FiltersByProject pins that the forwarder subscribes by
+// project dir (via the ?project= stream param) and the daemon delivers only the
+// owning project's records — even when a second project shares the hostname.
+func TestForwardRequests_FiltersByProject(t *testing.T) {
+	server, _, socketPath := startTestServer(t)
+
+	daemonRM := proxy.NewRequestManager(100)
+	server.SetRequestManager(daemonRM)
+
+	localRM := proxy.NewRequestManager(100)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go ForwardRequests(ctx, socketPath, "/projects/a", localRM)
+
+	// The bridge is stream-only (no backfill), so records must be produced after
+	// the forwarder subscribes. Record both projects on a tick until the local
+	// side observes A's record.
+	deadline := time.After(3 * time.Second)
+	tick := time.NewTicker(25 * time.Millisecond)
+	defer tick.Stop()
+
+	i := 0
+loop:
+	for {
+		select {
+		case <-deadline:
+			t.Fatal("forwarder never received project A's record")
+		case <-tick.C:
+			i++
+			ts := time.Now()
+			daemonRM.Record(proxy.RequestRecord{Timestamp: ts, Method: "GET", URL: "/a", Hostname: "api.local.dev", ProjectDir: "/projects/a"})
+			daemonRM.Record(proxy.RequestRecord{Timestamp: ts.Add(time.Duration(i)), Method: "GET", URL: "/b", Hostname: "api.local.dev", ProjectDir: "/projects/b"})
+			if localRM.Count() > 0 {
+				break loop
+			}
+		}
+	}
+
+	// Let any (incorrectly) delivered B records land, then assert none did.
+	time.Sleep(100 * time.Millisecond)
+	for _, rec := range localRM.Recent(proxy.RequestFilter{}) {
+		assert.Equal(t, "/projects/a", rec.ProjectDir, "forwarder must only receive project A's records")
+	}
+}

--- a/internal/proxyd/registry.go
+++ b/internal/proxyd/registry.go
@@ -187,7 +187,29 @@ func (r *Registry) Register(req RegisterRequest) (hostnames []string, newPorts [
 func (r *Registry) Deregister(projectDir string) (removedHostnames []string, emptyPorts []int) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	return r.deregisterLocked(projectDir)
+}
 
+// DeregisterIfPID removes a project's routes only if its CURRENT registration
+// still carries pid. The check and removal happen under one lock acquisition,
+// closing the race where the stale-PID sweep detects a dead generation, the
+// project re-registers with a live PID, and the sweep would otherwise tear
+// down the new live registration. Returns removed=false when the project is
+// gone or has re-registered under a different PID.
+func (r *Registry) DeregisterIfPID(projectDir string, pid int) (removed bool, removedHostnames []string, emptyPorts []int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	proj, ok := r.projects[projectDir]
+	if !ok || proj.PID != pid {
+		return false, nil, nil
+	}
+	removedHostnames, emptyPorts = r.deregisterLocked(projectDir)
+	return true, removedHostnames, emptyPorts
+}
+
+// deregisterLocked is the shared removal body; r.mu must be held.
+func (r *Registry) deregisterLocked(projectDir string) (removedHostnames []string, emptyPorts []int) {
 	proj, ok := r.projects[projectDir]
 	if !ok {
 		return nil, nil
@@ -270,20 +292,25 @@ func (r *Registry) IsEmpty() bool {
 	return len(r.routes) == 0
 }
 
-// CleanStalePIDs checks each registered project's PID and deregisters any
-// that are no longer running. Returns the project dirs that were cleaned up.
-func (r *Registry) CleanStalePIDs() []string {
+// StaleProject identifies a registration whose owning process has died.
+type StaleProject struct {
+	Dir string
+	PID int
+}
+
+// StalePIDs returns the registered projects whose PID is no longer running.
+// It only detects — removal goes through the consolidated removeProject path
+// (PID-guarded via DeregisterIfPID) so the crash path purges captured records
+// and body files the same way an explicit deregister does, without racing a
+// concurrent re-registration.
+func (r *Registry) StalePIDs() []StaleProject {
 	r.mu.RLock()
-	var stale []string
+	defer r.mu.RUnlock()
+	var stale []StaleProject
 	for dir, proj := range r.projects {
 		if !daemon.ProcessExists(proj.PID) {
-			stale = append(stale, dir)
+			stale = append(stale, StaleProject{Dir: dir, PID: proj.PID})
 		}
-	}
-	r.mu.RUnlock()
-
-	for _, dir := range stale {
-		r.Deregister(dir)
 	}
 	return stale
 }

--- a/internal/proxyd/registry.go
+++ b/internal/proxyd/registry.go
@@ -24,15 +24,20 @@ type Route struct {
 	ProjectDir   string
 	PID          int
 	RegisteredAt time.Time
+	// CaptureEnabled is stamped from the owning project's registration so the
+	// dynamic proxy can gate body capture per project (a capture-disabled
+	// project's traffic is recorded as metadata only).
+	CaptureEnabled bool
 }
 
 // ProjectRegistration tracks all routes belonging to a project.
 type ProjectRegistration struct {
-	Dir          string
-	PID          int
-	Domain       string
-	RouteKeys    []string // "hostname:port" keys into the routes map
-	RegisteredAt time.Time
+	Dir            string
+	PID            int
+	Domain         string
+	RouteKeys      []string // "hostname:port" keys into the routes map
+	RegisteredAt   time.Time
+	CaptureEnabled bool
 }
 
 // ListenerInfo tracks the protocol and route count for a port.
@@ -143,13 +148,14 @@ func (r *Registry) Register(req RegisterRequest) (hostnames []string, newPorts [
 	for _, p := range pending {
 		key := routeKey(p.hostname, p.port)
 		r.routes[key] = &Route{
-			Hostname:     p.hostname,
-			Port:         p.port,
-			Protocol:     p.protocol,
-			Target:       p.target,
-			ProjectDir:   req.ProjectDir,
-			PID:          req.PID,
-			RegisteredAt: now,
+			Hostname:       p.hostname,
+			Port:           p.port,
+			Protocol:       p.protocol,
+			Target:         p.target,
+			ProjectDir:     req.ProjectDir,
+			PID:            req.PID,
+			RegisteredAt:   now,
+			CaptureEnabled: req.CaptureEnabled,
 		}
 		routeKeys = append(routeKeys, key)
 		hostnames = append(hostnames, p.hostname)
@@ -168,11 +174,12 @@ func (r *Registry) Register(req RegisterRequest) (hostnames []string, newPorts [
 	}
 
 	r.projects[req.ProjectDir] = &ProjectRegistration{
-		Dir:          req.ProjectDir,
-		PID:          req.PID,
-		Domain:       req.Domain,
-		RouteKeys:    routeKeys,
-		RegisteredAt: now,
+		Dir:            req.ProjectDir,
+		PID:            req.PID,
+		Domain:         req.Domain,
+		RouteKeys:      routeKeys,
+		RegisteredAt:   now,
+		CaptureEnabled: req.CaptureEnabled,
 	}
 
 	for port, proto := range portsNeeded {

--- a/internal/proxyd/registry_test.go
+++ b/internal/proxyd/registry_test.go
@@ -290,6 +290,51 @@ func TestRegistry_ListenerPorts(t *testing.T) {
 	}
 }
 
+func TestRegistry_StampsCaptureEnabled(t *testing.T) {
+	reg := NewRegistry()
+
+	req := newTestRequest("/projects/a", "local.dev",
+		map[string]ServiceTarget{"api": {Host: "localhost", Port: 3000}},
+		80, 443,
+	)
+	req.CaptureEnabled = true
+	if _, _, err := reg.Register(req); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	// Every route the project registered carries the capture flag.
+	for _, port := range []int{80, 443} {
+		route, ok := reg.Lookup("api.local.dev", port)
+		if !ok {
+			t.Fatalf("Lookup(api.local.dev, %d) returned false", port)
+		}
+		if !route.CaptureEnabled {
+			t.Errorf("route on port %d: CaptureEnabled = false, want true", port)
+		}
+	}
+}
+
+func TestRegistry_CaptureDisabledByDefault(t *testing.T) {
+	reg := NewRegistry()
+
+	req := newTestRequest("/projects/a", "local.dev",
+		map[string]ServiceTarget{"api": {Host: "localhost", Port: 3000}},
+		0, 443,
+	)
+	// CaptureEnabled left false.
+	if _, _, err := reg.Register(req); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	route, ok := reg.Lookup("api.local.dev", 443)
+	if !ok {
+		t.Fatal("Lookup returned false")
+	}
+	if route.CaptureEnabled {
+		t.Error("route CaptureEnabled = true, want false")
+	}
+}
+
 func TestRegistry_DifferentPorts(t *testing.T) {
 	reg := NewRegistry()
 

--- a/internal/proxyd/server.go
+++ b/internal/proxyd/server.go
@@ -8,9 +8,11 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strconv"
 	"sync"
 	"time"
 
+	"github.com/charliek/prox/internal/constants"
 	"github.com/charliek/prox/internal/proxy"
 	"github.com/go-chi/chi/v5"
 )
@@ -441,9 +443,20 @@ func (s *Server) handleGetRequests(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Clamp limit with the same semantics as the project API's
+	// parseProxyRequestParams: invalid or out-of-range values fall back to
+	// the default rather than erroring, so a malformed limit degrades
+	// gracefully instead of rejecting the whole request.
+	limit := constants.DefaultProxyRequestLimit
+	if limitStr := r.URL.Query().Get("limit"); limitStr != "" {
+		if l, err := strconv.Atoi(limitStr); err == nil && l > 0 && l <= constants.MaxProxyRequests {
+			limit = l
+		}
+	}
+
 	filter := proxy.RequestFilter{
 		ProjectDir: projectDir,
-		Limit:      100,
+		Limit:      limit,
 	}
 
 	records := s.requestManager.Recent(filter)

--- a/internal/proxyd/server.go
+++ b/internal/proxyd/server.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"strings"
 	"sync"
 	"time"
 
@@ -142,6 +141,16 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// ProjectDir is the identity records are filtered and purged by; an empty
+	// one would produce records that no deregistration could ever clean up.
+	if req.ProjectDir == "" {
+		writeJSON(w, http.StatusBadRequest, ErrorResponse{
+			Error: "project_dir is required",
+			Code:  "BAD_REQUEST",
+		})
+		return
+	}
+
 	// Register routes
 	hostnames, newPorts, err := s.registry.Register(req)
 	if err != nil {
@@ -217,16 +226,7 @@ func (s *Server) handleDeregister(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	removedHostnames, emptyPorts := s.registry.Deregister(req.ProjectDir)
-
-	// Close listeners for ports with no remaining routes
-	if s.proxy != nil {
-		for _, port := range emptyPorts {
-			if err := s.proxy.RemoveListener(port); err != nil {
-				s.logger.Warn("failed to remove listener", "port", port, "error", err)
-			}
-		}
-	}
+	removedHostnames, emptyPorts := s.removeProject(req.ProjectDir)
 
 	s.logger.Info("deregistered project",
 		"project", req.ProjectDir,
@@ -249,6 +249,55 @@ func (s *Server) handleDeregister(w http.ResponseWriter, r *http.Request) {
 				s.RequestShutdown()
 			}
 		}()
+	}
+}
+
+// removeProject is the single consolidated project-removal path: it removes the
+// project's routes, closes listeners for ports that now have no routes, and
+// purges the project's captured requests (firing eviction callbacks so on-disk
+// body files are cleaned up). It is called from explicit deregister and from
+// the stale-PID crash-recovery sweep so the crash path can't leak records or
+// body files. Returns the removed hostnames and now-empty ports for logging.
+func (s *Server) removeProject(projectDir string) (removedHostnames []string, emptyPorts []int) {
+	if s.registry == nil {
+		return nil, nil
+	}
+
+	removedHostnames, emptyPorts = s.registry.Deregister(projectDir)
+	s.finishRemoval(projectDir, emptyPorts)
+	return removedHostnames, emptyPorts
+}
+
+// removeStaleProject is removeProject for the crash-recovery sweep: removal is
+// guarded on the registration still carrying the detected dead PID, so a
+// project that re-registered between detection and removal is left alone.
+func (s *Server) removeStaleProject(projectDir string, pid int) (removed bool, removedHostnames []string, emptyPorts []int) {
+	if s.registry == nil {
+		return false, nil, nil
+	}
+
+	removed, removedHostnames, emptyPorts = s.registry.DeregisterIfPID(projectDir, pid)
+	if !removed {
+		return false, nil, nil
+	}
+	s.finishRemoval(projectDir, emptyPorts)
+	return true, removedHostnames, emptyPorts
+}
+
+// finishRemoval closes listeners for now-empty ports and purges the project's
+// captured requests (firing eviction callbacks so on-disk body files are
+// cleaned up).
+func (s *Server) finishRemoval(projectDir string, emptyPorts []int) {
+	if s.proxy != nil {
+		for _, port := range emptyPorts {
+			if err := s.proxy.RemoveListener(port); err != nil {
+				s.logger.Warn("failed to remove listener", "port", port, "error", err)
+			}
+		}
+	}
+
+	if s.requestManager != nil {
+		s.requestManager.PurgeByProject(projectDir)
 	}
 }
 
@@ -326,13 +375,20 @@ func (s *Server) handleStreamRequests(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Parse domain filter from query params
-	var hostnames []string
-	if domains := r.URL.Query().Get("domains"); domains != "" {
-		hostnames = strings.Split(domains, ",")
+	// Filter the stream by owning project (exact match). Scoping by project
+	// dir rather than hostname prevents cross-project record delivery when two
+	// projects own the same hostname on different ports. The param is
+	// mandatory: an empty ProjectDir filter would match ALL projects' records,
+	// so a caller that forgot the param would silently receive everything.
+	projectDir := r.URL.Query().Get("project")
+	if projectDir == "" {
+		writeJSON(w, http.StatusBadRequest, ErrorResponse{
+			Error: "project query parameter is required",
+			Code:  "BAD_REQUEST",
+		})
+		return
 	}
-
-	filter := proxy.RequestFilter{Hostnames: hostnames}
+	filter := proxy.RequestFilter{ProjectDir: projectDir}
 	sub := s.requestManager.Subscribe(filter)
 	defer s.requestManager.Unsubscribe(sub.ID)
 
@@ -374,15 +430,20 @@ func (s *Server) handleGetRequests(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var hostnames []string
-	if domains := r.URL.Query().Get("domains"); domains != "" {
-		hostnames = strings.Split(domains, ",")
+	// Mandatory for the same reason as the stream endpoint: an empty
+	// ProjectDir filter matches every project's records.
+	projectDir := r.URL.Query().Get("project")
+	if projectDir == "" {
+		writeJSON(w, http.StatusBadRequest, ErrorResponse{
+			Error: "project query parameter is required",
+			Code:  "BAD_REQUEST",
+		})
+		return
 	}
 
-	limit := 100
 	filter := proxy.RequestFilter{
-		Hostnames: hostnames,
-		Limit:     limit,
+		ProjectDir: projectDir,
+		Limit:      100,
 	}
 
 	records := s.requestManager.Recent(filter)

--- a/internal/proxyd/server_lifecycle_test.go
+++ b/internal/proxyd/server_lifecycle_test.go
@@ -1,10 +1,12 @@
 package proxyd
 
 import (
+	"encoding/json"
 	"io"
 	"log/slog"
 	"os/exec"
 	"testing"
+	"time"
 
 	"github.com/charliek/prox/internal/proxy"
 	"github.com/stretchr/testify/assert"
@@ -155,6 +157,68 @@ func TestRequestEndpoints_RequireProjectParam(t *testing.T) {
 	require.NoError(t, err)
 	defer respStream.Body.Close()
 	assert.Equal(t, 400, respStream.StatusCode)
+}
+
+// TestHandleGetRequests_LimitClamp pins that the daemon socket's ?limit=
+// honors the same clamp semantics as the project API's
+// parseProxyRequestParams: valid values in (0, MaxProxyRequests] apply,
+// anything else (missing, zero, negative, or over the max) falls back to the
+// default of 100.
+func TestHandleGetRequests_LimitClamp(t *testing.T) {
+	server, client, _ := startTestServer(t)
+	rm := proxy.NewRequestManager(1500)
+	server.SetRequestManager(rm)
+
+	for i := 0; i < 150; i++ {
+		rm.Record(proxy.RequestRecord{
+			ID:         proxy.GenerateRequestID(time.Now(), "GET", "/x"),
+			Method:     "GET",
+			URL:        "/x",
+			ProjectDir: "/projects/a",
+		})
+	}
+
+	getCount := func(t *testing.T, query string) int {
+		t.Helper()
+		resp, err := client.httpClient.Get("http://proxyd/api/v1/requests?project=/projects/a" + query)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, 200, resp.StatusCode)
+
+		var body struct {
+			Requests []proxy.RequestRecord `json:"requests"`
+		}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+		return len(body.Requests)
+	}
+
+	t.Run("valid limit applies", func(t *testing.T) {
+		assert.Equal(t, 10, getCount(t, "&limit=10"))
+	})
+
+	t.Run("missing limit defaults to 100", func(t *testing.T) {
+		assert.Equal(t, 100, getCount(t, ""))
+	})
+
+	t.Run("zero limit defaults to 100", func(t *testing.T) {
+		assert.Equal(t, 100, getCount(t, "&limit=0"))
+	})
+
+	t.Run("negative limit defaults to 100", func(t *testing.T) {
+		assert.Equal(t, 100, getCount(t, "&limit=-5"))
+	})
+
+	t.Run("non-numeric limit defaults to 100", func(t *testing.T) {
+		assert.Equal(t, 100, getCount(t, "&limit=abc"))
+	})
+
+	t.Run("over-max limit defaults to 100", func(t *testing.T) {
+		assert.Equal(t, 100, getCount(t, "&limit=1001"))
+	})
+
+	t.Run("max limit applies", func(t *testing.T) {
+		assert.Equal(t, 150, getCount(t, "&limit=1000"))
+	})
 }
 
 // TestServer_RemoveProject_NilRequestManager guards the daemon-startup window

--- a/internal/proxyd/server_lifecycle_test.go
+++ b/internal/proxyd/server_lifecycle_test.go
@@ -1,0 +1,172 @@
+package proxyd
+
+import (
+	"io"
+	"log/slog"
+	"os/exec"
+	"testing"
+
+	"github.com/charliek/prox/internal/proxy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newLifecycleServer builds a Server wired to a registry and request manager
+// but without starting the socket listener — enough to exercise the
+// consolidated removeProject path directly.
+func newLifecycleServer() *Server {
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
+	s := NewServer(ServerConfig{SocketPath: "", Logger: logger, Version: "test"})
+	s.SetRegistry(NewRegistry())
+	s.SetRequestManager(proxy.NewRequestManager(100))
+	return s
+}
+
+// TestServer_RemoveProject_ScopedByProject pins the consolidated removal path:
+// two projects sharing a hostname on different ports don't remove each other's
+// routes or purge each other's records.
+func TestServer_RemoveProject_ScopedByProject(t *testing.T) {
+	s := newLifecycleServer()
+
+	// A and B both own hostname api.local.dev, but on different ports.
+	_, _, err := s.registry.Register(newTestRequest("/projects/a", "local.dev",
+		map[string]ServiceTarget{"api": {Host: "localhost", Port: 3000}}, 0, 443))
+	require.NoError(t, err)
+	_, _, err = s.registry.Register(newTestRequest("/projects/b", "local.dev",
+		map[string]ServiceTarget{"api": {Host: "localhost", Port: 4000}}, 0, 8443))
+	require.NoError(t, err)
+
+	// Records for each project, same hostname.
+	s.requestManager.Record(proxy.RequestRecord{ID: "a1", Method: "GET", URL: "/a", Hostname: "api.local.dev", ProjectDir: "/projects/a"})
+	s.requestManager.Record(proxy.RequestRecord{ID: "b1", Method: "GET", URL: "/b", Hostname: "api.local.dev", ProjectDir: "/projects/b"})
+
+	removed, _ := s.removeProject("/projects/a")
+	assert.Equal(t, []string{"api.local.dev"}, removed)
+
+	// A's route gone, B's route (same hostname, different port) survives.
+	_, okA := s.registry.Lookup("api.local.dev", 443)
+	assert.False(t, okA, "A's route should be removed")
+	_, okB := s.registry.Lookup("api.local.dev", 8443)
+	assert.True(t, okB, "B's route should survive")
+
+	// A's records purged, B's survive.
+	remaining := s.requestManager.Recent(proxy.RequestFilter{})
+	require.Len(t, remaining, 1)
+	assert.Equal(t, "b1", remaining[0].ID)
+}
+
+// TestServer_StalePIDSweep_PurgesRecords pins the crash path (CodeRabbit H2):
+// a project whose PID has died is detected by StalePIDs and removed through the
+// same consolidated removeProject path, so its captured records are purged —
+// the stale-PID sweep must not bypass record cleanup.
+func TestServer_StalePIDSweep_PurgesRecords(t *testing.T) {
+	s := newLifecycleServer()
+
+	// Produce a PID that is guaranteed dead: run a process to completion.
+	cmd := exec.Command("true")
+	require.NoError(t, cmd.Run())
+	deadPID := cmd.Process.Pid
+
+	req := newTestRequest("/projects/dead", "local.dev",
+		map[string]ServiceTarget{"api": {Host: "localhost", Port: 3000}}, 0, 443)
+	req.PID = deadPID
+	_, _, err := s.registry.Register(req)
+	require.NoError(t, err)
+
+	s.requestManager.Record(proxy.RequestRecord{ID: "d1", Method: "GET", URL: "/d", Hostname: "api.local.dev", ProjectDir: "/projects/dead"})
+	require.Equal(t, 1, s.requestManager.Count())
+
+	// The daemon sweep: detect stale PIDs, then remove via the PID-guarded path.
+	stale := s.registry.StalePIDs()
+	require.Equal(t, []StaleProject{{Dir: "/projects/dead", PID: deadPID}}, stale)
+	for _, sp := range stale {
+		removed, _, _ := s.removeStaleProject(sp.Dir, sp.PID)
+		assert.True(t, removed)
+	}
+
+	assert.True(t, s.registry.IsEmpty(), "registry should be empty after stale sweep")
+	assert.Equal(t, 0, s.requestManager.Count(), "stale project's records must be purged")
+}
+
+// TestServer_RemoveStaleProject_SkipsReRegistered pins the detection→removal
+// race fix: when a project re-registers (new live PID) between StalePIDs
+// detection and removal, the guarded removal must leave the new registration
+// and its records alone.
+func TestServer_RemoveStaleProject_SkipsReRegistered(t *testing.T) {
+	s := newLifecycleServer()
+
+	cmd := exec.Command("true")
+	require.NoError(t, cmd.Run())
+	deadPID := cmd.Process.Pid
+
+	req := newTestRequest("/projects/x", "local.dev",
+		map[string]ServiceTarget{"api": {Host: "localhost", Port: 3000}}, 0, 443)
+	req.PID = deadPID
+	_, _, err := s.registry.Register(req)
+	require.NoError(t, err)
+
+	stale := s.registry.StalePIDs()
+	require.Len(t, stale, 1)
+
+	// Simulate the race: project deregisters and re-registers with a live PID
+	// after detection but before removal.
+	s.registry.Deregister("/projects/x")
+	reReq := newTestRequest("/projects/x", "local.dev",
+		map[string]ServiceTarget{"api": {Host: "localhost", Port: 3001}}, 0, 443)
+	reReq.PID = 1 // always-alive PID (launchd/init)
+	_, _, err = s.registry.Register(reReq)
+	require.NoError(t, err)
+	s.requestManager.Record(proxy.RequestRecord{ID: "x1", Method: "GET", URL: "/x", ProjectDir: "/projects/x"})
+
+	removed, _, _ := s.removeStaleProject(stale[0].Dir, stale[0].PID)
+	assert.False(t, removed, "guarded removal must skip the re-registered project")
+	_, ok := s.registry.Lookup("api.local.dev", 443)
+	assert.True(t, ok, "live registration's route must survive")
+	assert.Equal(t, 1, s.requestManager.Count(), "live registration's records must survive")
+}
+
+// TestHandleRegister_RejectsEmptyProjectDir pins the identity requirement:
+// records are filtered and purged by ProjectDir, so a registration without one
+// would create records nothing could ever clean up.
+func TestHandleRegister_RejectsEmptyProjectDir(t *testing.T) {
+	_, client, _ := startTestServer(t)
+
+	req := newTestRequest("", "local.dev",
+		map[string]ServiceTarget{"api": {Host: "localhost", Port: 3000}}, 0, 443)
+	req.Version = "test-version" // pass the exact-match version gate
+	_, err := client.Register(req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "project_dir is required")
+}
+
+// TestRequestEndpoints_RequireProjectParam pins that both daemon request
+// endpoints reject an unscoped query rather than matching every project's
+// records.
+func TestRequestEndpoints_RequireProjectParam(t *testing.T) {
+	server, client, _ := startTestServer(t)
+	server.SetRequestManager(proxy.NewRequestManager(10))
+
+	resp, err := client.httpClient.Get("http://proxyd/api/v1/requests")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, 400, resp.StatusCode)
+
+	respStream, err := client.httpClient.Get("http://proxyd/api/v1/requests/stream")
+	require.NoError(t, err)
+	defer respStream.Body.Close()
+	assert.Equal(t, 400, respStream.StatusCode)
+}
+
+// TestServer_RemoveProject_NilRequestManager guards the daemon-startup window
+// where the request manager may not be set yet.
+func TestServer_RemoveProject_NilRequestManager(t *testing.T) {
+	s := newLifecycleServer()
+	s.requestManager = nil // model the startup window before the manager is wired
+
+	_, _, err := s.registry.Register(newTestRequest("/projects/a", "local.dev",
+		map[string]ServiceTarget{"api": {Host: "localhost", Port: 3000}}, 0, 443))
+	require.NoError(t, err)
+
+	require.NotPanics(t, func() { s.removeProject("/projects/a") })
+	assert.True(t, s.registry.IsEmpty())
+}

--- a/internal/tui/base.go
+++ b/internal/tui/base.go
@@ -2,13 +2,17 @@ package tui
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/charmbracelet/bubbles/textinput"
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/charliek/prox/internal/constants"
 	"github.com/charliek/prox/internal/domain"
 	"github.com/charliek/prox/internal/proxy"
 )
@@ -481,17 +485,7 @@ func (b *BaseModel) formatRequestDetail() []string {
 		}
 		bodyTitle += ")"
 		lines = append(lines, headerStyle.Render(bodyTitle))
-		if d.RequestBody.Data != "" {
-			if d.RequestBody.IsBinary {
-				lines = append(lines, dimStyle.Render("[binary data]"))
-			} else {
-				// Split body into lines
-				bodyLines := strings.Split(d.RequestBody.Data, "\n")
-				for _, line := range bodyLines {
-					lines = append(lines, "  "+line)
-				}
-			}
-		}
+		lines = append(lines, renderBodyLines(d.RequestBody)...)
 	}
 
 	// Response body
@@ -503,23 +497,33 @@ func (b *BaseModel) formatRequestDetail() []string {
 		}
 		bodyTitle += ")"
 		lines = append(lines, headerStyle.Render(bodyTitle))
-		if d.ResponseBody.Data != "" {
-			if d.ResponseBody.IsBinary {
-				lines = append(lines, dimStyle.Render("[binary data]"))
-			} else {
-				// Split body into lines
-				bodyLines := strings.Split(d.ResponseBody.Data, "\n")
-				for _, line := range bodyLines {
-					lines = append(lines, "  "+line)
-				}
-			}
-		}
+		lines = append(lines, renderBodyLines(d.ResponseBody)...)
 	}
 
 	// Footer hint
 	lines = append(lines, "")
 	lines = append(lines, dimStyle.Render("Press ESC to go back"))
 
+	return lines
+}
+
+// renderBodyLines renders the content lines for a captured body: an
+// unavailable (evicted) notice, a binary-data marker, or the body text split
+// into lines. Full rendering polish (JSON pretty-print) lands in a later commit.
+func renderBodyLines(body *BodyData) []string {
+	if body.Unavailable {
+		return []string{dimStyle.Render("(body no longer available)")}
+	}
+	if body.IsBinary {
+		return []string{dimStyle.Render("[binary data]")}
+	}
+	if body.Data == "" {
+		return nil
+	}
+	var lines []string
+	for _, line := range strings.Split(body.Data, "\n") {
+		lines = append(lines, "  "+line)
+	}
 	return lines
 }
 
@@ -889,7 +893,15 @@ func truncateError(err error, maxLen int) string {
 
 // convertRequestRecordToDetail converts a proxy.RequestRecord to RequestDetailData.
 // This is shared between Model (local mode) and ClientModel (API mode).
+// Bodies are loaded and content-decoded via the proxy loader so FilePath-backed
+// (disk-spilled) bodies are read rather than dropped.
 func convertRequestRecordToDetail(req proxy.RequestRecord) *RequestDetailData {
+	return convertRequestRecordToDetailWithDirs(req, captureAllowedDirs())
+}
+
+// convertRequestRecordToDetailWithDirs is convertRequestRecordToDetail with an
+// explicit FilePath allowlist, separated so tests can supply a temp directory.
+func convertRequestRecordToDetailWithDirs(req proxy.RequestRecord, allowedDirs []string) *RequestDetailData {
 	detail := &RequestDetailData{
 		ID:         req.ID,
 		Timestamp:  req.Timestamp.Format("2006-01-02 15:04:05.000"),
@@ -906,25 +918,59 @@ func convertRequestRecordToDetail(req proxy.RequestRecord) *RequestDetailData {
 		detail.ResponseHeaders = req.Details.ResponseHeaders
 
 		if req.Details.RequestBody != nil {
-			detail.RequestBody = &BodyData{
-				Size:        req.Details.RequestBody.Size,
-				Truncated:   req.Details.RequestBody.Truncated,
-				ContentType: req.Details.RequestBody.ContentType,
-				IsBinary:    req.Details.RequestBody.IsBinary,
-				Data:        string(req.Details.RequestBody.Data),
-			}
+			detail.RequestBody = convertCapturedBodyToBodyData(req.Details.RequestBody, allowedDirs)
 		}
-
 		if req.Details.ResponseBody != nil {
-			detail.ResponseBody = &BodyData{
-				Size:        req.Details.ResponseBody.Size,
-				Truncated:   req.Details.ResponseBody.Truncated,
-				ContentType: req.Details.ResponseBody.ContentType,
-				IsBinary:    req.Details.ResponseBody.IsBinary,
-				Data:        string(req.Details.ResponseBody.Data),
-			}
+			detail.ResponseBody = convertCapturedBodyToBodyData(req.Details.ResponseBody, allowedDirs)
 		}
 	}
 
 	return detail
+}
+
+// convertCapturedBodyToBodyData loads/decodes a captured body for TUI display.
+// An unavailable (evicted) body is marked so the renderer can note it rather
+// than showing garbage; binary and decoded-text semantics follow the loader.
+func convertCapturedBodyToBodyData(body *proxy.CapturedBody, allowedDirs []string) *BodyData {
+	bd := &BodyData{
+		Size:            body.Size,
+		Truncated:       body.Truncated,
+		ContentType:     body.ContentType,
+		ContentEncoding: body.ContentEncoding,
+		IsBinary:        body.IsBinary,
+	}
+
+	decoded, err := proxy.LoadDecodedBody(body, allowedDirs)
+	if err != nil || !decoded.Available {
+		bd.Unavailable = true
+		if decoded.UnavailableReason != "" {
+			bd.UnavailableReason = decoded.UnavailableReason
+		} else {
+			bd.UnavailableReason = "evicted"
+		}
+		return bd
+	}
+
+	bd.IsBinary = decoded.IsBinary
+	// Defense in depth (mirrors the API serve path): never string-convert bytes
+	// that are not valid UTF-8, even if the loaded record claims they are text —
+	// a socket-supplied flag or a mutated disk file must not reach the terminal
+	// as raw control bytes.
+	if !decoded.IsBinary && utf8.Valid(decoded.Data) {
+		bd.Data = string(decoded.Data)
+	} else {
+		bd.IsBinary = true
+	}
+	return bd
+}
+
+// captureAllowedDirs returns the directories a captured body's FilePath may
+// resolve within for the in-TUI loader: the local project capture dir
+// (cwd/.prox/capture) and the shared daemon capture dir under the user's home.
+func captureAllowedDirs() []string {
+	var primary string
+	if cwd, err := os.Getwd(); err == nil {
+		primary = filepath.Join(cwd, constants.CaptureDirectory)
+	}
+	return proxy.CaptureAllowedDirs(primary)
 }

--- a/internal/tui/base.go
+++ b/internal/tui/base.go
@@ -527,8 +527,12 @@ func bodySectionTitle(title string, b *BodyData) string {
 // unavailable (evicted) notice, a binary-data marker, or the body text split
 // into lines. Non-binary JSON bodies (Content-Type contains "json", or the
 // raw text is itself valid JSON) are pretty-printed 2-space indented; any
-// json.Indent failure falls back to the raw text unchanged, and non-JSON
-// text always renders byte-for-byte unchanged.
+// json.Indent failure falls back to the raw text. Text otherwise renders
+// unchanged except that ASCII control characters (< 0x20, other than tab and
+// the newlines used for line splitting) and DEL (0x7F) are replaced with the
+// Unicode replacement character, so ESC/BEL/OSC sequences from a captured body
+// cannot manipulate the terminal. (Classification usually marks such bodies
+// binary, but a socket-supplied record could lie; this is a cheap defense.)
 func renderBodyLines(body *BodyData) []string {
 	if body.Unavailable {
 		return []string{dimStyle.Render("(body no longer available)")}
@@ -550,9 +554,25 @@ func renderBodyLines(body *BodyData) []string {
 
 	var lines []string
 	for _, line := range strings.Split(text, "\n") {
-		lines = append(lines, "  "+line)
+		lines = append(lines, "  "+sanitizeControlChars(line))
 	}
 	return lines
+}
+
+// sanitizeControlChars replaces ASCII control characters that could manipulate
+// the terminal (everything < 0x20 except tab, plus DEL 0x7F) with the Unicode
+// replacement character. Newlines are already consumed by line splitting before
+// this runs, so only intra-line control bytes (ESC, BEL, etc.) are affected.
+func sanitizeControlChars(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r == '\t' {
+			return r
+		}
+		if r < 0x20 || r == 0x7f {
+			return '�'
+		}
+		return r
+	}, s)
 }
 
 // shouldPrettyPrintJSON reports whether a non-binary body should be run

--- a/internal/tui/base.go
+++ b/internal/tui/base.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -477,28 +479,10 @@ func (b *BaseModel) formatRequestDetail() []string {
 	}
 
 	// Request body
-	if d.RequestBody != nil && d.RequestBody.Size > 0 {
-		lines = append(lines, "")
-		bodyTitle := fmt.Sprintf("Request Body (%d bytes", d.RequestBody.Size)
-		if d.RequestBody.Truncated {
-			bodyTitle += ", truncated"
-		}
-		bodyTitle += ")"
-		lines = append(lines, headerStyle.Render(bodyTitle))
-		lines = append(lines, renderBodyLines(d.RequestBody)...)
-	}
+	lines = append(lines, renderBodySection("Request Body", d.RequestBody)...)
 
 	// Response body
-	if d.ResponseBody != nil && d.ResponseBody.Size > 0 {
-		lines = append(lines, "")
-		bodyTitle := fmt.Sprintf("Response Body (%d bytes", d.ResponseBody.Size)
-		if d.ResponseBody.Truncated {
-			bodyTitle += ", truncated"
-		}
-		bodyTitle += ")"
-		lines = append(lines, headerStyle.Render(bodyTitle))
-		lines = append(lines, renderBodyLines(d.ResponseBody)...)
-	}
+	lines = append(lines, renderBodySection("Response Body", d.ResponseBody)...)
 
 	// Footer hint
 	lines = append(lines, "")
@@ -507,9 +491,44 @@ func (b *BaseModel) formatRequestDetail() []string {
 	return lines
 }
 
+// renderBodySection renders one titled request/response body block: a header
+// line carrying size/Content-Type/Content-Encoding/truncation, followed by
+// the body content. Shared by both Model and ClientModel via BaseModel, so
+// this lands the rendering behavior once for both. Returns nil (nothing
+// rendered) when there is no body or it is empty, matching prior behavior.
+func renderBodySection(title string, b *BodyData) []string {
+	if b == nil || b.Size == 0 {
+		return nil
+	}
+	lines := []string{"", headerStyle.Render(bodySectionTitle(title, b))}
+	return append(lines, renderBodyLines(b)...)
+}
+
+// bodySectionTitle builds the section header, e.g.
+// "Request Body (35 bytes, application/json)" or
+// "Response Body (1234 bytes, application/json, gzip, truncated)". The
+// Content-Type and Content-Encoding segments are omitted when absent, and no
+// dangling comma/parens are left behind when every optional segment is empty.
+func bodySectionTitle(title string, b *BodyData) string {
+	parts := []string{fmt.Sprintf("%d bytes", b.Size)}
+	if b.ContentType != "" {
+		parts = append(parts, b.ContentType)
+	}
+	if b.ContentEncoding != "" {
+		parts = append(parts, b.ContentEncoding)
+	}
+	if b.Truncated {
+		parts = append(parts, "truncated")
+	}
+	return fmt.Sprintf("%s (%s)", title, strings.Join(parts, ", "))
+}
+
 // renderBodyLines renders the content lines for a captured body: an
 // unavailable (evicted) notice, a binary-data marker, or the body text split
-// into lines. Full rendering polish (JSON pretty-print) lands in a later commit.
+// into lines. Non-binary JSON bodies (Content-Type contains "json", or the
+// raw text is itself valid JSON) are pretty-printed 2-space indented; any
+// json.Indent failure falls back to the raw text unchanged, and non-JSON
+// text always renders byte-for-byte unchanged.
 func renderBodyLines(body *BodyData) []string {
 	if body.Unavailable {
 		return []string{dimStyle.Render("(body no longer available)")}
@@ -520,11 +539,30 @@ func renderBodyLines(body *BodyData) []string {
 	if body.Data == "" {
 		return nil
 	}
+
+	text := body.Data
+	if shouldPrettyPrintJSON(body) {
+		var buf bytes.Buffer
+		if err := json.Indent(&buf, []byte(body.Data), "", "  "); err == nil {
+			text = buf.String()
+		}
+	}
+
 	var lines []string
-	for _, line := range strings.Split(body.Data, "\n") {
+	for _, line := range strings.Split(text, "\n") {
 		lines = append(lines, "  "+line)
 	}
 	return lines
+}
+
+// shouldPrettyPrintJSON reports whether a non-binary body should be run
+// through json.Indent before display: either its Content-Type declares JSON,
+// or (no such declaration) the raw text happens to be valid JSON on its own.
+func shouldPrettyPrintJSON(body *BodyData) bool {
+	if strings.Contains(strings.ToLower(body.ContentType), "json") {
+		return true
+	}
+	return json.Valid([]byte(body.Data))
 }
 
 // filteredEntries returns log entries after applying filters

--- a/internal/tui/base_convert_test.go
+++ b/internal/tui/base_convert_test.go
@@ -1,0 +1,119 @@
+package tui
+
+import (
+	"bytes"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/charliek/prox/internal/proxy"
+)
+
+func gzipBytes(t *testing.T, data []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	_, err := gw.Write(data)
+	require.NoError(t, err)
+	require.NoError(t, gw.Close())
+	return buf.Bytes()
+}
+
+// TestConvertRequestRecordToDetail_FilePathBacked pins that a FilePath-backed
+// (disk-spilled) body is loaded — previously the TUI conversion read Data
+// directly and dropped disk bodies.
+func TestConvertRequestRecordToDetail_FilePathBacked(t *testing.T) {
+	dir := t.TempDir()
+	payload := []byte(`{"disk":"backed"}`)
+	fp := filepath.Join(dir, "res.bin")
+	require.NoError(t, os.WriteFile(fp, payload, 0600))
+
+	rec := proxy.RequestRecord{
+		ID:        "disk001",
+		Timestamp: time.Now(),
+		Method:    "GET",
+		URL:       "/data",
+		Details: &proxy.RequestDetails{
+			ResponseBody: &proxy.CapturedBody{
+				Size:         int64(len(payload)),
+				CapturedSize: int64(len(payload)),
+				ContentType:  "application/json",
+				FilePath:     fp,
+			},
+		},
+	}
+
+	detail := convertRequestRecordToDetailWithDirs(rec, []string{dir})
+	require.NotNil(t, detail.ResponseBody)
+	assert.False(t, detail.ResponseBody.Unavailable)
+	assert.False(t, detail.ResponseBody.IsBinary)
+	assert.Equal(t, string(payload), detail.ResponseBody.Data)
+}
+
+// TestConvertCapturedBodyToBodyData_InvalidUTF8NotStringified pins the TUI's
+// defense-in-depth: bytes that are not valid UTF-8 are never string-converted
+// for rendering, even when the stored record claims IsBinary=false (e.g. a
+// socket-supplied flag or a disk file mutated after classification).
+func TestConvertCapturedBodyToBodyData_InvalidUTF8NotStringified(t *testing.T) {
+	body := &proxy.CapturedBody{
+		Size:         4,
+		CapturedSize: 4,
+		ContentType:  "text/plain",
+		IsBinary:     false, // lies: data is not valid UTF-8
+		Data:         []byte{'h', 'i', 0xFF, 0xFE},
+	}
+
+	bd := convertCapturedBodyToBodyData(body, nil)
+	require.NotNil(t, bd)
+	assert.True(t, bd.IsBinary, "invalid UTF-8 must be reclassified binary")
+	assert.Empty(t, bd.Data, "invalid UTF-8 must not be string-converted")
+}
+
+func TestConvertRequestRecordToDetail_GzipFilePath(t *testing.T) {
+	dir := t.TempDir()
+	payload := []byte(`{"gzip":"on disk"}`)
+	fp := filepath.Join(dir, "res.bin")
+	require.NoError(t, os.WriteFile(fp, gzipBytes(t, payload), 0600))
+
+	rec := proxy.RequestRecord{
+		ID: "gz1",
+		Details: &proxy.RequestDetails{
+			ResponseBody: &proxy.CapturedBody{
+				ContentType:     "application/json",
+				ContentEncoding: "gzip",
+				IsBinary:        true,
+				FilePath:        fp,
+			},
+		},
+	}
+
+	detail := convertRequestRecordToDetailWithDirs(rec, []string{dir})
+	require.NotNil(t, detail.ResponseBody)
+	assert.False(t, detail.ResponseBody.IsBinary)
+	assert.Equal(t, string(payload), detail.ResponseBody.Data)
+}
+
+func TestConvertRequestRecordToDetail_EvictedFilePath(t *testing.T) {
+	dir := t.TempDir()
+	rec := proxy.RequestRecord{
+		ID: "ev1",
+		Details: &proxy.RequestDetails{
+			ResponseBody: &proxy.CapturedBody{
+				Size:        10,
+				ContentType: "application/json",
+				FilePath:    filepath.Join(dir, "gone.bin"),
+			},
+		},
+	}
+
+	detail := convertRequestRecordToDetailWithDirs(rec, []string{dir})
+	require.NotNil(t, detail.ResponseBody)
+	assert.True(t, detail.ResponseBody.Unavailable)
+	assert.Equal(t, "evicted", detail.ResponseBody.UnavailableReason)
+	assert.Empty(t, detail.ResponseBody.Data)
+}

--- a/internal/tui/base_render_test.go
+++ b/internal/tui/base_render_test.go
@@ -1,0 +1,156 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// joinBody renders a body section and joins the lines into one string so
+// tests can use assert.Contains and sidestep the ANSI styling that wraps
+// header lines.
+func joinBody(t *testing.T, title string, b *BodyData) string {
+	t.Helper()
+	return strings.Join(renderBodySection(title, b), "\n")
+}
+
+// TestRenderBodySection_JSONContentType pins that a body whose Content-Type
+// declares JSON is pretty-printed 2-space indented via json.Indent.
+func TestRenderBodySection_JSONContentType(t *testing.T) {
+	b := &BodyData{
+		Size:        18,
+		ContentType: "application/json",
+		Data:        `{"key":"value"}`,
+	}
+	out := joinBody(t, "Request Body", b)
+	assert.Contains(t, out, `"key": "value"`)
+	assert.Contains(t, out, "\n  {\n")
+}
+
+// TestRenderBodySection_ValidJSONWithoutContentType pins the json.Valid
+// fallback path: no Content-Type declares JSON, but the raw text parses as
+// JSON on its own, so it is still pretty-printed.
+func TestRenderBodySection_ValidJSONWithoutContentType(t *testing.T) {
+	b := &BodyData{
+		Size: 18,
+		Data: `{"key":"value"}`,
+	}
+	out := joinBody(t, "Request Body", b)
+	assert.Contains(t, out, `"key": "value"`)
+}
+
+// TestRenderBodySection_InvalidJSONWithJSONContentType pins that a
+// json.Indent failure falls back to the raw text unchanged, rather than
+// dropping or mangling the body.
+func TestRenderBodySection_InvalidJSONWithJSONContentType(t *testing.T) {
+	b := &BodyData{
+		Size:        13,
+		ContentType: "application/json",
+		Data:        `{not valid json`,
+	}
+	out := joinBody(t, "Request Body", b)
+	assert.Contains(t, out, "  {not valid json")
+	assert.NotContains(t, out, "  {\n")
+}
+
+// TestRenderBodySection_BinaryWithJSONContentType pins that a binary body
+// short-circuits to the "[binary data]" marker without any pretty-print
+// attempt, even when Content-Type claims JSON.
+func TestRenderBodySection_BinaryWithJSONContentType(t *testing.T) {
+	b := &BodyData{
+		Size:        4,
+		ContentType: "application/json",
+		IsBinary:    true,
+		Data:        `{"key":"value"}`, // must be ignored entirely
+	}
+	out := joinBody(t, "Request Body", b)
+	assert.Contains(t, out, "[binary data]")
+	assert.NotContains(t, out, `"key": "value"`)
+}
+
+// TestRenderBodySection_NonJSONTextUnchanged pins that ordinary text renders
+// byte-for-byte, line for line, with no pretty-print interference.
+func TestRenderBodySection_NonJSONTextUnchanged(t *testing.T) {
+	b := &BodyData{
+		Size:        16,
+		ContentType: "text/plain",
+		Data:        "plain text\nline2",
+	}
+	lines := renderBodySection("Request Body", b)
+	assert.Contains(t, lines, "  plain text")
+	assert.Contains(t, lines, "  line2")
+}
+
+// TestRenderBodySection_EmptyContentTypeTitle pins that an absent
+// Content-Type/Content-Encoding leaves no dangling comma or empty-segment
+// artifact in the section title.
+func TestRenderBodySection_EmptyContentTypeTitle(t *testing.T) {
+	b := &BodyData{
+		Size: 10,
+		Data: "plain text",
+	}
+	out := joinBody(t, "Request Body", b)
+	assert.Contains(t, out, "Request Body (10 bytes)")
+	assert.NotContains(t, out, ",  bytes")
+	assert.NotContains(t, out, ", )")
+	assert.NotContains(t, out, "(,")
+}
+
+// TestRenderBodySection_ContentTypeAndEncodingInTitle pins that both fields
+// appear in the section title when present, alongside the truncated flag.
+func TestRenderBodySection_ContentTypeAndEncodingInTitle(t *testing.T) {
+	b := &BodyData{
+		Size:            2048,
+		ContentType:     "application/json",
+		ContentEncoding: "gzip",
+		Truncated:       true,
+		Data:            `{"a":1}`,
+	}
+	out := joinBody(t, "Request Body", b)
+	assert.Contains(t, out, "Request Body (2048 bytes, application/json, gzip, truncated)")
+}
+
+// TestRenderBodySection_Unavailable pins the existing (body no longer
+// available) message for evicted/unreadable bodies, unchanged by this
+// refactor.
+func TestRenderBodySection_Unavailable(t *testing.T) {
+	b := &BodyData{
+		Size:              10,
+		Unavailable:       true,
+		UnavailableReason: "evicted",
+	}
+	out := joinBody(t, "Response Body", b)
+	assert.Contains(t, out, "(body no longer available)")
+}
+
+// TestFormatRequestDetail_BodySections is an integration-level check that
+// formatRequestDetail (shared by Model and ClientModel via BaseModel) wires
+// renderBodySection in for both request and response bodies.
+func TestFormatRequestDetail_BodySections(t *testing.T) {
+	b := &BaseModel{
+		requestDetail: &RequestDetailData{
+			ID:         "req-1",
+			Timestamp:  "2026-07-18 00:00:00.000",
+			Method:     "POST",
+			URL:        "/api/v1/things",
+			StatusCode: 200,
+			RequestBody: &BodyData{
+				Size:        18,
+				ContentType: "application/json",
+				Data:        `{"key":"value"}`,
+			},
+			ResponseBody: &BodyData{
+				Size:              10,
+				Unavailable:       true,
+				UnavailableReason: "evicted",
+			},
+		},
+	}
+
+	out := strings.Join(b.formatRequestDetail(), "\n")
+	assert.Contains(t, out, "Request Body (18 bytes, application/json)")
+	assert.Contains(t, out, `"key": "value"`)
+	assert.Contains(t, out, "Response Body (10 bytes)")
+	assert.Contains(t, out, "(body no longer available)")
+}

--- a/internal/tui/base_render_test.go
+++ b/internal/tui/base_render_test.go
@@ -82,6 +82,23 @@ func TestRenderBodySection_NonJSONTextUnchanged(t *testing.T) {
 	assert.Contains(t, lines, "  line2")
 }
 
+// TestRenderBodyLines_ControlCharsSanitized pins that terminal control
+// sequences embedded in a (mislabeled non-binary) captured body are neutralized
+// before rendering, so a socket-supplied record cannot emit raw ESC/BEL/OSC
+// bytes that manipulate the terminal.
+func TestRenderBodyLines_ControlCharsSanitized(t *testing.T) {
+	b := &BodyData{
+		ContentType: "text/plain",
+		Data:        "before\x1b]0;evil\x07after",
+	}
+	joined := strings.Join(renderBodyLines(b), "\n")
+	assert.NotContains(t, joined, "\x1b", "raw ESC must not reach the terminal")
+	assert.NotContains(t, joined, "\x07", "raw BEL must not reach the terminal")
+	assert.Contains(t, joined, "before")
+	assert.Contains(t, joined, "after")
+	assert.Contains(t, joined, "�", "control chars replaced with U+FFFD")
+}
+
 // TestRenderBodySection_EmptyContentTypeTitle pins that an absent
 // Content-Type/Content-Encoding leaves no dangling comma or empty-segment
 // artifact in the section title.

--- a/internal/tui/client.go
+++ b/internal/tui/client.go
@@ -3,6 +3,7 @@ package tui
 import (
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/charliek/prox/internal/api"
 	"github.com/charliek/prox/internal/domain"
 	"github.com/charliek/prox/internal/proxy"
 )
@@ -230,27 +231,31 @@ func (m ClientModel) fetchRequestDetail(id string) tea.Cmd {
 			detail.ResponseHeaders = resp.Details.ResponseHeaders
 
 			if resp.Details.RequestBody != nil {
-				detail.RequestBody = &BodyData{
-					Size:        resp.Details.RequestBody.Size,
-					Truncated:   resp.Details.RequestBody.Truncated,
-					ContentType: resp.Details.RequestBody.ContentType,
-					IsBinary:    resp.Details.RequestBody.IsBinary,
-					Data:        resp.Details.RequestBody.Data,
-				}
+				detail.RequestBody = clientBodyToBodyData(resp.Details.RequestBody)
 			}
 
 			if resp.Details.ResponseBody != nil {
-				detail.ResponseBody = &BodyData{
-					Size:        resp.Details.ResponseBody.Size,
-					Truncated:   resp.Details.ResponseBody.Truncated,
-					ContentType: resp.Details.ResponseBody.ContentType,
-					IsBinary:    resp.Details.ResponseBody.IsBinary,
-					Data:        resp.Details.ResponseBody.Data,
-				}
+				detail.ResponseBody = clientBodyToBodyData(resp.Details.ResponseBody)
 			}
 		}
 
 		return RequestDetailMsg{ID: id, Details: detail}
+	}
+}
+
+// clientBodyToBodyData maps an API CapturedBodyResponse to TUI BodyData. Data
+// is already decoded (text) or base64 (binary) by the server; an
+// unavailable_reason marks an evicted body.
+func clientBodyToBodyData(body *api.CapturedBodyResponse) *BodyData {
+	return &BodyData{
+		Size:              body.Size,
+		Truncated:         body.Truncated,
+		ContentType:       body.ContentType,
+		ContentEncoding:   body.ContentEncoding,
+		IsBinary:          body.IsBinary,
+		Data:              body.Data,
+		Unavailable:       body.UnavailableReason != "",
+		UnavailableReason: body.UnavailableReason,
 	}
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -123,11 +123,16 @@ type RequestDetailData struct {
 
 // BodyData holds captured body information
 type BodyData struct {
-	Size        int64
-	Truncated   bool
-	ContentType string
-	IsBinary    bool
-	Data        string
+	Size            int64
+	Truncated       bool
+	ContentType     string
+	ContentEncoding string
+	IsBinary        bool
+	Data            string
+	// Unavailable is true when the body existed but could no longer be loaded
+	// (e.g. its disk file was evicted); UnavailableReason explains why.
+	Unavailable       bool
+	UnavailableReason string
 }
 
 // restartResultClearDelay is how long to show restart result before clearing

--- a/test/integration/capture_daemon_test.go
+++ b/test/integration/capture_daemon_test.go
@@ -1,0 +1,394 @@
+package integration
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charliek/prox/internal/constants"
+	"github.com/charliek/prox/internal/proxy"
+	"github.com/charliek/prox/internal/proxyd"
+)
+
+// TestDaemonCapture_EndToEnd exercises the full daemon-mode capture path under
+// an ISOLATED HOME:
+//
+//   - A capture-enabled project (A) and a capture-disabled project (B) share one
+//     HTTP listener but own distinct hostnames, each routed to its own backend.
+//   - Traffic is driven through the dynamic proxy: a small (inline) POST to A, a
+//     large (>64KB, disk-backed) response from A, and a request to B.
+//   - Records are read back two ways — the daemon's /api/v1/requests?project=
+//     endpoint and a ForwardRequests bridge into a project-side RequestManager —
+//     and asserted: A carries request/response bodies, B is metadata-only, and
+//     neither project sees the other's records.
+//   - The disk-backed body file lives under the isolated HOME's .prox/capture and
+//     loads through proxy.LoadDecodedBody with that directory as the allowlist.
+func TestDaemonCapture_EndToEnd(t *testing.T) {
+	skipShort(t)
+
+	// Isolated HOME so the daemon capture dir (~/.prox/capture) is a temp dir and
+	// never touches the user's real state.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	daemonCaptureDir := constants.DaemonCaptureDir(home)
+
+	// Backends. A echoes the request body on any path except /large, which
+	// returns a >64KB body (forces disk-backed capture). B returns a fixed body.
+	largeBody := bytes.Repeat([]byte("L"), 100*1024) // 100KB > 64KB inline threshold
+	backendA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		if r.URL.Path == "/large" {
+			_, _ = w.Write(largeBody)
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		_, _ = w.Write(body) // echo
+	}))
+	defer backendA.Close()
+	backendB := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte("b-response"))
+	}))
+	defer backendB.Close()
+
+	hostA, portA := splitHostPort(t, backendA.URL)
+	hostB, portB := splitHostPort(t, backendB.URL)
+
+	// Daemon components, wired like RunDaemon but with an explicit capture dir and
+	// no cert manager (HTTP only).
+	socketPath := shortSocketPath(t)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	registry := proxyd.NewRegistry()
+	requestMgr := proxy.NewRequestManager(constants.DefaultProxyRequestBufferSize)
+
+	captureMgr, err := proxy.NewCaptureManagerAt(daemonCaptureDir, constants.DefaultCaptureMaxBodySize)
+	if err != nil {
+		t.Fatalf("NewCaptureManagerAt: %v", err)
+	}
+	defer captureMgr.Cleanup()
+	requestMgr.SetEvictionCallback(captureMgr.CleanupRequest)
+
+	dynamicProxy := proxyd.NewDynamicProxy(registry, nil, requestMgr, captureMgr, logger)
+
+	server := proxyd.NewServer(proxyd.ServerConfig{
+		SocketPath: socketPath,
+		Logger:     logger,
+		Version:    "test",
+	})
+	server.SetRegistry(registry)
+	server.SetProxy(dynamicProxy)
+	server.SetRequestManager(requestMgr)
+
+	go func() { _ = server.Start() }()
+	defer server.Shutdown(context.Background())
+	defer dynamicProxy.Shutdown(context.Background())
+
+	client := proxyd.NewClient(socketPath)
+	waitDaemonReady(t, client)
+
+	// One HTTP listener; A and B share the port with distinct domains.
+	proxyPort := freePort(t)
+	if _, err := client.Register(proxyd.RegisterRequest{
+		ProjectDir:     "/projects/a",
+		PID:            os.Getpid(),
+		Version:        "test",
+		Domain:         "a.local.test",
+		Services:       map[string]proxyd.ServiceTarget{"app": {Host: hostA, Port: portA}},
+		HTTPPort:       proxyPort,
+		CaptureEnabled: true,
+	}); err != nil {
+		t.Fatalf("Register A: %v", err)
+	}
+	if _, err := client.Register(proxyd.RegisterRequest{
+		ProjectDir:     "/projects/b",
+		PID:            os.Getpid(),
+		Version:        "test",
+		Domain:         "b.local.test",
+		Services:       map[string]proxyd.ServiceTarget{"app": {Host: hostB, Port: portB}},
+		HTTPPort:       proxyPort,
+		CaptureEnabled: false,
+	}); err != nil {
+		t.Fatalf("Register B: %v", err)
+	}
+
+	const hostnameA = "app.a.local.test"
+	const hostnameB = "app.b.local.test"
+
+	// Project-side bridges (the daemon stream is backfill-free, so start them
+	// before driving traffic).
+	localRMA := proxy.NewRequestManager(constants.DefaultProxyRequestBufferSize)
+	localRMB := proxy.NewRequestManager(constants.DefaultProxyRequestBufferSize)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go proxyd.ForwardRequests(ctx, socketPath, "/projects/a", localRMA)
+	go proxyd.ForwardRequests(ctx, socketPath, "/projects/b", localRMB)
+
+	// Confirm both bridges are live by pinging until each side observes a record.
+	// (Guards against subscribing after the real traffic was already published.)
+	waitBridgesLive(t, proxyPort, hostnameA, hostnameB, localRMA, localRMB)
+
+	// Drive the scenario traffic once each.
+	if got := driveProxy(t, proxyPort, hostnameA, http.MethodPost, "/echo", []byte("hello small")); got != "hello small" {
+		t.Fatalf("A /echo response = %q, want %q", got, "hello small")
+	}
+	if got := driveProxy(t, proxyPort, hostnameA, http.MethodGet, "/large", nil); len(got) != len(largeBody) {
+		t.Fatalf("A /large response len = %d, want %d", len(got), len(largeBody))
+	}
+	if got := driveProxy(t, proxyPort, hostnameB, http.MethodGet, "/", nil); got != "b-response" {
+		t.Fatalf("B response = %q, want %q", got, "b-response")
+	}
+
+	// --- Assert via the ForwardRequests bridge (project-side view) ---
+	echoRec := waitForRecord(t, localRMA, func(r proxy.RequestRecord) bool { return r.URL == "/echo" })
+	largeRec := waitForRecord(t, localRMA, func(r proxy.RequestRecord) bool { return r.URL == "/large" })
+	bRec := waitForRecord(t, localRMB, func(r proxy.RequestRecord) bool { return r.URL == "/" })
+
+	// A: small POST carries inline request + response bodies that round-trip.
+	if echoRec.Details == nil || echoRec.Details.RequestBody == nil || echoRec.Details.ResponseBody == nil {
+		t.Fatalf("A /echo record missing captured bodies: details=%+v", echoRec.Details)
+	}
+	if got := string(echoRec.Details.RequestBody.Data); got != "hello small" {
+		t.Errorf("A /echo request body = %q, want %q", got, "hello small")
+	}
+	if got := string(echoRec.Details.ResponseBody.Data); got != "hello small" {
+		t.Errorf("A /echo response body = %q, want %q", got, "hello small")
+	}
+
+	// A: large response is disk-backed — FilePath under the isolated HOME's
+	// capture dir, no inline Data, and it loads through the allowlist.
+	if largeRec.Details == nil || largeRec.Details.ResponseBody == nil {
+		t.Fatalf("A /large record missing response body")
+	}
+	resBody := largeRec.Details.ResponseBody
+	if resBody.FilePath == "" {
+		t.Fatalf("A /large response body expected disk-backed FilePath, got inline (captured_size=%d)", resBody.CapturedSize)
+	}
+	if !strings.HasPrefix(resBody.FilePath, daemonCaptureDir+string(filepath.Separator)) {
+		t.Errorf("A /large FilePath %q not under daemon capture dir %q", resBody.FilePath, daemonCaptureDir)
+	}
+	if _, err := os.Stat(resBody.FilePath); err != nil {
+		t.Errorf("A /large capture file not on disk: %v", err)
+	}
+	decoded, err := proxy.LoadDecodedBody(resBody, []string{daemonCaptureDir})
+	if err != nil {
+		t.Fatalf("LoadDecodedBody(disk-backed): %v", err)
+	}
+	if !decoded.Available {
+		t.Fatalf("disk-backed body unavailable: %q", decoded.UnavailableReason)
+	}
+	if !bytes.Equal(decoded.Data, largeBody) {
+		t.Errorf("disk-backed body mismatch: got %d bytes, want %d", len(decoded.Data), len(largeBody))
+	}
+
+	// B: capture disabled → metadata only, no Details.
+	if bRec.Details != nil {
+		t.Errorf("B record should be metadata-only, got Details=%+v", bRec.Details)
+	}
+
+	// No cross-project delivery on either bridge.
+	for _, r := range localRMA.Recent(proxy.RequestFilter{}) {
+		if r.ProjectDir != "/projects/a" {
+			t.Errorf("localRMA received foreign record: project=%q url=%q", r.ProjectDir, r.URL)
+		}
+	}
+	for _, r := range localRMB.Recent(proxy.RequestFilter{}) {
+		if r.ProjectDir != "/projects/b" {
+			t.Errorf("localRMB received foreign record: project=%q url=%q", r.ProjectDir, r.URL)
+		}
+	}
+
+	// --- Assert via the daemon /api/v1/requests?project= endpoint ---
+	aRecs := daemonGetRequests(t, socketPath, "/projects/a")
+	if findRecord(aRecs, "/echo") == nil {
+		t.Errorf("daemon /requests for A missing /echo record")
+	}
+	if r := findRecord(aRecs, "/echo"); r != nil {
+		if r.Details == nil || r.Details.RequestBody == nil || string(r.Details.RequestBody.Data) != "hello small" {
+			t.Errorf("daemon /requests A /echo body not captured: %+v", r.Details)
+		}
+	}
+	if r := findRecord(aRecs, "/large"); r == nil || r.Details == nil || r.Details.ResponseBody == nil || r.Details.ResponseBody.FilePath == "" {
+		t.Errorf("daemon /requests A /large not disk-backed as expected")
+	}
+	for _, r := range aRecs {
+		if r.ProjectDir != "/projects/a" {
+			t.Errorf("daemon /requests?project=/projects/a returned foreign record: %q", r.ProjectDir)
+		}
+	}
+
+	bRecs := daemonGetRequests(t, socketPath, "/projects/b")
+	if r := findRecord(bRecs, "/"); r == nil {
+		t.Errorf("daemon /requests for B missing record")
+	} else if r.Details != nil {
+		t.Errorf("daemon /requests B record should be metadata-only, got Details")
+	}
+	for _, r := range bRecs {
+		if r.ProjectDir != "/projects/b" {
+			t.Errorf("daemon /requests?project=/projects/b returned foreign record: %q", r.ProjectDir)
+		}
+	}
+}
+
+// --- helpers ---
+
+func splitHostPort(t *testing.T, rawURL string) (string, int) {
+	t.Helper()
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("parse url %q: %v", rawURL, err)
+	}
+	host, portStr, err := net.SplitHostPort(u.Host)
+	if err != nil {
+		t.Fatalf("split host:port %q: %v", u.Host, err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("port %q: %v", portStr, err)
+	}
+	return host, port
+}
+
+// shortSocketPath returns a socket path under /tmp to stay within the macOS
+// 104-byte Unix socket path limit (t.TempDir() can be too long).
+func shortSocketPath(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "prox-cap-")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	return filepath.Join(dir, "d.sock")
+}
+
+func freePort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve free port: %v", err)
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port
+}
+
+func waitDaemonReady(t *testing.T, client *proxyd.Client) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := client.Health(); err == nil {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("daemon socket did not become ready")
+}
+
+// driveProxy sends one request through the proxy listener with the given Host
+// header and returns the response body as a string.
+func driveProxy(t *testing.T, port int, hostname, method, path string, body []byte) string {
+	t.Helper()
+	var rdr io.Reader
+	if body != nil {
+		rdr = bytes.NewReader(body)
+	}
+	req, err := http.NewRequest(method, fmt.Sprintf("http://127.0.0.1:%d%s", port, path), rdr)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Host = hostname
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("drive %s %s: %v", method, path, err)
+	}
+	defer resp.Body.Close()
+	got, _ := io.ReadAll(resp.Body)
+	return string(got)
+}
+
+// waitBridgesLive pings A and B through the proxy until each project-side manager
+// has observed at least one record, confirming both SSE subscriptions are active.
+func waitBridgesLive(t *testing.T, port int, hostnameA, hostnameB string, localRMA, localRMB *proxy.RequestManager) {
+	t.Helper()
+	deadline := time.After(5 * time.Second)
+	tick := time.NewTicker(25 * time.Millisecond)
+	defer tick.Stop()
+	for {
+		if localRMA.Count() > 0 && localRMB.Count() > 0 {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("bridges did not go live (A=%d, B=%d)", localRMA.Count(), localRMB.Count())
+		case <-tick.C:
+			_ = driveProxy(t, port, hostnameA, http.MethodGet, "/ping", nil)
+			_ = driveProxy(t, port, hostnameB, http.MethodGet, "/ping", nil)
+		}
+	}
+}
+
+func waitForRecord(t *testing.T, rm *proxy.RequestManager, match func(proxy.RequestRecord) bool) proxy.RequestRecord {
+	t.Helper()
+	deadline := time.After(3 * time.Second)
+	tick := time.NewTicker(20 * time.Millisecond)
+	defer tick.Stop()
+	for {
+		for _, r := range rm.Recent(proxy.RequestFilter{}) {
+			if match(r) {
+				return r
+			}
+		}
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for matching record")
+		case <-tick.C:
+		}
+	}
+}
+
+func findRecord(recs []proxy.RequestRecord, urlPath string) *proxy.RequestRecord {
+	for i := range recs {
+		if recs[i].URL == urlPath {
+			return &recs[i]
+		}
+	}
+	return nil
+}
+
+// daemonGetRequests fetches records for a project from the daemon's unix-socket
+// /api/v1/requests endpoint.
+func daemonGetRequests(t *testing.T, socketPath, project string) []proxy.RequestRecord {
+	t.Helper()
+	client := &http.Client{Transport: &http.Transport{
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
+		},
+	}}
+	reqURL := fmt.Sprintf("http://proxyd/api/v1/requests?project=%s", url.QueryEscape(project))
+	resp, err := client.Get(reqURL)
+	if err != nil {
+		t.Fatalf("daemon GET /requests: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("daemon GET /requests status %d", resp.StatusCode)
+	}
+	var out struct {
+		Requests []proxy.RequestRecord `json:"requests"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode /requests: %v", err)
+	}
+	return out.Requests
+}


### PR DESCRIPTION
## Summary

Overhauls the requests/capture feature (the ngrok-inspector-style TUI + API) across four workstreams from a full-session analysis, executed as plan 005 with a 3-reviewer panel (Codex, GLM 5.2, CodeRabbit) and per-commit external reviews.

### WS1 — Body capture in shared-daemon mode (the headline)
The shared proxy daemon previously recorded metadata only; `prox requests <id> --body` in the daemon topology (how real projects run) always showed "capture not enabled". Now:
- The daemon runs its own CaptureManager at `~/.prox/capture`, gated **per project** via the previously-dead `CaptureEnabled` registration field (`prox up --capture` / `proxy.capture.enabled` just work).
- Records are scoped by **project identity**, not hostname (two projects can own one hostname on different ports — hostname scoping could leak/purge across projects). Daemon request endpoints now require `?project=`.
- One consolidated removal path (explicit deregister AND the stale-PID crash sweep, which previously bypassed cleanup entirely and leaked listeners) purges records + body files; the sweep is PID-guarded against re-registration races.
- The SSE bridge delivers full Details; its scanner was replaced with a bounded reader (the old 64KB `bufio.Scanner` limit would have silently killed the stream on any body-carrying event; the disk-write-failure fallback can produce ~2.7MB events).

### WS2 — Gzip/binary corruption fix
Compressed responses were previously captured and then destroyed: `Content-Type: application/json` forced "text", and JSON marshaling replaced the invalid UTF-8 gzip bytes with U+FFFD — unrecoverable. Now:
- Binary classification requires the complete retained buffer to be valid UTF-8 (full scan, not the old 512-byte sample that multipart bodies defeated).
- Bodies store raw wire bytes + `content_encoding`; gzip/x-gzip decode at serve time (10MB decoded cap, truncated/corrupt/unsupported → base64 raw, always recoverable). `is_binary` with `include=body` reflects the served bytes.
- `size` now reports the true original size; new `captured_size` reports retained bytes (a 1.5MB upload reports `size: 1500000`, not 1048576).
- Evicted bodies return HTTP 200 + `unavailable_reason: "evicted"` instead of ambiguous empty data.

### WS3 — Agent/LLM ergonomics
- New `url_contains` API filter; `--url`, `--since` (RFC3339 or `5m`), `--max-status` CLI flags: `prox requests --url /api --since 5m --min-status 400 --max-status 499`.
- `hostname` exposed in responses (port-stripped, IPv6-safe); daemon `/requests` honors `?limit=`.

### WS4 — TUI polish
- Body section titles show Content-Type/Content-Encoding; JSON bodies pretty-print (2-space `json.Indent`); disk-spilled bodies now load in the local TUI (previously blind to `FilePath`).

## Security hardening (from reviews)
- `FilePath` values arriving over the daemon socket are loaded only through a symlink-resolving allowlist (project + daemon capture dirs); `file_path` never appears in API JSON.
- Defense-in-depth UTF-8 validation before any string conversion in both API and TUI render paths.
- Request-ID generation now includes a per-process counter (identical simultaneous requests previously collided at 28 bits → capture-file overwrite/cross-delete).
- Canceled-request finalize race fixed (capture snapshots freeze before records are published/serialized); WebSocket upgrades record metadata only instead of garbage 200/empty captures.

## Verification
- Gate on every commit: `make lint && make test && make test-race && make build` (427+ tests, now ~490).
- Per-commit Codex correctness reviews: 11 findings fixed (each dispositioned in its commit message), 3 accepted as pre-existing/inherent and recorded in the plan.
- New daemon-mode **integration test** (isolated HOME): two projects (capture on/off) on one listener, inline + disk-spilled bodies, cross-project isolation, allowlisted loading.
- **Live functional pass** with the built binary in daemon mode under an isolated HOME (the user's real daemon untouched): gzip decode readable end-to-end, true sizes on truncation, 200KB disk spill served, `--url/--since` filters, evicted-body contract, daemon shutdown removes the capture dir. Transcript kept with the plan artifacts.

## Impact / notes
- **Daemon restart required after upgrade** to get daemon capture — the existing exact-version gate makes this loud (`prox proxy stop --force`).
- Same-version wire changes only (daemon and CLI always run the same binary version by design), so the `?domains=` → `?project=` endpoint change needs no compat shim.
- Dependency/privacy: no new dependencies; captured bodies stay on-machine under `~/.prox/capture` (0600/0700 perms); API serves them only on localhost with existing auth semantics.
- Accepted risks (plan §9): in-flight request completing after project purge leaves one FIFO-evicted record; deregister listener-close reorder window (pre-existing); PID-reuse liveness masking (pre-existing).

Deferred work is filed as issues (listed in a comment below).

---

<details>
<summary>Full plan 005 (panel-reviewed, with § Verified)</summary>

```markdown
# 005 — Requests/capture feature: daemon-mode capture, gzip fix, LLM ergonomics, TUI polish

Status: panel-reviewed (Codex + GLM 5.2 + CodeRabbit, 2026-07-18)
Repo: /Users/charliek/projects/prox (single-repo scope)
Baseline: main @ 05b86c1
Branch: feature/plan-005-requests-capture
Artifacts: ~/.claude/plans/prox/005-requests-capture-fixes/

Panel corrections incorporated (see §10 for dispositions):
- Full-buffer UTF-8 scan replaces 512-byte sampling (CodeRabbit H1, Codex).
- Project identity, not hostname, drives daemon record routing/purge (Codex).
- Exported capture abstraction pinned before daemon reuse (Codex, CodeRabbit M2).
- Forwarder SSE reader rewritten — 1MB scanner bound was invalid (Codex, CodeRabbit M1).
- Crash-path (stale-PID) purge via one consolidated removal function (CodeRabbit H2, Codex).
- Body-unavailable API contract, captured_size field, decode output cap (Codex).
- FilePath allowlist in loader (GLM). -race added to gate (GLM).
- Memory bound corrected to ~128MB (all three).

## 1. Problem / motivation

The requests feature (ngrok-inspector-style TUI + API for proxied HTTP
traffic) was analyzed end-to-end. Core capture works in the in-process
proxy path, but:

1. **Shared-daemon mode captures no bodies/headers** — the topology all of
   the user's real projects use. The "point an LLM or human at the payload
   sequence that caused an error" goal fails there.
2. **Gzip-encoded responses are captured corrupted and unrecoverable** via
   the API (invalid UTF-8 mangled by JSON string conversion).
3. **API/CLI ergonomics gaps** make agent-driven use clumsy (no URL filter,
   `since` missing from CLI, hostname never exposed, misleading
   "capture not enabled" hint).
4. **TUI polish**: no JSON pretty-print, Content-Type not shown.

## 2. Current state (verified against baseline)

- In-process proxy captures request bodies via TeeReader
  (`internal/proxy/capture.go:86-117`) and responses via
  `capturingResponseWriter` (`capture.go:297-383`); hybrid storage inline
  ≤64KB / disk above (`capture.go:236-269`), 1MB cap, ring buffer of 1000
  with eviction cleanup (`internal/proxy/proxy.go:85-87`). Verified live:
  POST bodies, 200KB disk path, 1.5MB truncation, SSE stream, filters.
- Daemon path records metadata only: `DynamicProxy.handler` uses a
  status-only writer and never constructs a CaptureManager
  (`internal/proxyd/dynamic_proxy.go:158-224`, `daemon.go:149-163`).
- Projects in daemon mode receive records via SSE bridge
  (`internal/proxyd/forwarder.go:21-92`) into a local RequestManager
  (`internal/cli/up.go:838-843`); `bufio.Scanner` default 64KB token limit
  at `forwarder.go:73`. The bridge is stream-only: no initial snapshot
  fetch on (re)connect.
- `RegisterRequest.CaptureEnabled` already sent by clients
  (`internal/proxyd/types.go:16-26`, `up.go:816`) but never read
  daemon-side. `prox up --capture` flag exists (`up.go:82,192-197`).
- Version gate is exact-match both directions (`daemon.go:48-58`,
  `server.go:125-135`) — no cross-version wire compat needed.
- Registry keys ownership by hostname:port (`registry.go:118-126`), so two
  projects may own the same hostname on different ports. The SSE bridge
  filters by hostname only (`server.go:330-335`), and `PurgeByHostnames`
  (`requests.go:294-343`, zero production callers) would purge across
  projects. Stale-PID cleanup calls `registry.Deregister` directly
  (`daemon.go:173-191`, `registry.go:275-289`), bypassing
  `handleDeregister`.
- Gzip corruption verified live: `isBinaryContent` trusts Content-Type
  first and samples only 512 bytes (`capture.go:398-432`); text path does
  `string(data)` then JSON-marshals, destroying invalid UTF-8
  (`internal/api/handlers.go:492-497`). (Note: the transport's missing
  `DisableCompression` is an observation, NOT a fix lever — the reverse
  proxy legitimately passes through encoded bytes when the client asked
  for them; the bug is in classification/serving.)
- Truncated bodies report captured size, not original, despite the field
  doc (`requests.go:38`; verified live with a 1.5MB upload → 1048576).
- API: `GET /api/v1/proxy/requests[,/{id},/stream]` (project API,
  distinct from the daemon's unix-socket `/api/v1/requests...`);
  filter params at `handlers.go:562-595`. CLI already emits `max_status`
  in `buildProxyRequestQueryParams` (`client.go:177`) — only the Cobra
  flag/validation/assignment are missing; `since` is absent end-to-end
  in the CLI. Daemon `handleGetRequests` hardcodes limit=100
  (`server.go:382`). `Hostname` recorded but never exposed
  (`responses.go:205-215`); local proxy never sets it
  (`proxy.go:442-453`).
- Daemon-mode projects have no CaptureManager (`up.go:877` standalone
  branch only): `convertCapturedBody` (`handlers.go:483-487`) skips disk
  bodies when it is nil, and TUI local conversion reads `Data` directly
  (`base.go:890-929`) — both FilePath-blind.
- TUI: detail render `formatRequestDetail` (`base.go:423-524`), body
  blocks duplicated at 476-517; `BodyData` already carries ContentType
  (`model.go:125-131`); Model and ClientModel share BaseModel so display
  changes land once.
- Gate (per Makefile + plan-004 convention):
  `make lint && make test && make test-race && make build` (~3min).

## 3. Design decisions (PINNED)

### WS1 — daemon-mode body capture

**D1. Daemon gets its own CaptureManager, capture dir `~/.prox/capture`.**
Constructed in `RunDaemon` alongside the RequestManager, enabled, 1MB max
body size. Constructor trap: `NewCaptureManager(cfg, workDir)` appends
`.prox/capture` to workDir — passing `~/.prox` would yield
`~/.prox/.prox/capture`. Add an explicit capture-dir constructor
(`NewCaptureManagerAt(captureDir string, maxBodySize int64)`) used by the
daemon; the existing constructor delegates to it. Cleanup: defer
`captureMgr.Cleanup()` immediately after construction so early startup
errors clean up; on graceful shutdown it runs LAST — after
`dynamicProxy.Shutdown` (in-flight handlers write capture files) and after
`server.Shutdown`. Also call `requestMgr.Close()` before `server.Shutdown`
so active SSE subscribers can't hold the socket server open (mirrors
standalone shutdown ordering).

**D2. Per-project capture gating via the existing `CaptureEnabled` wire
field.** `registry.Register` stamps capture enablement onto each route;
`DynamicProxy.handler` captures only when the matched route has it. Per-
project `MaxBodySize` NOT plumbed (global 1MB daemon-side) — future work.

**D3. Project identity on daemon records (Codex blocker fix).** Daemon
`RequestRecord`s gain `ProjectDir string` (JSON `project_dir,omitempty`),
stamped from the matched route's owning registration. The SSE bridge
subscribes by project (`?project=<dir>` on the daemon stream endpoint,
exact match) instead of hostname list; `RequestFilter` gains `ProjectDir`.
Purge becomes `PurgeByProject(projectDir)`. Hostname remains request
metadata only. This prevents cross-project record/body delivery and
cross-project purges when two projects own the same hostname on different
ports. (Alternative — global hostname ownership — rejected: more
restrictive for users, and identity is the semantically correct key.)

**D4. Eager details delivery over the existing SSE bridge (no lazy
body-fetch endpoint).** The daemon's stream already serializes complete
`RequestRecord`s; once Details are populated they flow automatically.
Precisely: inline bodies (≤64KB each) ride the event as base64 JSON;
larger bodies ride as a `FilePath` reference into `~/.prox/capture`
(shared filesystem, same-user trust model — the daemon socket already
assumes this; the daemon's `/requests` JSON endpoint equally serializes
these fields, acknowledged). Project-side, records land in the local
RequestManager; API/TUI read them via the D6 loader.
**Forwarder reader rewrite:** `bufio.Scanner` is replaced with a
`bufio.Reader`-based line reader. Rationale: the 64KB-inline assumption
does NOT bound events — on disk-write failure both capture paths fall
back to inline storage up to 1MB (`capture.go:137-148,255-262`),
producing >2.6MB of base64, and headers are unbounded by the body
threshold. The reader enforces an explicit per-event cap of
`2*base64Len(maxBodySize) + 1MB` slack; an oversized event is skipped
with a logged warning (stream continues) rather than killing the
subscription. Reuse `constants.Scanner*` buffer constants where they fit.
Alternative considered: metadata-only stream + lazy body-fetch socket
endpoint — smaller project memory but more surface (new endpoint, client
method, api dependency on daemon client, TUI changes); rejected.
Accepted cost: up to ~128MB worst-case duplicated inline-body memory per
subscribed project (1000 × 2 × 64KB), same order as standalone today.
Known gap carried as non-goal: the bridge remains stream-only (no
snapshot backfill on reconnect) — records proxied while a project is
disconnected are not retrievable from that project's API.

**D5. One consolidated project-removal path (CodeRabbit H2 / Codex).**
A single registry-level `RemoveProject(projectDir)` (or equivalent)
performs: route removal, `PurgeByProject` on the daemon RequestManager
(eviction callback deletes body files), listener cleanup. Called from
BOTH `handleDeregister` and the stale-PID sweep (which today bypasses the
handler), and from registration rollback where applicable. Crash-path
cleanup is a first-class acceptance criterion.

**D6. Body loading decoupled from CaptureManager, with path allowlist.**
Package-level loader in `internal/proxy`:
- `LoadCapturedBody(body *CapturedBody, allowedDirs []string) ([]byte, error)`
  — inline Data or FilePath read; FilePath MUST resolve inside one of
  `allowedDirs` (project capture dir, `~/.prox/capture`) via
  filepath-clean + rel check, else error (GLM security fix: a
  socket-supplied path cannot exfiltrate arbitrary files through the
  project API).
- `DecodeCapturedBody(body, raw []byte) DecodedBody` — encoding handling
  per D8.
- `LoadDecodedBody(body, allowedDirs) (DecodedBody, error)` — the
  composition. `DecodedBody{Data []byte, IsBinary bool, ContentEncoding
  string, Available bool, UnavailableReason string}` (structured result
  per Codex, not parallel returns).
Consumers: api `convertCapturedBody`, TUI `convertRequestRecordToDetail`
(fixes its FilePath-blindness). The CLI does NOT use the loader — it
consumes `CapturedBodyResponse` from the project API (`commands.go:527`);
it only needs rendering for the new response fields.
`CaptureManager.LoadBody` delegates to `LoadCapturedBody`.

**D7. Body-unavailable API contract.** When a FilePath body cannot be
read (evicted daemon-side, daemon restarted), the record remains HTTP 200
and `CapturedBodyResponse` reports `unavailable_reason: "evicted"` with
no `data`. Empty data alone is NOT the signal (indistinguishable from an
actually-empty body or `include=body` omitted). Propagated through
`BodyData` → both TUI conversions → CLI formatting
("(body no longer available)").

**D8. Misleading hint fixed.** With WS1, config/`--capture` propagate to
the daemon via registration, so the existing hint text becomes true in
daemon mode; the evicted case gets the D7 message instead of the hint.

### WS2 — gzip / binary-detection corruption

**D9. Integrity rule: content is never represented as text unless the
COMPLETE retained data is valid UTF-8.** `isBinaryContent` reworked:
known-binary content types stay binary; otherwise `utf8.Valid` over the
entire retained buffer + control-char scan decides (full scan, not the
current 512-byte sample — a multipart body that is textual for 512 bytes
then binary was exactly the corruption class to kill; ≤1MB scan cost
accepted). Valid UTF-8 may still be binary (control chars / known-binary
CT). Empty-body early return preserved. Serve path (`convertCapturedBody`)
re-validates before `string(data)` as defense in depth.

**D10. Store raw wire bytes + record `ContentEncoding`; decode at serve
time.** "Raw" is defined as: bytes delivered to the downstream client
(the response-writer capture point) / bytes received from the client (the
TeeReader capture point). New `CapturedBody.ContentEncoding` captured
from the corresponding `Content-Encoding` header.
`DecodeCapturedBody` behavior:
- Supported: `gzip`, `x-gzip` (case-insensitive, surrounding whitespace
  tolerated). `identity`/empty → no decode. Anything else — `deflate`,
  `br`, `zstd`, chained values (`gzip, br`) — unsupported → raw base64,
  `is_binary: true`. (`deflate`'s zlib-vs-raw ambiguity pushed to future
  work with br/zstd rather than shipping a half-right decoder.)
- Truncated bodies: no decode attempt (stream is broken) → raw base64.
- Decode output capped via `io.LimitReader` at 10MB decoded; exceeding
  the cap → treat as decode failure → raw base64 (zip-bomb guard).
- On successful decode: serve decoded bytes; `is_binary` in the response
  reflects the DECODED bytes; `content_encoding` reports the stored
  encoding. Stored `IsBinary` (raw) and served `is_binary` (decoded) may
  legitimately diverge — pinned in a unit test so a refactor doesn't
  collapse them.
Alternative — decompress at capture time — rejected: loses wire
fidelity, breaks size semantics, can't handle truncated streams.

**D11. Size semantics.** `size` = total encoded bytes observed by the
capture wrapper before truncation (counting continues after the cap; NOT
Content-Length, NOT decoded size). New `captured_size` = encoded bytes
retained. `truncated` ⇔ `captured_size < size`. Both fields on
`CapturedBody` and `CapturedBodyResponse`.

### WS3 — LLM/agent ergonomics (API + CLI)

**D12. API additions (backward-compatible):**
- `url_contains` filter on list + stream: case-insensitive substring over
  URL path+query only (never scheme/host — matches the TUI `s` filter's
  reference behavior). Added to `RequestFilter`, `parseProxyRequestParams`,
  `matchesFilter`, and `domain.ProxyRequestParams` (+`Since` there too).
- `hostname` field (`omitempty`) on `ProxyRequestResponse`; local proxy
  path stamps `Hostname` (host from `r.Host`, port stripped).
- Daemon socket `handleGetRequests` honors `?limit=`, same clamp
  semantics as the project API (invalid/out-of-range → default 100,
  max 1000).

**D13. CLI additions:** `--since` (RFC3339 or Go duration sugar, e.g.
`5m`, converted client-side from one captured `time.Now()`, serialized
RFC3339Nano; malformed → error), `--max-status` (validated 100-599 and
`min<=max` when both set), `--url <substr>`. `--json` gains new fields
automatically.

**D14. Non-goal: pagination/cursor API** (ring of 1000 + limit/since is
adequate for the agent use case; future work).

### WS4 — TUI polish (scoped down)

**D15. In scope: Content-Type in body section titles + JSON
pretty-printing** in the detail view. Factor duplicated body blocks
(`base.go:476-517`) into one `renderBodySection` helper. Pretty-print via
`json.Indent(dst, src, "", "  ")` (2-space, deterministic for tests) when
content type contains "json" OR `json.Valid` succeeds, body non-binary;
fall back to raw text on failure; non-JSON text byte-for-byte unchanged.

**D16. Deferred to GitHub issues (filed in Phase 6):**
- Explicit row cursor + `/` search-match navigation for requests.
- In-flight/streaming request visibility (record at header time).
- Per-project fairness/quotas + per-project max body size in shared daemon.
- Binary body preview (hex) in TUI.
- `deflate`/`zstd`/`br` decode support.
- Cursor pagination for the requests API.
- SSE bridge snapshot backfill on reconnect (record loss during backoff).

## 4. Deviations / non-goals

- No release/deploy; PR left open for user review.
- No changes to logs feature or supervisor.
- Daemon upgrade UX unchanged (exact-version gate forces restart —
  loud, not silent). User's long-running daemon must be restarted to get
  daemon capture.
- WebSocket/hijacked connections: no body capture after hijack (inherent).
- SSE bridge remains stream-only (no reconnect backfill) — see D16.
- Records proxied before a project connects are not in that project's
  local API (pre-existing; WS1 acceptance applies to records that arrive
  after registration).

## 5. Work breakdown (gated commits)

Gate per commit: `make lint && make test && make test-race && make build`.

- **C1 (opus) — Binary detection, size semantics, ContentEncoding.**
  D9 + D11 + ContentEncoding field (data model only).
  `capture.go`, `requests.go`. Tests: gzip-JSON classified binary;
  invalid-UTF-8-after-512-bytes (multipart-style) classified binary;
  empty body; valid-UTF-8-with-control-chars binary; size counts past
  truncation (multi-write, exact-cap boundary); captured_size vs size.
- **C2 (opus) — Exported capture abstraction + loaders/decode + API/TUI
  serve path.** Exported `CaptureResponseWriter` via
  `CaptureManager.WrapResponseWriter(w)` + `FinalizeResponse(id, w)` +
  exported `GenerateRequestID` (D-prereq for C4, per Codex M2);
  `NewCaptureManagerAt`; D6 loader hierarchy incl. FilePath allowlist;
  D10 decode; D7 unavailable contract; api `convertCapturedBody` rewrite
  (+`content_encoding`, `captured_size`, `unavailable_reason`); TUI
  conversions use loader; CLI renders new fields.
  Tests: gzip + x-gzip round-trip through API returns readable JSON
  (byte-equality on decoded content); corrupt stream, truncated-gzip,
  unsupported-encoding → base64 raw with is_binary true; decode-cap
  exceeded → raw; stored-IsBinary vs served-is_binary divergence;
  allowlist rejects out-of-root FilePath; `file_path` never appears in
  API JSON; disk-backed load; evicted-file → unavailable_reason, HTTP 200.
- **C3 (opus) — Project identity + lifecycle consolidation (daemon).**
  D3 + D5: ProjectDir on records, stream/filter/purge by project,
  consolidated `RemoveProject` used by deregister + stale-PID sweep +
  registration rollback; `requestMgr.Close()` in daemon shutdown.
  Tests: two projects, same hostname different ports — no cross
  delivery, no cross purge; stale-PID path purges records; deregister
  purges records.
- **C4 (opus) — Daemon capture core.** D1 + D2: CaptureManagerAt in
  RunDaemon, defer-cleanup + shutdown ordering, eviction wiring, route
  capture stamping, DynamicProxy capture wrap (request ID generated
  pre-proxy for file naming). Tests: captures when enabled, metadata-only
  when disabled; eviction deletes files; shutdown removes capture dir.
- **C5 (opus) — Delivery to projects, end-to-end.** D4 forwarder reader
  rewrite (+oversized-event skip), D7/D8 project-side surfacing.
  Integration test (test/integration): daemon-mode e2e with isolated
  HOME — two projects (capture on / off), POST with inline body, large
  disk-backed body, assert via project API (headers+bodies for enabled
  project, metadata-only for disabled, no cross-project records),
  daemon capture dir location under isolated HOME; forwarder unit test
  with largest-permitted event (1MB-inline fallback record) and
  oversized-event skip.
- **C6 (sonnet) — API/CLI ergonomics.** D12 + D13. Tests: filter
  matching (path+query only), param building, hostname stamping strips
  port, daemon limit clamp, CLI flag validation errors, url_contains on
  list and stream.
- **C7 (sonnet) — TUI polish.** D15. Tests on `formatRequestDetail`
  (direct-call style): JSON CT, valid JSON without CT, invalid JSON with
  JSON CT, binary with JSON CT, non-JSON text unchanged, empty CT title,
  Content-Type shown, unavailable body message.

Order: C1→C2 (decode needs ContentEncoding), C2→C4 (exported abstraction),
C3→C4→C5 (identity before capture before delivery). C6, C7 independent
after C2.

## 6. File map (indicative)

- internal/proxy/capture.go, requests.go — C1-C4
- internal/api/handlers.go, responses.go — C2, C6
- internal/domain/ (ProxyRequestParams) — C6
- internal/proxyd/daemon.go, registry.go, dynamic_proxy.go, server.go,
  forwarder.go, types.go — C3-C5
- internal/cli/up.go, client.go, commands.go — C5, C6
- internal/tui/base.go, model.go, client.go — C2, C7
- internal/constants/constants.go — capture/reader constants as needed
- test/integration/ — C5
- docs/reference/{api,cli,configuration,tui}.md — updated in the commit
  changing each surface

## 7. Acceptance criteria

WS1 (daemon capture):
- Two projects on one daemon (isolated HOME), A capture-enabled, B not:
  A's `prox requests <id> --body` (record arriving post-registration)
  returns headers + request/response bodies (inline AND disk-backed
  cases); B gets metadata only; neither sees the other's records.
- Explicit deregister AND stale-PID removal purge only the owning
  project's records + body files.
- Daemon shutdown removes `~/.prox/capture` (isolated HOME) and is not
  delayed by active SSE subscribers.
- Evicted/missing body file → HTTP 200 with `unavailable_reason`,
  CLI shows "(body no longer available)".

WS2 (integrity/decode):
- Gzip JSON response via `?include=body`: readable JSON text,
  `content_encoding: "gzip"`, decoded bytes byte-equal to the original
  payload, `is_binary: false` (decoded semantics).
- Truncated gzip: raw base64, `is_binary: true`.
- Any body whose complete retained bytes are not valid UTF-8 round-trips
  base64 byte-exact (multipart case included).
- 1.5MB upload: `size: 1572864`, `captured_size: 1048576`,
  `truncated: true`.

WS3 (ergonomics):
- `prox requests --url /api --since 5m --max-status 499` filters
  correctly; invalid flag values error cleanly.
- API list/stream honor `url_contains` (path+query only); responses
  include `hostname` (port-stripped); daemon socket honors `limit` with
  project-API clamp semantics.

WS4 (TUI):
- Detail view shows Content-Type in body titles; JSON renders 2-space
  indented; non-JSON text unchanged; binary/unavailable messages shown.

All: gate green per commit; no regressions.

## 8. Verification plan

Beyond automated tests (C5 carries the daemon-mode integration test):
a live two-topology functional pass repeating the analysis harness —
build binary; scratch project; drive plain/gzip/large/truncated/multipart
traffic with curl against (a) standalone http_port mode and (b) daemon
mode under an ISOLATED HOME (never the user's real running daemon);
assert bodies via `prox requests --body` and the JSON API, including the
evicted-body and two-project isolation cases. Artifacts (transcripts) to
`~/.claude/plans/prox/005-requests-capture-fixes/`. TUI rendering
verified by unit tests only (no PTY automation) — accepted coverage
limit.

## 9. Risks / open items

- Shared-daemon memory: ring 1000 × 2 × ≤64KB inline ≈ 128MB theoretical
  cap daemon-side and per subscribed project (TUI string conversion can
  roughly double displayed records). Typical dev traffic far below.
  Future: per-project quotas (issue).
- User's real daemon (0.1.2, long uptime) needs restart post-upgrade;
  version gate makes this loud.
- SSE bridge carries bodies + FilePaths over the unix socket — same-user
  trust model, unchanged; project API never exposes file_path (tested).
- Decode cap (10MB) is a judgment call; revisit if real payloads exceed.
- Accepted (C3 codex review): an in-flight request that completes AFTER its
  project's removeProject purge leaves one orphaned record (+ body files
  once C4 lands) that only FIFO eviction cleans; quiescing in-flight
  requests on deregister is disproportionate for a dev tool. Also
  pre-existing and unchanged: deregister's registry-release→listener-close
  window can 409 a rapid re-register (5s grace period mitigates), and PID
  reuse can mask a dead project from the stale sweep (pidfile.go liveness
  is signal-0 based).
- Panel D4 alternative (lazy fetch) remains the fallback if eager
  delivery shows problems in practice.

## § Verified (2026-07-18, post-implementation)

All 7 commits landed on feature/plan-005-requests-capture (547e385..84c4916),
each through the full gate (lint, test, test-race, build) plus per-commit
codex correctness reviews (11 findings fixed across C1-C6; dispositions in
commit messages; C7 display-only, self-reviewed).

Beyond automated tests, a live two-topology-style pass ran the real binary
in DAEMON MODE under an isolated HOME (details + raw results in
005-requests-capture-fixes/verification-transcript.md): gzip bodies decode
readable through the API and CLI (previously corrupted), original-vs-
captured sizes report correctly for a truncated 1.5MB upload, daemon-mode
body capture works end-to-end including 200KB disk spill, --url/--since
filters work, the evicted-body contract returns 200 + unavailable_reason,
and daemon shutdown removes ~/.prox/capture cleanly.

Known-unexercised paths (accepted): TUI rendering verified by unit tests
only (no PTY automation); forwarder oversized-event skip and WebSocket
hijack behavior verified at unit seams; two-project isolation and
stale-PID purge verified by the automated integration/lifecycle tests
rather than the live pass.

## 10. Panel dispositions (summary)

Adopted: CodeRabbit H1/H2/M1/M2/M3, L1-L3 acknowledgments; Codex blockers
(export boundary, project identity, scanner bound) + captured_size +
unavailable contract + decode cap/encoding-token handling + size
definition + lifecycle consolidation + shutdown ordering + AC/test
expansions + CLI max_status claim correction; GLM allowlist, -race gate,
baseline hash, is_binary post-decode pin, truncated-gzip AC, function
hierarchy pin, DisableCompression clarification, indent pin, url scope
pin, constructor-path trap.
Adapted: deflate dropped from scope (GLM's "zlib-vs-raw" ambiguity +
Codex's test demand resolved by deferring deflate/br/zstd together).
Skipped: removing model assignments / session context from the plan
(gauntlet execution convention — kept, harmless to outside readers);
markdown-table commit format (cosmetic); replacing line refs with symbol
refs (partially done where it mattered).
No contradictions between reviewers requiring user arbitration.

```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgMgg6eo4LgLTCkfYSARcH


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `url_contains`, `since`, and `max-status` filtering for proxy request search, including streaming results.
  - Proxy request responses now include `hostname`, and captured-body details are richer (decoded vs raw handling, `captured_size`, `content_encoding`, truncation, and unavailable indicators).
  - Added per-project capture controls with improved shared-daemon behavior; TUI now includes a Request Detail View with formatted headers and safe body rendering.
- **Documentation**
  - Updated API/CLI/configuration/TUI references to match the new filters, hostname fields, and captured-body/capture retention semantics.
- **Bug Fixes**
  - Hardened body decoding/fallbacks for gzip/corruption/eviction/invalid text, improved request size reporting, and tightened project-scoped streaming/API filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->