### PR TITLE
Requests: snapshot backfill on reconnect (#51) + in-flight visibility (#48)

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -248,6 +248,13 @@ curl -N "http://localhost:5555/api/v1/logs/stream?pattern=ERROR"
 
 Retrieve recent proxy requests (requires proxy to be enabled).
 
+When the project runs under the shared daemon, its request data is bridged from
+the daemon over the internal socket. On every (re)connect the bridge backfills a
+snapshot of the daemon's current ring for this project before resuming the live
+stream, closing gaps opened while the subscription was down (bounded by the
+daemon ring and the project's registration lifetime). Reconnects re-deliver no
+already-seen record, so this endpoint stays free of duplicates.
+
 **Query Parameters:**
 
 | Param | Type | Default | Description |

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -293,6 +293,11 @@ already-seen record, so this endpoint stays free of duplicates.
 `api.local.dev`); it is omitted when not recorded (older records, or a
 daemon-side record that predates this field).
 
+`in_flight` is `true` on a request whose response is still streaming (the
+backend has sent headers but the body hasn't finished); it is omitted
+entirely once the request completes. `duration_ms` stays `0` while
+`in_flight` is `true` — read it only once the field is gone.
+
 **Example:**
 
 ```bash
@@ -385,6 +390,15 @@ The stream is long-lived: it is exempt from the 30s request-timeout class and en
 
 data: {"id":"a1b2c3d4e5f6","timestamp":"2025-01-19T10:32:01.123Z","method":"GET","url":"/api/users","subdomain":"api","hostname":"api.local.dev","status_code":200,"duration_ms":45,"remote_addr":"127.0.0.1"}
 ```
+
+A proxied request emits **two** `data:` events sharing the same `id`: a
+start event the moment the backend's response headers arrive
+(`"in_flight":true`, `duration_ms` still `0`), and a completion event once
+the body finishes (no `in_flight` field, final `duration_ms`). There is no
+`event:` type field distinguishing them — consumers that key by `id` see a
+clean upsert; naive line-oriented consumers see one extra `data:` line per
+request. Early routing failures (no matching subdomain) emit only the
+completion event, since nothing was proxied.
 
 **Example:**
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -250,10 +250,12 @@ Retrieve recent proxy requests (requires proxy to be enabled).
 
 When the project runs under the shared daemon, its request data is bridged from
 the daemon over the internal socket. On every (re)connect the bridge backfills a
-snapshot of the daemon's current ring for this project before resuming the live
+snapshot of the daemon's current ring while continuing to consume the live
 stream, closing gaps opened while the subscription was down (bounded by the
-daemon ring and the project's registration lifetime). Reconnects re-deliver no
-already-seen record, so this endpoint stays free of duplicates.
+daemon ring and the project's registration lifetime). Snapshot replay and live
+delivery are concurrent; monotonic same-ID upserts keep stale copies from
+regressing a record, and reconnects re-deliver no already-seen record, so this
+endpoint stays free of duplicates.
 
 **Query Parameters:**
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -328,6 +328,8 @@ Each request is assigned a short hash ID (12 characters, git-style). These IDs a
 
 Body output requires request capture to be enabled with `prox up --capture` or `proxy.capture.enabled: true`. Capture applies in both standalone and shared-daemon mode — the enablement is propagated to the daemon at registration, and a daemon captures bodies only for the projects that opted in. When a request has no captured detail, `prox requests <id>` shows `(capture not enabled - use 'prox up --capture' to enable)`; if the body was captured but has since been evicted from the request buffer, it shows `(body no longer available)` instead. See [Request Capture](configuration.md#request-capture) for capture directories and daemon-upgrade notes.
 
+**In-flight requests:** a request whose response is still streaming (headers received, body not yet finished) shows `...` in the DURATION column of the table, `(in flight)` instead of `(Nms)` in `-f/--follow` output, and `Duration: (in flight)` with `(request in flight — details arrive on completion)` in the detail view. Table and TUI rows update in place once the request completes; `-f/--follow` output is a stream, so it prints a second line for the completion event (same ID, no `in_flight`). `--json` carries this as `"in_flight": true`, omitted once done.
+
 ### proxy
 
 Inspect and control the shared proxy daemon.

--- a/docs/reference/tui.md
+++ b/docs/reference/tui.md
@@ -57,6 +57,8 @@ The TUI has two views you can switch between with `Tab`:
 
 Status codes are color-coded: green (2xx), cyan (3xx), yellow (4xx), red (5xx), gray (0/unknown).
 
+A request whose response is still streaming shows its real header-time status but `...` in place of the duration until it completes; the row then updates in place (same position, no duplicate) rather than adding a new line.
+
 ## Keybindings
 
 ### General
@@ -112,6 +114,11 @@ Request Body (35 bytes, application/json)
   captured body cannot emit ESC/BEL/OSC sequences that manipulate the terminal.
   Binary bodies show `[binary data]`; bodies that could no longer be loaded
   (e.g. evicted from disk) show `(body no longer available)`.
+- A request still streaming its response shows `Duration: (in flight)` and,
+  since headers/bodies haven't been captured yet, `(request in flight —
+  details arrive on completion)` instead of the usual body sections. Detail
+  views do not live-update — reopen the request after it completes to see
+  its final headers and bodies.
 
 ## Process Filter Mode
 

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -860,7 +860,13 @@ func TestStreamProxyRequests(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(handlers.StreamProxyRequests))
 		defer srv.Close()
 
-		resp, err := http.Get(srv.URL)
+		// Bound the reads: if the handler stops emitting, the context ends the
+		// request and the blocked ReadString fails instead of hanging the suite.
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
+		require.NoError(t, err)
+		resp, err := http.DefaultClient.Do(req)
 		require.NoError(t, err)
 		defer resp.Body.Close()
 

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -852,6 +852,48 @@ func TestStreamProxyRequests(t *testing.T) {
 		assert.Contains(t, requestDataLines[0], "/api/orders/123")
 		assert.NotContains(t, body, "/api/products")
 	})
+
+	t.Run("emits in_flight for an in-flight record", func(t *testing.T) {
+		// A real server + incremental body read makes this deterministic: the
+		// handler writes ": connected" only after subscribing, so once that
+		// line is read the push below is guaranteed to be delivered.
+		srv := httptest.NewServer(http.HandlerFunc(handlers.StreamProxyRequests))
+		defer srv.Close()
+
+		resp, err := http.Get(srv.URL)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		reader := bufio.NewReader(resp.Body)
+		line, err := reader.ReadString('\n')
+		require.NoError(t, err)
+		require.Contains(t, line, ": connected")
+
+		// Push an in-flight record straight through the manager (the record
+		// itself, not the producer path, is under test here).
+		rm.Record(proxy.RequestRecord{
+			ID:         "inflight1",
+			Timestamp:  time.Now(),
+			Method:     "GET",
+			URL:        "/inflight",
+			Subdomain:  "test",
+			StatusCode: 200,
+			InFlight:   true,
+			RemoteAddr: "127.0.0.1",
+		})
+
+		var dataLine string
+		for {
+			l, err := reader.ReadString('\n')
+			require.NoError(t, err)
+			if strings.HasPrefix(l, "data: ") {
+				dataLine = l
+				break
+			}
+		}
+		assert.Contains(t, dataLine, "/inflight")
+		assert.Contains(t, dataLine, `"in_flight":true`)
+	})
 }
 
 func TestStreamProxyRequests_ProxyNotEnabled(t *testing.T) {

--- a/internal/api/responses.go
+++ b/internal/api/responses.go
@@ -213,6 +213,11 @@ type ProxyRequestResponse struct {
 	StatusCode int    `json:"status_code"`
 	DurationMs int64  `json:"duration_ms"`
 	RemoteAddr string `json:"remote_addr"`
+	// InFlight marks a record published at response-header time, before the
+	// body finished streaming; DurationMs stays 0 until the completion event
+	// replaces this record (same ID). Omitted for completed records so their
+	// JSON stays byte-identical to the pre-in-flight wire format.
+	InFlight bool `json:"in_flight,omitempty"`
 }
 
 // ProxyRequestsResponse represents the response for GET /proxy/requests
@@ -234,6 +239,7 @@ func ToProxyRequestResponse(req proxy.RequestRecord) ProxyRequestResponse {
 		StatusCode: req.StatusCode,
 		DurationMs: req.Duration.Milliseconds(),
 		RemoteAddr: req.RemoteAddr,
+		InFlight:   req.InFlight,
 	}
 }
 

--- a/internal/api/responses_test.go
+++ b/internal/api/responses_test.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -414,5 +416,55 @@ func TestToProxyRequestResponse_OmitsEmptyHostname(t *testing.T) {
 
 	if resp.Hostname != "" {
 		t.Errorf("expected empty Hostname, got %q", resp.Hostname)
+	}
+}
+
+func TestToProxyRequestResponse_MapsInFlight(t *testing.T) {
+	rec := proxy.RequestRecord{
+		ID:         "abc1234",
+		URL:        "/api/users",
+		StatusCode: 200,
+		InFlight:   true,
+	}
+
+	resp := ToProxyRequestResponse(rec)
+
+	if !resp.InFlight {
+		t.Error("expected InFlight to be true")
+	}
+}
+
+func TestToProxyRequestResponse_InFlightOmittedFromJSONWhenFalse(t *testing.T) {
+	rec := proxy.RequestRecord{
+		ID:  "abc1234",
+		URL: "/api/users",
+	}
+
+	resp := ToProxyRequestResponse(rec)
+
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+	if strings.Contains(string(data), "in_flight") {
+		t.Errorf("expected in_flight to be omitted from JSON, got %s", data)
+	}
+}
+
+func TestToProxyRequestResponse_InFlightPresentInJSONWhenTrue(t *testing.T) {
+	rec := proxy.RequestRecord{
+		ID:       "abc1234",
+		URL:      "/api/users",
+		InFlight: true,
+	}
+
+	resp := ToProxyRequestResponse(rec)
+
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+	if !strings.Contains(string(data), `"in_flight":true`) {
+		t.Errorf("expected in_flight:true in JSON, got %s", data)
 	}
 }

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -534,8 +534,12 @@ func runRequests(cmd *cobra.Command, args []string) error {
 			for _, req := range resp.Requests {
 				ts, _ := time.Parse(time.RFC3339Nano, req.Timestamp)
 				timeStr := ts.Format("15:04:05")
-				fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%dms\t%s\n",
-					req.ID, timeStr, req.Method, req.StatusCode, req.DurationMs, req.URL)
+				duration := fmt.Sprintf("%dms", req.DurationMs)
+				if req.InFlight {
+					duration = "..."
+				}
+				fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%s\t%s\n",
+					req.ID, timeStr, req.Method, req.StatusCode, duration, req.URL)
 			}
 			w.Flush()
 
@@ -569,7 +573,11 @@ func showRequestDetail(client *Client, id string, includeBody, jsonOutput bool) 
 	fmt.Printf("Method:  %s\n", resp.Method)
 	fmt.Printf("URL:     %s\n", resp.URL)
 	fmt.Printf("Status:  %d\n", resp.StatusCode)
-	fmt.Printf("Duration: %dms\n", resp.DurationMs)
+	if resp.InFlight {
+		fmt.Printf("Duration: (in flight)\n")
+	} else {
+		fmt.Printf("Duration: %dms\n", resp.DurationMs)
+	}
 	fmt.Printf("Remote:  %s\n", resp.RemoteAddr)
 
 	if resp.Details != nil {
@@ -594,6 +602,8 @@ func showRequestDetail(client *Client, id string, includeBody, jsonOutput bool) 
 		if resp.Details.ResponseBody != nil {
 			printCapturedBody("Response Body", resp.Details.ResponseBody, includeBody)
 		}
+	} else if resp.InFlight {
+		fmt.Println("\n(request in flight — details arrive on completion)")
 	} else {
 		fmt.Println("\n(capture not enabled - use 'prox up --capture' to enable)")
 	}
@@ -693,8 +703,12 @@ func printProxyRequest(req api.ProxyRequestResponse) {
 		}
 	}
 
-	fmt.Printf("%s %s %s%d%s %s (%dms)\n",
-		req.ID, timeStr, statusColor, req.StatusCode, resetColor, req.Method, req.DurationMs)
+	duration := fmt.Sprintf("(%dms)", req.DurationMs)
+	if req.InFlight {
+		duration = "(in flight)"
+	}
+	fmt.Printf("%s %s %s%d%s %s %s\n",
+		req.ID, timeStr, statusColor, req.StatusCode, resetColor, req.Method, duration)
 	fmt.Printf("       %s\n", req.URL)
 }
 

--- a/internal/cli/commands_test.go
+++ b/internal/cli/commands_test.go
@@ -592,6 +592,123 @@ func TestRunRequests_URLFilterPassthrough(t *testing.T) {
 	}
 }
 
+// TestRunRequests_TableRendersInFlightDuration verifies the list table's
+// DURATION column shows "..." for an in-flight row instead of the
+// misleading "0ms" (D10).
+func TestRunRequests_TableRendersInFlightDuration(t *testing.T) {
+	origFollow := requestsFollow
+	origJSON := requestsJSON
+	defer func() {
+		requestsFollow = origFollow
+		requestsJSON = origJSON
+	}()
+
+	originalApiAddr := apiAddr
+	defer func() { apiAddr = originalApiAddr }()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(api.ProxyRequestsResponse{
+			Requests: []api.ProxyRequestResponse{
+				{
+					ID:         "inflight1",
+					Timestamp:  time.Now().Format(time.RFC3339Nano),
+					Method:     "GET",
+					URL:        "/stream",
+					StatusCode: 200,
+					DurationMs: 0,
+					InFlight:   true,
+				},
+			},
+			FilteredCount: 1,
+			TotalCount:    1,
+		})
+	}))
+	defer server.Close()
+	apiAddr = server.URL
+
+	requestsFollow = false
+	requestsJSON = false
+
+	stdout, _ := captureOutput(t, func() {
+		if err := runRequests(requestsCmd, []string{}); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(stdout, "...") {
+		t.Errorf("expected DURATION column to render '...' for an in-flight row, got:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "0ms") {
+		t.Errorf("expected no '0ms' duration for an in-flight row, got:\n%s", stdout)
+	}
+}
+
+// TestPrintProxyRequest_InFlight verifies follow-mode prints "(in flight)"
+// instead of a fake "(0ms)" for an in-flight streamed record (D10).
+func TestPrintProxyRequest_InFlight(t *testing.T) {
+	req := api.ProxyRequestResponse{
+		ID:         "inflight1",
+		Timestamp:  time.Now().Format(time.RFC3339Nano),
+		Method:     "GET",
+		URL:        "/stream",
+		StatusCode: 200,
+		DurationMs: 0,
+		InFlight:   true,
+	}
+
+	stdout, _ := captureOutput(t, func() {
+		printProxyRequest(req)
+	})
+
+	if !strings.Contains(stdout, "(in flight)") {
+		t.Errorf("expected '(in flight)' in follow-mode output, got:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "(0ms)") {
+		t.Errorf("expected no '(0ms)' for an in-flight row, got:\n%s", stdout)
+	}
+}
+
+// TestShowRequestDetail_InFlight verifies the detail view shows
+// "(in flight)" for Duration and the in-flight note in place of the
+// "capture not enabled" hint when Details is nil because the request is
+// still streaming (D10).
+func TestShowRequestDetail_InFlight(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(api.ProxyRequestDetailResponse{
+			ProxyRequestResponse: api.ProxyRequestResponse{
+				ID:         "inflight1",
+				Timestamp:  time.Now().Format(time.RFC3339Nano),
+				Method:     "GET",
+				URL:        "/stream",
+				StatusCode: 200,
+				DurationMs: 0,
+				InFlight:   true,
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+
+	stdout, _ := captureOutput(t, func() {
+		if err := showRequestDetail(client, "inflight1", false, false); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(stdout, "Duration: (in flight)") {
+		t.Errorf("expected 'Duration: (in flight)', got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "(request in flight — details arrive on completion)") {
+		t.Errorf("expected in-flight details note, got:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "capture not enabled") {
+		t.Errorf("expected the misleading capture-not-enabled hint to be suppressed, got:\n%s", stdout)
+	}
+}
+
 func TestDownCmd_NoArgs(t *testing.T) {
 	// Verify downCmd has NoArgs validation
 	if downCmd.Args == nil {

--- a/internal/proxy/capture.go
+++ b/internal/proxy/capture.go
@@ -365,6 +365,10 @@ type CaptureResponseWriter struct {
 	wroteHeader bool
 	hijacked    bool
 	totalSeen   int64 // total bytes observed across all writes, counting past truncation
+
+	// firstResponseHook fires the registered callback once at the first final
+	// response event (see fireFirstResponse).
+	firstResponseHook
 }
 
 // newCaptureResponseWriter creates a new capturing response writer.
@@ -377,9 +381,17 @@ func newCaptureResponseWriter(w http.ResponseWriter, maxBodySize int64) *Capture
 }
 
 func (crw *CaptureResponseWriter) WriteHeader(code int) {
-	if !crw.wroteHeader {
-		crw.statusCode = code
-		crw.wroteHeader = true
+	// 1xx provisional responses (e.g. 103 Early Hints) are not the final
+	// status: they neither latch the recorded status nor fire the hook.
+	// ReverseProxy may forward them via WriteHeader before the real status.
+	if code >= 200 {
+		if !crw.wroteHeader {
+			crw.statusCode = code
+			crw.wroteHeader = true
+		}
+		// Order: latch status → invoke callback → delegate, so the in-flight
+		// record exists before any response bytes hit the wire.
+		crw.fireFirstResponse(code)
 	}
 	crw.ResponseWriter.WriteHeader(code)
 }
@@ -440,6 +452,9 @@ func (crw *CaptureResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) 
 		conn, rw, err := h.Hijack()
 		if err == nil {
 			crw.hijacked = true
+			// A successful upgrade never calls WriteHeader (the 101 is written
+			// raw to the hijacked conn), so fire the hook here with 101.
+			crw.fireFirstResponse(http.StatusSwitchingProtocols)
 		}
 		return conn, rw, err
 	}

--- a/internal/proxy/capture_test.go
+++ b/internal/proxy/capture_test.go
@@ -1,9 +1,11 @@
 package proxy
 
 import (
+	"bufio"
 	"bytes"
 	"compress/gzip"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -1025,5 +1027,85 @@ func TestContentEncodingCaptured(t *testing.T) {
 		require.NoError(t, wrappedBody.Close())
 
 		assert.Empty(t, capturedBody.ContentEncoding)
+	})
+}
+
+// hookHijacker is an http.ResponseWriter that also implements http.Hijacker,
+// backed by an in-memory net.Pipe, so a SUCCESSFUL Hijack() can be exercised in
+// a unit test (httptest.ResponseRecorder is not a Hijacker so it fails hijack).
+type hookHijacker struct {
+	*httptest.ResponseRecorder
+	conn net.Conn
+}
+
+func (h *hookHijacker) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return h.conn, bufio.NewReadWriter(bufio.NewReader(h.conn), bufio.NewWriter(h.conn)), nil
+}
+
+func newHookHijacker(t *testing.T) *hookHijacker {
+	t.Helper()
+	c1, c2 := net.Pipe()
+	t.Cleanup(func() { _ = c1.Close(); _ = c2.Close() })
+	return &hookHijacker{ResponseRecorder: httptest.NewRecorder(), conn: c1}
+}
+
+func TestCaptureResponseWriter_FirstResponseHook(t *testing.T) {
+	t.Run("repeated WriteHeader fires once with the first >=200 code", func(t *testing.T) {
+		crw := newCaptureResponseWriter(httptest.NewRecorder(), 1024)
+		var calls []int
+		crw.SetFirstResponseCallback(func(code int) { calls = append(calls, code) })
+
+		crw.WriteHeader(http.StatusCreated)
+		crw.WriteHeader(http.StatusInternalServerError)
+
+		assert.Equal(t, []int{http.StatusCreated}, calls)
+		assert.Equal(t, http.StatusCreated, crw.StatusCode(), "first-wins latch")
+	})
+
+	t.Run("1xx then 200 fires once with 200 and records 200", func(t *testing.T) {
+		crw := newCaptureResponseWriter(httptest.NewRecorder(), 1024)
+		var calls []int
+		crw.SetFirstResponseCallback(func(code int) { calls = append(calls, code) })
+
+		crw.WriteHeader(http.StatusEarlyHints) // 103
+		assert.Empty(t, calls, "1xx must not fire the hook")
+		assert.Equal(t, http.StatusOK, crw.StatusCode(), "1xx must not latch the status")
+
+		crw.WriteHeader(http.StatusOK)
+		assert.Equal(t, []int{http.StatusOK}, calls)
+		assert.Equal(t, http.StatusOK, crw.StatusCode())
+	})
+
+	t.Run("implicit bare Write does not fire the hook", func(t *testing.T) {
+		crw := newCaptureResponseWriter(httptest.NewRecorder(), 1024)
+		var calls []int
+		crw.SetFirstResponseCallback(func(code int) { calls = append(calls, code) })
+
+		_, _ = crw.Write([]byte("hi"))
+		assert.Empty(t, calls)
+	})
+
+	t.Run("failed hijack does not fire the hook", func(t *testing.T) {
+		// httptest.ResponseRecorder does not implement http.Hijacker.
+		crw := newCaptureResponseWriter(httptest.NewRecorder(), 1024)
+		var calls []int
+		crw.SetFirstResponseCallback(func(code int) { calls = append(calls, code) })
+
+		_, _, err := crw.Hijack()
+		require.Error(t, err)
+		assert.Empty(t, calls)
+	})
+
+	t.Run("successful hijack fires 101 once, no re-fire on late WriteHeader", func(t *testing.T) {
+		crw := newCaptureResponseWriter(newHookHijacker(t), 1024)
+		var calls []int
+		crw.SetFirstResponseCallback(func(code int) { calls = append(calls, code) })
+
+		_, _, err := crw.Hijack()
+		require.NoError(t, err)
+		assert.Equal(t, []int{http.StatusSwitchingProtocols}, calls)
+
+		crw.WriteHeader(http.StatusOK)
+		assert.Equal(t, []int{http.StatusSwitchingProtocols}, calls, "hook must not re-fire after hijack")
 	})
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -380,11 +380,10 @@ func (s *Service) createRouter() http.Handler {
 				"target", target.String(),
 				"error", err,
 			)
-			if crw != nil {
-				crw.WriteHeader(http.StatusBadGateway)
-			} else {
-				brw.WriteHeader(http.StatusBadGateway)
-			}
+			// http.Error writes the 502 through the wrapped writer (latching
+			// the status and firing the first-response hook); an explicit
+			// WriteHeader first would commit the response before http.Error
+			// could set its error headers.
 			http.Error(w, "Backend unavailable", http.StatusBadGateway)
 		}
 
@@ -583,10 +582,11 @@ type responseWriter struct {
 }
 
 func (rw *responseWriter) WriteHeader(code int) {
-	// Last-write-wins status, except 1xx provisional responses (e.g. 103 Early
-	// Hints) are ignored: they are not the final status and must not fire the
-	// hook or overwrite a real status.
-	if code >= 200 {
+	// Latch the FIRST final (>=200) status — net/http ignores later
+	// WriteHeader calls, so the first one is what the client actually got.
+	// 1xx provisional responses (e.g. 103 Early Hints) are delegated but are
+	// not the final status: they neither latch nor fire the hook.
+	if code >= 200 && !rw.responded {
 		rw.statusCode = code
 		// Order: latch status → invoke callback → delegate.
 		rw.fireFirstResponse(code)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -364,11 +364,13 @@ func (s *Service) createRouter() http.Handler {
 		// Choose response writer based on capture mode
 		var rw http.ResponseWriter
 		var crw *CaptureResponseWriter
+		var brw *responseWriter
 		if s.captureManager != nil && s.captureManager.Enabled() {
 			crw = s.captureManager.WrapResponseWriter(w)
 			rw = crw
 		} else {
-			rw = &responseWriter{ResponseWriter: w, statusCode: http.StatusOK}
+			brw = &responseWriter{ResponseWriter: w, statusCode: http.StatusOK}
+			rw = brw
 		}
 
 		// Custom error handler - log detailed error but return generic message to client
@@ -380,49 +382,76 @@ func (s *Service) createRouter() http.Handler {
 			)
 			if crw != nil {
 				crw.WriteHeader(http.StatusBadGateway)
-			} else if basicRw, ok := rw.(*responseWriter); ok {
-				basicRw.statusCode = http.StatusBadGateway
+			} else {
+				brw.WriteHeader(http.StatusBadGateway)
 			}
 			http.Error(w, "Backend unavailable", http.StatusBadGateway)
 		}
 
-		// Serve the request
-		proxy.ServeHTTP(rw, r)
-
-		// Build request details if capture is enabled
-		var details *RequestDetails
-		var statusCode int
-		if crw != nil && crw.Hijacked() {
-			// A successful reverse-proxy upgrade writes the 101 raw to the
-			// hijacked conn, bypassing WriteHeader, so the writer's statusCode
-			// is meaningless here. Record the protocol switch and record
-			// metadata only rather than a garbage 200/empty-body capture.
-			statusCode = http.StatusSwitchingProtocols
-			// The metadata-only record carries no Details, so eviction would
-			// never clean a request-body file spilled to disk before the
-			// upgrade; finalize and clean it up here to avoid orphaning it.
-			FinalizeRequestBody(r.Body)
-			s.captureManager.CleanupRequest(requestID)
-		} else if crw != nil {
-			statusCode = crw.StatusCode()
-			// Freeze the request-body capture before the record is published
-			// (see FinalizeRequestBody).
-			FinalizeRequestBody(r.Body)
-			resBody, resHeaders := s.captureManager.FinalizeResponse(requestID, crw)
-			details = &RequestDetails{
-				RequestHeaders:  reqHeaders,
-				ResponseHeaders: resHeaders,
-				RequestBody:     reqBody,
-				ResponseBody:    resBody,
-			}
-		} else if basicRw, ok := rw.(*responseWriter); ok {
-			statusCode = basicRw.statusCode
+		// Phase 1 (in-flight): register a first-response hook that publishes a
+		// header-time record via Record (plain append — the fresh ID cannot
+		// already exist). Field parity with the completion record is pinned:
+		// buildRecord computes every field identically; only StatusCode source
+		// (the hook arg), InFlight, Duration, and Details differ.
+		onFirst := func(statusCode int) {
+			s.requestManager.Record(s.buildRecord(r, subdomain, statusCode, startTime, requestID, nil, true))
+		}
+		if crw != nil {
+			crw.SetFirstResponseCallback(onFirst)
 		} else {
-			statusCode = http.StatusOK
+			brw.SetFirstResponseCallback(onFirst)
 		}
 
-		// Record the request (single recording point for all cases)
-		s.recordRequest(r, subdomain, statusCode, startTime, requestID, details)
+		// Phase 2 (completion): the finalize-freeze + record build runs in a
+		// defer registered BEFORE ServeHTTP with NO recover, so it executes on
+		// normal return AND while unwinding ReverseProxy's http.ErrAbortHandler
+		// panic (client disconnect / backend death mid-stream). The panic keeps
+		// propagating. Completion goes through Upsert (same ID as the in-flight
+		// record; final beats it).
+		defer func() {
+			// Build request details if capture is enabled
+			var details *RequestDetails
+			var statusCode int
+			switch {
+			case crw != nil && crw.Hijacked():
+				// A successful reverse-proxy upgrade writes the 101 raw to the
+				// hijacked conn, bypassing WriteHeader, so the writer's
+				// statusCode is meaningless here. Record the protocol switch and
+				// record metadata only rather than a garbage 200/empty-body
+				// capture.
+				statusCode = http.StatusSwitchingProtocols
+				// The metadata-only record carries no Details, so eviction would
+				// never clean a request-body file spilled to disk before the
+				// upgrade; finalize and clean it up here to avoid orphaning it.
+				FinalizeRequestBody(r.Body)
+				s.captureManager.CleanupRequest(requestID)
+			case crw != nil:
+				statusCode = crw.StatusCode()
+				// Freeze the request-body capture before the record is published
+				// (see FinalizeRequestBody).
+				FinalizeRequestBody(r.Body)
+				resBody, resHeaders := s.captureManager.FinalizeResponse(requestID, crw)
+				details = &RequestDetails{
+					RequestHeaders:  reqHeaders,
+					ResponseHeaders: resHeaders,
+					RequestBody:     reqBody,
+					ResponseBody:    resBody,
+				}
+			case brw.Hijacked():
+				// Non-capture WebSocket upgrade: record 101 to match the
+				// in-flight record and the capture path (the writer's default
+				// 200 would otherwise disagree).
+				statusCode = http.StatusSwitchingProtocols
+			default:
+				statusCode = brw.statusCode
+			}
+
+			// Completion recording point (Upsert: final beats the in-flight copy)
+			s.requestManager.Upsert(s.buildRecord(r, subdomain, statusCode, startTime, requestID, details, false))
+		}()
+
+		// Serve the request
+		proxy.ServeHTTP(rw, r)
 	})
 }
 
@@ -462,9 +491,17 @@ func (s *Service) extractSubdomain(host string) string {
 	return subdomain
 }
 
-// recordRequest records a request in the request manager.
-func (s *Service) recordRequest(r *http.Request, subdomain string, statusCode int, startTime time.Time, requestID string, details *RequestDetails) {
-	record := RequestRecord{
+// buildRecord assembles a RequestRecord from a request and derived fields. It is
+// the single field-parity point for the two-phase recording: the in-flight and
+// completion records for one request differ ONLY in inFlight (which zeroes
+// Duration and forces nil-carrying InFlight), the StatusCode source, and
+// Details. Every other field is this one expression.
+func (s *Service) buildRecord(r *http.Request, subdomain string, statusCode int, startTime time.Time, requestID string, details *RequestDetails, inFlight bool) RequestRecord {
+	duration := time.Duration(0)
+	if !inFlight {
+		duration = time.Since(startTime)
+	}
+	return RequestRecord{
 		ID:         requestID,
 		Timestamp:  startTime,
 		Method:     r.Method,
@@ -472,11 +509,18 @@ func (s *Service) recordRequest(r *http.Request, subdomain string, statusCode in
 		Subdomain:  subdomain,
 		Hostname:   stripHostPort(r.Host),
 		StatusCode: statusCode,
-		Duration:   time.Since(startTime),
+		Duration:   duration,
 		RemoteAddr: getClientIP(r),
+		InFlight:   inFlight,
 		Details:    details,
 	}
-	s.requestManager.Record(record)
+}
+
+// recordRequest records a final (non-in-flight) request via Record. Used by the
+// early-routing 404 paths, which never proxy the request and so have no
+// in-flight phase; the two-phase proxy path records completions via Upsert.
+func (s *Service) recordRequest(r *http.Request, subdomain string, statusCode int, startTime time.Time, requestID string, details *RequestDetails) {
+	s.requestManager.Record(s.buildRecord(r, subdomain, statusCode, startTime, requestID, details, false))
 }
 
 // getClientIP extracts the client IP from the request.
@@ -499,14 +543,54 @@ func getClientIP(r *http.Request) string {
 	return ip
 }
 
+// firstResponseHook holds the first-response callback machinery shared by the
+// package's response writers (CaptureResponseWriter and responseWriter). It
+// latches so the callback fires exactly once at the first FINAL response event
+// (see fireFirstResponse). Single-goroutine access per the http.ResponseWriter
+// contract; the callback is set before serving.
+type firstResponseHook struct {
+	onFirstResponse func(statusCode int)
+	responded       bool
+}
+
+// SetFirstResponseCallback registers a callback that fires exactly once at the
+// first FINAL response event (see fireFirstResponse).
+func (h *firstResponseHook) SetFirstResponseCallback(fn func(statusCode int)) {
+	h.onFirstResponse = fn
+}
+
+// fireFirstResponse invokes the first-response callback at most once. It is
+// driven ONLY from WriteHeader (final status) and a successful Hijack — never
+// from an implicit bare Write. The reverse proxy always calls WriteHeader
+// explicitly for normal responses and hijacks for upgrades, so no response
+// bytes reach the wire before the hook has run.
+func (h *firstResponseHook) fireFirstResponse(code int) {
+	if h.responded {
+		return
+	}
+	h.responded = true
+	if h.onFirstResponse != nil {
+		h.onFirstResponse(code)
+	}
+}
+
 // responseWriter wraps http.ResponseWriter to capture the status code.
 type responseWriter struct {
 	http.ResponseWriter
 	statusCode int
+	hijacked   bool
+	firstResponseHook
 }
 
 func (rw *responseWriter) WriteHeader(code int) {
-	rw.statusCode = code
+	// Last-write-wins status, except 1xx provisional responses (e.g. 103 Early
+	// Hints) are ignored: they are not the final status and must not fire the
+	// hook or overwrite a real status.
+	if code >= 200 {
+		rw.statusCode = code
+		// Order: latch status → invoke callback → delegate.
+		rw.fireFirstResponse(code)
+	}
 	rw.ResponseWriter.WriteHeader(code)
 }
 
@@ -520,9 +604,21 @@ func (rw *responseWriter) Flush() {
 // Hijack implements http.Hijacker for WebSocket support.
 func (rw *responseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	if h, ok := rw.ResponseWriter.(http.Hijacker); ok {
-		return h.Hijack()
+		conn, brw, err := h.Hijack()
+		if err == nil {
+			rw.hijacked = true
+			// A successful upgrade never calls WriteHeader (the 101 is written
+			// raw to the hijacked conn), so fire the hook here with 101.
+			rw.fireFirstResponse(http.StatusSwitchingProtocols)
+		}
+		return conn, brw, err
 	}
 	return nil, nil, errors.New("hijacking not supported")
+}
+
+// Hijacked reports whether the connection was taken over (WebSocket upgrade).
+func (rw *responseWriter) Hijacked() bool {
+	return rw.hijacked
 }
 
 // Push implements http.Pusher for HTTP/2 server push.

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -5,11 +5,13 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"sync"
 	"sync/atomic"
 	"syscall"
 	"testing"
@@ -421,4 +423,367 @@ func TestStart_PortConflict_HTTP(t *testing.T) {
 	// Original OS error is preserved via multi-unwrap
 	assert.NotNil(t, portErr.Cause)
 	assert.True(t, errors.Is(err, syscall.EADDRINUSE))
+}
+
+func TestResponseWriter_FirstResponseHook(t *testing.T) {
+	newRW := func(w http.ResponseWriter) *responseWriter {
+		return &responseWriter{ResponseWriter: w, statusCode: http.StatusOK}
+	}
+
+	t.Run("hook fires once but status is last-write-wins", func(t *testing.T) {
+		rw := newRW(httptest.NewRecorder())
+		var calls []int
+		rw.SetFirstResponseCallback(func(code int) { calls = append(calls, code) })
+
+		rw.WriteHeader(http.StatusCreated)
+		rw.WriteHeader(http.StatusAccepted)
+
+		assert.Equal(t, []int{http.StatusCreated}, calls, "hook fires once on first >=200")
+		assert.Equal(t, http.StatusAccepted, rw.statusCode, "status is last-write-wins")
+	})
+
+	t.Run("1xx then 200 fires once with 200 and records 200", func(t *testing.T) {
+		rw := newRW(httptest.NewRecorder())
+		var calls []int
+		rw.SetFirstResponseCallback(func(code int) { calls = append(calls, code) })
+
+		rw.WriteHeader(http.StatusEarlyHints) // 103
+		assert.Empty(t, calls, "1xx must not fire the hook")
+		assert.Equal(t, http.StatusOK, rw.statusCode, "1xx must not overwrite the status")
+
+		rw.WriteHeader(http.StatusOK)
+		assert.Equal(t, []int{http.StatusOK}, calls)
+		assert.Equal(t, http.StatusOK, rw.statusCode)
+	})
+
+	t.Run("implicit bare Write does not fire the hook", func(t *testing.T) {
+		rw := newRW(httptest.NewRecorder())
+		var calls []int
+		rw.SetFirstResponseCallback(func(code int) { calls = append(calls, code) })
+
+		_, _ = rw.Write([]byte("hi"))
+		assert.Empty(t, calls)
+	})
+
+	t.Run("failed hijack does not fire the hook", func(t *testing.T) {
+		rw := newRW(httptest.NewRecorder())
+		var calls []int
+		rw.SetFirstResponseCallback(func(code int) { calls = append(calls, code) })
+
+		_, _, err := rw.Hijack()
+		require.Error(t, err)
+		assert.Empty(t, calls)
+		assert.False(t, rw.Hijacked())
+	})
+
+	t.Run("successful hijack fires 101 once, no re-fire on late WriteHeader", func(t *testing.T) {
+		rw := newRW(newHookHijacker(t))
+		var calls []int
+		rw.SetFirstResponseCallback(func(code int) { calls = append(calls, code) })
+
+		_, _, err := rw.Hijack()
+		require.NoError(t, err)
+		assert.Equal(t, []int{http.StatusSwitchingProtocols}, calls)
+		assert.True(t, rw.Hijacked())
+
+		rw.WriteHeader(http.StatusOK)
+		assert.Equal(t, []int{http.StatusSwitchingProtocols}, calls)
+	})
+}
+
+// --- two-phase recording (D6/D7) e2e helpers ---
+
+// newTwoPhaseService builds a Service routing subdomain "app" to backendPort,
+// with capture on or off, under a quiet logger.
+func newTwoPhaseService(t *testing.T, captureEnabled bool, backendPort int) *Service {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	cfg := &config.ProxyConfig{
+		Enabled:  true,
+		HTTPPort: 6788,
+		Domain:   "local.myapp.dev",
+	}
+	if captureEnabled {
+		cfg.Capture = &config.CaptureConfig{Enabled: true}
+	}
+	services := map[string]config.ServiceConfig{
+		"app": {Port: backendPort, Host: "localhost"},
+	}
+	svc, err := NewService(cfg, services, nil, logger, t.TempDir())
+	require.NoError(t, err)
+	return svc
+}
+
+func readRecordEvent(t *testing.T, ch <-chan RequestRecord) RequestRecord {
+	t.Helper()
+	select {
+	case rec := <-ch:
+		return rec
+	case <-time.After(3 * time.Second):
+		t.Fatal("expected a subscriber event, got none")
+		return RequestRecord{}
+	}
+}
+
+func assertNoMoreEvents(t *testing.T, ch <-chan RequestRecord) {
+	t.Helper()
+	select {
+	case rec := <-ch:
+		t.Fatalf("unexpected extra subscriber event: %+v", rec)
+	case <-time.After(150 * time.Millisecond):
+	}
+}
+
+// assertFieldParity pins that the in-flight and completion records agree on
+// every field EXCEPT InFlight, Duration, and Details (the StatusCode source is
+// the same value in these tests, so it is asserted equal too).
+func assertFieldParity(t *testing.T, inflight, final RequestRecord) {
+	t.Helper()
+	assert.Equal(t, inflight.ID, final.ID)
+	assert.Equal(t, inflight.Timestamp, final.Timestamp)
+	assert.Equal(t, inflight.Method, final.Method)
+	assert.Equal(t, inflight.URL, final.URL)
+	assert.Equal(t, inflight.Subdomain, final.Subdomain)
+	assert.Equal(t, inflight.Hostname, final.Hostname)
+	assert.Equal(t, inflight.ProjectDir, final.ProjectDir)
+	assert.Equal(t, inflight.RemoteAddr, final.RemoteAddr)
+	assert.Equal(t, inflight.StatusCode, final.StatusCode)
+}
+
+func TestCreateRouter_TwoPhaseRecording(t *testing.T) {
+	for _, capture := range []bool{false, true} {
+		capture := capture
+		name := "capture-off"
+		if capture {
+			name = "capture-on"
+		}
+		t.Run(name, func(t *testing.T) {
+			release := make(chan struct{})
+			var once sync.Once
+			doRelease := func() { once.Do(func() { close(release) }) }
+			t.Cleanup(doRelease)
+
+			backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/plain")
+				w.WriteHeader(http.StatusAccepted) // 202 — distinctive non-200 header status
+				_, _ = w.Write([]byte("partial"))
+				w.(http.Flusher).Flush()
+				<-release
+				_, _ = w.Write([]byte("-rest"))
+			}))
+			defer backend.Close()
+			backendPort := backend.Listener.Addr().(*net.TCPAddr).Port
+
+			svc := newTwoPhaseService(t, capture, backendPort)
+			rm := svc.RequestManager()
+			router := svc.createRouter()
+
+			sub := rm.Subscribe(RequestFilter{})
+			defer rm.Unsubscribe(sub.ID)
+
+			req := httptest.NewRequest("GET", "/stream", nil)
+			req.Host = "app.local.myapp.dev:6788"
+			rec := httptest.NewRecorder()
+
+			done := make(chan struct{})
+			go func() {
+				router.ServeHTTP(rec, req)
+				close(done)
+			}()
+
+			// Phase 1: an in-flight record with the real header status appears
+			// while the body is still streaming.
+			var inflightID string
+			require.Eventually(t, func() bool {
+				recs := rm.Recent(RequestFilter{})
+				if len(recs) != 1 || !recs[0].InFlight {
+					return false
+				}
+				inflightID = recs[0].ID
+				return recs[0].StatusCode == http.StatusAccepted
+			}, 3*time.Second, 5*time.Millisecond, "in-flight record should appear mid-stream")
+
+			mid := rm.Recent(RequestFilter{})
+			require.Len(t, mid, 1)
+			assert.Equal(t, time.Duration(0), mid[0].Duration, "in-flight Duration is 0")
+			assert.Nil(t, mid[0].Details, "in-flight record carries no Details")
+
+			// Release and let the response complete.
+			doRelease()
+			select {
+			case <-done:
+			case <-time.After(3 * time.Second):
+				t.Fatal("handler did not complete after release")
+			}
+
+			finals := rm.Recent(RequestFilter{})
+			require.Len(t, finals, 1, "completion replaces the same ID in place, no duplicate row")
+			f := finals[0]
+			assert.Equal(t, inflightID, f.ID, "completion carries the in-flight ID")
+			assert.False(t, f.InFlight)
+			assert.Equal(t, http.StatusAccepted, f.StatusCode)
+			assert.Greater(t, f.Duration, time.Duration(0))
+			if capture {
+				require.NotNil(t, f.Details)
+				require.NotNil(t, f.Details.ResponseBody)
+				assert.Equal(t, "partial-rest", string(f.Details.ResponseBody.Data))
+			} else {
+				assert.Nil(t, f.Details)
+			}
+
+			// Exactly two subscriber events (in-flight then final), field parity.
+			ev1 := readRecordEvent(t, sub.Ch)
+			ev2 := readRecordEvent(t, sub.Ch)
+			assertNoMoreEvents(t, sub.Ch)
+			assert.True(t, ev1.InFlight)
+			assert.False(t, ev2.InFlight)
+			assertFieldParity(t, ev1, ev2)
+		})
+	}
+}
+
+func TestCreateRouter_EarlyNotFound_SingleFinalEvent(t *testing.T) {
+	svc := newTwoPhaseService(t, false, 1) // backend port irrelevant; no proxy happens
+	rm := svc.RequestManager()
+	router := svc.createRouter()
+
+	sub := rm.Subscribe(RequestFilter{})
+	defer rm.Unsubscribe(sub.ID)
+
+	req := httptest.NewRequest("GET", "/x", nil)
+	req.Host = "unknown-service.local.myapp.dev:6788" // resolves subdomain, but no such service
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusNotFound, rec.Code)
+
+	ev := readRecordEvent(t, sub.Ch)
+	assert.False(t, ev.InFlight, "early-404 emits a single FINAL event")
+	assert.Equal(t, http.StatusNotFound, ev.StatusCode)
+	assertNoMoreEvents(t, sub.Ch)
+
+	recs := rm.Recent(RequestFilter{})
+	require.Len(t, recs, 1)
+	assert.False(t, recs[0].InFlight)
+}
+
+func TestCreateRouter_ErrorHandler_InFlightThenFinal502(t *testing.T) {
+	// Route to a port nothing listens on so the reverse proxy's ErrorHandler
+	// runs (http.Error → WriteHeader(502) on the wrapper → in-flight hook).
+	svc := newTwoPhaseService(t, false, 1)
+	rm := svc.RequestManager()
+	router := svc.createRouter()
+
+	sub := rm.Subscribe(RequestFilter{})
+	defer rm.Unsubscribe(sub.ID)
+
+	req := httptest.NewRequest("GET", "/down", nil)
+	req.Host = "app.local.myapp.dev:6788"
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusBadGateway, rec.Code)
+
+	ev1 := readRecordEvent(t, sub.Ch)
+	ev2 := readRecordEvent(t, sub.Ch)
+	assertNoMoreEvents(t, sub.Ch)
+	assert.True(t, ev1.InFlight)
+	assert.Equal(t, http.StatusBadGateway, ev1.StatusCode)
+	assert.False(t, ev2.InFlight)
+	assert.Equal(t, http.StatusBadGateway, ev2.StatusCode)
+	assert.Equal(t, ev1.ID, ev2.ID)
+}
+
+func TestCreateRouter_ClientDisconnect_RecordsCompletion(t *testing.T) {
+	// Real front server so ReverseProxy panics http.ErrAbortHandler on the
+	// mid-stream copy failure (ResponseRecorder alone never triggers it).
+	release := make(chan struct{})
+	var once sync.Once
+	t.Cleanup(func() { once.Do(func() { close(release) }) })
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		for i := 0; i < 10000; i++ {
+			if _, err := w.Write([]byte("chunk-of-streaming-body-")); err != nil {
+				return
+			}
+			w.(http.Flusher).Flush()
+			select {
+			case <-release:
+				return
+			case <-time.After(2 * time.Millisecond):
+			}
+		}
+	}))
+	defer backend.Close()
+	backendPort := backend.Listener.Addr().(*net.TCPAddr).Port
+
+	svc := newTwoPhaseService(t, true, backendPort)
+	rm := svc.RequestManager()
+
+	front := httptest.NewServer(svc.createRouter())
+	defer front.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req, err := http.NewRequestWithContext(ctx, "GET", front.URL+"/stream", nil)
+	require.NoError(t, err)
+	req.Host = "app.local.myapp.dev"
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	// Read a little of the stream, then abort mid-stream.
+	buf := make([]byte, 8)
+	_, _ = io.ReadFull(resp.Body, buf)
+	cancel()
+	_ = resp.Body.Close()
+
+	// The deferred completion must record a final (not stuck in-flight) row.
+	require.Eventually(t, func() bool {
+		recs := rm.Recent(RequestFilter{})
+		return len(recs) == 1 && !recs[0].InFlight && recs[0].Duration > 0
+	}, 3*time.Second, 10*time.Millisecond, "aborted stream must produce a final record")
+
+	f := rm.Recent(RequestFilter{})[0]
+	assert.Equal(t, http.StatusOK, f.StatusCode)
+	require.NotNil(t, f.Details, "capture-on aborted stream still records (truncated) details")
+}
+
+func TestCreateRouter_BackendDeath_RecordsCompletion(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("partial-body-before-death"))
+		w.(http.Flusher).Flush()
+		// Abruptly kill the connection mid-body: hijack and close.
+		conn, _, err := w.(http.Hijacker).Hijack()
+		if err != nil {
+			return
+		}
+		_ = conn.Close()
+	}))
+	defer backend.Close()
+	backendPort := backend.Listener.Addr().(*net.TCPAddr).Port
+
+	svc := newTwoPhaseService(t, true, backendPort)
+	rm := svc.RequestManager()
+
+	front := httptest.NewServer(svc.createRouter())
+	defer front.Close()
+
+	req, err := http.NewRequest("GET", front.URL+"/stream", nil)
+	require.NoError(t, err)
+	req.Host = "app.local.myapp.dev"
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	_, _ = io.Copy(io.Discard, resp.Body) // drains until the backend death truncates it
+	_ = resp.Body.Close()
+
+	require.Eventually(t, func() bool {
+		recs := rm.Recent(RequestFilter{})
+		return len(recs) == 1 && !recs[0].InFlight && recs[0].Duration > 0
+	}, 3*time.Second, 10*time.Millisecond, "backend death mid-body must produce a final record")
+
+	f := rm.Recent(RequestFilter{})[0]
+	assert.Equal(t, http.StatusOK, f.StatusCode)
+	require.NotNil(t, f.Details)
 }

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -430,7 +430,7 @@ func TestResponseWriter_FirstResponseHook(t *testing.T) {
 		return &responseWriter{ResponseWriter: w, statusCode: http.StatusOK}
 	}
 
-	t.Run("hook fires once but status is last-write-wins", func(t *testing.T) {
+	t.Run("hook and status both latch the first final status", func(t *testing.T) {
 		rw := newRW(httptest.NewRecorder())
 		var calls []int
 		rw.SetFirstResponseCallback(func(code int) { calls = append(calls, code) })
@@ -439,7 +439,8 @@ func TestResponseWriter_FirstResponseHook(t *testing.T) {
 		rw.WriteHeader(http.StatusAccepted)
 
 		assert.Equal(t, []int{http.StatusCreated}, calls, "hook fires once on first >=200")
-		assert.Equal(t, http.StatusAccepted, rw.statusCode, "status is last-write-wins")
+		assert.Equal(t, http.StatusCreated, rw.statusCode,
+			"status latches the first final code — net/http ignores later WriteHeader calls")
 	})
 
 	t.Run("1xx then 200 fires once with 200 and records 200", func(t *testing.T) {

--- a/internal/proxy/requests.go
+++ b/internal/proxy/requests.go
@@ -28,6 +28,13 @@ type RequestRecord struct {
 	// even when two projects own the same hostname on different ports.
 	ProjectDir string `json:"project_dir,omitempty"`
 
+	// InFlight marks a record published at response-header time, before the
+	// response body finished. Such records carry the header-time status but
+	// zero Duration and nil Details; a completion update (same ID, InFlight
+	// false) replaces them via Upsert. Completed records are terminal:
+	// omitempty keeps their JSON identical to the pre-in-flight wire format.
+	InFlight bool `json:"in_flight,omitempty"`
+
 	// Details contains captured headers and bodies (nil when capture is disabled)
 	Details *RequestDetails `json:"details,omitempty"`
 }
@@ -174,6 +181,76 @@ func (m *RequestManager) Record(record RequestRecord) {
 
 	// Notify subscribers
 	m.notifySubscribers(record)
+}
+
+// Upsert applies a record as a monotonic two-state transition keyed by ID:
+//
+//	existing absent               → append (Record's eviction logic) + notify
+//	existing in-flight, incoming in-flight → no-op (duplicate delivery)
+//	existing in-flight, incoming final     → replace in place + notify
+//	existing final                → no-op (final is terminal)
+//
+// The no-op rows make concurrent interleavings safe: replaying a snapshot
+// while live stream events apply converges to the final record in any order,
+// with no duplicate or regressed notifications. Replace-in-place keeps the
+// ring slot (no head/count change, no eviction) — safe because in-flight
+// records carry no Details, so the transition only ever adds capture state.
+//
+// Unlike Record, subscribers are notified INSIDE the ring critical section:
+// same-ID notifications can never be observed out of transition order.
+// notifySubscribers only performs non-blocking channel sends under subMu,
+// and no path acquires mu while holding subMu, so this cannot block or
+// deadlock. The eviction callback (disk IO) still runs after unlock.
+func (m *RequestManager) Upsert(record RequestRecord) {
+	if record.ID == "" {
+		// Defensive: callers always supply IDs. Generate one and fall through
+		// to the normal append path (NOT Record, whose after-unlock notify
+		// would escape the ordering guarantee above).
+		record.ID = GenerateRequestID(record.Timestamp, record.Method, record.URL)
+	}
+
+	var evictedID string
+	var onEvict EvictionCallback
+
+	m.mu.Lock()
+	// Scan newest→oldest: in-flight records live in the newest slots.
+	idx := -1
+	for i := 0; i < m.count; i++ {
+		j := (m.head - 1 - i + m.capacity) % m.capacity
+		if m.buffer[j].ID == record.ID {
+			idx = j
+			break
+		}
+	}
+
+	switch {
+	case idx >= 0 && (!m.buffer[idx].InFlight || record.InFlight):
+		// Terminal existing record, or duplicate in-flight delivery.
+		m.mu.Unlock()
+		return
+	case idx >= 0:
+		// In-flight → final: replace in place, ring position preserved.
+		m.buffer[idx] = record
+	default:
+		if m.count == m.capacity {
+			evicted := m.buffer[m.head]
+			if evicted.ID != "" && evicted.Details != nil {
+				evictedID = evicted.ID
+				onEvict = m.onEvict
+			}
+		}
+		m.buffer[m.head] = record
+		m.head = (m.head + 1) % m.capacity
+		if m.count < m.capacity {
+			m.count++
+		}
+	}
+	m.notifySubscribers(record)
+	m.mu.Unlock()
+
+	if evictedID != "" && onEvict != nil {
+		onEvict(evictedID)
+	}
 }
 
 // Recent returns the most recent requests matching the filter.

--- a/internal/proxy/requests_test.go
+++ b/internal/proxy/requests_test.go
@@ -1,6 +1,9 @@
 package proxy
 
 import (
+	"encoding/json"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -356,4 +359,250 @@ func TestRequestManager_PurgeByProject(t *testing.T) {
 	// Purging an empty project dir is a no-op.
 	m.PurgeByProject("")
 	assert.Len(t, m.Recent(RequestFilter{}), 1)
+}
+
+// drainRecords empties a subscription channel without blocking.
+func drainRecords(ch chan RequestRecord) []RequestRecord {
+	var out []RequestRecord
+	for {
+		select {
+		case r := <-ch:
+			out = append(out, r)
+		default:
+			return out
+		}
+	}
+}
+
+func TestRequestManager_Upsert_StateMachine(t *testing.T) {
+	inflight := func(id string) RequestRecord {
+		return RequestRecord{ID: id, Method: "GET", URL: "/stream", StatusCode: 200, InFlight: true}
+	}
+	final := func(id string) RequestRecord {
+		return RequestRecord{ID: id, Method: "GET", URL: "/stream", StatusCode: 200, Duration: 42 * time.Millisecond}
+	}
+
+	t.Run("absent inflight appends and notifies", func(t *testing.T) {
+		m := NewRequestManager(10)
+		sub := m.Subscribe(RequestFilter{})
+		m.Upsert(inflight("r1"))
+		assert.Equal(t, 1, m.Count())
+		events := drainRecords(sub.Ch)
+		require.Len(t, events, 1)
+		assert.True(t, events[0].InFlight)
+	})
+
+	t.Run("absent final appends and notifies", func(t *testing.T) {
+		m := NewRequestManager(10)
+		sub := m.Subscribe(RequestFilter{})
+		m.Upsert(final("r1"))
+		assert.Equal(t, 1, m.Count())
+		assert.Len(t, drainRecords(sub.Ch), 1)
+	})
+
+	t.Run("inflight over inflight is a silent no-op", func(t *testing.T) {
+		m := NewRequestManager(10)
+		first := inflight("r1")
+		first.RemoteAddr = "10.0.0.1"
+		m.Upsert(first)
+		sub := m.Subscribe(RequestFilter{})
+
+		dup := inflight("r1")
+		dup.RemoteAddr = "10.0.0.2" // must NOT be written
+		m.Upsert(dup)
+
+		assert.Equal(t, 1, m.Count())
+		got, ok := m.GetByID("r1")
+		require.True(t, ok)
+		assert.Equal(t, "10.0.0.1", got.RemoteAddr)
+		assert.Empty(t, drainRecords(sub.Ch))
+	})
+
+	t.Run("inflight to final replaces in place and notifies", func(t *testing.T) {
+		m := NewRequestManager(10)
+		m.Upsert(inflight("r1"))
+		sub := m.Subscribe(RequestFilter{})
+
+		done := final("r1")
+		done.Details = &RequestDetails{RequestHeaders: map[string][]string{"X": {"y"}}}
+		m.Upsert(done)
+
+		assert.Equal(t, 1, m.Count())
+		got, ok := m.GetByID("r1")
+		require.True(t, ok)
+		assert.False(t, got.InFlight)
+		assert.Equal(t, 42*time.Millisecond, got.Duration)
+		require.NotNil(t, got.Details)
+
+		events := drainRecords(sub.Ch)
+		require.Len(t, events, 1)
+		assert.False(t, events[0].InFlight)
+	})
+
+	t.Run("final is terminal against inflight and final", func(t *testing.T) {
+		m := NewRequestManager(10)
+		m.Upsert(final("r1"))
+		sub := m.Subscribe(RequestFilter{})
+
+		m.Upsert(inflight("r1")) // stale buffered start event
+		dupFinal := final("r1")
+		dupFinal.StatusCode = 599 // must NOT be written
+		m.Upsert(dupFinal)
+
+		got, ok := m.GetByID("r1")
+		require.True(t, ok)
+		assert.False(t, got.InFlight)
+		assert.Equal(t, 200, got.StatusCode)
+		assert.Equal(t, 1, m.Count())
+		assert.Empty(t, drainRecords(sub.Ch))
+	})
+
+	t.Run("empty ID generates and appends", func(t *testing.T) {
+		m := NewRequestManager(10)
+		rec := final("")
+		rec.Timestamp = time.Now()
+		m.Upsert(rec)
+		assert.Equal(t, 1, m.Count())
+		assert.NotEmpty(t, m.Recent(RequestFilter{})[0].ID)
+	})
+}
+
+func TestRequestManager_Upsert_PreservesRingPosition(t *testing.T) {
+	m := NewRequestManager(10)
+
+	m.Upsert(RequestRecord{ID: "old", Method: "GET", URL: "/old"})
+	m.Upsert(RequestRecord{ID: "stream", Method: "GET", URL: "/stream", InFlight: true})
+	m.Upsert(RequestRecord{ID: "new", Method: "GET", URL: "/new"})
+
+	// Completing "stream" must not move it to the newest position.
+	m.Upsert(RequestRecord{ID: "stream", Method: "GET", URL: "/stream", Duration: time.Second})
+
+	recent := m.Recent(RequestFilter{})
+	require.Len(t, recent, 3)
+	assert.Equal(t, "new", recent[0].ID)
+	assert.Equal(t, "stream", recent[1].ID)
+	assert.Equal(t, "old", recent[2].ID)
+	assert.False(t, recent[1].InFlight)
+	assert.Equal(t, time.Second, recent[1].Duration)
+}
+
+func TestRequestManager_Upsert_AppendEvictsLikeRecord(t *testing.T) {
+	m := NewRequestManager(2)
+	var evicted []string
+	m.SetEvictionCallback(func(id string) { evicted = append(evicted, id) })
+
+	details := &RequestDetails{RequestHeaders: map[string][]string{"X": {"y"}}}
+	m.Record(RequestRecord{ID: "a", Details: details})
+	m.Record(RequestRecord{ID: "b"})
+
+	// Ring full: appending via Upsert must evict "a" (Details-carrying).
+	m.Upsert(RequestRecord{ID: "c"})
+	assert.Equal(t, []string{"a"}, evicted)
+
+	// Updating in place must NOT evict anything.
+	m.Upsert(RequestRecord{ID: "b", InFlight: true}) // no-op: b is final
+	m.Upsert(RequestRecord{ID: "c", InFlight: true}) // no-op: c is final
+	assert.Equal(t, []string{"a"}, evicted)
+	assert.Equal(t, 2, m.Count())
+}
+
+func TestRequestManager_Upsert_StuckInFlightWithoutCompletion(t *testing.T) {
+	// Documented outcome (plan 006 §9): if a completion event is lost and no
+	// later snapshot carries the final record, the row stays in-flight until
+	// evicted. Pinned so the semantics are deliberate, not accidental.
+	m := NewRequestManager(10)
+	m.Upsert(RequestRecord{ID: "lost", InFlight: true})
+	for i := 0; i < 5; i++ {
+		m.Upsert(RequestRecord{ID: GenerateRequestID(time.Now(), "GET", "/x"), StatusCode: 200})
+	}
+	got, ok := m.GetByID("lost")
+	require.True(t, ok)
+	assert.True(t, got.InFlight)
+}
+
+func TestRequestManager_Upsert_PurgeAfterUpdateCompacts(t *testing.T) {
+	m := NewRequestManager(10)
+	m.Upsert(RequestRecord{ID: "p1", ProjectDir: "/p", InFlight: true})
+	m.Upsert(RequestRecord{ID: "q1", ProjectDir: "/q", InFlight: true})
+	m.Upsert(RequestRecord{ID: "p1", ProjectDir: "/p", StatusCode: 200})
+	m.Upsert(RequestRecord{ID: "q1", ProjectDir: "/q", StatusCode: 200})
+
+	m.PurgeByProject("/p")
+
+	remaining := m.Recent(RequestFilter{})
+	require.Len(t, remaining, 1)
+	assert.Equal(t, "q1", remaining[0].ID)
+
+	// The ring stays consistent for further writes after compaction.
+	m.Upsert(RequestRecord{ID: "q2", ProjectDir: "/q", StatusCode: 200})
+	assert.Equal(t, 2, m.Count())
+}
+
+func TestRequestManager_Upsert_ConcurrentTransitions(t *testing.T) {
+	// Race in-flight and final Upserts for the same IDs (with concurrent
+	// readers and purges) and assert: storage always converges to final, and
+	// no subscriber ever observes in-flight AFTER final for the same ID —
+	// the under-lock notify guarantee.
+	m := NewRequestManager(100)
+	sub := m.Subscribe(RequestFilter{})
+
+	seenFinal := make(map[string]bool)
+	violation := false
+	consumed := make(chan struct{})
+	go func() {
+		defer close(consumed)
+		for rec := range sub.Ch {
+			if rec.InFlight && seenFinal[rec.ID] {
+				violation = true
+			}
+			if !rec.InFlight {
+				seenFinal[rec.ID] = true
+			}
+		}
+	}()
+
+	const n = 50
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		id := fmt.Sprintf("req-%d", i)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			m.Upsert(RequestRecord{ID: id, InFlight: true, StatusCode: 200})
+		}()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			m.Upsert(RequestRecord{ID: id, StatusCode: 200, Duration: time.Millisecond})
+		}()
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 10; i++ {
+			m.Recent(RequestFilter{})
+			m.PurgeByProject("/nonexistent")
+		}
+	}()
+	wg.Wait()
+	m.Close()
+	<-consumed
+
+	assert.False(t, violation, "subscriber observed in-flight after final for the same ID")
+	for i := 0; i < n; i++ {
+		id := fmt.Sprintf("req-%d", i)
+		got, ok := m.GetByID(id)
+		require.True(t, ok, id)
+		assert.False(t, got.InFlight, id)
+	}
+}
+
+func TestRequestRecord_InFlightOmittedWhenFinal(t *testing.T) {
+	data, err := json.Marshal(RequestRecord{ID: "r1", StatusCode: 200})
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "in_flight")
+
+	data, err = json.Marshal(RequestRecord{ID: "r1", StatusCode: 200, InFlight: true})
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"in_flight":true`)
 }

--- a/internal/proxyd/client.go
+++ b/internal/proxyd/client.go
@@ -8,7 +8,11 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
+	"strconv"
 	"time"
+
+	"github.com/charliek/prox/internal/proxy"
 )
 
 // Client communicates with the proxy daemon over its Unix socket.
@@ -125,6 +129,55 @@ func (c *Client) Routes() ([]RouteInfo, error) {
 	return result.Routes, nil
 }
 
+// Requests fetches a snapshot of the daemon's recent records for a project over
+// the Unix socket (GET /api/v1/requests?project=<dir>&limit=<n>), decoding the
+// {"requests":[...]} wrapper. The daemon returns records newest-first.
+//
+// The decode is all-or-nothing: the entire response body is read and
+// unmarshalled into a slice before any record is returned, so a truncated or
+// malformed body yields (nil, error) rather than a partial set — a caller
+// replaying the result into a RequestManager applies zero records on failure.
+//
+// ctx bounds the fetch: the forwarder passes its own context so a shutdown or
+// reconnect cancels an in-flight snapshot instead of waiting out the client's
+// 30s timeout. limit must be supplied explicitly (an omitted limit backfills
+// only the daemon's default of 100).
+func (c *Client) Requests(ctx context.Context, projectDir string, limit int) ([]proxy.RequestRecord, error) {
+	q := url.Values{}
+	q.Set("project", projectDir)
+	q.Set("limit", strconv.Itoa(limit))
+
+	resp, err := c.getWithContext(ctx, "/api/v1/requests?"+q.Encode())
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, c.readError(resp)
+	}
+
+	// Read the whole body before decoding so a truncated response fails the
+	// unmarshal (all-or-nothing) rather than yielding a partial slice.
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading requests response: %w", err)
+	}
+	var result struct {
+		Requests []proxy.RequestRecord `json:"requests"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("decoding requests response: %w", err)
+	}
+	// The daemon always emits a non-nil slice ("requests":[] when empty), so a
+	// nil slice means valid JSON of the wrong shape ({} or a misspelled key) —
+	// treat it as malformed rather than a silent empty backfill.
+	if result.Requests == nil {
+		return nil, fmt.Errorf("snapshot response missing requests key")
+	}
+	return result.Requests, nil
+}
+
 // Shutdown requests the daemon to shut down.
 func (c *Client) Shutdown(force bool) error {
 	path := "/api/v1/shutdown"
@@ -146,14 +199,22 @@ func (c *Client) Shutdown(force bool) error {
 // get performs an HTTP GET to the daemon.
 func (c *Client) get(path string) (*http.Response, error) {
 	// "http://proxyd" is a dummy host — the Unix socket transport ignores it.
-	url := "http://proxyd" + path
-	return c.httpClient.Get(url)
+	return c.httpClient.Get("http://proxyd" + path)
+}
+
+// getWithContext performs an HTTP GET to the daemon bound to ctx, so a caller
+// can cancel the request (e.g. on shutdown) without waiting out the client's
+// timeout. The existing get helper is left ctx-less for its callers.
+func (c *Client) getWithContext(ctx context.Context, path string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://proxyd"+path, nil)
+	if err != nil {
+		return nil, err
+	}
+	return c.httpClient.Do(req)
 }
 
 // post performs an HTTP POST to the daemon with a JSON body.
 func (c *Client) post(path string, body any) (*http.Response, error) {
-	url := "http://proxyd" + path
-
 	var bodyReader io.Reader
 	if body != nil {
 		data, err := json.Marshal(body)
@@ -163,7 +224,7 @@ func (c *Client) post(path string, body any) (*http.Response, error) {
 		bodyReader = bytes.NewReader(data)
 	}
 
-	return c.httpClient.Post(url, "application/json", bodyReader)
+	return c.httpClient.Post("http://proxyd"+path, "application/json", bodyReader)
 }
 
 // readError reads an error response from the daemon.

--- a/internal/proxyd/client.go
+++ b/internal/proxyd/client.go
@@ -157,17 +157,22 @@ func (c *Client) Requests(ctx context.Context, projectDir string, limit int) ([]
 		return nil, c.readError(resp)
 	}
 
-	// Read the whole body before decoding so a truncated response fails the
-	// unmarshal (all-or-nothing) rather than yielding a partial slice.
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading requests response: %w", err)
-	}
+	// Stream-decode into the wrapper (no io.ReadAll: a full snapshot's raw
+	// JSON alongside its decoded records would double peak memory). The
+	// all-or-nothing contract holds: Decode either fully unmarshals the
+	// wrapper or errors, and on error no records are returned; a truncated
+	// response fails the decode rather than yielding a partial slice.
 	var result struct {
 		Requests []proxy.RequestRecord `json:"requests"`
 	}
-	if err := json.Unmarshal(body, &result); err != nil {
+	dec := json.NewDecoder(resp.Body)
+	if err := dec.Decode(&result); err != nil {
 		return nil, fmt.Errorf("decoding requests response: %w", err)
+	}
+	// Reject trailing non-whitespace data — a concatenated or garbled
+	// response should not pass as a valid snapshot.
+	if _, err := dec.Token(); err != io.EOF {
+		return nil, fmt.Errorf("trailing data after requests response")
 	}
 	// The daemon always emits a non-nil slice ("requests":[] when empty), so a
 	// nil slice means valid JSON of the wrong shape ({} or a misspelled key) —

--- a/internal/proxyd/client_server_test.go
+++ b/internal/proxyd/client_server_test.go
@@ -1,11 +1,20 @@
 package proxyd
 
 import (
+	"context"
+	"fmt"
+	"io"
 	"log/slog"
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/charliek/prox/internal/constants"
+	"github.com/charliek/prox/internal/proxy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func startTestServer(t *testing.T) (*Server, *Client, string) {
@@ -213,6 +222,76 @@ func TestShutdownProtected(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Shutdown(force): %v", err)
 	}
+}
+
+// TestClientRequests pins the Client.Requests contract against the real daemon
+// endpoint: it URL-escapes awkward project dirs (spaces/#) so the server matches
+// them, honors the explicit limit, and decodes the {"requests":[...]} wrapper.
+func TestClientRequests(t *testing.T) {
+	server, client, _ := startTestServer(t)
+
+	daemonRM := proxy.NewRequestManager(100)
+	server.SetRequestManager(daemonRM)
+
+	// A project dir with a space and a '#': if the client did not URL-escape it,
+	// the '#' would be treated as a fragment and the server's project filter
+	// would never match, returning zero records.
+	const dir = "/weird dir #1"
+	for i := 0; i < 5; i++ {
+		daemonRM.Record(proxy.RequestRecord{
+			ID: fmt.Sprintf("r%d", i), ProjectDir: dir, Method: "GET", URL: "/x", Timestamp: time.Now(),
+		})
+	}
+	// A record for a different project must never leak into the filtered result.
+	daemonRM.Record(proxy.RequestRecord{ID: "other", ProjectDir: "/other", Method: "GET", URL: "/y", Timestamp: time.Now()})
+
+	t.Run("escapes dir, honors limit, decodes wrapper", func(t *testing.T) {
+		recs, err := client.Requests(t.Context(), dir, 3)
+		require.NoError(t, err)
+		require.Len(t, recs, 3, "explicit limit honored")
+		for _, r := range recs {
+			assert.Equal(t, dir, r.ProjectDir, "escaped project matched server-side")
+		}
+	})
+
+	t.Run("full snapshot with MaxProxyRequests limit", func(t *testing.T) {
+		recs, err := client.Requests(t.Context(), dir, constants.MaxProxyRequests)
+		require.NoError(t, err)
+		assert.Len(t, recs, 5, "all of the project's records, none of /other's")
+	})
+}
+
+// TestClientRequests_TruncatedBodyAllOrNothing pins that a truncated 200
+// response yields (nil, error) — no partial records leak through the wrapper.
+func TestClientRequests_TruncatedBodyAllOrNothing(t *testing.T) {
+	socketPath := startRawSSEServerMux(t,
+		func(_ http.ResponseWriter, _ *http.Request) {},
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"requests":[{"id":"abc","method":"GET"`) // truncated mid-object
+		})
+
+	client := NewClient(socketPath)
+	recs, err := client.Requests(context.Background(), "/p", constants.MaxProxyRequests)
+	require.Error(t, err)
+	assert.Nil(t, recs, "all-or-nothing: no partial records on a truncated body")
+}
+
+// TestClientRequests_WrongShapeWrapper pins that a 200 with valid JSON of the
+// wrong shape ({} — missing the "requests" key) is treated as malformed rather
+// than a silent empty backfill: the daemon always emits a non-nil slice.
+func TestClientRequests_WrongShapeWrapper(t *testing.T) {
+	socketPath := startRawSSEServerMux(t,
+		func(_ http.ResponseWriter, _ *http.Request) {},
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{}`)
+		})
+
+	client := NewClient(socketPath)
+	recs, err := client.Requests(context.Background(), "/p", constants.MaxProxyRequests)
+	require.Error(t, err)
+	assert.Nil(t, recs, "missing requests key must error, not read as empty")
 }
 
 func TestDomainConflictViaClient(t *testing.T) {

--- a/internal/proxyd/dynamic_proxy.go
+++ b/internal/proxyd/dynamic_proxy.go
@@ -175,10 +175,16 @@ func (dp *DynamicProxy) handler(port int) http.Handler {
 		captureEnabled := route.CaptureEnabled && dp.captureManager != nil && dp.captureManager.Enabled()
 
 		// Generate the request ID BEFORE proxying so capture files (written by
-		// FinalizeResponse) are named consistently with the recorded record.
-		requestID := ""
-		if captureEnabled {
-			requestID = proxy.GenerateRequestID(startTime, r.Method, r.URL.String())
+		// FinalizeResponse) are named consistently with the recorded record,
+		// AND so the in-flight and completion records share an ID on every
+		// route (capture or not).
+		requestID := proxy.GenerateRequestID(startTime, r.Method, r.URL.String())
+
+		// Extract subdomain for backward compat (computed before ServeHTTP so
+		// the in-flight and completion records share the expression).
+		subdomain := ""
+		if idx := strings.Index(hostname, "."); idx != -1 {
+			subdomain = hostname[:idx]
 		}
 
 		target := &url.URL{
@@ -238,14 +244,55 @@ func (dp *DynamicProxy) handler(port int) http.Handler {
 			http.Error(w, "Backend unavailable", http.StatusBadGateway)
 		}
 
-		rp.ServeHTTP(rw, r)
+		// buildRecord is the single field-parity point for the two-phase
+		// recording: the in-flight and completion records for one request differ
+		// ONLY in inFlight (which zeroes Duration), the StatusCode source, and
+		// Details. Every other field is this one expression.
+		buildRecord := func(statusCode int, details *proxy.RequestDetails, inFlight bool) proxy.RequestRecord {
+			duration := time.Duration(0)
+			if !inFlight {
+				duration = time.Since(startTime)
+			}
+			return proxy.RequestRecord{
+				ID:         requestID,
+				Timestamp:  startTime,
+				Method:     r.Method,
+				URL:        r.URL.String(),
+				Subdomain:  subdomain,
+				Hostname:   hostname,
+				ProjectDir: route.ProjectDir,
+				StatusCode: statusCode,
+				Duration:   duration,
+				RemoteAddr: r.RemoteAddr,
+				InFlight:   inFlight,
+				Details:    details,
+			}
+		}
 
-		// Record the request
+		// Phase 1 (in-flight): register a first-response hook that publishes a
+		// header-time record via Record (plain append — the fresh ID cannot
+		// already exist). buildRecord pins field parity with the completion
+		// record below.
 		if dp.requestManager != nil {
-			// Extract subdomain for backward compat
-			subdomain := ""
-			if idx := strings.Index(hostname, "."); idx != -1 {
-				subdomain = hostname[:idx]
+			onFirst := func(statusCode int) {
+				dp.requestManager.Record(buildRecord(statusCode, nil, true))
+			}
+			if crw != nil {
+				crw.SetFirstResponseCallback(onFirst)
+			} else {
+				srw.SetFirstResponseCallback(onFirst)
+			}
+		}
+
+		// Phase 2 (completion): the finalize-freeze + record build runs in a
+		// defer registered BEFORE ServeHTTP with NO recover, so it executes on
+		// normal return AND while unwinding ReverseProxy's http.ErrAbortHandler
+		// panic (client disconnect / backend death mid-stream). The panic keeps
+		// propagating; net/http suppresses ErrAbortHandler. Completion goes
+		// through Upsert (same ID as the in-flight record; final beats it).
+		defer func() {
+			if dp.requestManager == nil {
+				return
 			}
 
 			// Finalize capture (if enabled) and derive the status code from the
@@ -280,24 +327,19 @@ func (dp *DynamicProxy) handler(port int) http.Handler {
 					RequestBody:     reqBody,
 					ResponseBody:    resBody,
 				}
+			case srw.Hijacked():
+				// Non-capture WebSocket upgrade: record 101 to match the
+				// in-flight record and the capture path (the writer's default
+				// 200 would otherwise disagree).
+				statusCode = http.StatusSwitchingProtocols
 			default:
 				statusCode = srw.statusCode
 			}
 
-			dp.requestManager.Record(proxy.RequestRecord{
-				ID:         requestID, // empty for non-capture routes; Record generates one
-				Timestamp:  startTime,
-				Method:     r.Method,
-				URL:        r.URL.String(),
-				Subdomain:  subdomain,
-				Hostname:   hostname,
-				ProjectDir: route.ProjectDir,
-				StatusCode: statusCode,
-				Duration:   time.Since(startTime),
-				RemoteAddr: r.RemoteAddr,
-				Details:    details,
-			})
-		}
+			dp.requestManager.Upsert(buildRecord(statusCode, details, false))
+		}()
+
+		rp.ServeHTTP(rw, r)
 	})
 }
 
@@ -306,12 +348,45 @@ type statusResponseWriter struct {
 	http.ResponseWriter
 	statusCode  int
 	wroteHeader bool
+	hijacked    bool
+
+	// onFirstResponse, if set, fires exactly once at the first final response
+	// event — see fireFirstResponse. responded latches so it can never re-fire.
+	onFirstResponse func(statusCode int)
+	responded       bool
+}
+
+// SetFirstResponseCallback registers a callback that fires exactly once at the
+// first FINAL response event (see fireFirstResponse). Single-goroutine access
+// per the http.ResponseWriter contract; set before serving.
+func (w *statusResponseWriter) SetFirstResponseCallback(fn func(statusCode int)) {
+	w.onFirstResponse = fn
+}
+
+// fireFirstResponse invokes the first-response callback at most once. It is
+// driven ONLY from WriteHeader (final status) and a successful Hijack — never
+// from an implicit bare Write. The reverse proxy always calls WriteHeader
+// explicitly for normal responses and hijacks for upgrades.
+func (w *statusResponseWriter) fireFirstResponse(code int) {
+	if w.responded {
+		return
+	}
+	w.responded = true
+	if w.onFirstResponse != nil {
+		w.onFirstResponse(code)
+	}
 }
 
 func (w *statusResponseWriter) WriteHeader(code int) {
-	if !w.wroteHeader {
-		w.statusCode = code
-		w.wroteHeader = true
+	// 1xx provisional responses (e.g. 103 Early Hints) are not the final
+	// status: they neither latch the recorded status nor fire the hook.
+	if code >= 200 {
+		if !w.wroteHeader {
+			w.statusCode = code
+			w.wroteHeader = true
+		}
+		// Order: latch status → invoke callback → delegate.
+		w.fireFirstResponse(code)
 	}
 	w.ResponseWriter.WriteHeader(code)
 }
@@ -326,9 +401,21 @@ func (w *statusResponseWriter) Flush() {
 // Hijack implements http.Hijacker for WebSocket support.
 func (w *statusResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	if h, ok := w.ResponseWriter.(http.Hijacker); ok {
-		return h.Hijack()
+		conn, rw, err := h.Hijack()
+		if err == nil {
+			w.hijacked = true
+			// A successful upgrade never calls WriteHeader (the 101 is written
+			// raw to the hijacked conn), so fire the hook here with 101.
+			w.fireFirstResponse(http.StatusSwitchingProtocols)
+		}
+		return conn, rw, err
 	}
 	return nil, nil, errors.New("hijacking not supported")
+}
+
+// Hijacked reports whether the connection was taken over (WebSocket upgrade).
+func (w *statusResponseWriter) Hijacked() bool {
+	return w.hijacked
 }
 
 // Unwrap returns the underlying ResponseWriter for http.ResponseController compatibility.

--- a/internal/proxyd/dynamic_proxy.go
+++ b/internal/proxyd/dynamic_proxy.go
@@ -236,11 +236,10 @@ func (dp *DynamicProxy) handler(port int) http.Handler {
 				"target", target.String(),
 				"error", err,
 			)
-			if crw != nil {
-				crw.WriteHeader(http.StatusBadGateway)
-			} else {
-				srw.statusCode = http.StatusBadGateway
-			}
+			// http.Error writes the 502 through the wrapped writer (latching
+			// the status and firing the first-response hook); an explicit
+			// WriteHeader first would commit the response before http.Error
+			// could set its error headers.
 			http.Error(w, "Backend unavailable", http.StatusBadGateway)
 		}
 

--- a/internal/proxyd/dynamic_proxy_test.go
+++ b/internal/proxyd/dynamic_proxy_test.go
@@ -3,6 +3,7 @@ package proxyd
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"io"
 	"log/slog"
 	"net"
@@ -13,11 +14,14 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/charliek/prox/internal/constants"
 	"github.com/charliek/prox/internal/proxy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // newTestBackend starts an httptest server running h and returns its host, port,
@@ -230,6 +234,11 @@ func TestDynamicProxy_Hijacked_RecordsSwitchingProtocols(t *testing.T) {
 
 	dp, rm, _ := newCaptureProxy(t, true, host, port, 10)
 
+	// Subscribe before driving: the ring holds ONE record (in-flight 101 then a
+	// final 101 upserted in place), but a subscriber sees TWO events.
+	sub := rm.Subscribe(proxy.RequestFilter{ProjectDir: "/projects/a"})
+	defer rm.Unsubscribe(sub.ID)
+
 	clientEnd, testEnd := net.Pipe()
 	defer clientEnd.Close()
 	defer testEnd.Close()
@@ -265,6 +274,17 @@ func TestDynamicProxy_Hijacked_RecordsSwitchingProtocols(t *testing.T) {
 	if rec0.Details != nil {
 		t.Error("Details should be nil for a hijacked (metadata-only) record")
 	}
+
+	// Two subscriber events: in-flight 101 then final 101 metadata-only.
+	ev1 := readProxydEvent(t, sub.Ch)
+	ev2 := readProxydEvent(t, sub.Ch)
+	assertNoMoreProxydEvents(t, sub.Ch)
+	assert.True(t, ev1.InFlight)
+	assert.Equal(t, http.StatusSwitchingProtocols, ev1.StatusCode)
+	assert.False(t, ev2.InFlight)
+	assert.Equal(t, http.StatusSwitchingProtocols, ev2.StatusCode)
+	assert.Nil(t, ev2.Details)
+	assertProxydFieldParity(t, ev1, ev2)
 }
 
 func TestDynamicProxy_ErrorHandler_CaptureRecordsBadGateway(t *testing.T) {
@@ -331,4 +351,302 @@ func TestDaemonCaptureDir_IsolatedHome(t *testing.T) {
 	if fi, err := os.Stat(want); err != nil || !fi.IsDir() {
 		t.Errorf("capture dir %s not created (err=%v)", want, err)
 	}
+}
+
+// --- first-response hook + two-phase recording (C4) ---
+
+func readProxydEvent(t *testing.T, ch <-chan proxy.RequestRecord) proxy.RequestRecord {
+	t.Helper()
+	select {
+	case rec := <-ch:
+		return rec
+	case <-time.After(3 * time.Second):
+		t.Fatal("expected a subscriber event, got none")
+		return proxy.RequestRecord{}
+	}
+}
+
+func assertNoMoreProxydEvents(t *testing.T, ch <-chan proxy.RequestRecord) {
+	t.Helper()
+	select {
+	case rec := <-ch:
+		t.Fatalf("unexpected extra subscriber event: %+v", rec)
+	case <-time.After(150 * time.Millisecond):
+	}
+}
+
+// assertProxydFieldParity pins that the in-flight and completion records agree
+// on every field except InFlight, Duration, and Details (StatusCode is the same
+// value in these tests, so it is asserted equal too).
+func assertProxydFieldParity(t *testing.T, inflight, final proxy.RequestRecord) {
+	t.Helper()
+	assert.Equal(t, inflight.ID, final.ID)
+	assert.Equal(t, inflight.Timestamp, final.Timestamp)
+	assert.Equal(t, inflight.Method, final.Method)
+	assert.Equal(t, inflight.URL, final.URL)
+	assert.Equal(t, inflight.Subdomain, final.Subdomain)
+	assert.Equal(t, inflight.Hostname, final.Hostname)
+	assert.Equal(t, inflight.ProjectDir, final.ProjectDir)
+	assert.Equal(t, inflight.RemoteAddr, final.RemoteAddr)
+	assert.Equal(t, inflight.StatusCode, final.StatusCode)
+}
+
+// newPipeHijackRecorder returns a hijackRecorder whose Hijack() succeeds,
+// backed by an in-memory net.Pipe.
+func newPipeHijackRecorder(t *testing.T) *hijackRecorder {
+	t.Helper()
+	c1, c2 := net.Pipe()
+	t.Cleanup(func() { _ = c1.Close(); _ = c2.Close() })
+	go func() { _, _ = io.Copy(io.Discard, c2) }() // drain what the writer flushes
+	return &hijackRecorder{ResponseRecorder: httptest.NewRecorder(), conn: c1}
+}
+
+func TestStatusResponseWriter_FirstResponseHook(t *testing.T) {
+	newSRW := func(w http.ResponseWriter) *statusResponseWriter {
+		return &statusResponseWriter{ResponseWriter: w, statusCode: http.StatusOK}
+	}
+
+	t.Run("repeated WriteHeader fires once with the first >=200 code", func(t *testing.T) {
+		srw := newSRW(httptest.NewRecorder())
+		var calls []int
+		srw.SetFirstResponseCallback(func(code int) { calls = append(calls, code) })
+
+		srw.WriteHeader(http.StatusCreated)
+		srw.WriteHeader(http.StatusInternalServerError)
+
+		assert.Equal(t, []int{http.StatusCreated}, calls)
+		assert.Equal(t, http.StatusCreated, srw.statusCode, "first-wins latch")
+	})
+
+	t.Run("1xx then 200 fires once with 200 and records 200", func(t *testing.T) {
+		srw := newSRW(httptest.NewRecorder())
+		var calls []int
+		srw.SetFirstResponseCallback(func(code int) { calls = append(calls, code) })
+
+		srw.WriteHeader(http.StatusEarlyHints) // 103
+		assert.Empty(t, calls, "1xx must not fire the hook")
+		assert.Equal(t, http.StatusOK, srw.statusCode, "1xx must not latch the status")
+
+		srw.WriteHeader(http.StatusOK)
+		assert.Equal(t, []int{http.StatusOK}, calls)
+		assert.Equal(t, http.StatusOK, srw.statusCode)
+	})
+
+	t.Run("implicit bare Write does not fire the hook", func(t *testing.T) {
+		srw := newSRW(httptest.NewRecorder())
+		var calls []int
+		srw.SetFirstResponseCallback(func(code int) { calls = append(calls, code) })
+
+		_, _ = srw.Write([]byte("hi"))
+		assert.Empty(t, calls)
+	})
+
+	t.Run("failed hijack does not fire the hook", func(t *testing.T) {
+		srw := newSRW(httptest.NewRecorder()) // ResponseRecorder is not a Hijacker
+		var calls []int
+		srw.SetFirstResponseCallback(func(code int) { calls = append(calls, code) })
+
+		_, _, err := srw.Hijack()
+		require.Error(t, err)
+		assert.Empty(t, calls)
+		assert.False(t, srw.Hijacked())
+	})
+
+	t.Run("successful hijack fires 101 once, no re-fire on late WriteHeader", func(t *testing.T) {
+		srw := newSRW(newPipeHijackRecorder(t))
+		var calls []int
+		srw.SetFirstResponseCallback(func(code int) { calls = append(calls, code) })
+
+		_, _, err := srw.Hijack()
+		require.NoError(t, err)
+		assert.Equal(t, []int{http.StatusSwitchingProtocols}, calls)
+		assert.True(t, srw.Hijacked())
+
+		srw.WriteHeader(http.StatusOK)
+		assert.Equal(t, []int{http.StatusSwitchingProtocols}, calls)
+	})
+}
+
+func TestDynamicProxy_TwoPhaseRecording(t *testing.T) {
+	for _, capture := range []bool{false, true} {
+		capture := capture
+		name := "capture-off"
+		if capture {
+			name = "capture-on"
+		}
+		t.Run(name, func(t *testing.T) {
+			release := make(chan struct{})
+			var once sync.Once
+			doRelease := func() { once.Do(func() { close(release) }) }
+			t.Cleanup(doRelease)
+
+			host, port := newTestBackend(t, func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/plain")
+				w.WriteHeader(http.StatusAccepted) // 202
+				_, _ = w.Write([]byte("partial"))
+				w.(http.Flusher).Flush()
+				<-release
+				_, _ = w.Write([]byte("-rest"))
+			})
+
+			dp, rm, _ := newCaptureProxy(t, capture, host, port, 10)
+			filter := proxy.RequestFilter{ProjectDir: "/projects/a"}
+
+			sub := rm.Subscribe(filter)
+			defer rm.Unsubscribe(sub.ID)
+
+			req := httptest.NewRequest("GET", "http://api.local.dev/stream", nil)
+			req.Host = "api.local.dev"
+			rec := httptest.NewRecorder()
+
+			done := make(chan struct{})
+			go func() {
+				dp.handler(80).ServeHTTP(rec, req)
+				close(done)
+			}()
+
+			var inflightID string
+			require.Eventually(t, func() bool {
+				recs := rm.Recent(filter)
+				if len(recs) != 1 || !recs[0].InFlight {
+					return false
+				}
+				inflightID = recs[0].ID
+				return recs[0].StatusCode == http.StatusAccepted
+			}, 3*time.Second, 5*time.Millisecond, "in-flight record should appear mid-stream")
+
+			mid := rm.Recent(filter)
+			require.Len(t, mid, 1)
+			assert.Equal(t, time.Duration(0), mid[0].Duration)
+			assert.Nil(t, mid[0].Details, "in-flight record carries no Details")
+
+			doRelease()
+			select {
+			case <-done:
+			case <-time.After(3 * time.Second):
+				t.Fatal("handler did not complete after release")
+			}
+
+			finals := rm.Recent(filter)
+			require.Len(t, finals, 1, "completion replaces the same ID in place")
+			f := finals[0]
+			assert.Equal(t, inflightID, f.ID)
+			assert.False(t, f.InFlight)
+			assert.Equal(t, http.StatusAccepted, f.StatusCode)
+			assert.Greater(t, f.Duration, time.Duration(0))
+			if capture {
+				require.NotNil(t, f.Details)
+				require.NotNil(t, f.Details.ResponseBody)
+				assert.Equal(t, "partial-rest", string(f.Details.ResponseBody.Data))
+			} else {
+				assert.Nil(t, f.Details)
+			}
+
+			ev1 := readProxydEvent(t, sub.Ch)
+			ev2 := readProxydEvent(t, sub.Ch)
+			assertNoMoreProxydEvents(t, sub.Ch)
+			assert.True(t, ev1.InFlight)
+			assert.False(t, ev2.InFlight)
+			assertProxydFieldParity(t, ev1, ev2)
+		})
+	}
+}
+
+func TestDynamicProxy_Hijacked_NonCapture_Records101(t *testing.T) {
+	// The deliberate D8 behavior change: a non-capture hijacked request now
+	// records 101 (previously the writer's default 200).
+	host, port := newTestBackend(t, func(w http.ResponseWriter, r *http.Request) {
+		conn, _, err := w.(http.Hijacker).Hijack()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		_, _ = conn.Write([]byte("HTTP/1.1 101 Switching Protocols\r\n" +
+			"Connection: Upgrade\r\nUpgrade: websocket\r\n\r\n"))
+	})
+
+	dp, rm, _ := newCaptureProxy(t, false, host, port, 10) // capture OFF
+	sub := rm.Subscribe(proxy.RequestFilter{ProjectDir: "/projects/a"})
+	defer rm.Unsubscribe(sub.ID)
+
+	hr := newPipeHijackRecorder(t)
+	req := httptest.NewRequest("GET", "http://api.local.dev/ws", nil)
+	req.Host = "api.local.dev"
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Upgrade", "websocket")
+
+	done := make(chan struct{})
+	go func() {
+		dp.handler(80).ServeHTTP(hr, req)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("hijacked request did not complete within 5s")
+	}
+
+	records := rm.Recent(proxy.RequestFilter{ProjectDir: "/projects/a"})
+	require.Len(t, records, 1)
+	assert.Equal(t, http.StatusSwitchingProtocols, records[0].StatusCode,
+		"non-capture hijack now records 101, not the writer's default 200")
+	assert.Nil(t, records[0].Details)
+
+	ev1 := readProxydEvent(t, sub.Ch)
+	ev2 := readProxydEvent(t, sub.Ch)
+	assertNoMoreProxydEvents(t, sub.Ch)
+	assert.True(t, ev1.InFlight)
+	assert.Equal(t, http.StatusSwitchingProtocols, ev1.StatusCode)
+	assert.False(t, ev2.InFlight)
+	assert.Equal(t, http.StatusSwitchingProtocols, ev2.StatusCode)
+}
+
+func TestDynamicProxy_ClientDisconnect_RecordsCompletion(t *testing.T) {
+	// Real front server so ReverseProxy panics http.ErrAbortHandler on the
+	// mid-stream copy failure; the deferred completion must still record.
+	release := make(chan struct{})
+	var once sync.Once
+	t.Cleanup(func() { once.Do(func() { close(release) }) })
+
+	host, port := newTestBackend(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		for i := 0; i < 10000; i++ {
+			if _, err := w.Write([]byte("chunk-of-streaming-body-")); err != nil {
+				return
+			}
+			w.(http.Flusher).Flush()
+			select {
+			case <-release:
+				return
+			case <-time.After(2 * time.Millisecond):
+			}
+		}
+	})
+
+	dp, rm, _ := newCaptureProxy(t, true, host, port, 10)
+	front := httptest.NewServer(dp.handler(80))
+	defer front.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req, err := http.NewRequestWithContext(ctx, "GET", front.URL+"/stream", nil)
+	require.NoError(t, err)
+	req.Host = "api.local.dev"
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	buf := make([]byte, 8)
+	_, _ = io.ReadFull(resp.Body, buf)
+	cancel()
+	_ = resp.Body.Close()
+
+	filter := proxy.RequestFilter{ProjectDir: "/projects/a"}
+	require.Eventually(t, func() bool {
+		recs := rm.Recent(filter)
+		return len(recs) == 1 && !recs[0].InFlight && recs[0].Duration > 0
+	}, 3*time.Second, 10*time.Millisecond, "aborted stream must produce a final record")
+
+	f := rm.Recent(filter)[0]
+	assert.Equal(t, http.StatusOK, f.StatusCode)
+	require.NotNil(t, f.Details, "capture-on aborted stream still records details")
 }

--- a/internal/proxyd/forwarder.go
+++ b/internal/proxyd/forwarder.go
@@ -24,12 +24,24 @@ import (
 // projectDir must be the same value sent as RegisterRequest.ProjectDir so the
 // daemon-side filter (which scopes records by owning project) matches.
 //
+// On every (re)connect the bridge also backfills a snapshot of the daemon's
+// current ring for this project (see streamRequests / backfillSnapshot), closing
+// any gap opened while the subscription was down. The subscription itself stays
+// lossy (bounded, non-blocking channels), so the guarantee is bounded gap
+// closure, not losslessness.
+//
 // It runs until ctx is cancelled. On disconnect, it reconnects with backoff.
 func ForwardRequests(ctx context.Context, socketPath string, projectDir string, localRM *proxy.RequestManager) {
+	// One snapshot client for the whole forwarder lifetime: its transport pools
+	// the idle unix connection across reconnect attempts, rather than leaking a
+	// fresh idle conn per attempt (the daemon only reaps idle conns after 60s, so
+	// a reconnect storm would otherwise accumulate them).
+	snapClient := NewClient(socketPath)
+
 	backoff := 500 * time.Millisecond
 
 	for {
-		err := streamRequests(ctx, socketPath, projectDir, localRM)
+		err := streamRequests(ctx, socketPath, snapClient, projectDir, localRM)
 		if ctx.Err() != nil {
 			return // context cancelled, clean shutdown
 		}
@@ -48,7 +60,8 @@ func ForwardRequests(ctx context.Context, socketPath string, projectDir string, 
 }
 
 // streamRequests opens an SSE connection to the daemon and processes events.
-func streamRequests(ctx context.Context, socketPath, projectDir string, localRM *proxy.RequestManager) error {
+// snapClient is the shared daemon client used for the backfill snapshot.
+func streamRequests(ctx context.Context, socketPath string, snapClient *Client, projectDir string, localRM *proxy.RequestManager) error {
 	// Create HTTP client that dials the Unix socket
 	dialer := &net.Dialer{}
 	client := &http.Client{
@@ -74,6 +87,25 @@ func streamRequests(ctx context.Context, socketPath, projectDir string, localRM 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("daemon SSE returned %d", resp.StatusCode)
 	}
+
+	// The daemon Subscribes before it writes response headers, so once Do
+	// returned 200 the subscription is already live. Backfill a snapshot of the
+	// daemon's ring concurrently with the read loop below: launching it in a
+	// goroutine (rather than fetching before entering the loop) ensures the
+	// forwarder never sits blocked on a slow snapshot while live events pile up
+	// — a >100-event burst during the fetch would overflow the daemon-side
+	// subscription channel, the exact gap this backfill exists to close.
+	//
+	// The fetch is scoped to attemptCtx, cancelled when streamRequests returns
+	// (defer). This bounds the snapshot to THIS connection attempt: a stalled
+	// fetch cannot outlive its stream and replay a stale snapshot after a later
+	// attempt has already established fresh state (whose distinct IDs would
+	// bypass Upsert's dedupe and cause wrong evictions / duplicate notifies).
+	// The goroutine exits when the fetch completes OR attemptCtx is cancelled,
+	// so it never leaks; it writes only to localRM, which outlives the stream.
+	attemptCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	go backfillSnapshot(attemptCtx, snapClient, projectDir, localRM)
 
 	// Read SSE events line by line. bufio.Scanner is NOT used: its token size is
 	// capped (and even a raised cap would kill the subscription on the first
@@ -103,7 +135,11 @@ func streamRequests(ctx context.Context, socketPath, projectDir string, localRM 
 				jsonData := trimmed[len(dataPrefix):]
 				var record proxy.RequestRecord
 				if err := json.Unmarshal(jsonData, &record); err == nil {
-					localRM.Record(record)
+					// Upsert (not Record): applying live events through the
+					// monotonic state machine makes interleaving with the
+					// concurrent snapshot replay safe — duplicates and stale
+					// in-flight events are no-ops, so nothing is delivered twice.
+					localRM.Upsert(record)
 				}
 				// Malformed events are skipped silently, as before.
 			}
@@ -115,6 +151,39 @@ func streamRequests(ctx context.Context, socketPath, projectDir string, localRM 
 			}
 			return readErr
 		}
+	}
+}
+
+// backfillSnapshot fetches the daemon's current record snapshot for projectDir
+// and replays it into localRM, closing any gap opened while the SSE bridge was
+// disconnected. It is launched from streamRequests once the subscription is
+// live and drains concurrently with the read loop; Upsert's monotonic state
+// machine makes any interleaving of {snapshot copy, live copy, completion} safe
+// (duplicates and stale in-flight events are no-ops), so records are never
+// delivered twice.
+//
+// The limit is pinned to constants.MaxProxyRequests (the daemon ring size) so a
+// full ring backfills completely; an omitted limit would silently cap at the
+// daemon's default of 100. Client.Requests decodes all-or-nothing, so a
+// truncated body applies zero records.
+//
+// On any failure — non-200, decode error, timeout, or ctx cancellation — it
+// logs one warning and returns, leaving the stream to run in degraded,
+// stream-only mode. A failed backfill never tears down the bridge.
+//
+// ctx is the per-attempt context, so a stream error/return cancels an in-flight
+// fetch; client is the forwarder's shared snapshot client (pooled unix conn).
+func backfillSnapshot(ctx context.Context, client *Client, projectDir string, localRM *proxy.RequestManager) {
+	records, err := client.Requests(ctx, projectDir, constants.MaxProxyRequests)
+	if err != nil {
+		log.Printf("prox: request snapshot backfill failed: %v", err)
+		return
+	}
+
+	// The endpoint returns records newest-first; replay oldest-first so ring
+	// order tracks arrival order as closely as the live stream would have.
+	for i := len(records) - 1; i >= 0; i-- {
+		localRM.Upsert(records[i])
 	}
 }
 

--- a/internal/proxyd/forwarder.go
+++ b/internal/proxyd/forwarder.go
@@ -182,7 +182,12 @@ func backfillSnapshot(ctx context.Context, client *Client, projectDir string, lo
 
 	// The endpoint returns records newest-first; replay oldest-first so ring
 	// order tracks arrival order as closely as the live stream would have.
+	// Bail out mid-replay if the attempt ended: a snapshot fetched by a dying
+	// attempt should not keep replaying after a newer attempt took over.
 	for i := len(records) - 1; i >= 0; i-- {
+		if ctx.Err() != nil {
+			return
+		}
 		localRM.Upsert(records[i])
 	}
 }

--- a/internal/proxyd/forwarder_test.go
+++ b/internal/proxyd/forwarder_test.go
@@ -5,10 +5,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"os"
 	"path/filepath"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -18,10 +21,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// startRawSSEServer starts an HTTP server on a unix socket that serves handler
-// for every request, and returns the socket path. It lets a test control the
-// exact SSE bytes the forwarder reads (framing, oversized lines, etc.).
-func startRawSSEServer(t *testing.T, handler http.HandlerFunc) string {
+// startRawSSEServer starts an HTTP server on a unix socket that serves streamH
+// on the SSE stream endpoint, and returns the socket path. It lets a test
+// control the exact SSE bytes the forwarder reads (framing, oversized lines,
+// etc.). The snapshot endpoint (/api/v1/requests, hit by the forwarder's
+// backfill) returns an empty snapshot so it stays a no-op for stream-only tests.
+func startRawSSEServer(t *testing.T, streamH http.HandlerFunc) string {
+	return startRawSSEServerMux(t, streamH, func(w http.ResponseWriter, _ *http.Request) {
+		writeSnapshot(w, nil)
+	})
+}
+
+// startRawSSEServerMux is startRawSSEServer with an explicit snapshot handler so
+// backfill tests can control the /api/v1/requests response independently of the
+// SSE stream.
+func startRawSSEServerMux(t *testing.T, streamH, requestsH http.HandlerFunc) string {
 	t.Helper()
 
 	// Short temp dir to stay under the Unix socket 104-byte path limit on macOS.
@@ -36,10 +50,36 @@ func startRawSSEServer(t *testing.T, handler http.HandlerFunc) string {
 	if err != nil {
 		t.Fatalf("listen on unix socket: %v", err)
 	}
-	srv := &http.Server{Handler: handler}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/requests/stream", streamH)
+	mux.HandleFunc("/api/v1/requests", requestsH)
+	srv := &http.Server{Handler: mux}
 	go func() { _ = srv.Serve(ln) }()
 	t.Cleanup(func() { _ = srv.Close() })
 	return socketPath
+}
+
+// writeSnapshot writes records as the daemon's {"requests":[...]} snapshot
+// wrapper. records must already be newest-first (as the daemon returns them). A
+// nil slice is normalized to [] to mirror the real daemon, which always emits a
+// non-nil slice ("requests":[] when empty) — never null.
+func writeSnapshot(w http.ResponseWriter, records []proxy.RequestRecord) {
+	if records == nil {
+		records = []proxy.RequestRecord{}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"requests": records})
+}
+
+// holdOpenStream sends the SSE preamble, then blocks until the forwarder's
+// context cancels the request — keeping the subscription live so the forwarder
+// does not reconnect (and re-backfill) during a test.
+func holdOpenStream(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	if f, ok := w.(http.Flusher); ok {
+		f.Flush()
+	}
+	<-r.Context().Done()
 }
 
 // TestStreamRequests_LargeInlineBodies pins that a record carrying the
@@ -74,7 +114,7 @@ func TestStreamRequests_LargeInlineBodies(t *testing.T) {
 
 	localRM := proxy.NewRequestManager(100)
 	// streamRequests returns nil once the server closes the stream (io.EOF).
-	require.NoError(t, streamRequests(context.Background(), socketPath, "/p", localRM))
+	require.NoError(t, streamRequests(context.Background(), socketPath, NewClient(socketPath), "/p", localRM))
 
 	require.Equal(t, 1, localRM.Count())
 	got := localRM.Recent(proxy.RequestFilter{})[0]
@@ -111,7 +151,7 @@ func TestStreamRequests_OversizeEventSkippedStreamContinues(t *testing.T) {
 	})
 
 	localRM := proxy.NewRequestManager(100)
-	require.NoError(t, streamRequests(context.Background(), socketPath, "/p", localRM))
+	require.NoError(t, streamRequests(context.Background(), socketPath, NewClient(socketPath), "/p", localRM))
 
 	require.Equal(t, 1, localRM.Count(), "oversize event skipped, following event delivered")
 	got := localRM.Recent(proxy.RequestFilter{})[0]
@@ -133,9 +173,9 @@ func TestForwardRequests_FiltersByProject(t *testing.T) {
 
 	go ForwardRequests(ctx, socketPath, "/projects/a", localRM)
 
-	// The bridge is stream-only (no backfill), so records must be produced after
-	// the forwarder subscribes. Record both projects on a tick until the local
-	// side observes A's record.
+	// The bridge backfills a snapshot on connect and then applies live events;
+	// this test exercises the live path, recording both projects on a tick until
+	// the local side observes A's record.
 	deadline := time.After(3 * time.Second)
 	tick := time.NewTicker(25 * time.Millisecond)
 	defer tick.Stop()
@@ -162,4 +202,315 @@ loop:
 	for _, rec := range localRM.Recent(proxy.RequestFilter{}) {
 		assert.Equal(t, "/projects/a", rec.ProjectDir, "forwarder must only receive project A's records")
 	}
+}
+
+// smallRecords builds n newest-first records with distinct IDs (rec-000 is the
+// oldest, rec-<n-1> the newest) for backfill tests.
+func smallRecords(n int) []proxy.RequestRecord {
+	records := make([]proxy.RequestRecord, n)
+	base := time.Now()
+	for i := 0; i < n; i++ {
+		idx := n - 1 - i // newest-first
+		records[i] = proxy.RequestRecord{
+			ID:         fmt.Sprintf("rec-%04d", idx),
+			Timestamp:  base.Add(time.Duration(idx) * time.Millisecond),
+			Method:     "GET",
+			URL:        fmt.Sprintf("/r/%d", idx),
+			ProjectDir: "/p",
+		}
+	}
+	return records
+}
+
+// TestBackfill_AllRecordsDeliveredPinsLimit pins that a full ring (>100 records)
+// existing daemon-side before the first connect is delivered locally in its
+// entirety — which requires the forwarder to request the explicit
+// constants.MaxProxyRequests limit, not the daemon's default of 100.
+func TestBackfill_AllRecordsDeliveredPinsLimit(t *testing.T) {
+	const n = 150
+	records := smallRecords(n)
+
+	limitCh := make(chan string, 1)
+	socketPath := startRawSSEServerMux(t, holdOpenStream,
+		func(w http.ResponseWriter, r *http.Request) {
+			select {
+			case limitCh <- r.URL.Query().Get("limit"):
+			default:
+			}
+			writeSnapshot(w, records)
+		})
+
+	localRM := proxy.NewRequestManager(constants.MaxProxyRequests)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go ForwardRequests(ctx, socketPath, "/p", localRM)
+
+	require.Eventually(t, func() bool { return localRM.Count() == n }, 3*time.Second, 10*time.Millisecond,
+		"all %d snapshot records must be delivered locally", n)
+
+	select {
+	case gotLimit := <-limitCh:
+		assert.Equal(t, "1000", gotLimit, "backfill must request the explicit MaxProxyRequests limit")
+	case <-time.After(time.Second):
+		t.Fatal("snapshot endpoint was never hit")
+	}
+}
+
+// TestBackfill_RecordsAddedDuringDisconnectAppearAfterReconnect pins that
+// records the daemon accrues while the bridge is severed are delivered once the
+// forwarder reconnects and re-backfills. The gap records are served ONLY on the
+// second connection, so the test cannot pass via the first attempt's backfill —
+// it must observe a genuine reconnect.
+func TestBackfill_RecordsAddedDuringDisconnectAppearAfterReconnect(t *testing.T) {
+	var connects int32
+
+	socketPath := startRawSSEServerMux(t,
+		func(w http.ResponseWriter, r *http.Request) {
+			n := atomic.AddInt32(&connects, 1)
+			w.Header().Set("Content-Type", "text/event-stream")
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
+			if n == 1 {
+				return // force a disconnect on the first connect
+			}
+			<-r.Context().Done() // hold open after reconnect
+		},
+		func(w http.ResponseWriter, _ *http.Request) {
+			// The stream handler increments connects before Do returns 200, so by
+			// the time this attempt's backfill fetches, connects reflects the
+			// current attempt. Serve gap records only from the second attempt on.
+			if atomic.LoadInt32(&connects) >= 2 {
+				writeSnapshot(w, smallRecords(2)) // gap records: rec-0000, rec-0001
+			} else {
+				writeSnapshot(w, nil)
+			}
+		})
+
+	localRM := proxy.NewRequestManager(100)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go ForwardRequests(ctx, socketPath, "/p", localRM)
+
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt32(&connects) >= 2 && localRM.Count() == 2
+	}, 4*time.Second, 10*time.Millisecond, "gap records must appear only after a reconnect")
+
+	require.GreaterOrEqual(t, atomic.LoadInt32(&connects), int32(2), "a genuine reconnect must have occurred")
+	ids := map[string]bool{}
+	for _, rec := range localRM.Recent(proxy.RequestFilter{}) {
+		ids[rec.ID] = true
+	}
+	assert.True(t, ids["rec-0000"] && ids["rec-0001"], "both gap records delivered")
+}
+
+// TestBackfill_OverlapDedupe pins that a record present in BOTH the snapshot and
+// the live stream is delivered to local subscribers exactly once — for a final
+// record and for an in-flight one (the monotonic state machine no-ops the dupe).
+func TestBackfill_OverlapDedupe(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		inFlight bool
+	}{
+		{"final", false},
+		{"in_flight", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := proxy.RequestRecord{
+				ID:         "dup-1",
+				Timestamp:  time.Now(),
+				Method:     "GET",
+				URL:        "/x",
+				ProjectDir: "/p",
+				StatusCode: 200,
+				InFlight:   tc.inFlight,
+			}
+			data, err := json.Marshal(rec)
+			require.NoError(t, err)
+
+			// The snapshot must provably serve the overlapping record before the
+			// stream sends its copy, so the assertion cannot be satisfied by the
+			// stream event alone — both copies enter the pipeline, exactly one
+			// notifies.
+			var snapshotHits int32
+			snapshotServed := make(chan struct{})
+			var once sync.Once
+
+			socketPath := startRawSSEServerMux(t,
+				func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type", "text/event-stream")
+					if f, ok := w.(http.Flusher); ok {
+						f.Flush()
+					}
+					select {
+					case <-snapshotServed:
+					case <-r.Context().Done():
+						return
+					}
+					fmt.Fprintf(w, "data: %s\n\n", data)
+					if f, ok := w.(http.Flusher); ok {
+						f.Flush()
+					}
+					<-r.Context().Done()
+				},
+				func(w http.ResponseWriter, _ *http.Request) {
+					atomic.AddInt32(&snapshotHits, 1)
+					writeSnapshot(w, []proxy.RequestRecord{rec})
+					once.Do(func() { close(snapshotServed) })
+				})
+
+			localRM := proxy.NewRequestManager(100)
+			sub := localRM.Subscribe(proxy.RequestFilter{})
+			defer localRM.Unsubscribe(sub.ID)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			go ForwardRequests(ctx, socketPath, "/p", localRM)
+
+			// Collect notifications for a fixed window; both the snapshot copy and
+			// the stream copy apply, but only the first notifies.
+			var got []proxy.RequestRecord
+			deadline := time.After(time.Second)
+		collect:
+			for {
+				select {
+				case rec := <-sub.Ch:
+					got = append(got, rec)
+				case <-deadline:
+					break collect
+				}
+			}
+			require.GreaterOrEqual(t, atomic.LoadInt32(&snapshotHits), int32(1), "snapshot must have served the overlapping record")
+			require.Len(t, got, 1, "overlapping record delivered exactly once")
+			assert.Equal(t, "dup-1", got[0].ID)
+			assert.Equal(t, 1, localRM.Count())
+		})
+	}
+}
+
+// TestBackfill_ConcurrentDrainDelayedSnapshot pins that live events are applied
+// without waiting for a slow snapshot fetch — the read loop drains concurrently
+// with the backfill goroutine. The snapshot handler blocks on a channel (no
+// timing window): the live event must be delivered while it is still blocked.
+func TestBackfill_ConcurrentDrainDelayedSnapshot(t *testing.T) {
+	release := make(chan struct{})
+	socketPath := startRawSSEServerMux(t,
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			rec := proxy.RequestRecord{ID: "live-1", Timestamp: time.Now(), Method: "GET", URL: "/l", ProjectDir: "/p"}
+			data, _ := json.Marshal(rec)
+			fmt.Fprintf(w, "data: %s\n\n", data)
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
+			<-r.Context().Done()
+		},
+		func(w http.ResponseWriter, r *http.Request) {
+			// Block the snapshot until released; live events must not wait for it.
+			select {
+			case <-release:
+			case <-r.Context().Done():
+				return
+			}
+			writeSnapshot(w, nil)
+		})
+
+	localRM := proxy.NewRequestManager(100)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go ForwardRequests(ctx, socketPath, "/p", localRM)
+
+	// The snapshot is still blocked (release not yet closed); the live event must
+	// nevertheless be delivered — proof the read loop drains concurrently.
+	require.Eventually(t, func() bool { return localRM.Count() == 1 }, 2*time.Second, 10*time.Millisecond,
+		"live event must be delivered while the snapshot fetch is blocked")
+
+	// Release the snapshot so the backfill goroutine finishes cleanly.
+	close(release)
+}
+
+// TestBackfill_SnapshotFailureStreamStillDelivers pins that a failed snapshot
+// (non-200 or truncated JSON) applies zero records via all-or-nothing decode,
+// while live stream events keep flowing (degraded, stream-only mode).
+func TestBackfill_SnapshotFailureStreamStillDelivers(t *testing.T) {
+	streamRec := proxy.RequestRecord{ID: "stream-1", Timestamp: time.Now(), Method: "GET", URL: "/s", ProjectDir: "/p"}
+	streamData, err := json.Marshal(streamRec)
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		name    string
+		handler http.HandlerFunc
+	}{
+		{"http_500", func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "boom", http.StatusInternalServerError)
+		}},
+		{"truncated_json", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"requests":[{"id":"x","method":"GET"`) // truncated mid-object
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			socketPath := startRawSSEServerMux(t,
+				func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type", "text/event-stream")
+					fmt.Fprintf(w, "data: %s\n\n", streamData)
+					if f, ok := w.(http.Flusher); ok {
+						f.Flush()
+					}
+					<-r.Context().Done()
+				},
+				tc.handler)
+
+			localRM := proxy.NewRequestManager(100)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			go ForwardRequests(ctx, socketPath, "/p", localRM)
+
+			require.Eventually(t, func() bool { return localRM.Count() == 1 }, 2*time.Second, 10*time.Millisecond)
+			// Let any erroneous snapshot apply race in, then confirm still just the
+			// stream record.
+			time.Sleep(200 * time.Millisecond)
+			require.Equal(t, 1, localRM.Count(), "snapshot failure must apply zero records")
+			assert.Equal(t, "stream-1", localRM.Recent(proxy.RequestFilter{})[0].ID)
+		})
+	}
+}
+
+// TestBackfillSnapshot_CtxCancelExitsCleanly pins that the backfill goroutine
+// exits promptly when ctx is cancelled during a hung snapshot fetch — no leak,
+// no records applied.
+func TestBackfillSnapshot_CtxCancelExitsCleanly(t *testing.T) {
+	entered := make(chan struct{})
+	block := make(chan struct{})
+	t.Cleanup(func() { close(block) })
+
+	socketPath := startRawSSEServerMux(t,
+		func(_ http.ResponseWriter, _ *http.Request) {}, // stream unused
+		func(_ http.ResponseWriter, r *http.Request) {
+			close(entered) // signal the fetch has reached the handler
+			// Hang until the test ends or the client's ctx cancels the request.
+			select {
+			case <-block:
+			case <-r.Context().Done():
+			}
+		})
+
+	localRM := proxy.NewRequestManager(100)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		backfillSnapshot(ctx, NewClient(socketPath), "/p", localRM)
+		close(done)
+	}()
+
+	// Cancel only once the fetch is provably mid-flight inside the handler.
+	<-entered
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("backfillSnapshot did not exit after ctx cancel")
+	}
+	assert.Equal(t, 0, localRM.Count(), "no records applied on cancelled fetch")
 }

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -228,6 +228,7 @@ func forwardClientProxyRequests(ctx context.Context, p *tea.Program, client TUIC
 				StatusCode: req.StatusCode,
 				Duration:   time.Duration(req.DurationMs) * time.Millisecond,
 				RemoteAddr: req.RemoteAddr,
+				InFlight:   req.InFlight,
 			}
 			p.Send(ProxyRequestMsg(record))
 		}

--- a/internal/tui/base.go
+++ b/internal/tui/base.go
@@ -146,17 +146,34 @@ func (b *BaseModel) handleLogEntry(entry domain.LogEntry) {
 	}
 }
 
-// handleProxyRequest handles a new proxy request message
+// handleProxyRequest handles a new proxy request message. It upserts by ID:
+// a same-ID re-record (in-flight followed by its completion) replaces the
+// existing row in place rather than appending a duplicate, scanning from the
+// newest entry since that's where a live in-flight row lives. In-place
+// replacement keeps every other row's index stable, which matters because
+// detail-selection maps viewport line numbers to indices into proxyRequests.
 func (b *BaseModel) handleProxyRequest(req proxy.RequestRecord) {
 	// Check if we're at/near bottom BEFORE adding new content
 	wasNearBottom := b.isNearBottom()
 
-	b.proxyRequests = append(b.proxyRequests, req)
-	// Keep only last requests - create new slice to release memory from old requests
-	if len(b.proxyRequests) > maxProxyRequests {
-		newRequests := make([]proxy.RequestRecord, maxProxyRequests)
-		copy(newRequests, b.proxyRequests[len(b.proxyRequests)-maxProxyRequests:])
-		b.proxyRequests = newRequests
+	replaced := false
+	if req.ID != "" {
+		for i := len(b.proxyRequests) - 1; i >= 0; i-- {
+			if b.proxyRequests[i].ID == req.ID {
+				b.proxyRequests[i] = req
+				replaced = true
+				break
+			}
+		}
+	}
+	if !replaced {
+		b.proxyRequests = append(b.proxyRequests, req)
+		// Keep only last requests - create new slice to release memory from old requests
+		if len(b.proxyRequests) > maxProxyRequests {
+			newRequests := make([]proxy.RequestRecord, maxProxyRequests)
+			copy(newRequests, b.proxyRequests[len(b.proxyRequests)-maxProxyRequests:])
+			b.proxyRequests = newRequests
+		}
 	}
 	b.updateViewport()
 
@@ -453,8 +470,22 @@ func (b *BaseModel) formatRequestDetail() []string {
 	lines = append(lines, fmt.Sprintf("  Method:   %s", d.Method))
 	lines = append(lines, fmt.Sprintf("  URL:      %s", d.URL))
 	lines = append(lines, fmt.Sprintf("  Status:   %d", d.StatusCode))
-	lines = append(lines, fmt.Sprintf("  Duration: %dms", d.DurationMs))
+	if d.InFlight {
+		lines = append(lines, "  Duration: (in flight)")
+	} else {
+		lines = append(lines, fmt.Sprintf("  Duration: %dms", d.DurationMs))
+	}
 	lines = append(lines, fmt.Sprintf("  Remote:   %s", d.RemoteAddr))
+
+	// Details arrive only on completion: an in-flight record is guaranteed
+	// nil Details (see proxy.RequestRecord.InFlight), so it never has
+	// headers/bodies to render here. That's expected, not a "capture
+	// disabled" state, so it gets its own note instead of silently
+	// rendering nothing.
+	if d.InFlight {
+		lines = append(lines, "")
+		lines = append(lines, dimStyle.Render("(request in flight — details arrive on completion)"))
+	}
 
 	// Request headers
 	if len(d.RequestHeaders) > 0 {
@@ -682,12 +713,17 @@ func (b *BaseModel) formatProxyRequest(req proxy.RequestRecord) string {
 	}
 	status := statusStyle.Render(fmt.Sprintf("%3d", req.StatusCode))
 
-	// Format duration with overflow handling
+	// Format duration with overflow handling. In-flight rows have no
+	// duration yet (the response is still streaming) — render dots in place
+	// of digits, padded to the same 5-char width so columns stay aligned.
 	durationMs := req.Duration.Milliseconds()
 	var duration string
-	if durationMs > 9999 {
+	switch {
+	case req.InFlight:
+		duration = "  ..."
+	case durationMs > 9999:
 		duration = "9999+"
-	} else {
+	default:
 		duration = fmt.Sprintf("%5d", durationMs)
 	}
 
@@ -969,6 +1005,7 @@ func convertRequestRecordToDetailWithDirs(req proxy.RequestRecord, allowedDirs [
 		StatusCode: req.StatusCode,
 		DurationMs: req.Duration.Milliseconds(),
 		RemoteAddr: req.RemoteAddr,
+		InFlight:   req.InFlight,
 	}
 
 	if req.Details != nil {

--- a/internal/tui/base_render_test.go
+++ b/internal/tui/base_render_test.go
@@ -171,3 +171,63 @@ func TestFormatRequestDetail_BodySections(t *testing.T) {
 	assert.Contains(t, out, "Response Body (10 bytes)")
 	assert.Contains(t, out, "(body no longer available)")
 }
+
+// TestFormatRequestDetail_InFlight_ShowsDurationNote verifies the Duration
+// line reads "(in flight)" instead of a bogus "0ms" for a still-streaming
+// request (D10).
+func TestFormatRequestDetail_InFlight_ShowsDurationNote(t *testing.T) {
+	b := &BaseModel{
+		requestDetail: &RequestDetailData{
+			ID:         "req-1",
+			Timestamp:  "2026-07-18 00:00:00.000",
+			Method:     "GET",
+			URL:        "/api/v1/stream",
+			StatusCode: 200,
+			InFlight:   true,
+		},
+	}
+
+	out := strings.Join(b.formatRequestDetail(), "\n")
+	assert.Contains(t, out, "Duration: (in flight)")
+	assert.NotContains(t, out, "Duration: 0ms")
+}
+
+// TestFormatRequestDetail_InFlight_NoDetailsNote verifies that a nil-Details
+// in-flight record gets an explanatory note rather than silently rendering
+// no headers/bodies section (which would otherwise be indistinguishable from
+// "capture not enabled").
+func TestFormatRequestDetail_InFlight_NoDetailsNote(t *testing.T) {
+	b := &BaseModel{
+		requestDetail: &RequestDetailData{
+			ID:         "req-1",
+			Timestamp:  "2026-07-18 00:00:00.000",
+			Method:     "GET",
+			URL:        "/api/v1/stream",
+			StatusCode: 200,
+			InFlight:   true,
+		},
+	}
+
+	out := strings.Join(b.formatRequestDetail(), "\n")
+	assert.Contains(t, out, "(request in flight — details arrive on completion)")
+}
+
+// TestFormatRequestDetail_Completed_NoInFlightNote verifies a completed
+// record with no captured Details (capture disabled) does NOT get the
+// in-flight note.
+func TestFormatRequestDetail_Completed_NoInFlightNote(t *testing.T) {
+	b := &BaseModel{
+		requestDetail: &RequestDetailData{
+			ID:         "req-1",
+			Timestamp:  "2026-07-18 00:00:00.000",
+			Method:     "GET",
+			URL:        "/api/v1/stream",
+			StatusCode: 200,
+			DurationMs: 42,
+		},
+	}
+
+	out := strings.Join(b.formatRequestDetail(), "\n")
+	assert.NotContains(t, out, "in flight")
+	assert.Contains(t, out, "Duration: 42ms")
+}

--- a/internal/tui/client.go
+++ b/internal/tui/client.go
@@ -224,6 +224,7 @@ func (m ClientModel) fetchRequestDetail(id string) tea.Cmd {
 			StatusCode: resp.StatusCode,
 			DurationMs: resp.DurationMs,
 			RemoteAddr: resp.RemoteAddr,
+			InFlight:   resp.InFlight,
 		}
 
 		if resp.Details != nil {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -107,14 +107,18 @@ type RequestDetailErrorMsg struct {
 
 // RequestDetailData holds the detailed information about a request for TUI display
 type RequestDetailData struct {
-	ID              string
-	Timestamp       string
-	Method          string
-	URL             string
-	Subdomain       string
-	StatusCode      int
-	DurationMs      int64
-	RemoteAddr      string
+	ID         string
+	Timestamp  string
+	Method     string
+	URL        string
+	Subdomain  string
+	StatusCode int
+	DurationMs int64
+	RemoteAddr string
+	// InFlight marks a request whose response is still streaming: Duration
+	// renders as "(in flight)" and a nil Details gets an explanatory note
+	// instead of being treated as "capture not enabled".
+	InFlight        bool
 	RequestHeaders  map[string][]string
 	ResponseHeaders map[string][]string
 	RequestBody     *BodyData

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -325,6 +325,7 @@ func TestModel_ProxyRequestMsg(t *testing.T) {
 
 	// Send a proxy request through Update()
 	req := proxy.RequestRecord{
+		ID:         "req-1",
 		Timestamp:  time.Now(),
 		Subdomain:  "web",
 		Method:     "POST",
@@ -352,6 +353,7 @@ func TestModel_ProxyRequestMsg(t *testing.T) {
 
 	// Add another request and verify both are present
 	req2 := proxy.RequestRecord{
+		ID:         "req-2",
 		Timestamp:  time.Now(),
 		Subdomain:  "api",
 		Method:     "GET",
@@ -372,6 +374,54 @@ func TestModel_ProxyRequestMsg(t *testing.T) {
 	filtered = m.filteredProxyRequests()
 	assert.Len(t, filtered, 1)
 	assert.Equal(t, "/api/users", filtered[0].URL)
+
+	// A same-ID re-record (e.g. an in-flight row's completion event) updates
+	// the row in place rather than appending a duplicate.
+	req1Updated := req
+	req1Updated.StatusCode = 204
+	req1Updated.Duration = 99 * time.Millisecond
+
+	newModel, _ = m.Update(ProxyRequestMsg(req1Updated))
+	m = newModel.(Model)
+
+	assert.Len(t, m.proxyRequests, 2, "same-ID update must not duplicate the row")
+	assert.Equal(t, 204, m.proxyRequests[0].StatusCode)
+	assert.Equal(t, 99*time.Millisecond, m.proxyRequests[0].Duration)
+}
+
+// TestModel_ProxyRequestMsg_SelectionStable verifies that upserting an
+// earlier row in place (D10) leaves a scrolled/selected position untouched:
+// detail-selection maps viewport line numbers to indices into proxyRequests,
+// so an in-place replacement must not shift any other row's index.
+func TestModel_ProxyRequestMsg_SelectionStable(t *testing.T) {
+	model := newTestModel()
+	model.ready = true
+	model.viewMode = ViewModeRequests
+	model.followMode = false // otherwise handleProxyRequest re-snaps to bottom
+
+	model.proxyRequests = []proxy.RequestRecord{
+		{ID: "req-a", Timestamp: time.Now(), Method: "GET", URL: "/a", StatusCode: 200},
+		{ID: "req-b", Timestamp: time.Now(), Method: "GET", URL: "/b", StatusCode: 200},
+		{ID: "req-c", Timestamp: time.Now(), Method: "GET", URL: "/c", StatusCode: 200},
+	}
+	model.updateViewport()
+
+	// Simulate a scrolled selection sitting on the third row.
+	model.viewport.YOffset = 2
+	assert.Equal(t, "req-c", model.getSelectedRequest())
+
+	// Update the FIRST row in place (an earlier row completing).
+	updated := model.proxyRequests[0]
+	updated.StatusCode = 204
+	newModel, _ := model.Update(ProxyRequestMsg(updated))
+	m := newModel.(Model)
+
+	assert.Len(t, m.proxyRequests, 3, "in-place update must not change the row count")
+	assert.Equal(t, 2, m.viewport.YOffset, "scroll position must be unchanged")
+	assert.Equal(t, "req-c", m.getSelectedRequest(), "selection must be unchanged")
+	assert.Equal(t, 204, m.proxyRequests[0].StatusCode, "the target row must reflect the update")
+	assert.Equal(t, "req-b", m.proxyRequests[1].ID, "other rows must keep their index")
+	assert.Equal(t, "req-c", m.proxyRequests[2].ID, "other rows must keep their index")
 }
 
 func TestViewModeSwitch(t *testing.T) {
@@ -453,6 +503,28 @@ func TestFormatProxyRequest_DurationOverflow(t *testing.T) {
 
 	// Verify status code is 3 chars right-aligned
 	assert.Contains(t, formatted, "200")
+}
+
+func TestFormatProxyRequest_InFlight(t *testing.T) {
+	model := newTestModel()
+
+	// An in-flight record carries the real header-time status but no
+	// duration yet; the duration column renders dots instead of digits,
+	// padded to the same 5-char width as the completed-request case.
+	req := proxy.RequestRecord{
+		Timestamp:  time.Now(),
+		Subdomain:  "api",
+		Method:     "GET",
+		URL:        "/stream",
+		StatusCode: 200,
+		InFlight:   true,
+	}
+
+	formatted := model.formatProxyRequest(req)
+
+	assert.Contains(t, formatted, "  ...ms", "duration column should render dots, 5-char padded, with the ms suffix")
+	assert.NotContains(t, formatted, "0ms", "in-flight rows must not render a fake zero duration")
+	assert.Contains(t, formatted, "200", "status should show the real header-time code")
 }
 
 func TestFormatProxyRequest_Padding(t *testing.T) {

--- a/test/integration/inflight_backfill_daemon_test.go
+++ b/test/integration/inflight_backfill_daemon_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -42,6 +43,11 @@ func TestInFlight_EndToEnd(t *testing.T) {
 	// on `released` until the test lets it finish. Other paths respond normally
 	// so waitBridgeLive's pings succeed.
 	released := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(released) }) }
+	// Always unblock the backend on exit: a failed assertion before the
+	// explicit release would otherwise leave backend.Close() hanging.
+	t.Cleanup(release)
 	const partial = "partial-body-"
 	const rest = "rest-of-body"
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -126,7 +132,7 @@ func TestInFlight_EndToEnd(t *testing.T) {
 	inflightID := inflight.ID
 
 	// Release the backend and let the request complete.
-	close(released)
+	release()
 	res := <-resultCh
 	if res.err != nil {
 		t.Fatalf("slow request failed: %v", res.err)

--- a/test/integration/inflight_backfill_daemon_test.go
+++ b/test/integration/inflight_backfill_daemon_test.go
@@ -1,0 +1,421 @@
+package integration
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charliek/prox/internal/constants"
+	"github.com/charliek/prox/internal/proxy"
+	"github.com/charliek/prox/internal/proxyd"
+)
+
+// TestInFlight_EndToEnd exercises the two-phase (in-flight → completion)
+// recording path end-to-end through the daemon topology, observed via the
+// PROJECT's API-visible state (its local RequestManager fed by ForwardRequests):
+//
+//   - A capture-enabled project routes to a backend that writes response headers
+//     plus a partial body, then blocks on a channel until the test releases it —
+//     deterministic, no sleeps for correctness.
+//   - While the backend is still held, the project side already shows the record
+//     with in_flight=true and the real header-time status (bodies still
+//     streaming, so no Details yet).
+//   - After release, the SAME ID becomes final: in_flight=false, Duration>0, and
+//     Details populated (headers + body) — and the ring holds exactly one record
+//     for that ID (the completion replaced the in-flight row in place, no dup).
+func TestInFlight_EndToEnd(t *testing.T) {
+	skipShort(t)
+
+	topo := newDaemonTopo(t)
+
+	// Backend: /slow writes headers + a partial body, flushes so the reverse
+	// proxy receives the response header (firing the in-flight hook), then blocks
+	// on `released` until the test lets it finish. Other paths respond normally
+	// so waitBridgeLive's pings succeed.
+	released := make(chan struct{})
+	const partial = "partial-body-"
+	const rest = "rest-of-body"
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		if r.URL.Path == "/slow" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(partial))
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush() // push header + partial body to the reverse proxy now
+			}
+			<-released
+			_, _ = w.Write([]byte(rest))
+			return
+		}
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer backend.Close()
+	host, port := splitHostPort(t, backend.URL)
+
+	proxyPort := freePort(t)
+	const projectDir = "/projects/inflight"
+	const hostname = "app.inflight.local.test"
+	if _, err := topo.client.Register(proxyd.RegisterRequest{
+		ProjectDir:     projectDir,
+		PID:            os.Getpid(),
+		Version:        "test",
+		Domain:         "inflight.local.test",
+		Services:       map[string]proxyd.ServiceTarget{"app": {Host: host, Port: port}},
+		HTTPPort:       proxyPort,
+		CaptureEnabled: true,
+	}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	// Project-side bridge (the daemon stream is backfill-plus-live, so start it
+	// before driving traffic and confirm it is live).
+	localRM := proxy.NewRequestManager(constants.DefaultProxyRequestBufferSize)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go proxyd.ForwardRequests(ctx, topo.socketPath, projectDir, localRM)
+	waitBridgeLive(t, proxyPort, hostname, localRM)
+
+	// Drive the slow request in a background goroutine — it stays open until we
+	// release the backend. (Build the request by hand rather than via driveProxy,
+	// whose t.Fatalf must not be called off the test goroutine.)
+	type driveResult struct {
+		body string
+		err  error
+	}
+	resultCh := make(chan driveResult, 1)
+	go func() {
+		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://127.0.0.1:%d/slow", proxyPort), nil)
+		if err != nil {
+			resultCh <- driveResult{err: err}
+			return
+		}
+		req.Host = hostname
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			resultCh <- driveResult{err: err}
+			return
+		}
+		defer resp.Body.Close()
+		b, err := io.ReadAll(resp.Body)
+		resultCh <- driveResult{body: string(b), err: err}
+	}()
+
+	// While the backend is still held, the project side sees the in-flight record
+	// with the real header-time status and no Details yet.
+	inflight := waitForRecord(t, localRM, func(r proxy.RequestRecord) bool {
+		return r.URL == "/slow" && r.InFlight
+	})
+	if inflight.StatusCode != http.StatusOK {
+		t.Errorf("in-flight status = %d, want %d", inflight.StatusCode, http.StatusOK)
+	}
+	if inflight.Duration != 0 {
+		t.Errorf("in-flight Duration = %v, want 0", inflight.Duration)
+	}
+	if inflight.Details != nil {
+		t.Errorf("in-flight record should have nil Details, got %+v", inflight.Details)
+	}
+	inflightID := inflight.ID
+
+	// Release the backend and let the request complete.
+	close(released)
+	res := <-resultCh
+	if res.err != nil {
+		t.Fatalf("slow request failed: %v", res.err)
+	}
+	if want := partial + rest; res.body != want {
+		t.Errorf("slow response body = %q, want %q", res.body, want)
+	}
+
+	// The SAME ID now becomes final: in_flight false, real duration, Details.
+	final := waitForRecord(t, localRM, func(r proxy.RequestRecord) bool {
+		return r.ID == inflightID && !r.InFlight
+	})
+	if final.StatusCode != http.StatusOK {
+		t.Errorf("final status = %d, want %d", final.StatusCode, http.StatusOK)
+	}
+	if final.Duration <= 0 {
+		t.Errorf("final Duration = %v, want > 0", final.Duration)
+	}
+	if final.Details == nil || final.Details.ResponseBody == nil {
+		t.Fatalf("final record missing Details/ResponseBody: %+v", final.Details)
+	}
+	if len(final.Details.RequestHeaders) == 0 && len(final.Details.ResponseHeaders) == 0 {
+		t.Errorf("final record missing captured headers: %+v", final.Details)
+	}
+	if got := string(final.Details.ResponseBody.Data); got != partial+rest {
+		t.Errorf("final response body = %q, want %q", got, partial+rest)
+	}
+
+	// Field parity: everything but status-source/duration/details/in_flight is
+	// identical between the two events.
+	if final.Method != inflight.Method || final.URL != inflight.URL ||
+		final.Hostname != inflight.Hostname || final.ProjectDir != inflight.ProjectDir ||
+		!final.Timestamp.Equal(inflight.Timestamp) {
+		t.Errorf("field parity mismatch:\n in-flight=%+v\n final=%+v", inflight, final)
+	}
+
+	// Exactly one row for that ID — the completion replaced the in-flight record
+	// in place rather than appending a duplicate.
+	if n := countRecordsByID(localRM, inflightID); n != 1 {
+		t.Errorf("ring holds %d records for ID %s, want exactly 1", n, inflightID)
+	}
+}
+
+// TestBackfill_EndToEnd exercises the forwarder snapshot backfill end-to-end:
+//
+//   - A capture-enabled project is registered and its bridge (ForwardRequests) is
+//     brought up; one request is proxied and delivered live (the pre-gap record).
+//   - The bridge is severed (its ctx is cancelled and the goroutine is awaited),
+//     while the daemon keeps the registration and its ring. Several requests are
+//     driven through the daemon during the gap, including one whose response is
+//     >64KB and spills to the daemon capture dir.
+//   - The bridge is restarted with a fresh ctx and the SAME local RequestManager;
+//     the gap records appear locally via backfill — including the disk-backed body
+//     loaded through proxy.LoadDecodedBody with the daemon capture dir allowlisted.
+//   - Records already present locally before the gap are not duplicated on
+//     reconnect (backfill re-delivery of a final record is a no-op).
+func TestBackfill_EndToEnd(t *testing.T) {
+	skipShort(t)
+
+	topo := newDaemonTopo(t)
+
+	largeBody := bytes.Repeat([]byte("L"), 100*1024) // 100KB > 64KB inline threshold
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		if r.URL.Path == "/large" {
+			_, _ = w.Write(largeBody)
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		_, _ = w.Write(body) // echo
+	}))
+	defer backend.Close()
+	host, port := splitHostPort(t, backend.URL)
+
+	proxyPort := freePort(t)
+	const projectDir = "/projects/gap"
+	const hostname = "app.gap.local.test"
+	if _, err := topo.client.Register(proxyd.RegisterRequest{
+		ProjectDir:     projectDir,
+		PID:            os.Getpid(),
+		Version:        "test",
+		Domain:         "gap.local.test",
+		Services:       map[string]proxyd.ServiceTarget{"app": {Host: host, Port: port}},
+		HTTPPort:       proxyPort,
+		CaptureEnabled: true,
+	}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	localRM := proxy.NewRequestManager(constants.DefaultProxyRequestBufferSize)
+
+	// --- Bridge up: deliver one pre-gap record live ---
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	done1 := make(chan struct{})
+	go func() {
+		proxyd.ForwardRequests(ctx1, topo.socketPath, projectDir, localRM)
+		close(done1)
+	}()
+	waitBridgeLive(t, proxyPort, hostname, localRM)
+
+	if got := driveProxy(t, proxyPort, hostname, http.MethodPost, "/before", []byte("pre-gap")); got != "pre-gap" {
+		t.Fatalf("/before response = %q, want %q", got, "pre-gap")
+	}
+	beforeRec := waitForRecord(t, localRM, func(r proxy.RequestRecord) bool {
+		return r.URL == "/before" && !r.InFlight
+	})
+	beforeID := beforeRec.ID
+
+	// --- Sever the bridge (forwarder down) while the daemon stays registered ---
+	// Awaiting done1 guarantees the forwarder goroutine has fully returned, so no
+	// subsequent traffic can be delivered live: the gap is real.
+	cancel1()
+	<-done1
+
+	// --- Drive gap traffic (retained only in the daemon ring) ---
+	if got := driveProxy(t, proxyPort, hostname, http.MethodPost, "/gap1", []byte("g1")); got != "g1" {
+		t.Fatalf("/gap1 response = %q, want %q", got, "g1")
+	}
+	if got := driveProxy(t, proxyPort, hostname, http.MethodPost, "/gap2", []byte("g2")); got != "g2" {
+		t.Fatalf("/gap2 response = %q, want %q", got, "g2")
+	}
+	if got := driveProxy(t, proxyPort, hostname, http.MethodGet, "/large", nil); len(got) != len(largeBody) {
+		t.Fatalf("/large response len = %d, want %d", len(got), len(largeBody))
+	}
+
+	// Sanity: with the bridge down, none of the gap records reached the project
+	// side yet — they exist only in the daemon ring.
+	for _, u := range []string{"/gap1", "/gap2", "/large"} {
+		for _, r := range localRM.Recent(proxy.RequestFilter{}) {
+			if r.URL == u {
+				t.Fatalf("gap record %q reached the project side while the bridge was down", u)
+			}
+		}
+	}
+
+	// --- Restart the bridge with a fresh ctx and the SAME local manager ---
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	defer cancel2()
+	go proxyd.ForwardRequests(ctx2, topo.socketPath, projectDir, localRM)
+
+	// Gap records appear locally via backfill.
+	gap1 := waitForRecord(t, localRM, func(r proxy.RequestRecord) bool {
+		return r.URL == "/gap1" && !r.InFlight
+	})
+	gap2 := waitForRecord(t, localRM, func(r proxy.RequestRecord) bool {
+		return r.URL == "/gap2" && !r.InFlight
+	})
+	largeRec := waitForRecord(t, localRM, func(r proxy.RequestRecord) bool {
+		return r.URL == "/large" && !r.InFlight && r.Details != nil
+	})
+
+	// The gap request bodies round-tripped (inline) via the backfilled records.
+	if gap1.Details == nil || gap1.Details.RequestBody == nil || string(gap1.Details.RequestBody.Data) != "g1" {
+		t.Errorf("/gap1 backfilled request body wrong: %+v", gap1.Details)
+	}
+	if gap2.Details == nil || gap2.Details.RequestBody == nil || string(gap2.Details.RequestBody.Data) != "g2" {
+		t.Errorf("/gap2 backfilled request body wrong: %+v", gap2.Details)
+	}
+
+	// The large response is disk-backed under the daemon capture dir and loads
+	// through the allowlist — the same body-loading path the existing e2e uses.
+	if largeRec.Details.ResponseBody == nil {
+		t.Fatalf("/large backfilled record missing response body")
+	}
+	resBody := largeRec.Details.ResponseBody
+	if resBody.FilePath == "" {
+		t.Fatalf("/large response body expected disk-backed FilePath, got inline (captured_size=%d)", resBody.CapturedSize)
+	}
+	if !strings.HasPrefix(resBody.FilePath, topo.daemonCaptureDir+string(filepath.Separator)) {
+		t.Errorf("/large FilePath %q not under daemon capture dir %q", resBody.FilePath, topo.daemonCaptureDir)
+	}
+	decoded, err := proxy.LoadDecodedBody(resBody, []string{topo.daemonCaptureDir})
+	if err != nil {
+		t.Fatalf("LoadDecodedBody(disk-backed): %v", err)
+	}
+	if !decoded.Available {
+		t.Fatalf("disk-backed body unavailable: %q", decoded.UnavailableReason)
+	}
+	if !bytes.Equal(decoded.Data, largeBody) {
+		t.Errorf("disk-backed body mismatch: got %d bytes, want %d", len(decoded.Data), len(largeBody))
+	}
+
+	// No duplicates: the pre-gap record was already present locally, and the
+	// backfill re-delivers it as a no-op (final is terminal). Gap records arrive
+	// exactly once.
+	if n := countRecordsByID(localRM, beforeID); n != 1 {
+		t.Errorf("pre-gap record %s duplicated after reconnect: %d rows", beforeID, n)
+	}
+	if n := countRecordsByID(localRM, gap1.ID); n != 1 {
+		t.Errorf("/gap1 record %s duplicated: %d rows", gap1.ID, n)
+	}
+	if n := countRecordsByID(localRM, gap2.ID); n != 1 {
+		t.Errorf("/gap2 record %s duplicated: %d rows", gap2.ID, n)
+	}
+	if n := countRecordsByID(localRM, largeRec.ID); n != 1 {
+		t.Errorf("/large record %s duplicated: %d rows", largeRec.ID, n)
+	}
+}
+
+// --- helpers (daemon-topology, in-flight/backfill) ---
+
+// daemonTopo bundles the pieces of a running daemon under an ISOLATED HOME that
+// the in-flight/backfill e2e tests drive traffic through.
+type daemonTopo struct {
+	socketPath       string
+	daemonCaptureDir string
+	client           *proxyd.Client
+}
+
+// newDaemonTopo stands up the daemon components (registry, request manager,
+// capture manager, dynamic proxy, unix-socket server) wired like RunDaemon but
+// with an explicit capture dir and no cert manager (HTTP only), under an
+// isolated HOME so ~/.prox/capture is a temp dir. It mirrors the setup block in
+// TestDaemonCapture_EndToEnd; registration is left to the caller. Cleanup is
+// registered via t.Cleanup in the same order the sibling test defers it.
+func newDaemonTopo(t *testing.T) daemonTopo {
+	t.Helper()
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	daemonCaptureDir := constants.DaemonCaptureDir(home)
+
+	socketPath := shortSocketPath(t)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	registry := proxyd.NewRegistry()
+	requestMgr := proxy.NewRequestManager(constants.DefaultProxyRequestBufferSize)
+
+	captureMgr, err := proxy.NewCaptureManagerAt(daemonCaptureDir, constants.DefaultCaptureMaxBodySize)
+	if err != nil {
+		t.Fatalf("NewCaptureManagerAt: %v", err)
+	}
+	t.Cleanup(func() { captureMgr.Cleanup() })
+	requestMgr.SetEvictionCallback(captureMgr.CleanupRequest)
+
+	dynamicProxy := proxyd.NewDynamicProxy(registry, nil, requestMgr, captureMgr, logger)
+
+	server := proxyd.NewServer(proxyd.ServerConfig{
+		SocketPath: socketPath,
+		Logger:     logger,
+		Version:    "test",
+	})
+	server.SetRegistry(registry)
+	server.SetProxy(dynamicProxy)
+	server.SetRequestManager(requestMgr)
+
+	go func() { _ = server.Start() }()
+	t.Cleanup(func() { _ = server.Shutdown(context.Background()) })
+	t.Cleanup(func() { _ = dynamicProxy.Shutdown(context.Background()) })
+
+	client := proxyd.NewClient(socketPath)
+	waitDaemonReady(t, client)
+
+	return daemonTopo{
+		socketPath:       socketPath,
+		daemonCaptureDir: daemonCaptureDir,
+		client:           client,
+	}
+}
+
+// waitBridgeLive pings the given project through the proxy until its local
+// manager has observed at least one record, confirming the SSE subscription is
+// active (single-project variant of waitBridgesLive).
+func waitBridgeLive(t *testing.T, port int, hostname string, localRM *proxy.RequestManager) {
+	t.Helper()
+	deadline := time.After(5 * time.Second)
+	tick := time.NewTicker(25 * time.Millisecond)
+	defer tick.Stop()
+	for {
+		if localRM.Count() > 0 {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("bridge did not go live (count=%d)", localRM.Count())
+		case <-tick.C:
+			_ = driveProxy(t, port, hostname, http.MethodGet, "/ping", nil)
+		}
+	}
+}
+
+// countRecordsByID returns how many records in the manager's ring carry the
+// given ID — used to assert an in-flight → completion upsert replaces in place
+// (exactly one row) rather than appending a duplicate.
+func countRecordsByID(rm *proxy.RequestManager, id string) int {
+	n := 0
+	for _, r := range rm.Recent(proxy.RequestFilter{}) {
+		if r.ID == id {
+			n++
+		}
+	}
+	return n
+}


### PR DESCRIPTION
Implements #51 (forwarder snapshot backfill) and #48 (in-flight request visibility) from plan 006, as five gated commits. Closes #51. Closes #48.

## What changed

**Shared seam (C1).** `RequestManager.Upsert` — a monotonic two-state transition keyed by record ID: absent→append, in-flight→final replaces in place (ring position preserved), duplicate-in-flight and anything-over-final are silent no-ops. Notification happens inside the ring critical section so same-ID events can never be observed out of order. `RequestRecord.InFlight` (`in_flight`, omitempty — completed-record JSON is byte-identical to before).

**#51 — snapshot backfill (C2).** On every (re)connect, after the SSE subscription is live, the forwarder fetches `GET /api/v1/requests?project=<dir>&limit=1000` from the daemon socket (new ctx-aware `Client.Requests`) concurrently with the live read loop, and replays it oldest-first through `Upsert`. Records proxied while the bridge was down are now retrievable from the project's API/CLI, bodies included. The snapshot is attempt-scoped (a stalled fetch dies with its stream attempt), decodes all-or-nothing, and degrades to today's stream-only behavior on failure. Guarantee is bounded gap closure (daemon ring + registration lifetime), not losslessness.

**#48 — in-flight visibility (C3+C4).** All three response writers gain a first-response hook (fires once at first WriteHeader ≥200 or successful Hijack; 1xx delegated but never latched — fixes a latent 103-latching bug). Both proxy paths publish an in-flight record at response-header time and complete it via `Upsert` from a defer with no recover — so client disconnects / backend death mid-stream (ReverseProxy's `ErrAbortHandler` panic) now record an honest final row where before they recorded nothing. SSE streams emit two `data:` events per proxied request (same record JSON, `in_flight` field — JSON-line consumers degrade gracefully). TUI rows upsert in place (`...` duration column); CLI table/follow/detail render in-flight forms.

**Deliberate behavior changes:** non-capture hijacked requests record 101 instead of 200 (paths now agree); daemon mints request IDs for non-capture routes; aborted streams record instead of vanishing.

## Verification

- Full gate per commit: `make lint && make test && make test-race && make build`.
- Per-commit codex reviews (adversarial on the concurrency commits): 6 findings across C1-C3, all fixed (empty-ID notify ordering; attempt-scoped snapshot ctx; shared snapshot client; wrapper-shape validation; test hardening). C4 adversarial review: clean.
- New integration e2e (`test/integration/inflight_backfill_daemon_test.go`): in-flight visible mid-stream through the real daemon bridge, same-ID finalization; bridge severed → gap traffic → reconnect backfill with disk-spilled body, no duplicates.
- Live pass with the real binary, isolated HOME, daemon mode: mid-stream `in_flight: true` via CLI/JSON; same-ID completion with captured body; `curl -m 2` abort → final record at 2011ms (not stuck); daemon socket interposed with a relay → bridge severed while registered → 3 gap records backfilled with bodies after backoff reconnect, zero duplicate IDs.

## Notes / accepted risks

- The SSE subscription remains lossy by design (non-blocking 100-slot channels); a dropped completion event leaves a row in-flight until a later reconnect's snapshot heals it — if the daemon ring evicted it first, the row stays in-flight until local eviction (pinned by a documented-outcome test). Future work: staleness reaper / sequence-numbered resync.
- Issue #51's "restarted while the daemon kept serving" scenario is bounded by plan-005 lifecycle semantics (deregister/stale-sweep purge records); backfill covers reconnect-while-registered gaps.
- Requests hung before response headers stay invisible until completion (issue #48 pins recording at response-header time).
- Wire-format additions are safe under the exact-version gate; a long-running daemon needs a restart to serve the new fields (loudly enforced).

<details>
<summary>Plan 006 (full text)</summary>

```markdown
# 006 — Requests: forwarder snapshot backfill (#51) + in-flight visibility (#48)

Status: panel-reviewed (Codex + GLM 5.2 + CodeRabbit, 2026-07-18)
Repo: /Users/charliek/projects/prox (single-repo scope)
Baseline: main @ 8d48948
Branch: feature/plan-006-backfill-inflight
Artifacts: ~/.claude/plans/prox/006-backfill-inflight/
Issues: #51 (backfill, first), #48 (in-flight), one PR. Fallback pinned by the
user: if #48 proves more invasive than planned, ship C1+C2 (#51) alone and
re-plan #48 separately — the commit ordering below keeps that split clean.

Panel corrections incorporated (dispositions in §10):
- Upsert pinned as a monotonic state machine; in-flight duplicates are
  no-ops (Codex critical; CodeRabbit M3, GLM).
- Backfill drains the stream concurrently with the snapshot fetch; the
  guarantee is bounded gap closure, not "race-free" (Codex critical, GLM
  Hole A).
- Upsert notifies under the ring lock so same-ID event order can't regress
  (Codex).
- Completion recording moves into a defer — client abort/backend death
  mid-stream (ReverseProxy's ErrAbortHandler panic) now records instead of
  leaving a stuck in-flight row (CodeRabbit H1, Codex).
- 1xx provisional responses excluded from status latch + hook (Codex).
- Commit order: consumers (surfacing) land before producers (two-phase
  recording) (Codex).
- Snapshot decode all-or-nothing; explicit limit test; ctx-aware snapshot
  fetch (GLM Hole C, Codex).
- Field parity between in-flight and completion events pinned (CodeRabbit
  M2); event-count criteria scoped (all three).

## 1. Problem / motivation

Both issues are deferred work from plan 005 (PR #46).

1. **#51 — SSE bridge gaps.** The daemon→project request bridge
   (`ForwardRequests`) is stream-only. Records the daemon proxies while a
   project's SSE subscription is down (reconnect backoff, dropped events)
   never reach the project's local RequestManager, so its API/TUI/CLI can't
   see them even though the daemon still holds them.
2. **#48 — in-flight invisibility.** Both proxy paths record a request only
   after `ServeHTTP` returns. A long-lived streaming response (SSE, slow
   download, LLM token stream) is invisible in `prox requests` and the TUI
   until it completes — and if the client or backend aborts mid-stream,
   ReverseProxy panics with `http.ErrAbortHandler` and the request is never
   recorded at all.

## 2. Current state (verified this session)

Bridge (#51):
- `ForwardRequests` (internal/proxyd/forwarder.go:28-48): reconnect loop,
  backoff 500ms doubling to a max of 8s (cap check precedes doubling), errors
  discarded. `streamRequests` (forwarder.go:51-119) builds its own
  unix-socket `http.Client` (no timeout — correct for SSE), hits
  `/api/v1/requests/stream?project=<dir>`, reads events via `readEventLine`
  with a `constants.MaxSSEEventSize` per-event cap (forwarder.go:86-118;
  constant at internal/constants/constants.go:123-133, ≈3.7MB), and calls
  `localRM.Record(record)` per event — append-blind.
- Daemon socket endpoints (internal/proxyd/server.go): `handleStreamRequests`
  (:362-424) — mandatory `?project=`, `Subscribe` happens BEFORE response
  headers are written (:387-404), so once the client's `Do` returns 200 the
  subscription is already live; events are
  `data: <json.Marshal(proxy.RequestRecord)>\n\n`, raw record, no `event:`
  field. `handleGetRequests` (:426-464) — mandatory `?project=`, `?limit=`
  honored when `0 < l <= constants.MaxProxyRequests` (1000) else default
  100 (an omitted limit backfills only 100 — must be passed explicitly),
  response `{"requests": [...]}` of raw records (Details included, same
  unix-socket trust model as the stream).
- `proxyd.Client` (internal/proxyd/client.go:15-178) has Health/Register/
  Deregister/Status/Routes/Shutdown — **no requests method**. 30s client
  timeout (fine for a unix-socket snapshot; a timeout lands in the
  degraded-mode branch below).
- `RequestManager` (internal/proxy/requests.go): `Record` appends at head
  under `mu`, unlocks, fires the eviction callback, then notifies
  (:145-177); `notifySubscribers` non-blocking send, drops when a
  subscriber's 100-slot channel is full (:278-291) — the subscription is
  inherently lossy; `GetByID` linear scan (:206-220); `PurgeByProject`
  compacts (:336-377). **No update-in-place.**
- Forwarder test pins the gap: "The bridge is stream-only (no backfill), so
  records must be produced after the forwarder subscribes"
  (internal/proxyd/forwarder_test.go:137-138).
- Lifecycle (bounds what backfill can deliver): EVERY removal path purges the
  project's records — explicit deregister and stale-PID sweep both funnel
  into `removeProject`/`finishRemoval` → `PurgeByProject`
  (internal/proxyd/server.go:257-304). Re-register while a registration
  exists 409s (registry.go:79-81) and `prox up` hard-fails on it
  (up.go:819-822); stale sweep runs every 30s (daemon.go:33). So daemon
  records do NOT survive a graceful `prox up` restart — issue #51's
  "restarted while the daemon kept serving" framing only holds for
  reconnect-while-registered gaps (SSE drop, dropped events, crash windows).
- Forwarder wiring: `tryDaemonProxy` starts `go proxyd.ForwardRequests(ctx,
  proxyd.SocketPath(), cwd, localRM)` after successful registration
  (up.go:839-843); `cwd` is the same value registered as ProjectDir.

Recording (#48):
- Standalone path (internal/proxy/proxy.go:303-427): requestID minted up
  front (:308); early 404s (no subdomain / unknown service) record
  immediately against the BARE `w` (:313, :321) — they never touch the
  wrapped writer; capture path wraps with `CaptureResponseWriter`, else
  local `responseWriter` (:364-372, writer at :502-539 — status
  last-write-wins, no wroteHeader guard); ErrorHandler routes 502 through
  the active writer (:375-387; `http.Error` reaches the wrapper's
  `WriteHeader(502)`); after `proxy.ServeHTTP` (:390) a three-way branch
  (hijacked → 101 + CleanupRequest; capture → FinalizeRequestBody freeze +
  FinalizeResponse; plain) feeds the **single recording point**
  `recordRequest` (:424-425, body :465-480). **All of this is skipped when
  ReverseProxy panics with `http.ErrAbortHandler`** (response-body copy
  failure: backend died or client disconnected mid-stream) — today those
  requests produce no record.
- Daemon path (internal/proxyd/dynamic_proxy.go:162-302): same shape;
  no-route 404 records nothing (:168-171); requestID minted **only when
  captureEnabled** (:179-182); non-capture writer `statusResponseWriter`
  (:304-337, wroteHeader guard latches the FIRST WriteHeader — including a
  1xx provisional, a latent bug the hook must not inherit); recording at
  :287-299 stamps `ProjectDir: route.ProjectDir`. Non-capture hijacked
  requests fall into the `default` branch and record the writer's initial
  200 (the capture branch forces 101, :256-268). RemoteAddr differs by
  path: standalone records `getClientIP(r)` (proxy.go:476), daemon records
  raw `r.RemoteAddr` (dynamic_proxy.go:297).
- Status first becomes known at the writers' `WriteHeader`
  (capture.go:379-385). Go's ReverseProxy upgrade path never calls
  `WriteHeader` — it writes the 101 raw to the hijacked conn — so a
  header-time hook must also fire on successful `Hijack()`
  (capture.go:438-447 sets `hijacked`). ReverseProxy always calls
  `WriteHeader` explicitly for normal responses; it can forward 1xx
  provisional responses (e.g. 103) through `WriteHeader` before the final
  status.
- Finalize-freeze semantics (must not regress): `FinalizeRequestBody`
  freezes the request-body capture before the record is published
  (capture.go:338-352); post-finalize writes are discarded
  (capture.go:248-250). Pinned by TestFinalizeRequestBody
  (capture_test.go:888-911) and the dynamic-proxy hijack/error tests
  (dynamic_proxy_test.go:219-268, :270-305; the hijack test covers the
  capture path only).
- Surfacing: single conversion point `ToProxyRequestResponse`
  (internal/api/responses.go:226-238; struct :206-216 — no in-flight
  field). Project SSE stream marshals the response DTO
  (handlers.go:538-592). TUI list rows via `formatProxyRequest`
  (internal/tui/base.go:659-702; status<100 rendered dim as "unknown/error"
  :672-673 — status 0 is ALREADY overloaded, so in-flight needs an explicit
  field, not a sentinel status); `handleProxyRequest` is append-only
  (base.go:150-170) — a same-ID re-record would duplicate a row;
  detail-selection maps viewport lines to request indices (base.go:650-653),
  so in-place row replacement keeps selection stable; attach-mode
  reconstruction drops Details and would drop any new field unless copied
  (app.go:222-231); the TUI detail view has no capture hint — it renders
  whatever Details it converted. CLI: table (commands.go:530-544),
  follow-mode `printProxyRequest` (:675-699), detail `showRequestDetail`
  (:551-602, "capture not enabled" hint at :598 — CLI only).
- Version gate is exact-match both directions (plan 005) — wire-format
  additions (new field, new client call) are safe; the user's long-running
  daemon needs a restart, loudly enforced.

Gate (Makefile, plan-004/005 convention):
`make lint && make test && make test-race && make build` (~3min).

## 3. Design decisions (PINNED)

### Shared seam

**D1. `RequestManager.Upsert(record RequestRecord)` — a monotonic two-state
transition keyed by ID.** State machine (records are either in-flight or
final; final is terminal):

| Existing (by ID) | Incoming  | Action                                  |
|------------------|-----------|-----------------------------------------|
| absent           | either    | append (Record's eviction logic) + notify |
| in-flight        | in-flight | **no-op** — no write, no notify         |
| in-flight        | final     | replace in place + notify               |
| final            | either    | **no-op** — no write, no notify         |

- Empty incoming ID: generate and append (defensive; callers supply IDs).
- Lookup: linear scan newest→oldest, no index map (ring positions shift
  under `PurgeByProject` compaction; O(1000) accepted — in-flight updates
  hit the newest slots first; the recording paths avoid the guaranteed
  miss-scan for brand-new records by using `Record` for the in-flight
  insert, see D6).
- The two no-op rows are what make interleavings safe everywhere else in
  this plan: snapshot replay of already-delivered records is silent (no
  `-f --json` spam on reconnect, whether the dupe is final OR in-flight),
  and a stale buffered in-flight event can never regress a completed
  record. In-flight records never change fields in this design (start and
  completion are the only two events); if that ever changes, add an
  explicit revision counter rather than weakening the no-op rules.
- Replace-in-place keeps the ring slot (no head/count change, no eviction;
  safe because in-flight records carry no Details — the transition only
  ever ADDS capture state, preserving the eviction-callback invariant that
  only Details-carrying records need file cleanup).
- **Locking/notify order (deviation from `Record`, deliberate):** lookup,
  write, AND `notifySubscribers` happen inside one `mu` critical section,
  so same-ID notifications can never be observed out of transition order
  (notify is non-blocking sends only — safe under the lock; `subMu` is
  never held while acquiring `mu`, no lock-order cycle). The eviction
  callback (disk IO) still runs after unlock, as in `Record`. `Record`
  itself keeps its current semantics and tests untouched.

**D2. `RequestRecord.InFlight bool` (`json:"in_flight,omitempty"`).**
In-flight records carry the header-time status, `Duration: 0`, and
`Details: nil` (bodies are still streaming; partial capture reads are a
race we refuse to open — Details appear only on the completion update, so
the finalize-freeze contract is untouched). Completed records never carry
`InFlight: true`. Omitempty keeps completed-record JSON byte-identical to
today's.

### WS1 — #51 snapshot backfill

**D3. Backfill on every (re)connect, inside `streamRequests`, with the
stream drained concurrently.** The guarantee is **bounded gap closure**,
not losslessness — the underlying subscription stays lossy (100-slot
non-blocking channel), and backfill is limited to records still in the
daemon's ring within the current registration lifetime.

1. Open the SSE connection first. When `client.Do` returns 200 the
   daemon-side subscription is already live (server writes headers after
   `Subscribe` — verified above).
2. **Launch the snapshot fetch in a goroutine** and immediately enter the
   SSE read loop, applying live events via `localRM.Upsert` as they
   arrive. The forwarder must never sit blocked on the snapshot while the
   stream backs up (a >100-event burst during a slow fetch would drop
   events daemon-side — the exact gap this feature closes). Snapshot:
   new `Client.Requests(ctx, projectDir, limit)` on the existing daemon
   client (`GET /api/v1/requests?project=<dir>&limit=1000`, decoding the
   `{"requests":[...]}` wrapper); ctx is the forwarder's ctx so shutdown
   never waits out the 30s client timeout; limit explicitly
   `constants.MaxProxyRequests` = daemon ring size (an omitted limit
   silently backfills only 100 — pinned by test). The forwarder constructs
   `proxyd.NewClient(socketPath)` for this; the SSE connection keeps its
   own timeout-less client.
3. When the fetch returns, **decode all-or-nothing** (unmarshal the full
   response before the first Upsert — a truncated/partial body must apply
   zero records), then replay oldest-first (endpoint returns newest-first;
   reverse it) through `localRM.Upsert` from the fetch goroutine.
   Interleaving with the concurrent read loop is safe by D1's state
   machine + under-lock notify: any order of {snapshot copy, stream copy,
   completion} converges to the final record with no duplicate or
   out-of-order notifications. Details ride along (bodies/FilePaths are
   part of the record wire format — `prox requests <id> --body` works for
   a gap record; the daemon capture dir is already in the project's
   allowlist per plan 005 D6).
4. Snapshot failure (non-200, decode error, timeout, ctx cancel): log one
   warning and continue with the stream — degraded mode identical to
   today's behavior; never tear down the bridge over a failed backfill.
Ordering caveat, accepted: a backfilled gap record appends at the ring's
newest position (ring order ≠ timestamp order for that record; record
timestamps stay correct). Completion updates never move a record — it
keeps its response-header-time ring position.

**D4. Lifecycle semantics unchanged (non-goal).** Purge-on-deregister and
the stale-PID purge stay exactly as plan 005 pinned them; records still do
not survive a graceful `prox up` restart, and issue #51's scenario 2 is
corrected accordingly when closing the issue. The crash-then-restart 409
(`prox up` fails until the 30s sweep clears the dead registration) is a
pre-existing UX wart, out of scope, noted in §9.

### WS2 — #48 in-flight visibility

**D5. First-response hook on all three response writers.** Each writer
(`CaptureResponseWriter`, `statusResponseWriter`, standalone
`responseWriter`) gains an optional `onFirstResponse func(statusCode int)`
callback with pinned semantics:
- Fires exactly ONCE (single `responded` bool; single-goroutine per
  request), at the FIRST of: `WriteHeader(code)` with a **final** status
  (`code >= 200` — 1xx provisional responses such as 103 neither fire the
  hook nor latch the recorded status, in every writer; ReverseProxy can
  forward them before the real status), or successful `Hijack()` (fired
  with `http.StatusSwitchingProtocols`; ReverseProxy's upgrade path never
  calls WriteHeader). A failed Hijack never fires it.
- Order within WriteHeader: latch status → invoke callback → delegate to
  the underlying writer (the record exists before response bytes hit the
  wire).
- The hook fires only from `WriteHeader`/`Hijack` — never from implicit
  bare `Write` (ReverseProxy always calls WriteHeader explicitly; pin this
  invariant in a code comment on the hook). `responseWriter`'s
  last-write-wins statusCode semantics are unchanged apart from ignoring
  1xx; `statusResponseWriter`/`CaptureResponseWriter` keep first-wins
  latching, now skipping 1xx. ErrorHandler paths reach the hook through
  `http.Error` → `WriteHeader(502)` on the wrapper (the daemon
  ErrorHandler's direct `srw.statusCode = 502` assignment stays, harmless).

**D6. Two-phase recording in both handlers.** Before `ServeHTTP`, the
handler registers a hook closure that records the in-flight record via
`RequestManager.Record` (plain append — the freshly minted ID cannot exist,
so Upsert's miss-scan is pointless; the forwarder is the only Upsert writer
on a localRM, and handler-side rings have no other writer for that ID),
gated on the respective requestManager being non-nil. **Field parity is
pinned: the in-flight record computes every field with the same expression
as that path's completion record** (Timestamp=startTime, Method, URL,
Subdomain, Hostname, ProjectDir [daemon], RemoteAddr per-path as today) —
only StatusCode source (hook arg), `InFlight: true`, `Duration: 0`, and
`Details: nil` differ; C4's tests assert field-for-field equality between
the two events minus exactly those. `dynamic_proxy` always mints the
request ID (moves out of the `captureEnabled` gate, :179-182; fix the
now-stale comment at :288) so completion can match the in-flight record on
non-capture routes.

**D7. Completion recording moves into a `defer` (no recover).** The entire
post-ServeHTTP block (hijack branch, finalize-freeze + FinalizeResponse,
status derivation, completion Upsert) runs in a deferred closure in both
handlers, so it executes on normal return AND while unwinding
ReverseProxy's `http.ErrAbortHandler` panic (client disconnect / backend
death mid-stream — the motivating streaming case). The panic propagates
(net/http suppresses ErrAbortHandler); nothing recovers. Aborted streams
record their real header status with the truncated captured body and
`Duration` = time-to-abort — turning today's "no record at all" into an
honest record, and making a permanently-stuck in-flight row impossible
from this path. Pre-header panics (shouldn't-happen: our own code) record
the writer's latched default; accepted. Early-404 paths in proxy.go keep
their direct single-shot `Record` (bare `w`, no in-flight phase — correct:
nothing was proxied). Completion goes through `Upsert` (final beats the
in-flight copy; both events carry the same ID).

**D8. Hijack status consistency.** The two status writers learn a
`hijacked` flag (CaptureResponseWriter already has one); non-capture
hijacked requests now record 101 instead of the writer's initial 200 —
deliberate small behavior fix (called out in the commit message) so the
in-flight 101 and the completion record agree in every path. Capture-path
hijack semantics (metadata-only, CleanupRequest, no FinalizeResponse) are
untouched.

**D9. SSE event shape (pinned by the user's brief): the same record JSON
with the `in_flight` field — two `data:` events per proxied request (start
+ completion), no `event:` type field.** Applies identically to the daemon
socket stream (raw record) and the project API stream (response DTO).
JSON-line consumers that ignore unknown fields see today's shape plus an
extra line per request; consumers keyed by `id` see a clean upsert. The
alternative (`event: start/complete` SSE types) was rejected: it breaks
naive `data:`-line consumers and adds a second wire shape for no
information gain over the boolean.

**D10. Rendering.**
- API: `ProxyRequestResponse.InFlight bool` (`json:"in_flight,omitempty"`),
  stamped in `ToProxyRequestResponse`; `duration_ms` stays 0 while in
  flight. `RequestDetailData` (TUI) gains `InFlight`, copied in both the
  local and API conversion paths.
- TUI: `handleProxyRequest` upserts by ID (scan `proxyRequests` from the
  end, replace match in place, else append + cap-trim) — one row per
  request updating live; in-place replacement keeps detail-selection
  indices stable (pinned by test). In-flight rows render the duration
  column as `  ...` (status shows the real header-time code with its
  normal color). Detail view: shows `Duration: (in flight)` and, when
  Details is nil because the request is in flight, "(request in flight —
  details arrive on completion)". **Open detail views do NOT live-update
  on completion** (both local and attach modes — reopen to see final
  details; the list row behind it updates). Attach-mode record
  reconstruction (app.go:222-231) copies InFlight.
- CLI: list table renders DURATION as `...` for in-flight rows; follow-mode
  `printProxyRequest` prints `(in flight)` instead of `(Nms)`;
  `prox requests <id>` detail gates the misleading "capture not enabled"
  hint on in-flight and prints the in-flight note instead. `--json`
  carries the new field automatically.

## 4. Deviations / non-goals

- No per-project quotas (#49), no #50 items unless they fall out naturally
  (none identified), no pagination, no purge/lifecycle changes (D4).
- No SSE keepalive/heartbeat for the bridge; silently-dropped events are
  healed only by backfill on the next reconnect (a half-open stream can
  stay stale indefinitely — pre-existing).
- Backfill is bounded: only records still in the daemon's 1000-slot ring
  AND within the current registration lifetime are recoverable.
- No partial-body visibility while streaming (Details only on completion);
  no live in-flight field updates (monotonic two-state design, D1).
- Requests hung before response headers stay invisible until completion
  (recording at request start was considered and rejected: status-less
  rows collide with the TUI's status-0 error rendering, and issue #48
  pins header time).
- TUI verified by direct-call unit tests only (no PTY automation) — same
  accepted limit as plan 005.
- PR left open for user review; no release/deploy.

## 5. Work breakdown (gated commits)

Gate per commit: `make lint && make test && make test-race && make build`.
Consumer-readiness (C3) lands before event production (C4) so every commit
is behaviorally coherent — at no commit does the TUI duplicate rows or the
API face an unknown field. The #51 fallback split point is after C2.

- **C1 (fable — critical shared seam) — RequestManager.Upsert + InFlight
  field.** D1 + D2, data model only. Tests: full state-machine matrix
  (absent/in-flight/final × in-flight/final) including both no-op rows
  (no write, no notify — subscriber channel stays empty); update-in-place
  preserves ring position/count; append path evicts with callback exactly
  like Record; empty-ID defensive path; PurgeByProject after in-place
  updates still compacts correctly; concurrency under `-race`: racing
  in-flight/final Upserts on one ID converge to final with no subscriber
  ever seeing in-flight AFTER final (under-lock notify), concurrent
  Recent/PurgeByProject; "completion dropped and absent from any later
  snapshot → row stays in-flight" documented-outcome test; existing Record
  tests untouched.
- **C2 (opus) — #51 snapshot backfill.** D3: `Client.Requests(ctx, ...)` +
  concurrent-drain backfill in `streamRequests` + Record→Upsert in the
  read loop. Tests (extend forwarder_test.go's raw-SSE harness with a
  `/api/v1/requests` handler; `Client.Requests` contract tests live with
  the client/server tests): >100 records existing before first connect are
  all delivered (pins the explicit limit); records added during a forced
  disconnect appear after reconnect; overlap dedupe for BOTH a final and
  an in-flight record present in snapshot and stream (delivered once);
  delayed snapshot while >100 live events stream in — all live events
  delivered (concurrent drain); snapshot 500 / truncated-JSON → zero
  records applied, stream still delivers; ctx cancel during fetch exits
  cleanly; URL-escaped project dirs; the stream-only pinning comment/test
  updated. Docs: api.md note.
- **C3 (sonnet) — surfacing (consumer readiness).** D10: API field +
  DTO/detail conversions, TUI upsert + rendering + selection-stability +
  detail in-flight note, CLI rendering, attach-mode InFlight copy. Tests:
  same-ID ProxyRequestMsg updates row not duplicates; selection/scroll
  stable across an in-place update; in-flight formatProxyRequest; detail
  in-flight note; CLI table/follow/detail in-flight forms; project API
  SSE emits `in_flight` (stream handler test); ToProxyRequestResponse
  mapping. Docs: api.md (in_flight, two events), cli.md, tui.md.
- **C4 (opus) — #48 two-phase recording (producers).** D5-D8: writer
  hooks, in-flight closures + deferred completion in both handlers,
  unconditional ID minting, hijack-101 consistency. Tests: per-writer hook
  matrix (repeated WriteHeader fires once; 103→200 fires once with 200
  and records 200 — all three writers; failed hijack no-fire; successful
  hijack fires 101; ErrorHandler 502); blocking backend (header sent, body
  held) → in-flight record visible mid-request, same ID finalized with
  Details/duration on release — standalone/daemon × capture on/off
  matrix; field parity between the two events (minus
  status-source/duration/details/in_flight); client disconnect mid-stream
  against a REAL httptest.Server (ErrAbortHandler path) → completion
  recorded with truncated body, no stuck in-flight row; backend death
  mid-body likewise; hijack → in-flight 101 then final 101 metadata-only
  (capture AND non-capture — extends dynamic_proxy hijack test);
  early-404 paths emit exactly one final event; two events for
  proxy-served requests; finalize-freeze tests stay green.
- **C5 (opus) — integration tests.** test/integration daemon-topology:
  (a) in-flight e2e — slow-streaming backend through the daemon, project
  API shows the record `in_flight` mid-stream, finalized after;
  (b) backfill e2e — records created daemon-side (capture on) while the
  project's forwarder is down are visible via the project API after
  reconnect, `--body` resolving from the daemon capture dir included.

Order: C1→C2 (#51 complete; fallback split point) →C3→C4→C5.

## 6. File map (indicative)

- internal/proxy/requests.go — C1
- internal/proxyd/client.go, forwarder.go — C2
- internal/api/responses.go — C3
- internal/tui/base.go, app.go, model.go — C3
- internal/cli/commands.go — C3
- internal/proxy/proxy.go, capture.go — C4
- internal/proxyd/dynamic_proxy.go — C4
- test/integration/ — C5
- docs/reference/{api,cli,tui}.md — C2/C3

## 7. Acceptance criteria

#51:
- With a project registered and its bridge severed, records proxied during
  the gap — bounded by the daemon ring and the registration lifetime — are
  retrievable through the project's API/CLI after reconnect, including
  `--body` on a gap record.
- Reconnect against an unchanged daemon ring produces no duplicate rows
  and re-notifies NOTHING already delivered — final or in-flight (no
  `-f --json` spam).
- A full ring (>100 records) backfills completely (explicit limit).
- Snapshot fetch failure (non-200, malformed/truncated JSON, timeout,
  shutdown) applies zero partial records and degrades to today's
  stream-only behavior; live events keep flowing during a slow fetch.

#48 (scope: proxied requests whose backend response headers arrive; early
routing 404s emit exactly one final event; daemon no-route 404s record
nothing, as today):
- A streaming response is visible (list + stream, both proxy paths,
  capture on and off) with `in_flight: true` and its real final-status
  while the body is still streaming; on completion the SAME ID — at its
  original ring position — carries final duration/sizes/Details and no
  in-flight marker. Exactly two subscriber events per such request (for a
  subscriber connected before the response header, absent channel
  overflow), field-parity between them.
- **Client abort / backend death mid-stream produces a final record**
  (real header status, truncated body, duration-to-abort) — never a
  permanently in-flight row.
- 1xx provisional responses (103→200): hook fires once with 200; recorded
  status is 200 in all writers.
- WebSocket upgrade: in-flight 101 at hijack time; completion record 101,
  metadata-only, in both capture and non-capture paths (non-capture
  200→101 is a pinned deliberate change).
- Backend-unreachable: 502 in-flight + 502 final.
- TUI shows one row per request updating in place with stable selection;
  CLI table/follow/detail render in-flight distinctly; JSON carries
  `in_flight`; open detail views intentionally do not live-update.
- No regression of finalize-freeze or capture-hijack cleanup semantics.

All: gate green per commit.

## 8. Verification plan

C5 carries the automated e2e for both features. Beyond that, a live pass
with the real binary in daemon mode under an ISOLATED HOME (never the
user's real daemon), artifacts to ~/.claude/plans/prox/006-backfill-inflight/:
1. **In-flight live:** scratch project with a slow-SSE backend (python
   stdlib server streaming ~15s); curl through the daemon proxy; while
   streaming, `prox requests` + `prox requests -f --json` show the record
   with `in_flight: true`; after completion the same ID shows final
   duration and body via `--body`. Also Ctrl-C the curl mid-stream and
   verify a final (not stuck in-flight) record.
2. **Backfill live:** interpose a relay on the daemon socket (daemon's
   bound unix socket renamed, a small python relay at the canonical path)
   so the bridge can be severed while the project stays registered; sever,
   drive traffic through the daemon's TCP listener during the gap, restore
   the relay, and verify the gap records (with bodies) appear via
   `prox requests` after the forwarder's backoff reconnect.

## 9. Risks / open items

- The subscription remains lossy by design (non-blocking 100-slot
  channels). Concurrent drain removes the snapshot-window amplification,
  but a dropped COMPLETION event still leaves a row in-flight locally
  until a reconnect whose snapshot still holds the completed record; if
  the daemon ring evicted it first, the row is stuck in-flight until local
  eviction (pinned documented-outcome test in C1). Accepted for a dev
  tool; future work if it bites: staleness reaper or sequence-numbered
  resync (would need a protocol change).
- Doubled event rate (two events per proxied request) makes channel-full
  drops somewhat more likely under bursts. Accepted.
- Snapshot response can be large (up to the daemon ring's inline Details,
  ~128MB theoretical); decoded transiently client-side over a unix socket
  within the 30s client timeout — timeout lands in degraded mode.
  Accepted.
- In-flight record evicted from a full ring before completion → completion
  appends as a fresh record (correct data, ring order slightly off).
- Pre-existing, untouched: crash-restart 409 until the 30s sweep; records
  purged on graceful restart (D4); orphaned record if a request completes
  after its project's purge (plan 005 §9); half-open SSE with no
  heartbeat.
- Version gate forces daemon restart for the user — loud, unchanged.

## § Verified (2026-07-18, post-implementation)

All 5 commits landed on feature/plan-006-backfill-inflight
(3eed05f..e898b13), each through the full gate (lint, test, test-race,
build). Per-commit reviews: codex adversarial on C1/C2/C4 (1 + 3 + 0
findings, all fixed — C1 empty-ID notify ordering; C2 attempt-scoped
snapshot ctx, shared client, wrapper validation, 4 test-hardening items),
codex routine on C3 (2 minor, fixed), C5 test-only self-reviewed.
Simplify passes on C2 (no change), C3 (2 small), C4 (2 dedups).

Beyond automated tests, a live pass ran the real binary in daemon mode
under an isolated HOME (details in
006-backfill-inflight/verification-transcript.md): a streaming SSE request
was visible with in_flight true and real status while streaming and
finalized to the same single row with duration and captured body; a
client abort at 2s produced a final record (not stuck in-flight); and with
the daemon socket interposed by a relay, records proxied while the bridge
was severed were retrievable — with bodies — after the forwarder's backoff
reconnect, with zero duplicate IDs.

Known-unexercised live (accepted): backend-death/1xx/hijack/error-path
pairs and channel-overflow drain verified at unit/integration seams only;
TUI rendering by direct-call unit tests (no PTY automation). A twice-seen
`make test` flake did not reproduce across 6 sequential full runs plus
targeted -count=5 stress; attributed to overlapping concurrent test
invocations (subagent runs) contending for ports/processes, not the
product change — watch CI.

## 10. Panel dispositions (summary)

Adopted (Codex): Upsert monotonic state-machine table incl. in-flight
duplicate no-op; concurrent stream drain during snapshot + "bounded, not
race-free" framing + ctx-aware fetch; under-lock notify for same-ID order;
1xx exclusion from hook and status latch; ErrAbortHandler defer (also
CodeRabbit H1); commit reorder consumers-before-producers; hook API spec
(fire-once, WriteHeader-only + hijack, failed-hijack no-fire, order,
implicit-Write invariant comment); AC scoping and abort-as-AC; TUI
RequestDetailData.InFlight + pinned no-live-update detail; capture-hint
wording corrected (CLI-only); forwarder client/ctx wiring spelled out;
expanded test list (103, real-server abort, URL escaping, project-API SSE
field, >100 backfill, overlap-in-flight dedupe).
Adopted (CodeRabbit): H1 defer; M1 event-count scoping; M2 field parity +
test; M3 in-flight re-notify (superseded by Codex's stronger no-op rule);
M4 single-critical-section pin + race tests; L1 Record-for-insert; L2
responseWriter semantics pinned unchanged (plus 1xx guard); L3 selection
stability test; L4 client construction/timeout notes; L5 stale comment.
Adopted (GLM): Hole A concurrent drain (Codex variant chosen: apply
directly, no buffering — safe under the state machine); Hole B stuck-row
documented-outcome test + reaper noted as future work; Hole C
all-or-nothing decode + test; explicit-limit test; 30s-timeout
degraded-mode note; handleGetRequests pointer in §2; --body-from-daemon-dir
e2e case.
Skipped: GLM's Write-override on responseWriter (option b) — ReverseProxy
always calls WriteHeader; invariant pinned by comment + tests instead
(Codex agreed hook must be WriteHeader-only). Codex's "define fable/opus/
sonnet labels" — gauntlet execution convention, kept as in plan 005.
Contradictions: none requiring user arbitration (drain-vs-buffer resolved
in favor of direct apply; M3-vs-state-machine resolved by the stronger
rule).
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgMgg6eo4LgLTCkfYSARcH


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Proxy requests now publish an initial **in-flight** record when response headers are available, then **update in place** with final status/details when streaming completes.
  * CLI, JSON output, and the TUI render streaming durations as **(in flight)** and show completion details afterward.
  * Reconnecting daemon bridges backfill missed records and avoid duplicates.
  * Streaming documentation now defines consistent start/completion message behavior and shared request IDs.

* **Bug Fixes**
  * Improved correctness for upgrades, client disconnects, backend failures, and early routing errors, ensuring consistent finalization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->