### PR TITLE
Daemon crash-restart self-heal (#55) + TUI requests cursor/search (#47) + detail live-refresh (#54)

### DIFF
--- a/docs/discovery/shared-proxy-across-projects.md
+++ b/docs/discovery/shared-proxy-across-projects.md
@@ -102,7 +102,7 @@ Like Option A, but the daemon auto-starts when the first `prox up` needs a proxy
 | Opt-in vs default | Shared proxy behavior is automatic for any project with a configured proxy. There is no `shared` config field. |
 | Domain conflicts | Duplicate `hostname:port` registrations fail. |
 | Certificate management | HTTPS certificates are managed by the shared daemon as routes are registered. |
-| Stale route cleanup | The daemon tracks project PIDs and removes stale registrations for dead processes. |
+| Stale route cleanup | The daemon tracks project PIDs and removes stale registrations for dead processes, both on a periodic sweep and inline: restarting `prox up` in the same directory after a crash (e.g. `kill -9`) detects the dead registration and replaces it immediately, without waiting for the sweep. A second registration whose owning process is still alive is still rejected. |
 | Visibility and debugging | `prox proxy status` and `prox proxy routes` expose daemon state. |
 | Registration protocol | Projects communicate with the daemon over the Unix socket at `~/.prox/proxy.sock`. |
 

--- a/docs/reference/tui.md
+++ b/docs/reference/tui.md
@@ -141,9 +141,14 @@ Request Body (35 bytes, application/json)
   (e.g. evicted from disk) show `(body no longer available)`.
 - A request still streaming its response shows `Duration: (in flight)` and,
   since headers/bodies haven't been captured yet, `(request in flight —
-  details arrive on completion)` instead of the usual body sections. Detail
-  views do not live-update — reopen the request after it completes to see
-  its final headers and bodies.
+  details arrive on completion)` instead of the usual body sections.
+- Detail views live-update: when the open request completes, the view
+  refreshes in place with its final duration, headers, and bodies, and your
+  scroll position is preserved. In local mode (`prox up`) this happens
+  instantly from the streamed record; in client mode (`prox attach`) it
+  re-fetches the request in the background, with no loading flicker. If that
+  background re-fetch fails, the last snapshot stays on screen and the note
+  changes to `(live refresh failed — press esc and re-enter to reload)`.
 
 ## Process Filter Mode
 

--- a/docs/reference/tui.md
+++ b/docs/reference/tui.md
@@ -83,7 +83,7 @@ A request whose response is still streaming shows its real header-time status bu
 | `f` | Open process filter (multi-select) |
 | `/` | Substring filter, committed on `Enter` (hides non-matching) |
 | `s` | Substring filter, applied live (hides non-matching) |
-| `r` | Restart highlighted process |
+| `r` | Restart the soloed process (select with `1`-`9` first) |
 
 ### Requests View
 

--- a/docs/reference/tui.md
+++ b/docs/reference/tui.md
@@ -81,17 +81,42 @@ A request whose response is still streaming shows its real header-time status bu
 | --- | ------ |
 | `1-9` | Solo process (press again for all) |
 | `f` | Open process filter (multi-select) |
-| `/` | Search (highlight matches) |
-| `n` / `N` | Next/previous search match |
-| `s` | String filter (hide non-matching) |
+| `/` | Substring filter, committed on `Enter` (hides non-matching) |
+| `s` | Substring filter, applied live (hides non-matching) |
 | `r` | Restart highlighted process |
 
 ### Requests View
 
+The requests view has an explicit **cursor row** (marked with `❯`). The
+navigation keys move that cursor rather than scrolling raw lines, and the
+viewport scrolls the minimum needed to keep the cursor on screen.
+
 | Key | Action |
 | --- | ------ |
-| `s` | String filter (on URL/method/subdomain) |
-| `Enter` | Open detail view for the selected request |
+| `j` / `↓` | Move cursor down (onto the newest row resumes auto-follow) |
+| `k` / `↑` | Move cursor up (pauses auto-follow) |
+| `g` / `Home` | Move cursor to the top (pauses auto-follow) |
+| `G` / `End` | Move cursor to the bottom (resumes auto-follow) |
+| `PgUp` / `PgDn` | Move cursor half a page |
+| `F` | Toggle auto-follow (on pins the cursor to the newest row) |
+| `/` | Search URL/method/subdomain — jumps the cursor to a match (does not filter) |
+| `n` / `N` | Jump the cursor to the next/previous match (wraps) |
+| `s` | String filter (on URL/method/subdomain) — hides non-matching rows |
+| `Enter` | Open detail view for the cursor row |
+| `Esc` | Return from detail, or clear the filter and search |
+
+**Auto-follow** pins the cursor to the newest row and keeps the list scrolled
+to the bottom as requests arrive. Moving the cursor up (`k`, `PgUp`, `g`)
+pauses follow; moving it back onto the newest row (`j`/`PgDn`), or pressing
+`G`/`End`/`F`, resumes it. While follow is paused, arriving requests never move
+the cursor off the row you selected.
+
+**Search vs. filter.** `/` in the requests view *navigates* — it jumps the
+cursor to matching rows and leaves every row visible — so it composes with an
+active `s` filter (matches are computed over the filtered list) instead of
+replacing it. `s` still *filters*, hiding non-matching rows. The status bar
+shows the search indicator as `/<query> (i/k)` (cursor on match _i_ of _k_) or
+`/<query> (k matches)` when the cursor is not on a match.
 
 ## Request Detail View
 
@@ -147,14 +172,20 @@ Press `f` to open the multi-select process filter:
 
 ## Search Mode
 
-Press `/` to enter search mode:
+Press `/` to enter search mode. An input field appears at the bottom; the
+behavior depends on the active view:
 
-- Input field appears at bottom
-- Matching text is highlighted in the log view
-- Logs continue to flow while searching
-- `n` / `N` navigate between matches
-- `Enter` exits search mode (highlights remain)
-- `Esc` clears search and highlights
+- **Logs view:** `/` is a case-insensitive substring filter committed on
+  `Enter` — matching lines are kept and non-matching ones hidden (the same
+  effect as `s`, which applies live instead of on `Enter`). There is no match
+  highlighting and no `n`/`N` navigation in the logs view.
+- **Requests view:** `/` is case-insensitive substring *navigation* over
+  URL/method/subdomain. On `Enter` the cursor jumps to the first match
+  at-or-after its current row (wrapping); `n`/`N` then jump to the next and
+  previous matches (wrapping). No rows are hidden, so search composes with an
+  active `s` filter.
+- `Esc` cancels the input; in normal mode `Esc` clears the committed
+  filter/search.
 
 ## String Filter Mode
 

--- a/internal/proxyd/daemon.go
+++ b/internal/proxyd/daemon.go
@@ -219,8 +219,11 @@ func RunDaemon(ctx context.Context) error {
 					)
 				}
 				if len(stale) > 0 && registry.IsEmpty() {
-					logger.Info("all routes cleaned up, shutting down")
-					server.RequestShutdown()
+					// Graced (not immediate) so a crash restart landing during
+					// this sweep — its self-heal replace completing just after —
+					// cancels the shutdown when the re-check sees its registration.
+					logger.Info("all routes cleaned up, scheduling shutdown check")
+					server.scheduleShutdownWhenEmpty()
 				}
 			}
 		}

--- a/internal/proxyd/registry.go
+++ b/internal/proxyd/registry.go
@@ -69,6 +69,25 @@ func routeKey(hostname string, port int) string {
 	return fmt.Sprintf("%s:%d", hostname, port)
 }
 
+// ProjectConflictError is returned by Register when the target project dir is
+// already registered. It carries the existing registration's PID, captured
+// under the same lock acquisition that detected the conflict, so callers can
+// decide (via a liveness check) whether the holder is a running prox up or a
+// crashed one whose registration can be replaced. It is matched with
+// errors.As; every other Register error stays plain and is never retried.
+type ProjectConflictError struct {
+	Dir string
+	PID int
+}
+
+func (e *ProjectConflictError) Error() string {
+	return fmt.Sprintf(
+		"project %s is already registered by a running prox up (PID %d); "+
+			"stop it or run 'prox proxy stop --force'",
+		e.Dir, e.PID,
+	)
+}
+
 // Register adds a project's routes to the registry.
 // Returns the registered hostnames, any new ports that need listeners, or an error on conflict.
 func (r *Registry) Register(req RegisterRequest) (hostnames []string, newPorts []PortSpec, err error) {
@@ -76,8 +95,8 @@ func (r *Registry) Register(req RegisterRequest) (hostnames []string, newPorts [
 	defer r.mu.Unlock()
 
 	// Check if this project is already registered
-	if _, exists := r.projects[req.ProjectDir]; exists {
-		return nil, nil, fmt.Errorf("project %s is already registered; deregister first", req.ProjectDir)
+	if existing, exists := r.projects[req.ProjectDir]; exists {
+		return nil, nil, &ProjectConflictError{Dir: req.ProjectDir, PID: existing.PID}
 	}
 
 	// Reject same port for both HTTP and HTTPS

--- a/internal/proxyd/registry_test.go
+++ b/internal/proxyd/registry_test.go
@@ -1,6 +1,8 @@
 package proxyd
 
 import (
+	"errors"
+	"strings"
 	"testing"
 )
 
@@ -242,10 +244,85 @@ func TestRegistry_DuplicateProject(t *testing.T) {
 		t.Fatalf("Register: %v", err)
 	}
 
-	// Try to register the same project again
+	// Try to register the same project again — a typed conflict carrying the
+	// existing registration's dir and PID.
 	_, _, err := reg.Register(req)
 	if err == nil {
 		t.Fatal("expected duplicate project error, got nil")
+	}
+	var conflict *ProjectConflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("error = %v, want *ProjectConflictError", err)
+	}
+	if conflict.Dir != "/projects/a" {
+		t.Errorf("conflict.Dir = %q, want /projects/a", conflict.Dir)
+	}
+	if conflict.PID != req.PID {
+		t.Errorf("conflict.PID = %d, want %d", conflict.PID, req.PID)
+	}
+	if !strings.Contains(err.Error(), "already registered by a running prox up") ||
+		!strings.Contains(err.Error(), "prox proxy stop --force") {
+		t.Errorf("error message = %q, want the upgraded holder-naming message", err.Error())
+	}
+}
+
+// TestRegistry_ConflictCarriesNewPIDAfterReRegister pins that the typed
+// conflict reflects the CURRENT registration: after a project deregisters and
+// re-registers under a different PID, the conflict names the new PID, not the
+// original one.
+func TestRegistry_ConflictCarriesNewPIDAfterReRegister(t *testing.T) {
+	reg := NewRegistry()
+
+	req := newTestRequest("/projects/a", "local.dev",
+		map[string]ServiceTarget{"api": {Host: "localhost", Port: 3000}},
+		0, 443,
+	)
+	req.PID = 111
+	if _, _, err := reg.Register(req); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	reg.Deregister("/projects/a")
+	req.PID = 222
+	if _, _, err := reg.Register(req); err != nil {
+		t.Fatalf("re-Register: %v", err)
+	}
+
+	_, _, err := reg.Register(req)
+	var conflict *ProjectConflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("error = %v, want *ProjectConflictError", err)
+	}
+	if conflict.PID != 222 {
+		t.Errorf("conflict.PID = %d, want 222 (the current registration's PID)", conflict.PID)
+	}
+}
+
+// TestRegistry_RouteConflictIsUntyped pins that a non-same-dir conflict (another
+// project owning the hostname:port) stays a plain error — it must never be
+// mistaken for a replaceable stale registration.
+func TestRegistry_RouteConflictIsUntyped(t *testing.T) {
+	reg := NewRegistry()
+
+	reqA := newTestRequest("/projects/a", "local.dev",
+		map[string]ServiceTarget{"api": {Host: "localhost", Port: 3000}},
+		0, 443,
+	)
+	if _, _, err := reg.Register(reqA); err != nil {
+		t.Fatalf("Register A: %v", err)
+	}
+
+	reqB := newTestRequest("/projects/b", "local.dev",
+		map[string]ServiceTarget{"api": {Host: "localhost", Port: 4000}},
+		0, 443,
+	)
+	_, _, err := reg.Register(reqB)
+	if err == nil {
+		t.Fatal("expected route conflict error, got nil")
+	}
+	var conflict *ProjectConflictError
+	if errors.As(err, &conflict) {
+		t.Errorf("route conflict should be untyped, got *ProjectConflictError: %v", err)
 	}
 }
 

--- a/internal/proxyd/selfheal_test.go
+++ b/internal/proxyd/selfheal_test.go
@@ -1,0 +1,233 @@
+package proxyd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/charliek/prox/internal/proxy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newProxyServer builds a Server wired to a real DynamicProxy with real TCP
+// listeners (HTTP only, no certMgr) — enough to prove the self-heal actually
+// closes and rebinds a physical listener, which the registry-only scaffold
+// cannot.
+func newProxyServer(t *testing.T) *Server {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
+	s := NewServer(ServerConfig{SocketPath: "", Logger: logger, Version: "test"})
+	reg := NewRegistry()
+	rm := proxy.NewRequestManager(100)
+	dp := NewDynamicProxy(reg, nil, rm, nil, logger)
+	s.SetRegistry(reg)
+	s.SetProxy(dp)
+	s.SetRequestManager(rm)
+	t.Cleanup(func() { _ = dp.Shutdown(context.Background()) })
+	return s
+}
+
+// freePort binds an ephemeral port, closes it, and returns the number for a
+// registration to rebind. A small race is accepted (tests only).
+func freePort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+	require.NoError(t, ln.Close())
+	return port
+}
+
+func deadPID(t *testing.T) int {
+	t.Helper()
+	cmd := exec.Command("true")
+	require.NoError(t, cmd.Run())
+	return cmd.Process.Pid
+}
+
+// registerOK drives a setup registration to success, tolerating the transient
+// PORT_BIND_FAILED that a fresh-port bind can hit when the OS briefly holds a
+// just-closed ephemeral port (the small port race the plan sanctions for
+// tests). The production self-heal replace path has its own bind retry; this is
+// only for test scaffolding that rebinds ports outside that path.
+func registerOK(t *testing.T, s *Server, req RegisterRequest) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		status, body := s.register(req)
+		if status == http.StatusOK {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("register never succeeded: status=%d body=%v", status, body)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// TestSelfHeal_E2E_DeadPIDRebindsAndServes is the pinned real-listener e2e: a
+// dead-PID registration binds a port, a same-dir restart under a live PID
+// self-heals (closes and rebinds the listener), and a proxied HTTP request
+// round-trips through the new registration.
+func TestSelfHeal_E2E_DeadPIDRebindsAndServes(t *testing.T) {
+	backendHost, backendPort := newTestBackend(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "hello from backend")
+	})
+
+	s := newProxyServer(t)
+	port := freePort(t)
+
+	deadReq := RegisterRequest{
+		ProjectDir: "/projects/dead", PID: deadPID(t), Version: "test", Domain: "local.dev",
+		Services: map[string]ServiceTarget{"api": {Host: backendHost, Port: backendPort}},
+		HTTPPort: port,
+	}
+	registerOK(t, s, deadReq)
+
+	// Restart: same dir + port, live PID. Self-heal closes and rebinds the port.
+	reReq := deadReq
+	reReq.PID = os.Getpid()
+	status, body := s.register(reReq)
+	require.Equal(t, http.StatusOK, status, "self-heal re-register should succeed: %v", body)
+
+	// A proxied request round-trips through the new registration. The rebind has
+	// a brief unbound window, so retry briefly.
+	var resp *http.Response
+	var err error
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		httpReq, _ := http.NewRequest("GET", fmt.Sprintf("http://127.0.0.1:%d/", port), nil)
+		httpReq.Host = "api.local.dev"
+		resp, err = http.DefaultClient.Do(httpReq)
+		if err == nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	require.NoError(t, err, "proxied request should reach the rebound listener")
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "hello from backend", string(respBody))
+}
+
+// TestSelfHeal_Concurrency_RegisterVsSweep runs registration attempts racing the
+// sweep's removeStaleProject on the same dead dir under -race. The lifecycle
+// mutex must make every outcome either a self-heal with a routable listener or
+// a clean conflict — never PORT_BIND_FAILED, never a purged new generation.
+func TestSelfHeal_Concurrency_RegisterVsSweep(t *testing.T) {
+	backendHost, backendPort := newTestBackend(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "ok")
+	})
+	s := newProxyServer(t)
+	port := freePort(t)
+	dead := deadPID(t)
+
+	baseReq := RegisterRequest{
+		ProjectDir: "/projects/dead", Version: "test", Domain: "local.dev",
+		Services: map[string]ServiceTarget{"api": {Host: backendHost, Port: backendPort}},
+		HTTPPort: port,
+	}
+
+	const iterations = 40
+	successes := 0
+	for i := 0; i < iterations; i++ {
+		// Clean slate, then seed a fresh dead registration binding the port.
+		s.removeProject("/projects/dead")
+		deadReq := baseReq
+		deadReq.PID = dead
+		registerOK(t, s, deadReq)
+
+		var wg sync.WaitGroup
+		var regStatus int
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			reReq := baseReq
+			reReq.PID = os.Getpid()
+			regStatus, _ = s.register(reReq)
+		}()
+		go func() {
+			defer wg.Done()
+			s.removeStaleProject("/projects/dead", dead)
+		}()
+		wg.Wait()
+
+		require.Contains(t, []int{http.StatusOK, http.StatusConflict}, regStatus,
+			"iteration %d: only self-heal success or clean conflict is acceptable (got %d)", i, regStatus)
+
+		if regStatus == http.StatusOK {
+			successes++
+			_, ok := s.registry.Lookup("api.local.dev", port)
+			assert.True(t, ok, "iteration %d: successful self-heal must leave a routable listener", i)
+
+			// The route must be backed by a real listening socket, not just
+			// registry bookkeeping.
+			conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+			require.NoError(t, err, "iteration %d: self-heal listener must accept connections", i)
+			_ = conn.Close()
+
+			// A late sweep tick for the dead PID must not touch the live
+			// generation's route or records.
+			recID := fmt.Sprintf("newgen-%d", i)
+			s.requestManager.Record(proxy.RequestRecord{ID: recID, ProjectDir: "/projects/dead", Method: "GET", URL: "/n", Details: &proxy.RequestDetails{}})
+			removed, _, _ := s.removeStaleProject("/projects/dead", dead)
+			assert.False(t, removed, "iteration %d: late sweep must skip the live generation", i)
+			_, ok = s.registry.Lookup("api.local.dev", port)
+			assert.True(t, ok, "iteration %d: live route must survive a late sweep", i)
+			_, ok = s.requestManager.GetByID(recID)
+			assert.True(t, ok, "iteration %d: new generation's record must survive a late sweep", i)
+		}
+	}
+	// The race must not be able to starve the restart entirely — the whole
+	// point of #55 is that the re-register wins against a dead holder.
+	require.Positive(t, successes, "at least one self-heal must succeed across %d iterations", iterations)
+}
+
+// TestSelfHeal_RollbackBindFailSchedulesShutdown pins that a self-heal replace
+// whose listener rebind fails rolls back to an empty registry AND schedules the
+// graced shutdown check — an emptied registry must never strand an idle daemon.
+func TestSelfHeal_RollbackBindFailSchedulesShutdown(t *testing.T) {
+	backendHost, backendPort := newTestBackend(t, func(http.ResponseWriter, *http.Request) {})
+	s := newProxyServer(t)
+	s.shutdownDelay = 20 * time.Millisecond
+
+	// Occupy a port so the self-heal's rebind onto it fails. Bind all interfaces
+	// (":0") so the daemon's ":port" bind is guaranteed to collide.
+	occupied, err := net.Listen("tcp", ":0")
+	require.NoError(t, err)
+	defer occupied.Close()
+	occupiedPort := occupied.Addr().(*net.TCPAddr).Port
+
+	deadReq := RegisterRequest{
+		ProjectDir: "/projects/dead", PID: deadPID(t), Version: "test", Domain: "local.dev",
+		Services: map[string]ServiceTarget{"api": {Host: backendHost, Port: backendPort}},
+		HTTPPort: freePort(t),
+	}
+	registerOK(t, s, deadReq)
+
+	// Restart onto the occupied port: self-heal replaces the dead registration,
+	// then the rebind fails, rolling back to an empty registry.
+	reReq := deadReq
+	reReq.PID = os.Getpid()
+	reReq.HTTPPort = occupiedPort
+	status, body := s.register(reReq)
+	require.Equal(t, http.StatusInternalServerError, status, "bind failure expected: %v", body)
+	require.True(t, s.registry.IsEmpty(), "rollback must empty the registry")
+
+	select {
+	case <-s.ShutdownCh():
+		// graced shutdown scheduled — correct
+	case <-time.After(2 * time.Second):
+		t.Fatal("a rollback that emptied the registry must schedule a shutdown check")
+	}
+}

--- a/internal/proxyd/selfheal_test.go
+++ b/internal/proxyd/selfheal_test.go
@@ -215,6 +215,13 @@ func TestSelfHeal_RollbackBindFailSchedulesShutdown(t *testing.T) {
 	}
 	registerOK(t, s, deadReq)
 
+	// A record captured for the project while its routes were briefly visible
+	// (shared-port listener window) must not survive the rollback as an
+	// orphan — pre-seed one to pin the purge.
+	s.requestManager.Record(proxy.RequestRecord{
+		ID: "rollback-orphan", ProjectDir: "/projects/dead", Method: "GET", URL: "/w",
+	})
+
 	// Restart onto the occupied port: self-heal replaces the dead registration,
 	// then the rebind fails, rolling back to an empty registry.
 	reReq := deadReq
@@ -223,6 +230,8 @@ func TestSelfHeal_RollbackBindFailSchedulesShutdown(t *testing.T) {
 	status, body := s.register(reReq)
 	require.Equal(t, http.StatusInternalServerError, status, "bind failure expected: %v", body)
 	require.True(t, s.registry.IsEmpty(), "rollback must empty the registry")
+	_, found := s.requestManager.GetByID("rollback-orphan")
+	require.False(t, found, "rollback must purge the project's captured records")
 
 	select {
 	case <-s.ShutdownCh():

--- a/internal/proxyd/server.go
+++ b/internal/proxyd/server.go
@@ -3,6 +3,7 @@ package proxyd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -10,9 +11,11 @@ import (
 	"os"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/charliek/prox/internal/constants"
+	"github.com/charliek/prox/internal/daemon"
 	"github.com/charliek/prox/internal/proxy"
 	"github.com/go-chi/chi/v5"
 )
@@ -30,6 +33,24 @@ type Server struct {
 	shutdownCh chan struct{}
 	shutdownMu sync.Mutex
 	startedAt  time.Time
+
+	// shutdownDelay is the grace period scheduleShutdownWhenEmpty waits before
+	// re-checking an emptied registry, giving a rapid down/up (or a crash
+	// restart landing during a sweep) time to re-register. Injectable in tests.
+	shutdownDelay time.Duration
+
+	// lifecycleMu serializes control-plane lifecycle transactions
+	// (registry mutation + physical listener add/remove + record purge) so a
+	// concurrent sweep tick can't close a fresh registration's listeners, fail
+	// its retry with PORT_BIND_FAILED, or purge its records. The data plane
+	// (route Lookup, proxying, SSE) never touches this mutex.
+	lifecycleMu sync.Mutex
+
+	// lifecycleEpoch increments on every registry mutation. A grace timer
+	// scheduled by scheduleShutdownWhenEmpty captures the epoch and stands
+	// down if it changed, so a timer from an older empty period can't cut a
+	// newer grace period short.
+	lifecycleEpoch atomic.Uint64
 
 	// Core components
 	registry       *Registry
@@ -49,12 +70,13 @@ func NewServer(cfg ServerConfig) *Server {
 	r := chi.NewRouter()
 
 	s := &Server{
-		socketPath: cfg.SocketPath,
-		version:    cfg.Version,
-		router:     r,
-		logger:     cfg.Logger,
-		shutdownCh: make(chan struct{}),
-		startedAt:  time.Now(),
+		socketPath:    cfg.SocketPath,
+		version:       cfg.Version,
+		router:        r,
+		logger:        cfg.Logger,
+		shutdownCh:    make(chan struct{}),
+		startedAt:     time.Now(),
+		shutdownDelay: 5 * time.Second,
 	}
 
 	s.registerRoutes()
@@ -79,6 +101,16 @@ func (s *Server) SetRequestManager(rm *proxy.RequestManager) {
 // ShutdownCh returns a channel that is closed when the daemon should exit.
 func (s *Server) ShutdownCh() <-chan struct{} {
 	return s.shutdownCh
+}
+
+// isShuttingDown reports whether daemon shutdown has been requested.
+func (s *Server) isShuttingDown() bool {
+	select {
+	case <-s.shutdownCh:
+		return true
+	default:
+		return false
+	}
 }
 
 // RequestShutdown signals the daemon to exit.
@@ -153,14 +185,64 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Register routes
-	hostnames, newPorts, err := s.registry.Register(req)
-	if err != nil {
-		writeJSON(w, http.StatusConflict, ErrorResponse{
-			Error: err.Error(),
-			Code:  "REGISTRATION_CONFLICT",
+	// PID identifies the registration's generation and is the liveness key for
+	// crash-restart self-heal. ProcessExists(0)/negative PIDs have
+	// signal-broadcast semantics and would read as permanently alive, so a
+	// crashed generation with a bad PID could never be replaced.
+	if req.PID <= 0 {
+		writeJSON(w, http.StatusBadRequest, ErrorResponse{
+			Error: "pid must be a positive process id",
+			Code:  "BAD_REQUEST",
 		})
 		return
+	}
+
+	status, body := s.register(req)
+	writeJSON(w, status, body)
+}
+
+// register runs the full register-through-listener-start lifecycle transaction
+// under lifecycleMu (registry mutation, crash-restart self-heal, cert
+// generation, listener add, and all rollbacks) and returns the HTTP status and
+// response body for the caller to write once the lock is released. Serializing
+// the whole transaction means a concurrent sweep tick can't tear down the new
+// generation's listeners or purge its records mid-flow.
+func (s *Server) register(req RegisterRequest) (int, any) {
+	s.lifecycleMu.Lock()
+	defer s.lifecycleMu.Unlock()
+
+	// A register that queued behind a shutdown decision must not report
+	// success from a daemon that is already exiting.
+	if s.isShuttingDown() {
+		return http.StatusServiceUnavailable, ErrorResponse{
+			Error: "daemon is shutting down; retry to start a fresh daemon",
+			Code:  "SHUTTING_DOWN",
+		}
+	}
+
+	hostnames, newPorts, err := s.registry.Register(req)
+	replaced := false
+	if err != nil {
+		var conflict *ProjectConflictError
+		if !errors.As(err, &conflict) {
+			// Route/validation conflict — a real error, never retried.
+			return http.StatusConflict, ErrorResponse{Error: err.Error(), Code: "REGISTRATION_CONFLICT"}
+		}
+		if daemon.ProcessExists(conflict.PID) {
+			// A second live prox up in the same dir is a genuine conflict.
+			return http.StatusConflict, ErrorResponse{Error: err.Error(), Code: "REGISTRATION_CONFLICT"}
+		}
+		// The holder crashed without deregistering. Replace its stale
+		// registration inline (PID-guarded; purges its records + body files and
+		// closes its listeners) and retry once. Under lifecycleMu the retry
+		// cannot lose a race, so a single retry is a correctness guarantee.
+		s.logger.Warn("replacing stale registration", "project", conflict.Dir, "pid", conflict.PID)
+		s.removeStaleProjectLocked(conflict.Dir, conflict.PID)
+		hostnames, newPorts, err = s.registry.Register(req)
+		if err != nil {
+			return http.StatusConflict, ErrorResponse{Error: err.Error(), Code: "REGISTRATION_CONFLICT"}
+		}
+		replaced = true
 	}
 
 	// Ensure certs exist for HTTPS domains before starting listeners
@@ -169,32 +251,41 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 			if ps.Protocol == "https" {
 				if err := s.proxy.certMgr.EnsureDomain(req.Domain); err != nil {
 					s.registry.Deregister(req.ProjectDir)
-					writeJSON(w, http.StatusInternalServerError, ErrorResponse{
+					s.lifecycleEpoch.Add(1)
+					s.scheduleShutdownWhenEmpty()
+					return http.StatusInternalServerError, ErrorResponse{
 						Error: fmt.Sprintf("failed to generate certs for %s: %v", req.Domain, err),
 						Code:  "CERT_GENERATION_FAILED",
-					})
-					return
+					}
 				}
 				break // one EnsureDomain per domain is sufficient
 			}
 		}
 	}
 
-	// Start listeners for new ports
+	// Start listeners for new ports. A self-heal replace closed the crashed
+	// generation's listener just now and rebinds the same port back-to-back;
+	// the OS can hold the port for a few ms after close, so that path needs a
+	// brief bind retry to keep the restart this fix exists for from failing.
 	if s.proxy != nil {
+		bind := s.proxy.AddListener
+		if replaced {
+			bind = s.addListenerWithBriefRetry
+		}
 		var startedPorts []int
 		for _, ps := range newPorts {
-			if err := s.proxy.AddListener(ps.Port, ps.Protocol); err != nil {
-				// Rollback: stop listeners we already started, then deregister
+			if err := bind(ps.Port, ps.Protocol); err != nil {
+				// Rollback: stop listeners we already started, then deregister.
 				for _, p := range startedPorts {
 					_ = s.proxy.RemoveListener(p)
 				}
 				s.registry.Deregister(req.ProjectDir)
-				writeJSON(w, http.StatusInternalServerError, ErrorResponse{
+				s.lifecycleEpoch.Add(1)
+				s.scheduleShutdownWhenEmpty()
+				return http.StatusInternalServerError, ErrorResponse{
 					Error: fmt.Sprintf("failed to bind port %d: %v", ps.Port, err),
 					Code:  "PORT_BIND_FAILED",
-				})
-				return
+				}
 			}
 			startedPorts = append(startedPorts, ps.Port)
 		}
@@ -207,7 +298,8 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 		"hostnames", hostnames,
 	)
 
-	writeJSON(w, http.StatusOK, RegisterResponse{Registered: hostnames})
+	s.lifecycleEpoch.Add(1)
+	return http.StatusOK, RegisterResponse{Registered: hostnames}
 }
 
 func (s *Server) handleDeregister(w http.ResponseWriter, r *http.Request) {
@@ -241,17 +333,35 @@ func (s *Server) handleDeregister(w http.ResponseWriter, r *http.Request) {
 		"removed": removedHostnames,
 	})
 
-	// If registry is empty, shut down the daemon
-	if s.registry.IsEmpty() {
-		s.logger.Info("no routes registered, shutting down daemon")
-		go func() {
-			// Brief grace period for rapid down/up cycles
-			time.Sleep(5 * time.Second)
-			if s.registry.IsEmpty() {
-				s.RequestShutdown()
-			}
-		}()
+	// If registry is empty, schedule a graced shutdown check.
+	s.scheduleShutdownWhenEmpty()
+}
+
+// scheduleShutdownWhenEmpty requests daemon shutdown after a grace period when
+// the registry has no routes left, but only if it is STILL empty when the grace
+// expires — a rapid down/up cycle, or a crash restart landing during a sweep,
+// re-registers within the window and cancels the shutdown. Used by explicit
+// deregister, the stale-PID sweep, and register rollback paths (an emptied
+// registry after a failed self-heal replace would otherwise strand an idle
+// daemon forever). No-op when the registry is non-empty at call time.
+func (s *Server) scheduleShutdownWhenEmpty() {
+	if s.registry == nil || !s.registry.IsEmpty() {
+		return
 	}
+	s.logger.Info("no routes registered, scheduling shutdown check")
+	epoch := s.lifecycleEpoch.Load()
+	go func() {
+		time.Sleep(s.shutdownDelay)
+		// Re-check under lifecycleMu so an in-flight register transaction
+		// finishes before the decision, and stand down if ANY lifecycle
+		// mutation happened since scheduling — a newer empty period gets its
+		// own timer with the full grace.
+		s.lifecycleMu.Lock()
+		defer s.lifecycleMu.Unlock()
+		if s.lifecycleEpoch.Load() == epoch && s.registry.IsEmpty() {
+			s.RequestShutdown()
+		}
+	}()
 }
 
 // removeProject is the single consolidated project-removal path: it removes the
@@ -261,11 +371,19 @@ func (s *Server) handleDeregister(w http.ResponseWriter, r *http.Request) {
 // the stale-PID crash-recovery sweep so the crash path can't leak records or
 // body files. Returns the removed hostnames and now-empty ports for logging.
 func (s *Server) removeProject(projectDir string) (removedHostnames []string, emptyPorts []int) {
+	s.lifecycleMu.Lock()
+	defer s.lifecycleMu.Unlock()
+	return s.removeProjectLocked(projectDir)
+}
+
+// removeProjectLocked is removeProject's body; lifecycleMu must be held. It lets
+// register run a stale-registration replace while already holding the mutex.
+func (s *Server) removeProjectLocked(projectDir string) (removedHostnames []string, emptyPorts []int) {
 	if s.registry == nil {
 		return nil, nil
 	}
-
 	removedHostnames, emptyPorts = s.registry.Deregister(projectDir)
+	s.lifecycleEpoch.Add(1)
 	s.finishRemoval(projectDir, emptyPorts)
 	return removedHostnames, emptyPorts
 }
@@ -274,14 +392,22 @@ func (s *Server) removeProject(projectDir string) (removedHostnames []string, em
 // guarded on the registration still carrying the detected dead PID, so a
 // project that re-registered between detection and removal is left alone.
 func (s *Server) removeStaleProject(projectDir string, pid int) (removed bool, removedHostnames []string, emptyPorts []int) {
+	s.lifecycleMu.Lock()
+	defer s.lifecycleMu.Unlock()
+	return s.removeStaleProjectLocked(projectDir, pid)
+}
+
+// removeStaleProjectLocked is removeStaleProject's body; lifecycleMu must be
+// held. register calls it to replace a crashed generation inline.
+func (s *Server) removeStaleProjectLocked(projectDir string, pid int) (removed bool, removedHostnames []string, emptyPorts []int) {
 	if s.registry == nil {
 		return false, nil, nil
 	}
-
 	removed, removedHostnames, emptyPorts = s.registry.DeregisterIfPID(projectDir, pid)
 	if !removed {
 		return false, nil, nil
 	}
+	s.lifecycleEpoch.Add(1)
 	s.finishRemoval(projectDir, emptyPorts)
 	return true, removedHostnames, emptyPorts
 }
@@ -301,6 +427,28 @@ func (s *Server) finishRemoval(projectDir string, emptyPorts []int) {
 	if s.requestManager != nil {
 		s.requestManager.PurgeByProject(projectDir)
 	}
+}
+
+// addListenerWithBriefRetry binds a listener, retrying briefly on a transient
+// bind failure. Used only on the self-heal replace path, where the crashed
+// generation's listener was just closed and the same port is rebound
+// immediately: the kernel can hold the port for a few milliseconds after close,
+// so a single bind would intermittently return EADDRINUSE and fail the very
+// restart this fix exists to make succeed. A genuinely occupied port still
+// fails after the bounded window.
+func (s *Server) addListenerWithBriefRetry(port int, protocol string) error {
+	const (
+		attempts = 10
+		backoff  = 20 * time.Millisecond
+	)
+	var err error
+	for i := 0; i < attempts; i++ {
+		if err = s.proxy.AddListener(port, protocol); err == nil {
+			return nil
+		}
+		time.Sleep(backoff)
+	}
+	return err
 }
 
 func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {

--- a/internal/proxyd/server.go
+++ b/internal/proxyd/server.go
@@ -248,9 +248,7 @@ func (s *Server) register(req RegisterRequest) (int, any) {
 		for _, ps := range newPorts {
 			if ps.Protocol == "https" {
 				if err := s.proxy.certMgr.EnsureDomain(req.Domain); err != nil {
-					s.registry.Deregister(req.ProjectDir)
-					s.lifecycleEpoch.Add(1)
-					s.scheduleShutdownWhenEmpty()
+					s.rollbackRegistration(req.ProjectDir)
 					return http.StatusInternalServerError, ErrorResponse{
 						Error: fmt.Sprintf("failed to generate certs for %s: %v", req.Domain, err),
 						Code:  "CERT_GENERATION_FAILED",
@@ -276,9 +274,7 @@ func (s *Server) register(req RegisterRequest) (int, any) {
 				for _, p := range startedPorts {
 					_ = s.proxy.RemoveListener(p)
 				}
-				s.registry.Deregister(req.ProjectDir)
-				s.lifecycleEpoch.Add(1)
-				s.scheduleShutdownWhenEmpty()
+				s.rollbackRegistration(req.ProjectDir)
 				return http.StatusInternalServerError, ErrorResponse{
 					Error: fmt.Sprintf("failed to bind port %d: %v", ps.Port, err),
 					Code:  "PORT_BIND_FAILED",
@@ -424,6 +420,21 @@ func (s *Server) finishRemoval(projectDir string, emptyPorts []int) {
 	if s.requestManager != nil {
 		s.requestManager.PurgeByProject(projectDir)
 	}
+}
+
+// rollbackRegistration unwinds a registration whose cert or listener phase
+// failed: deregister, purge any records captured for the project in the window
+// where its routes were already visible to existing shared-port listeners
+// (raw Deregister would orphan them until FIFO eviction), bump the lifecycle
+// epoch, and schedule the graced shutdown check so an emptied registry can't
+// strand an idle daemon. lifecycleMu must be held.
+func (s *Server) rollbackRegistration(projectDir string) {
+	s.registry.Deregister(projectDir)
+	if s.requestManager != nil {
+		s.requestManager.PurgeByProject(projectDir)
+	}
+	s.lifecycleEpoch.Add(1)
+	s.scheduleShutdownWhenEmpty()
 }
 
 // addListenerWithBriefRetry binds a listener, retrying briefly on a transient

--- a/internal/proxyd/server.go
+++ b/internal/proxyd/server.go
@@ -221,7 +221,6 @@ func (s *Server) register(req RegisterRequest) (int, any) {
 	}
 
 	hostnames, newPorts, err := s.registry.Register(req)
-	replaced := false
 	if err != nil {
 		var conflict *ProjectConflictError
 		if !errors.As(err, &conflict) {
@@ -242,7 +241,6 @@ func (s *Server) register(req RegisterRequest) (int, any) {
 		if err != nil {
 			return http.StatusConflict, ErrorResponse{Error: err.Error(), Code: "REGISTRATION_CONFLICT"}
 		}
-		replaced = true
 	}
 
 	// Ensure certs exist for HTTPS domains before starting listeners
@@ -263,18 +261,17 @@ func (s *Server) register(req RegisterRequest) (int, any) {
 		}
 	}
 
-	// Start listeners for new ports. A self-heal replace closed the crashed
-	// generation's listener just now and rebinds the same port back-to-back;
-	// the OS can hold the port for a few ms after close, so that path needs a
-	// brief bind retry to keep the restart this fix exists for from failing.
+	// Start listeners for new ports, retrying briefly on a transient bind
+	// failure: the OS can hold a just-closed port for a few ms, and the close
+	// may be OURS from moments ago on EITHER path — the self-heal replace
+	// closes the crashed generation's listener inline, and a registration
+	// landing right after a sweep tick rebinds a port the sweep just closed
+	// (the sweep-wins ordering; caught by CI in the register-vs-sweep race
+	// test). A genuinely occupied port still fails after the bounded window.
 	if s.proxy != nil {
-		bind := s.proxy.AddListener
-		if replaced {
-			bind = s.addListenerWithBriefRetry
-		}
 		var startedPorts []int
 		for _, ps := range newPorts {
-			if err := bind(ps.Port, ps.Protocol); err != nil {
+			if err := s.addListenerWithBriefRetry(ps.Port, ps.Protocol); err != nil {
 				// Rollback: stop listeners we already started, then deregister.
 				for _, p := range startedPorts {
 					_ = s.proxy.RemoveListener(p)
@@ -430,12 +427,13 @@ func (s *Server) finishRemoval(projectDir string, emptyPorts []int) {
 }
 
 // addListenerWithBriefRetry binds a listener, retrying briefly on a transient
-// bind failure. Used only on the self-heal replace path, where the crashed
-// generation's listener was just closed and the same port is rebound
-// immediately: the kernel can hold the port for a few milliseconds after close,
-// so a single bind would intermittently return EADDRINUSE and fail the very
-// restart this fix exists to make succeed. A genuinely occupied port still
-// fails after the bounded window.
+// bind failure: the kernel can hold a just-closed port for a few milliseconds,
+// and the daemon itself may have closed it moments earlier — the self-heal
+// replace closes the crashed generation's listener inline, and a registration
+// arriving right after a sweep tick rebinds a port the sweep just closed.
+// A single bind would intermittently return EADDRINUSE and fail the very
+// restart the self-heal exists to make succeed. Used for every registration
+// bind; a genuinely occupied port still fails after the bounded window.
 func (s *Server) addListenerWithBriefRetry(port int, protocol string) error {
 	const (
 		attempts = 10

--- a/internal/proxyd/server_lifecycle_test.go
+++ b/internal/proxyd/server_lifecycle_test.go
@@ -4,7 +4,10 @@ import (
 	"encoding/json"
 	"io"
 	"log/slog"
-	"os/exec"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 
@@ -65,13 +68,11 @@ func TestServer_StalePIDSweep_PurgesRecords(t *testing.T) {
 	s := newLifecycleServer()
 
 	// Produce a PID that is guaranteed dead: run a process to completion.
-	cmd := exec.Command("true")
-	require.NoError(t, cmd.Run())
-	deadPID := cmd.Process.Pid
+	dead := deadPID(t)
 
 	req := newTestRequest("/projects/dead", "local.dev",
 		map[string]ServiceTarget{"api": {Host: "localhost", Port: 3000}}, 0, 443)
-	req.PID = deadPID
+	req.PID = dead
 	_, _, err := s.registry.Register(req)
 	require.NoError(t, err)
 
@@ -80,7 +81,7 @@ func TestServer_StalePIDSweep_PurgesRecords(t *testing.T) {
 
 	// The daemon sweep: detect stale PIDs, then remove via the PID-guarded path.
 	stale := s.registry.StalePIDs()
-	require.Equal(t, []StaleProject{{Dir: "/projects/dead", PID: deadPID}}, stale)
+	require.Equal(t, []StaleProject{{Dir: "/projects/dead", PID: dead}}, stale)
 	for _, sp := range stale {
 		removed, _, _ := s.removeStaleProject(sp.Dir, sp.PID)
 		assert.True(t, removed)
@@ -97,13 +98,9 @@ func TestServer_StalePIDSweep_PurgesRecords(t *testing.T) {
 func TestServer_RemoveStaleProject_SkipsReRegistered(t *testing.T) {
 	s := newLifecycleServer()
 
-	cmd := exec.Command("true")
-	require.NoError(t, cmd.Run())
-	deadPID := cmd.Process.Pid
-
 	req := newTestRequest("/projects/x", "local.dev",
 		map[string]ServiceTarget{"api": {Host: "localhost", Port: 3000}}, 0, 443)
-	req.PID = deadPID
+	req.PID = deadPID(t)
 	_, _, err := s.registry.Register(req)
 	require.NoError(t, err)
 
@@ -219,6 +216,223 @@ func TestHandleGetRequests_LimitClamp(t *testing.T) {
 	t.Run("max limit applies", func(t *testing.T) {
 		assert.Equal(t, 150, getCount(t, "&limit=1000"))
 	})
+}
+
+// TestServer_SelfHeal_DeadPIDReRegister pins the #55 crash-restart fix at the
+// server level: a same-dir registration whose holder PID is dead is replaced
+// inline (200-equivalent), the dead generation's records AND their on-disk body
+// files are purged, and an unrelated project is left completely untouched.
+func TestServer_SelfHeal_DeadPIDReRegister(t *testing.T) {
+	s := newLifecycleServer()
+
+	// A body file that must be deleted when the dead generation's record is
+	// purged — the eviction callback fires only for records carrying Details.
+	bodyFile := filepath.Join(t.TempDir(), "body.bin")
+	require.NoError(t, os.WriteFile(bodyFile, []byte("stale body"), 0o600))
+	s.requestManager.SetEvictionCallback(func(id string) {
+		if id == "dead-rec" {
+			_ = os.Remove(bodyFile)
+		}
+	})
+
+	// An unrelated project whose registration and records must survive.
+	otherReq := newTestRequest("/projects/other", "other.dev",
+		map[string]ServiceTarget{"api": {Host: "localhost", Port: 5000}}, 0, 8443)
+	otherReq.PID = os.Getpid()
+	_, _, err := s.registry.Register(otherReq)
+	require.NoError(t, err)
+	s.requestManager.Record(proxy.RequestRecord{ID: "other-rec", ProjectDir: "/projects/other", Method: "GET", URL: "/o", Details: &proxy.RequestDetails{}})
+
+	// Dead generation: register under a PID that is guaranteed dead.
+	deadReq := newTestRequest("/projects/dead", "local.dev",
+		map[string]ServiceTarget{"api": {Host: "localhost", Port: 3000}}, 0, 443)
+	deadReq.PID = deadPID(t)
+	_, _, err = s.registry.Register(deadReq)
+	require.NoError(t, err)
+	s.requestManager.Record(proxy.RequestRecord{ID: "dead-rec", ProjectDir: "/projects/dead", Method: "GET", URL: "/d", Details: &proxy.RequestDetails{}})
+
+	// Restart: same dir, a live PID. Self-heal replaces the dead registration.
+	reReq := deadReq
+	reReq.PID = os.Getpid()
+	status, body := s.register(reReq)
+	require.Equal(t, http.StatusOK, status, "self-heal re-register should succeed: %v", body)
+
+	// New generation is registered under the live PID.
+	assert.Equal(t, 2, s.registry.ProjectCount())
+	route, ok := s.registry.Lookup("api.local.dev", 443)
+	require.True(t, ok, "new generation's route must be registered")
+	assert.Equal(t, os.Getpid(), route.PID, "route must carry the live generation's PID")
+
+	// Dead generation's record purged, including its on-disk body file.
+	_, ok = s.requestManager.GetByID("dead-rec")
+	assert.False(t, ok, "dead generation's record must be purged")
+	assert.NoFileExists(t, bodyFile, "dead generation's body file must be deleted")
+
+	// Unrelated project untouched.
+	_, ok = s.registry.Lookup("api.other.dev", 8443)
+	assert.True(t, ok, "unrelated project's route must survive")
+	_, ok = s.requestManager.GetByID("other-rec")
+	assert.True(t, ok, "unrelated project's records must survive")
+}
+
+// TestServer_SelfHeal_LivePIDStillConflicts pins that a second prox up in the
+// same dir while the first is ALIVE still fails with a 409 naming the holder,
+// never a silent replace.
+func TestServer_SelfHeal_LivePIDStillConflicts(t *testing.T) {
+	s := newLifecycleServer()
+
+	req := newTestRequest("/projects/live", "local.dev",
+		map[string]ServiceTarget{"api": {Host: "localhost", Port: 3000}}, 0, 443)
+	req.PID = os.Getpid() // self — guaranteed alive
+	_, _, err := s.registry.Register(req)
+	require.NoError(t, err)
+
+	status, body := s.register(req)
+	require.Equal(t, http.StatusConflict, status)
+	errResp, ok := body.(ErrorResponse)
+	require.True(t, ok, "conflict body should be an ErrorResponse")
+	assert.Equal(t, "REGISTRATION_CONFLICT", errResp.Code)
+	assert.Contains(t, errResp.Error, "already registered by a running prox up")
+	assert.Contains(t, errResp.Error, strconv.Itoa(os.Getpid()), "message must name the holding PID")
+}
+
+// TestServer_Register_RouteConflictNotRetried pins that a different-project
+// route conflict (another project owning the hostname:port) is a plain 409 and
+// is never mistaken for a replaceable stale registration.
+func TestServer_Register_RouteConflictNotRetried(t *testing.T) {
+	s := newLifecycleServer()
+
+	reqA := newTestRequest("/projects/a", "local.dev",
+		map[string]ServiceTarget{"api": {Host: "localhost", Port: 3000}}, 0, 443)
+	reqA.PID = os.Getpid()
+	_, _, err := s.registry.Register(reqA)
+	require.NoError(t, err)
+
+	reqB := newTestRequest("/projects/b", "local.dev",
+		map[string]ServiceTarget{"api": {Host: "localhost", Port: 4000}}, 0, 443)
+	reqB.PID = os.Getpid()
+	status, body := s.register(reqB)
+	require.Equal(t, http.StatusConflict, status)
+	errResp := body.(ErrorResponse)
+	assert.Equal(t, "REGISTRATION_CONFLICT", errResp.Code)
+
+	// A's registration is intact; B never displaced it.
+	assert.Equal(t, 1, s.registry.ProjectCount())
+	route, ok := s.registry.Lookup("api.local.dev", 443)
+	require.True(t, ok)
+	assert.Equal(t, "/projects/a", route.ProjectDir)
+}
+
+// TestHandleRegister_RejectsNonPositivePID pins the PID>0 validation: a PID of
+// 0 or negative has signal-broadcast semantics that would read as permanently
+// alive, so a crashed generation with such a PID could never be replaced.
+func TestHandleRegister_RejectsNonPositivePID(t *testing.T) {
+	_, client, _ := startTestServer(t)
+
+	for _, pid := range []int{0, -1} {
+		req := newTestRequest("/projects/a", "local.dev",
+			map[string]ServiceTarget{"api": {Host: "localhost", Port: 3000}}, 0, 443)
+		req.Version = "test-version"
+		req.PID = pid
+		_, err := client.Register(req)
+		require.Error(t, err, "pid=%d must be rejected", pid)
+		assert.Contains(t, err.Error(), "pid must be a positive process id")
+	}
+}
+
+// TestScheduleShutdownWhenEmpty_StaysEmpty pins that an emptied registry gets a
+// graced shutdown request when it is still empty after the delay.
+func TestScheduleShutdownWhenEmpty_StaysEmpty(t *testing.T) {
+	s := newLifecycleServer()
+	s.shutdownDelay = 20 * time.Millisecond
+
+	s.scheduleShutdownWhenEmpty()
+
+	select {
+	case <-s.ShutdownCh():
+		// shutdown requested — correct
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected a shutdown request for a registry that stays empty")
+	}
+}
+
+// TestScheduleShutdownWhenEmpty_RegistrationDuringDelayCancels pins that a
+// registration landing within the grace window cancels the shutdown.
+func TestScheduleShutdownWhenEmpty_RegistrationDuringDelayCancels(t *testing.T) {
+	s := newLifecycleServer()
+	s.shutdownDelay = 60 * time.Millisecond
+
+	s.scheduleShutdownWhenEmpty()
+
+	// A registration lands during the grace window, through the real locked
+	// register path (the timer's re-check synchronizes on lifecycleMu, so the
+	// direct registry call would not exercise the race this test pins).
+	req := newTestRequest("/projects/a", "local.dev",
+		map[string]ServiceTarget{"api": {Host: "localhost", Port: 3000}}, 0, 443)
+	req.PID = os.Getpid()
+	status, body := s.register(req)
+	require.Equal(t, http.StatusOK, status, "register failed: %v", body)
+
+	select {
+	case <-s.ShutdownCh():
+		t.Fatal("shutdown must not fire when a registration lands during the grace period")
+	case <-time.After(200 * time.Millisecond):
+		// no shutdown — correct
+	}
+}
+
+// TestScheduleShutdownWhenEmpty_StaleEpochStandsDown pins that a grace timer
+// from an older empty period stands down after ANY lifecycle mutation, so it
+// cannot cut a newer empty period's grace short.
+func TestScheduleShutdownWhenEmpty_StaleEpochStandsDown(t *testing.T) {
+	s := newLifecycleServer()
+	s.shutdownDelay = 30 * time.Millisecond
+
+	s.scheduleShutdownWhenEmpty() // timer A captures the pre-mutation epoch
+
+	// Mutations during A's grace: a register then a removal, leaving the
+	// registry empty again but at a newer epoch.
+	req := newTestRequest("/projects/a", "local.dev",
+		map[string]ServiceTarget{"api": {Host: "localhost", Port: 3000}}, 0, 443)
+	req.PID = os.Getpid()
+	status, body := s.register(req)
+	require.Equal(t, http.StatusOK, status, "register failed: %v", body)
+	s.removeProject("/projects/a")
+
+	// Timer A fires into an empty registry but a changed epoch — it must
+	// stand down rather than shut the daemon.
+	select {
+	case <-s.ShutdownCh():
+		t.Fatal("a stale-epoch timer must not shut the daemon down")
+	case <-time.After(120 * time.Millisecond):
+	}
+
+	// A fresh timer at the current epoch shuts down normally.
+	s.scheduleShutdownWhenEmpty()
+	select {
+	case <-s.ShutdownCh():
+		// correct
+	case <-time.After(2 * time.Second):
+		t.Fatal("a current-epoch timer over an empty registry must shut down")
+	}
+}
+
+// TestRegister_WhileShuttingDown_Returns503 pins that a register that queued
+// behind a shutdown decision reports SHUTTING_DOWN instead of a false success
+// from a daemon that is already exiting.
+func TestRegister_WhileShuttingDown_Returns503(t *testing.T) {
+	s := newLifecycleServer()
+	s.RequestShutdown()
+
+	req := newTestRequest("/projects/a", "local.dev",
+		map[string]ServiceTarget{"api": {Host: "localhost", Port: 3000}}, 0, 443)
+	req.PID = os.Getpid()
+	status, body := s.register(req)
+	require.Equal(t, http.StatusServiceUnavailable, status)
+	er, ok := body.(ErrorResponse)
+	require.True(t, ok, "expected ErrorResponse, got %T", body)
+	assert.Equal(t, "SHUTTING_DOWN", er.Code)
+	assert.True(t, s.registry.IsEmpty(), "no registration may land after shutdown")
 }
 
 // TestServer_RemoveProject_NilRequestManager guards the daemon-startup window

--- a/internal/tui/base.go
+++ b/internal/tui/base.go
@@ -83,6 +83,13 @@ type BaseModel struct {
 	requestDetail     *RequestDetailData
 	detailLoading     bool
 	detailError       error
+	// detailRefreshFailed marks a live-refresh attempt (attach mode only —
+	// D16) that failed while a snapshot was already on screen: the snapshot
+	// is kept rather than replaced by the error view, and
+	// formatRequestDetail swaps the "(request in flight...)" note for a
+	// refresh-failed one instead. Cleared on any successful detail apply and
+	// on leaving the detail view (esc).
+	detailRefreshFailed bool
 
 	// Dimensions
 	width  int
@@ -401,6 +408,7 @@ func (b *BaseModel) handleNavigationKey(msg tea.KeyMsg) bool {
 			b.selectedRequestID = ""
 			b.requestDetail = nil
 			b.detailError = nil
+			b.detailRefreshFailed = false
 			b.updateViewport()
 			return true
 		}
@@ -699,6 +707,17 @@ func (b *BaseModel) ensureCursorVisible() {
 	}
 }
 
+// clampViewportToContent pulls the viewport back when a content replacement
+// left the scroll offset past the end — a capture-disabled final detail can be
+// SHORTER than the in-flight view it replaces (the in-flight note vanishes and
+// no body sections take its place), stranding a bottom-scrolled reader on
+// blank overscroll.
+func (b *BaseModel) clampViewportToContent() {
+	if maxOffset := b.viewport.TotalLineCount() - b.viewport.Height; b.viewport.YOffset > maxOffset {
+		b.viewport.SetYOffset(max(0, maxOffset))
+	}
+}
+
 // updateViewport updates the viewport content
 func (b *BaseModel) updateViewport() {
 	var lines []string
@@ -798,7 +817,14 @@ func (b *BaseModel) formatRequestDetail() []string {
 	// rendering nothing.
 	if d.InFlight {
 		lines = append(lines, "")
-		lines = append(lines, dimStyle.Render("(request in flight — details arrive on completion)"))
+		if b.detailRefreshFailed {
+			// A live-refresh attempt (attach mode — D16) failed while this
+			// in-flight snapshot was on screen: say so instead of silently
+			// re-promising details that may never arrive automatically.
+			lines = append(lines, dimStyle.Render("(live refresh failed — press esc and re-enter to reload)"))
+		} else {
+			lines = append(lines, dimStyle.Render("(request in flight — details arrive on completion)"))
+		}
 	}
 
 	// Request headers

--- a/internal/tui/base.go
+++ b/internal/tui/base.go
@@ -54,8 +54,14 @@ type BaseModel struct {
 	// Filtering
 	filterProcesses map[string]bool // Which processes to show
 	soloProcess     string          // Single process to show (1-9 keys)
-	searchPattern   string          // Current search/filter pattern
-	searchMatches   []int           // Line indices matching search
+	searchPattern   string          // Current search/filter pattern (the `s` filter)
+
+	// requestSearchQuery is the requests-view `/` search term. It is DELIBERATELY
+	// separate from searchPattern: in the requests view `/` navigates (jumps the
+	// cursor to matches) rather than filtering, so it composes with — never
+	// overwrites — an active `s` filter. Match state is never stored; n/N rescan
+	// the filtered list at keypress time (D12/D13).
+	requestSearchQuery string
 
 	// Auto-scroll
 	followMode bool // Auto-scroll to bottom on new logs
@@ -255,10 +261,19 @@ func (b *BaseModel) handleSearchKey(msg tea.KeyMsg) (bool, tea.Cmd) {
 		return true, nil
 
 	case "enter":
-		b.searchPattern = b.textInput.Value()
 		b.mode = ModeNormal
 		b.textInput.Blur()
-		b.updateSearchMatches()
+		if b.viewMode == ViewModeRequests {
+			// Requests view: `/` is navigation, not filtration. Commit the query
+			// to requestSearchQuery (searchPattern — the `s` filter — untouched)
+			// and jump the cursor to the first match at-or-after it (D12).
+			b.requestSearchQuery = b.textInput.Value()
+			b.jumpToRequestSearchMatch()
+			b.updateViewport()
+			return true, nil
+		}
+		// Logs view: `/` is a substring filter committed on Enter (D14).
+		b.searchPattern = b.textInput.Value()
 		b.updateViewport()
 		return true, nil
 	}
@@ -347,6 +362,21 @@ func (b *BaseModel) handleNavigationKey(msg tea.KeyMsg) bool {
 		}
 		return true
 
+	case "n", "N":
+		// Requests-view search navigation only: n jumps to the next match
+		// strictly after the cursor, N to the previous, both wrapping (D13).
+		// No-op (and unhandled elsewhere) outside the requests view.
+		if b.viewMode == ViewModeRequests {
+			dir := 1
+			if msg.String() == "N" {
+				dir = -1
+			}
+			b.cycleRequestSearchMatch(dir)
+			b.updateViewport()
+			return true
+		}
+		return false
+
 	case "1", "2", "3", "4", "5", "6", "7", "8", "9":
 		// Solo process in logs view only (1-9 keys do nothing in requests view)
 		if b.viewMode == ViewModeLogs {
@@ -374,10 +404,10 @@ func (b *BaseModel) handleNavigationKey(msg tea.KeyMsg) bool {
 			b.updateViewport()
 			return true
 		}
-		// Clear filters
+		// Clear filters (and the requests-view search query — D13).
 		b.soloProcess = ""
 		b.searchPattern = ""
-		b.searchMatches = nil
+		b.requestSearchQuery = ""
 		b.updateViewport()
 		return true
 
@@ -488,19 +518,102 @@ func (b *BaseModel) halfPageStep() int {
 	return step
 }
 
-// updateSearchMatches updates the search match indices
-func (b *BaseModel) updateSearchMatches() {
-	b.searchMatches = nil
-	if b.searchPattern == "" {
+// requestMatchesSearch reports whether a request matches the requests-view `/`
+// query: a case-insensitive substring over URL, Method, and Subdomain — the
+// same fields the `s` filter matches (D12).
+func requestMatchesSearch(req proxy.RequestRecord, query string) bool {
+	return containsIgnoreCase(req.URL, query) ||
+		containsIgnoreCase(req.Method, query) ||
+		containsIgnoreCase(req.Subdomain, query)
+}
+
+// jumpToRequestSearchMatch moves the cursor to the first row matching
+// requestSearchQuery at-or-after the current cursor, wrapping (D12). "At-or-after"
+// is deliberate: a fresh search may already sit on the best match; n advances.
+// No-op when the query is empty or nothing matches (cursor unmoved). A match
+// disengages follow so the jump sticks (resolveRequestCursor would otherwise
+// re-pin to the newest row); it never RE-engages follow — a search jump is
+// positioning, not scrolling intent (D13).
+func (b *BaseModel) jumpToRequestSearchMatch() {
+	b.seekRequestSearchMatch(0)
+}
+
+// cycleRequestSearchMatch moves the cursor to the next (dir +1) or previous
+// (dir -1) matching row STRICTLY past the current cursor, wrapping (D13).
+func (b *BaseModel) cycleRequestSearchMatch(dir int) {
+	b.seekRequestSearchMatch(dir)
+}
+
+// seekRequestSearchMatch scans the filtered list for a matching row and moves
+// the cursor to it. dir 0 = at-or-after the cursor (the `/`-commit jump,
+// includes the cursor's own row); dir +1/-1 = strictly next/previous (n/N).
+// Derived at keypress time — no match list is ever stored (D13).
+func (b *BaseModel) seekRequestSearchMatch(dir int) {
+	if b.requestSearchQuery == "" {
 		return
 	}
-
-	// Find matching lines
-	for i, entry := range b.logEntries {
-		if containsIgnoreCase(entry.Line, b.searchPattern) {
-			b.searchMatches = append(b.searchMatches, i)
+	requests := b.filteredProxyRequests()
+	n := len(requests)
+	if n == 0 {
+		return
+	}
+	start := b.cursorIdx
+	if start < 0 {
+		start = 0
+	}
+	if dir == 0 {
+		// At-or-after: offsets 0..n-1 forward, cursor row first.
+		for i := 0; i < n; i++ {
+			idx := (start + i) % n
+			if requestMatchesSearch(requests[idx], b.requestSearchQuery) {
+				b.landSearchJump(requests, idx, n)
+				return
+			}
+		}
+		return
+	}
+	// Strictly past the cursor: offsets 1..n-1 in dir, wrapping. The cursor's
+	// own row is never revisited, so n/N are no-ops when it is the sole match.
+	for i := 1; i < n; i++ {
+		idx := ((start+dir*i)%n + n) % n
+		if requestMatchesSearch(requests[idx], b.requestSearchQuery) {
+			b.landSearchJump(requests, idx, n)
+			return
 		}
 	}
+}
+
+// landSearchJump places the cursor on a search match. Follow mode is
+// disengaged only when the jump moves the cursor off the newest row — a jump
+// must stick against follow's pin-to-newest, but a match landing ON the
+// newest row leaves follow untouched (never re-engaged either; search jumps
+// are positioning, not scrolling intent).
+func (b *BaseModel) landSearchJump(requests []proxy.RequestRecord, idx, n int) {
+	if idx != n-1 {
+		b.followMode = false
+	}
+	b.setRequestCursor(requests, idx)
+}
+
+// requestSearchMatchInfo derives the status-bar match indicator for the current
+// requestSearchQuery over requests (the filtered list): total match count, and
+// the cursor's 1-based position among matches (0 when the cursor is not on a
+// match). Never stored — recomputed for the status bar (D13). requests is
+// passed in rather than recomputed here so statusBar can share a single
+// filteredProxyRequests() scan with the visible/total count.
+func (b *BaseModel) requestSearchMatchInfo(requests []proxy.RequestRecord) (position, total int) {
+	if b.requestSearchQuery == "" {
+		return 0, 0
+	}
+	for i, req := range requests {
+		if requestMatchesSearch(req, b.requestSearchQuery) {
+			total++
+			if i == b.cursorIdx {
+				position = total
+			}
+		}
+	}
+	return position, total
 }
 
 // isNearBottom checks if the viewport is at or near the bottom
@@ -979,6 +1092,50 @@ func (b *BaseModel) processPanel() string {
 	return headerStyle.Render(header)
 }
 
+// statusLeftDefault builds the left status-bar text for normal mode (no input
+// prompt active). requests is the requests-view filtered list (unused in the
+// logs view), passed in so callers can share one filteredProxyRequests() scan
+// with the visible/total count. Precedence differs by view (D13):
+//   - Requests view: the `/` search indicator wins when a query is set —
+//     "/<query> (i/k)" with i the cursor's 1-based position among matches when
+//     the cursor is on a match, else "/<query> (k matches)" (0 included) — with
+//     "| filter: <pattern>" appended when the `s` filter is also active. soloProcess
+//     is a logs-view concept and is never shown here.
+//   - Logs view: today's precedence — solo wins, then the `s` filter.
+//   - Otherwise (either view): the `s` filter line, then the default hint.
+func (b *BaseModel) statusLeftDefault(extraInfo string, requests []proxy.RequestRecord) string {
+	if b.viewMode == ViewModeRequests && b.requestSearchQuery != "" {
+		position, total := b.requestSearchMatchInfo(requests)
+		var indicator string
+		if position > 0 {
+			indicator = fmt.Sprintf("/%s (%d/%d)", b.requestSearchQuery, position, total)
+		} else {
+			indicator = fmt.Sprintf("/%s (%d matches)", b.requestSearchQuery, total)
+		}
+		if b.searchPattern != "" {
+			indicator += fmt.Sprintf(" | filter: %s", b.searchPattern)
+		}
+		return indicator
+	}
+	if b.viewMode != ViewModeRequests && b.soloProcess != "" {
+		return fmt.Sprintf("Showing: %s (ESC to clear)", b.soloProcess)
+	}
+	if b.searchPattern != "" {
+		return fmt.Sprintf("Filter: %s (ESC to clear)", b.searchPattern)
+	}
+	return b.statusDefaultHint(extraInfo)
+}
+
+// statusDefaultHint is the fallback status-bar hint shown when no filter, search,
+// or solo is active.
+func (b *BaseModel) statusDefaultHint(extraInfo string) string {
+	hint := "Tab: switch view | ? for help"
+	if extraInfo != "" {
+		hint += " | " + extraInfo
+	}
+	return hint
+}
+
 // statusBar renders the bottom status bar
 func (b *BaseModel) statusBar(extraInfo string) string {
 	var left, right string
@@ -992,6 +1149,14 @@ func (b *BaseModel) statusBar(extraInfo string) string {
 		viewIndicator = "[Request Detail]"
 	}
 
+	// Requests-view filtered list, computed once and shared below between the
+	// left-side search indicator and the right-side visible count so a single
+	// render doesn't rescan b.proxyRequests twice.
+	var requests []proxy.RequestRecord
+	if b.viewMode == ViewModeRequests {
+		requests = b.filteredProxyRequests()
+	}
+
 	// Left side: mode/filter info
 	switch b.mode {
 	case ModeFilter:
@@ -1001,23 +1166,14 @@ func (b *BaseModel) statusBar(extraInfo string) string {
 	case ModeStringFilter:
 		left = "String filter: " + b.textInput.View()
 	default:
-		if b.soloProcess != "" {
-			left = fmt.Sprintf("Showing: %s (ESC to clear)", b.soloProcess)
-		} else if b.searchPattern != "" {
-			left = fmt.Sprintf("Filter: %s (ESC to clear)", b.searchPattern)
-		} else {
-			left = "Tab: switch view | ? for help"
-			if extraInfo != "" {
-				left += " | " + extraInfo
-			}
-		}
+		left = b.statusLeftDefault(extraInfo, requests)
 	}
 
 	// Right side: follow mode and count
 	var visible, total int
 	var label string
 	if b.viewMode == ViewModeRequests {
-		visible = len(b.filteredProxyRequests())
+		visible = len(requests)
 		total = len(b.proxyRequests)
 		label = "requests"
 	} else {
@@ -1031,8 +1187,10 @@ func (b *BaseModel) statusBar(extraInfo string) string {
 	}
 	right = fmt.Sprintf("%s %s %d/%d %s", viewIndicator, followIndicator, visible, total, label)
 
-	// Calculate widths
-	leftWidth := b.width - len(right) - 4
+	// Calculate widths. Use display width (lipgloss.Width), never byte len: a
+	// Unicode search query in `left` would misplace the right-aligned counts if
+	// the layout math counted bytes (D13).
+	leftWidth := b.width - lipgloss.Width(right) - 4
 	if leftWidth < 0 {
 		leftWidth = 0
 	}
@@ -1099,8 +1257,8 @@ Navigation:
 Filtering:
   1-9        Solo process (toggle)
   f          Filter mode (process selection)
-  /          Pattern filter (regex)
-  s          String filter (substring)
+  /          Substring filter (hide non-matching, commit on Enter)
+  s          Substring filter (hide non-matching, applied live)
   ESC        Clear filters
 
 Other:
@@ -1133,21 +1291,25 @@ func (b *BaseModel) requestsHelpView() string {
 Views:
   Tab        Switch to Logs view
 
-Navigation:
-  j/↓        Scroll down
-  k/↑        Scroll up (pauses auto-follow)
-  g/Home     Go to top (pauses auto-follow)
-  G/End      Go to bottom (resumes auto-follow)
-  PgUp/PgDn  Page up/down
+Navigation (moves the cursor row):
+  j/↓        Move cursor down (onto newest row resumes auto-follow)
+  k/↑        Move cursor up (pauses auto-follow)
+  g/Home     Move cursor to top (pauses auto-follow)
+  G/End      Move cursor to bottom (resumes auto-follow)
+  PgUp/PgDn  Move cursor half a page
   F          Toggle auto-follow mode
 
+Search (jumps the cursor, does NOT filter):
+  /          Search URL/method/subdomain (jump to match at/after cursor)
+  n/N        Jump to next/previous match (wraps)
+
 Request Details:
-  Enter      View details for selected request
-  ESC        Return to request list (or clear filters)
+  Enter      View details for the cursor row
+  ESC        Return to request list (or clear filters/search)
 
 Filtering:
   s          String filter (URL/method/subdomain)
-  ESC        Clear filters
+  ESC        Clear filters and search
 
 Other:
   ?          Toggle help

--- a/internal/tui/base.go
+++ b/internal/tui/base.go
@@ -60,6 +60,14 @@ type BaseModel struct {
 	// Auto-scroll
 	followMode bool // Auto-scroll to bottom on new logs
 
+	// Requests-view cursor (ID-anchored). cursorID names the row the cursor
+	// sits on; cursorIdx is its index in the filtered list. Both are mutated
+	// ONLY through setRequestCursor so they can never disagree. cursorID "" is
+	// the explicit no-cursor sentinel (production record IDs are always
+	// non-empty — both proxy paths mint them), and cursorIdx -1 pairs with it.
+	cursorID  string
+	cursorIdx int
+
 	// Last restart result for feedback
 	lastRestartProcess string
 	lastRestartError   error
@@ -150,12 +158,9 @@ func (b *BaseModel) handleLogEntry(entry domain.LogEntry) {
 // a same-ID re-record (in-flight followed by its completion) replaces the
 // existing row in place rather than appending a duplicate, scanning from the
 // newest entry since that's where a live in-flight row lives. In-place
-// replacement keeps every other row's index stable, which matters because
-// detail-selection maps viewport line numbers to indices into proxyRequests.
+// replacement keeps every other row's index stable, and the ID-anchored cursor
+// (resolveRequestCursor) rides along on its row regardless.
 func (b *BaseModel) handleProxyRequest(req proxy.RequestRecord) {
-	// Check if we're at/near bottom BEFORE adding new content
-	wasNearBottom := b.isNearBottom()
-
 	replaced := false
 	if req.ID != "" {
 		for i := len(b.proxyRequests) - 1; i >= 0; i-- {
@@ -175,9 +180,30 @@ func (b *BaseModel) handleProxyRequest(req proxy.RequestRecord) {
 			b.proxyRequests = newRequests
 		}
 	}
-	b.updateViewport()
 
-	// If user was at bottom, re-enable follow mode and stay at bottom
+	// In the detail view an arrival updates only the list data: the viewport is
+	// showing the open detail, so re-rendering/scrolling it would yank the
+	// reader (today's GotoBottom wart). No follow change either. C4 layers the
+	// in-place detail refresh on top of this guard.
+	if b.viewMode == ViewModeRequestDetail {
+		return
+	}
+
+	// In the requests view, follow re-engagement is cursor-based, never
+	// isNearBottom-based: with a short list that fits the viewport AtBottom()
+	// is ALWAYS true, so consulting it would re-engage follow on every arrival
+	// and yank the cursor off the row the user navigated to. Arrivals never
+	// change followMode here; updateViewport re-resolves the cursor and, per
+	// D7, either GotoBottom (follow on) or keeps the cursor row visible.
+	if b.viewMode == ViewModeRequests {
+		b.updateViewport()
+		return
+	}
+
+	// Logs view: the requests list isn't on screen, so keep today's
+	// isNearBottom follow semantics for the (logs) viewport untouched.
+	wasNearBottom := b.isNearBottom()
+	b.updateViewport()
 	if wasNearBottom {
 		b.followMode = true
 		b.viewport.GotoBottom()
@@ -356,34 +382,74 @@ func (b *BaseModel) handleNavigationKey(msg tea.KeyMsg) bool {
 		return true
 
 	case "up", "k":
+		if b.viewMode == ViewModeRequests {
+			b.moveRequestCursor(-1)
+			return true
+		}
 		b.viewport.LineUp(1)
 		b.followMode = false
 		return true
 
 	case "down", "j":
+		if b.viewMode == ViewModeRequests {
+			b.moveRequestCursor(1)
+			return true
+		}
 		b.viewport.LineDown(1)
 		return true
 
 	case "pgup":
+		if b.viewMode == ViewModeRequests {
+			b.moveRequestCursor(-b.halfPageStep())
+			return true
+		}
 		b.viewport.HalfViewUp()
 		b.followMode = false
 		return true
 
 	case "pgdown":
+		if b.viewMode == ViewModeRequests {
+			b.moveRequestCursor(b.halfPageStep())
+			return true
+		}
 		b.viewport.HalfViewDown()
 		return true
 
 	case "home", "g":
+		if b.viewMode == ViewModeRequests {
+			requests := b.filteredProxyRequests()
+			b.setRequestCursor(requests, 0)
+			b.followMode = false
+			b.updateViewport()
+			return true
+		}
 		b.viewport.GotoTop()
 		b.followMode = false
 		return true
 
 	case "end", "G":
+		if b.viewMode == ViewModeRequests {
+			requests := b.filteredProxyRequests()
+			b.followMode = true
+			b.setRequestCursor(requests, len(requests)-1)
+			b.updateViewport()
+			return true
+		}
 		b.viewport.GotoBottom()
 		b.followMode = true
 		return true
 
 	case "F":
+		if b.viewMode == ViewModeRequests {
+			b.followMode = !b.followMode
+			if b.followMode {
+				// Toggling follow on pins the cursor to the newest row.
+				requests := b.filteredProxyRequests()
+				b.setRequestCursor(requests, len(requests)-1)
+			}
+			b.updateViewport()
+			return true
+		}
 		b.followMode = !b.followMode
 		if b.followMode {
 			b.viewport.GotoBottom()
@@ -392,6 +458,34 @@ func (b *BaseModel) handleNavigationKey(msg tea.KeyMsg) bool {
 	}
 
 	return false
+}
+
+// moveRequestCursor moves the requests-view cursor by delta rows (negative =
+// up, positive = down) through the sole mutator, then re-renders. The follow
+// rule is sign-driven and matches the per-key semantics exactly: upward
+// movement (k/pgup) disengages follow, while downward movement (j/pgdown)
+// re-engages follow only when the cursor lands on the last (newest) row — the
+// cursor analog of "scrolled back to the bottom".
+func (b *BaseModel) moveRequestCursor(delta int) {
+	requests := b.filteredProxyRequests()
+	b.setRequestCursor(requests, b.cursorIdx+delta)
+	if delta < 0 {
+		b.followMode = false
+	} else if len(requests) > 0 && b.cursorIdx == len(requests)-1 {
+		b.followMode = true
+	}
+	b.updateViewport()
+}
+
+// halfPageStep is the cursor step for pgup/pgdown in the requests view: half a
+// viewport page, matching the logs view's HalfView semantics, and never less
+// than one row so paging always makes progress on a tiny viewport.
+func (b *BaseModel) halfPageStep() int {
+	step := b.viewport.Height / 2
+	if step < 1 {
+		step = 1
+	}
+	return step
 }
 
 // updateSearchMatches updates the search match indices
@@ -417,6 +511,81 @@ func (b *BaseModel) isNearBottom() bool {
 	return b.viewport.ScrollPercent() >= nearBottomThreshold
 }
 
+// setRequestCursor is the SOLE mutator of the requests-view cursor. It clamps
+// idx into [0, len(requests)-1] and updates cursorIdx and cursorID together so
+// the pair can never disagree; an empty list resets to the no-cursor sentinel
+// (cursorIdx -1, cursorID ""). Every mover — nav keys and resolveRequestCursor —
+// goes through here.
+func (b *BaseModel) setRequestCursor(requests []proxy.RequestRecord, idx int) {
+	if len(requests) == 0 {
+		b.cursorIdx = -1
+		b.cursorID = ""
+		return
+	}
+	if idx < 0 {
+		idx = 0
+	}
+	if idx > len(requests)-1 {
+		idx = len(requests) - 1
+	}
+	b.cursorIdx = idx
+	b.cursorID = requests[idx].ID
+}
+
+// resolveRequestCursor re-anchors the cursor against the current filtered list
+// at the render choke point, so every mutation source (upsert, append+trim,
+// live filter keystrokes, esc clear, follow toggles, view transitions) lands
+// with a coherent cursor. Precedence:
+//   - follow mode pins the cursor to the newest (last) row;
+//   - else if cursorID is still present, its current index (in-place upserts and
+//     appends never move the cursor off its row);
+//   - else the stale cursorIdx is clamped and re-anchored to whatever row now
+//     sits at that index (trim/filter removed the old row; empty→non-empty with
+//     follow off lands on row 0).
+func (b *BaseModel) resolveRequestCursor(requests []proxy.RequestRecord) {
+	if len(requests) == 0 {
+		b.setRequestCursor(requests, 0) // resets to the no-cursor sentinel
+		return
+	}
+	if b.followMode {
+		b.setRequestCursor(requests, len(requests)-1)
+		return
+	}
+	if b.cursorID != "" { // "" is the no-cursor sentinel; never a real ID
+		for i, req := range requests {
+			if req.ID == b.cursorID {
+				b.setRequestCursor(requests, i)
+				return
+			}
+		}
+	}
+	// Stale cursor (row filtered/trimmed away) or first anchor with follow off:
+	// clamp the last-known index and re-anchor to the row now there.
+	b.setRequestCursor(requests, b.cursorIdx)
+}
+
+// ensureCursorVisible scrolls the viewport the minimum amount needed to bring
+// the cursor row on-screen. Called from updateViewport (the SetContent choke
+// point) so the marker is visible after EVERY transition — tab-in from a
+// scrolled logs view, resize, append/trim, filter edit, detail-return — not
+// just after a keypress.
+func (b *BaseModel) ensureCursorVisible() {
+	if b.cursorIdx < 0 {
+		return // no-cursor sentinel (empty list)
+	}
+	// A grown viewport (or shrunk list) can leave YOffset past the last valid
+	// offset — the cursor then sits "in range" of a window that shows blank
+	// overscroll. Reclamp before the minimal-scroll branches.
+	if maxOffset := b.viewport.TotalLineCount() - b.viewport.Height; b.viewport.YOffset > maxOffset {
+		b.viewport.SetYOffset(max(0, maxOffset))
+	}
+	if b.cursorIdx < b.viewport.YOffset {
+		b.viewport.SetYOffset(b.cursorIdx)
+	} else if b.cursorIdx >= b.viewport.YOffset+b.viewport.Height {
+		b.viewport.SetYOffset(b.cursorIdx - b.viewport.Height + 1)
+	}
+}
+
 // updateViewport updates the viewport content
 func (b *BaseModel) updateViewport() {
 	var lines []string
@@ -426,9 +595,18 @@ func (b *BaseModel) updateViewport() {
 		lines = b.formatRequestDetail()
 	case ViewModeRequests:
 		requests := b.filteredProxyRequests()
-		for _, req := range requests {
-			line := b.formatProxyRequest(req)
-			lines = append(lines, line)
+		// Resolve the cursor against the just-computed filtered list BEFORE
+		// formatting so the marker (baked into content below) and the scroll
+		// invariant agree within this single render (D6/D8).
+		b.resolveRequestCursor(requests)
+		for i, req := range requests {
+			// Prefix the cursor row with a styled marker and every other row
+			// with two spaces so columns stay aligned (D10).
+			marker := "  "
+			if i == b.cursorIdx {
+				marker = cursorStyle.Render("❯ ")
+			}
+			lines = append(lines, marker+b.formatProxyRequest(req))
 		}
 	default: // ViewModeLogs
 		entries := b.filteredEntries()
@@ -440,6 +618,29 @@ func (b *BaseModel) updateViewport() {
 
 	content := strings.Join(lines, "\n")
 	b.viewport.SetContent(content)
+
+	// Cursor visibility invariant for the requests view (D7). Runs after
+	// SetContent so the marker is on-screen after every transition, not just
+	// keypresses. Follow mode overrides to the bottom. Logs/detail views keep
+	// their own scroll untouched.
+	if b.viewMode == ViewModeRequests {
+		if b.followMode {
+			b.viewport.GotoBottom()
+		} else {
+			b.ensureCursorVisible()
+		}
+	}
+}
+
+// renderDetailFromTop re-renders the viewport and scrolls it to the top. It is
+// the shared tail of both models' Enter-into-detail transitions: a detail
+// opened from deep in the list would otherwise inherit the list's YOffset. The
+// GotoTop must follow updateViewport (the detail-view render deliberately never
+// touches YOffset) and must stay out of updateViewport itself, which also runs
+// on background arrivals where re-scrolling would yank the reader.
+func (b *BaseModel) renderDetailFromTop() {
+	b.updateViewport()
+	b.viewport.GotoTop()
 }
 
 // formatRequestDetail formats the request detail view
@@ -665,25 +866,15 @@ func (b *BaseModel) filteredProxyRequests() []proxy.RequestRecord {
 	return result
 }
 
-// getSelectedRequest returns the request ID at the current viewport line in requests view.
-// Returns empty string if not in requests view or no request is selected.
+// getSelectedRequest returns the ID of the cursor row in the requests view,
+// which Enter opens. Returns "" outside the requests view or when the list is
+// empty (the no-cursor sentinel). The cursor is kept current by
+// resolveRequestCursor at every render, so cursorID is always a live row's ID.
 func (b *BaseModel) getSelectedRequest() string {
 	if b.viewMode != ViewModeRequests {
 		return ""
 	}
-
-	requests := b.filteredProxyRequests()
-	if len(requests) == 0 {
-		return ""
-	}
-
-	// Get the line index from viewport position
-	lineIdx := b.viewport.YOffset
-	if lineIdx >= 0 && lineIdx < len(requests) {
-		return requests[lineIdx].ID
-	}
-
-	return ""
+	return b.cursorID
 }
 
 // formatProxyRequest formats a single proxy request for display

--- a/internal/tui/client.go
+++ b/internal/tui/client.go
@@ -191,7 +191,7 @@ func (m ClientModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.detailLoading = true
 				m.requestDetail = nil
 				m.detailError = nil
-				m.updateViewport()
+				m.renderDetailFromTop()
 				return m, m.fetchRequestDetail(requestID)
 			}
 		}

--- a/internal/tui/client.go
+++ b/internal/tui/client.go
@@ -17,6 +17,16 @@ type ClientModel struct {
 
 	// Connection state
 	connectionError error // Last API connection error, nil if connected
+
+	// detailFetchSeq counts every fetchRequestDetail call (Enter and D16's
+	// background live-refresh alike); each call's closure captures its own
+	// seq. RequestDetailMsg/RequestDetailErrorMsg carry the seq they were
+	// produced for, and the handlers only apply a result whose seq equals
+	// the current value — a stale or superseded (overlapping) fetch can
+	// never clobber a newer one. Attach-mode-only concept (local mode never
+	// fetches), so it lives here rather than on BaseModel, matching
+	// connectionError above.
+	detailFetchSeq int
 }
 
 // NewClientModel creates a new TUI model for client mode
@@ -86,7 +96,17 @@ func (m ClientModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.handleLogEntry(domain.LogEntry(msg))
 
 	case ProxyRequestMsg:
-		m.handleProxyRequest(proxy.RequestRecord(msg))
+		record := proxy.RequestRecord(msg)
+		m.handleProxyRequest(record)
+		// Live-refresh an open detail view once its request completes (D16).
+		// Streamed attach records never carry Details (§2), so — unlike
+		// local mode — a re-fetch is required. detailLoading is deliberately
+		// left alone: the existing (in-flight) snapshot stays on screen with
+		// no loading flicker while the fetch runs in the background.
+		if m.viewMode == ViewModeRequestDetail && m.selectedRequestID == record.ID && !record.InFlight {
+			m.detailFetchSeq++
+			cmds = append(cmds, m.fetchRequestDetail(record.ID, m.detailFetchSeq))
+		}
 
 	case ProcessesMsg:
 		m.processes = []domain.ProcessInfo(msg)
@@ -114,17 +134,40 @@ func (m ClientModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.lastRestartError = nil
 
 	case RequestDetailMsg:
-		m.detailLoading = false
-		if msg.ID == m.selectedRequestID {
-			m.requestDetail = msg.Details
-			m.detailError = nil
-			m.updateViewport()
+		// Every mutation — including detailLoading, previously cleared
+		// before this guard for ALL results including stale ones — lives
+		// inside the ID+seq guard: a stale-ID or superseded-seq result
+		// (an overlapping fetch this one was not the last to start) is
+		// dropped entirely, so it can never clear the loading state or
+		// content owned by the current selection/fetch (D16).
+		if msg.ID == m.selectedRequestID && msg.Seq == m.detailFetchSeq {
+			// Belt-and-braces content guard: a payload that is itself still
+			// in-flight can't supersede an already-displayed final
+			// snapshot (e.g. a server-side race in GetProxyRequest) — drop
+			// it rather than regress the view.
+			supersededByFinal := msg.Details != nil && msg.Details.InFlight &&
+				m.requestDetail != nil && !m.requestDetail.InFlight
+			if !supersededByFinal {
+				m.detailLoading = false
+				m.requestDetail = msg.Details
+				m.detailError = nil
+				m.detailRefreshFailed = false
+				m.updateViewport()
+				m.clampViewportToContent()
+			}
 		}
 
 	case RequestDetailErrorMsg:
-		m.detailLoading = false
-		if msg.ID == m.selectedRequestID {
-			m.detailError = msg.Err
+		if msg.ID == m.selectedRequestID && msg.Seq == m.detailFetchSeq {
+			m.detailLoading = false
+			if m.requestDetail != nil {
+				// A background live-refresh failed: keep the snapshot on
+				// screen and surface the failure instead of replacing a
+				// useful view with the error screen (D16).
+				m.detailRefreshFailed = true
+			} else {
+				m.detailError = msg.Err
+			}
 			m.updateViewport()
 		}
 
@@ -191,8 +234,10 @@ func (m ClientModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.detailLoading = true
 				m.requestDetail = nil
 				m.detailError = nil
+				m.detailRefreshFailed = false
 				m.renderDetailFromTop()
-				return m, m.fetchRequestDetail(requestID)
+				m.detailFetchSeq++
+				return m, m.fetchRequestDetail(requestID, m.detailFetchSeq)
 			}
 		}
 		return m, nil
@@ -206,12 +251,15 @@ func (m ClientModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-// fetchRequestDetail returns a command to fetch request details from the API
-func (m ClientModel) fetchRequestDetail(id string) tea.Cmd {
+// fetchRequestDetail returns a command to fetch request details from the API,
+// tagged with seq (the caller's just-incremented m.detailFetchSeq at the time
+// of the call) so the Update handler can tell this result apart from any
+// other overlapping fetch for the same or a different request (D16).
+func (m ClientModel) fetchRequestDetail(id string, seq int) tea.Cmd {
 	return func() tea.Msg {
 		resp, err := m.client.GetProxyRequest(id, true) // Include body
 		if err != nil {
-			return RequestDetailErrorMsg{ID: id, Err: err}
+			return RequestDetailErrorMsg{ID: id, Seq: seq, Err: err}
 		}
 
 		// Convert API response to RequestDetailData
@@ -240,7 +288,7 @@ func (m ClientModel) fetchRequestDetail(id string) tea.Cmd {
 			}
 		}
 
-		return RequestDetailMsg{ID: id, Details: detail}
+		return RequestDetailMsg{ID: id, Seq: seq, Details: detail}
 	}
 }
 

--- a/internal/tui/client_model_test.go
+++ b/internal/tui/client_model_test.go
@@ -1,0 +1,121 @@
+package tui
+
+import (
+	"sync"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/charliek/prox/internal/api"
+	"github.com/charliek/prox/internal/domain"
+)
+
+// stubTUIClient is a test double for the TUIClient interface (app.go). It
+// records the IDs passed to GetProxyRequest and returns canned detail/error
+// responses, so ClientModel Enter/detail flows can be exercised without a live
+// daemon. Shared C2 deliverable — C4 reuses it for the attach-mode
+// detail-refresh tests.
+type stubTUIClient struct {
+	mu           sync.Mutex
+	requestedIDs []string // every GetProxyRequest id, in call order
+	detailResp   *api.ProxyRequestDetailResponse
+	detailErr    error
+}
+
+func (s *stubTUIClient) GetProcesses() (*api.ProcessListResponse, error) {
+	return &api.ProcessListResponse{}, nil
+}
+
+func (s *stubTUIClient) RestartProcess(string) error { return nil }
+
+func (s *stubTUIClient) StreamLogsChannel(domain.LogParams) (<-chan api.LogEntryResponse, error) {
+	ch := make(chan api.LogEntryResponse)
+	close(ch)
+	return ch, nil
+}
+
+func (s *stubTUIClient) StreamProxyRequestsChannel(domain.ProxyRequestParams) (<-chan api.ProxyRequestResponse, error) {
+	ch := make(chan api.ProxyRequestResponse)
+	close(ch)
+	return ch, nil
+}
+
+func (s *stubTUIClient) GetProxyRequest(id string, _ bool) (*api.ProxyRequestDetailResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.requestedIDs = append(s.requestedIDs, id)
+	if s.detailErr != nil {
+		return nil, s.detailErr
+	}
+	if s.detailResp != nil {
+		return s.detailResp, nil
+	}
+	return &api.ProxyRequestDetailResponse{
+		ProxyRequestResponse: api.ProxyRequestResponse{ID: id},
+	}, nil
+}
+
+// lastRequestedID returns the most recent GetProxyRequest id, or "".
+func (s *stubTUIClient) lastRequestedID() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.requestedIDs) == 0 {
+		return ""
+	}
+	return s.requestedIDs[len(s.requestedIDs)-1]
+}
+
+// newClientRequestsModel builds a ClientModel in the requests view holding n
+// requests, viewport content sized to viewportHeight (see newRequestsModel).
+func newClientRequestsModel(stub *stubTUIClient, n, viewportHeight int) ClientModel {
+	m := NewClientModel(stub)
+	m.viewMode = ViewModeRequests
+	m.proxyRequests = makeTestRequests(n)
+	nm, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: viewportHeight + 6})
+	return nm.(ClientModel)
+}
+
+func clientUpdate(m ClientModel, msg tea.Msg) ClientModel {
+	nm, _ := m.Update(msg)
+	return nm.(ClientModel)
+}
+
+// TestClientModel_EnterOpensCursorRow verifies the attach-mode Enter path opens
+// the cursor row by ID: the returned fetch command targets the cursor's request,
+// not the viewport's top row.
+func TestClientModel_EnterOpensCursorRow(t *testing.T) {
+	stub := &stubTUIClient{}
+	m := newClientRequestsModel(stub, 10, 5)
+	// Move the cursor off the newest row so the test proves it is cursor-driven.
+	m = clientUpdate(m, keyRune('k')) // req-008, follow off
+	m = clientUpdate(m, keyRune('k')) // req-007
+	require.Equal(t, "req-007", m.cursorID)
+
+	newModel, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = newModel.(ClientModel)
+	assert.Equal(t, ViewModeRequestDetail, m.viewMode)
+	assert.Equal(t, "req-007", m.selectedRequestID)
+	assert.True(t, m.detailLoading)
+	require.NotNil(t, cmd, "Enter must return a fetch command")
+
+	// Executing the command performs the fetch; the stub records the id.
+	msg := cmd()
+	detailMsg, ok := msg.(RequestDetailMsg)
+	require.True(t, ok, "fetch command should produce a RequestDetailMsg")
+	assert.Equal(t, "req-007", detailMsg.ID)
+	assert.Equal(t, "req-007", stub.lastRequestedID(), "the fetch targets the cursor row")
+}
+
+// TestClientModel_EnterGotoTop pins that attach-mode Enter starts the detail at
+// the top even when opened from deep in a scrolled list.
+func TestClientModel_EnterGotoTop(t *testing.T) {
+	stub := &stubTUIClient{}
+	m := newClientRequestsModel(stub, 30, 5) // follow on -> viewport scrolled down
+	require.Greater(t, m.viewport.YOffset, 0)
+
+	m = clientUpdate(m, tea.KeyMsg{Type: tea.KeyEnter})
+	assert.Equal(t, ViewModeRequestDetail, m.viewMode)
+	assert.Equal(t, 0, m.viewport.YOffset)
+}

--- a/internal/tui/client_model_test.go
+++ b/internal/tui/client_model_test.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+	"errors"
+	"strings"
 	"sync"
 	"testing"
 
@@ -118,4 +120,221 @@ func TestClientModel_EnterGotoTop(t *testing.T) {
 	m = clientUpdate(m, tea.KeyMsg{Type: tea.KeyEnter})
 	assert.Equal(t, ViewModeRequestDetail, m.viewMode)
 	assert.Equal(t, 0, m.viewport.YOffset)
+}
+
+// newClientDetailModel builds a ready ClientModel with no requests loaded
+// (D16's guard tests drive detail state directly rather than through a live
+// requests list).
+func newClientDetailModel(stub *stubTUIClient) ClientModel {
+	m := NewClientModel(stub)
+	nm, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 11})
+	return nm.(ClientModel)
+}
+
+// finalDetailFor builds a completed (non-in-flight) RequestDetailData for id,
+// carrying a header so tests can assert Details actually rendered.
+func finalDetailFor(id string) *RequestDetailData {
+	return &RequestDetailData{
+		ID:             id,
+		Method:         "GET",
+		URL:            "/x",
+		StatusCode:     200,
+		DurationMs:     42,
+		InFlight:       false,
+		RequestHeaders: map[string][]string{"X-Test": {"yes"}},
+	}
+}
+
+// inFlightDetailFor builds an in-flight RequestDetailData snapshot for id.
+func inFlightDetailFor(id string) *RequestDetailData {
+	return &RequestDetailData{ID: id, Method: "GET", URL: "/x", InFlight: true}
+}
+
+// TestClientModel_DetailLiveRefresh_MatchingFinalReturnsFetchCmd pins the
+// live half of D16 end to end: opening the detail on an in-flight request via
+// Enter, then feeding the matching final ProxyRequestMsg, returns a re-fetch
+// command and never flips detailLoading (the existing snapshot stays on
+// screen with no loading flicker while the background fetch runs).
+func TestClientModel_DetailLiveRefresh_MatchingFinalReturnsFetchCmd(t *testing.T) {
+	stub := &stubTUIClient{detailResp: &api.ProxyRequestDetailResponse{
+		ProxyRequestResponse: api.ProxyRequestResponse{ID: "req-000", InFlight: true},
+	}}
+	m := newClientRequestsModel(stub, 1, 5)
+	require.Equal(t, "req-000", m.cursorID)
+
+	newModel, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = newModel.(ClientModel)
+	require.NotNil(t, cmd)
+	m = clientUpdate(m, cmd())
+	require.NotNil(t, m.requestDetail)
+	require.True(t, m.requestDetail.InFlight)
+	require.False(t, m.detailLoading)
+
+	newModel, cmd2 := m.Update(ProxyRequestMsg(finalRecordFor("req-000")))
+	m = newModel.(ClientModel)
+	assert.False(t, m.detailLoading, "background refresh sets no loading flicker")
+	require.NotNil(t, cmd2, "completion triggers a re-fetch")
+
+	msg := cmd2()
+	detailMsg, ok := msg.(RequestDetailMsg)
+	require.True(t, ok)
+	assert.Equal(t, "req-000", detailMsg.ID)
+	assert.Equal(t, m.detailFetchSeq, detailMsg.Seq)
+}
+
+// TestClientModel_DetailLiveRefresh_StaleIDDroppedKeepsLoading pins that a
+// result for a request OTHER than the one currently selected is dropped
+// entirely — including detailLoading, which today (pre-D16) was cleared
+// before the ID check and could stomp the loading state of a newer,
+// currently-in-flight fetch for a different row.
+func TestClientModel_DetailLiveRefresh_StaleIDDroppedKeepsLoading(t *testing.T) {
+	stub := &stubTUIClient{}
+	m := newClientDetailModel(stub)
+	m.viewMode = ViewModeRequestDetail
+	m.selectedRequestID = "req-B"
+	m.detailLoading = true
+	m.detailFetchSeq = 2
+
+	m = clientUpdate(m, RequestDetailMsg{ID: "req-A", Seq: 2, Details: finalDetailFor("req-A")})
+
+	assert.True(t, m.detailLoading, "a stale-ID result must not clear the current fetch's loading state")
+	assert.Nil(t, m.requestDetail, "a stale-ID result must not populate the wrong request's detail")
+}
+
+// TestClientModel_DetailLiveRefresh_SupersededSeqSuccessDropped pins that a
+// success result from an earlier, superseded fetch for the SAME id is
+// dropped once a newer fetch has been started (seq mismatch).
+func TestClientModel_DetailLiveRefresh_SupersededSeqSuccessDropped(t *testing.T) {
+	stub := &stubTUIClient{}
+	m := newClientDetailModel(stub)
+	m.viewMode = ViewModeRequestDetail
+	m.selectedRequestID = "req-1"
+	m.detailFetchSeq = 3
+	existing := inFlightDetailFor("req-1")
+	m.requestDetail = existing
+
+	m = clientUpdate(m, RequestDetailMsg{ID: "req-1", Seq: 2, Details: finalDetailFor("req-1")})
+
+	assert.Same(t, existing, m.requestDetail, "a superseded-seq success must not replace the current snapshot")
+}
+
+// TestClientModel_DetailLiveRefresh_SupersededSeqErrorDropped mirrors the
+// success case for RequestDetailErrorMsg: an error from an earlier,
+// superseded fetch must not touch detailError/detailRefreshFailed.
+func TestClientModel_DetailLiveRefresh_SupersededSeqErrorDropped(t *testing.T) {
+	stub := &stubTUIClient{}
+	m := newClientDetailModel(stub)
+	m.viewMode = ViewModeRequestDetail
+	m.selectedRequestID = "req-1"
+	m.detailFetchSeq = 3
+	existing := inFlightDetailFor("req-1")
+	m.requestDetail = existing
+	m.detailLoading = true
+
+	m = clientUpdate(m, RequestDetailErrorMsg{ID: "req-1", Seq: 2, Err: errors.New("boom")})
+
+	assert.True(t, m.detailLoading, "a superseded-seq error must not mutate loading state")
+	assert.Same(t, existing, m.requestDetail)
+	assert.False(t, m.detailRefreshFailed, "a superseded-seq error must not set the refresh-failed note")
+	assert.Nil(t, m.detailError)
+}
+
+// TestClientModel_DetailLiveRefresh_InFlightPayloadAfterFinalDropped pins the
+// belt-and-braces content guard: a current-seq, current-ID payload that is
+// itself still in-flight cannot supersede an already-displayed FINAL
+// snapshot (e.g. a server-side race in GetProxyRequest).
+func TestClientModel_DetailLiveRefresh_InFlightPayloadAfterFinalDropped(t *testing.T) {
+	stub := &stubTUIClient{}
+	m := newClientDetailModel(stub)
+	m.viewMode = ViewModeRequestDetail
+	m.selectedRequestID = "req-1"
+	m.detailFetchSeq = 1
+	finalDetail := finalDetailFor("req-1")
+	m.requestDetail = finalDetail
+
+	m = clientUpdate(m, RequestDetailMsg{ID: "req-1", Seq: 1, Details: inFlightDetailFor("req-1")})
+
+	assert.Same(t, finalDetail, m.requestDetail, "an in-flight payload must not regress an already-final view")
+}
+
+// TestClientModel_DetailLiveRefresh_FinalAfterInFlightApplies pins the normal
+// success path: a current-seq, current-ID final payload applies over an
+// in-flight (or failed) snapshot and clears detailRefreshFailed.
+func TestClientModel_DetailLiveRefresh_FinalAfterInFlightApplies(t *testing.T) {
+	stub := &stubTUIClient{}
+	m := newClientDetailModel(stub)
+	m.viewMode = ViewModeRequestDetail
+	m.selectedRequestID = "req-1"
+	m.detailFetchSeq = 1
+	m.requestDetail = inFlightDetailFor("req-1")
+	m.detailRefreshFailed = true // simulate a prior failed attempt
+
+	final := finalDetailFor("req-1")
+	m = clientUpdate(m, RequestDetailMsg{ID: "req-1", Seq: 1, Details: final})
+
+	require.NotNil(t, m.requestDetail)
+	assert.False(t, m.requestDetail.InFlight)
+	assert.Equal(t, final, m.requestDetail)
+	assert.False(t, m.detailRefreshFailed, "a successful apply clears the refresh-failed note")
+}
+
+// TestClientModel_DetailLiveRefresh_ErrorWithDisplayedDetailKeepsSnapshot
+// pins the refresh-failure UX: a current-seq error that arrives while a
+// snapshot is already displayed keeps that snapshot on screen (never the
+// error view) and sets detailRefreshFailed, which formatRequestDetail
+// renders as a distinct note in place of the "(in flight)" one.
+func TestClientModel_DetailLiveRefresh_ErrorWithDisplayedDetailKeepsSnapshot(t *testing.T) {
+	stub := &stubTUIClient{}
+	m := newClientDetailModel(stub)
+	m.viewMode = ViewModeRequestDetail
+	m.selectedRequestID = "req-1"
+	m.detailFetchSeq = 1
+	snapshot := inFlightDetailFor("req-1")
+	m.requestDetail = snapshot
+
+	m = clientUpdate(m, RequestDetailErrorMsg{ID: "req-1", Seq: 1, Err: errors.New("boom")})
+
+	assert.Same(t, snapshot, m.requestDetail, "the snapshot must be kept, not cleared")
+	assert.Nil(t, m.detailError, "the error view must not take over while a snapshot is displayed")
+	assert.True(t, m.detailRefreshFailed)
+	rendered := strings.Join(m.formatRequestDetail(), "\n")
+	assert.Contains(t, rendered, "live refresh failed")
+	assert.NotContains(t, rendered, "details arrive on completion")
+}
+
+// TestClientModel_DetailLiveRefresh_ErrorWithNothingDisplayedShowsErrorView
+// pins that today's initial-failure behavior is preserved: a current-seq
+// error with NO snapshot displayed renders the error view.
+func TestClientModel_DetailLiveRefresh_ErrorWithNothingDisplayedShowsErrorView(t *testing.T) {
+	stub := &stubTUIClient{}
+	m := newClientDetailModel(stub)
+	m.viewMode = ViewModeRequestDetail
+	m.selectedRequestID = "req-1"
+	m.detailFetchSeq = 1
+	m.detailLoading = true
+
+	m = clientUpdate(m, RequestDetailErrorMsg{ID: "req-1", Seq: 1, Err: errors.New("boom")})
+
+	assert.False(t, m.detailLoading)
+	require.Error(t, m.detailError)
+	assert.False(t, m.detailRefreshFailed)
+	rendered := strings.Join(m.formatRequestDetail(), "\n")
+	assert.Contains(t, rendered, "Error: boom")
+}
+
+// TestClientModel_DetailLiveRefresh_EscClearsRefreshFailed pins that leaving
+// the detail view (esc) clears detailRefreshFailed alongside requestDetail,
+// so re-entering the detail on a fresh Enter never inherits a stale note.
+func TestClientModel_DetailLiveRefresh_EscClearsRefreshFailed(t *testing.T) {
+	stub := &stubTUIClient{}
+	m := newClientDetailModel(stub)
+	m.viewMode = ViewModeRequestDetail
+	m.selectedRequestID = "req-1"
+	m.requestDetail = inFlightDetailFor("req-1")
+	m.detailRefreshFailed = true
+
+	m = clientUpdate(m, tea.KeyMsg{Type: tea.KeyEsc})
+
+	assert.Equal(t, ViewModeRequests, m.viewMode)
+	assert.False(t, m.detailRefreshFailed)
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -93,15 +93,22 @@ type RestartResultMsg struct {
 // RestartResultClearMsg is sent to clear the restart result after a delay
 type RestartResultClearMsg struct{}
 
-// RequestDetailMsg is sent when request details are loaded
+// RequestDetailMsg is sent when request details are loaded. Seq is the
+// fetchRequestDetail call's sequence number (ClientModel.detailFetchSeq at
+// dispatch time) — the handler drops any msg whose Seq doesn't match the
+// current value, so a stale or superseded fetch can never clobber a newer
+// one (D16).
 type RequestDetailMsg struct {
 	ID      string
+	Seq     int
 	Details *RequestDetailData
 }
 
-// RequestDetailErrorMsg is sent when loading request details fails
+// RequestDetailErrorMsg is sent when loading request details fails. Seq is
+// the fetchRequestDetail call's sequence number (see RequestDetailMsg).
 type RequestDetailErrorMsg struct {
 	ID  string
+	Seq int
 	Err error
 }
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1,11 +1,14 @@
 package tui
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/charliek/prox/internal/domain"
 	"github.com/charliek/prox/internal/logs"
@@ -389,39 +392,36 @@ func TestModel_ProxyRequestMsg(t *testing.T) {
 	assert.Equal(t, 99*time.Millisecond, m.proxyRequests[0].Duration)
 }
 
-// TestModel_ProxyRequestMsg_SelectionStable verifies that upserting an
-// earlier row in place (D10) leaves a scrolled/selected position untouched:
-// detail-selection maps viewport line numbers to indices into proxyRequests,
-// so an in-place replacement must not shift any other row's index.
+// TestModel_ProxyRequestMsg_SelectionStable pins the cursor invariant (D11):
+// the ID-anchored cursor survives an in-place upsert of ANOTHER row and of its
+// OWN row without moving, so an arriving completion never changes what Enter
+// opens.
 func TestModel_ProxyRequestMsg_SelectionStable(t *testing.T) {
-	model := newTestModel()
-	model.ready = true
-	model.viewMode = ViewModeRequests
-	model.followMode = false // otherwise handleProxyRequest re-snaps to bottom
+	m := newRequestsModel(3, 20)
+	m = updateModel(m, keyRune('g')) // cursor row 0, follow off
+	m = updateModel(m, keyRune('j')) // cursor row 1 (req-001), not the last row
+	assert.Equal(t, "req-001", m.cursorID)
+	assert.Equal(t, 1, m.cursorIdx)
+	assert.False(t, m.followMode)
 
-	model.proxyRequests = []proxy.RequestRecord{
-		{ID: "req-a", Timestamp: time.Now(), Method: "GET", URL: "/a", StatusCode: 200},
-		{ID: "req-b", Timestamp: time.Now(), Method: "GET", URL: "/b", StatusCode: 200},
-		{ID: "req-c", Timestamp: time.Now(), Method: "GET", URL: "/c", StatusCode: 200},
-	}
-	model.updateViewport()
-
-	// Simulate a scrolled selection sitting on the third row.
-	model.viewport.YOffset = 2
-	assert.Equal(t, "req-c", model.getSelectedRequest())
-
-	// Update the FIRST row in place (an earlier row completing).
-	updated := model.proxyRequests[0]
-	updated.StatusCode = 204
-	newModel, _ := model.Update(ProxyRequestMsg(updated))
-	m := newModel.(Model)
-
+	// In-place upsert of ANOTHER row (row 0 completing) must not move the cursor.
+	other := m.proxyRequests[0]
+	other.StatusCode = 204
+	m = updateModel(m, ProxyRequestMsg(other))
 	assert.Len(t, m.proxyRequests, 3, "in-place update must not change the row count")
-	assert.Equal(t, 2, m.viewport.YOffset, "scroll position must be unchanged")
-	assert.Equal(t, "req-c", m.getSelectedRequest(), "selection must be unchanged")
+	assert.Equal(t, "req-001", m.cursorID, "cursor stays on its row by ID")
+	assert.Equal(t, 1, m.cursorIdx)
 	assert.Equal(t, 204, m.proxyRequests[0].StatusCode, "the target row must reflect the update")
-	assert.Equal(t, "req-b", m.proxyRequests[1].ID, "other rows must keep their index")
-	assert.Equal(t, "req-c", m.proxyRequests[2].ID, "other rows must keep their index")
+	assert.Equal(t, "req-002", m.proxyRequests[2].ID, "other rows keep their index")
+
+	// In-place upsert of the cursor's OWN row must not move it either.
+	own := m.proxyRequests[1]
+	own.StatusCode = 500
+	m = updateModel(m, ProxyRequestMsg(own))
+	assert.Len(t, m.proxyRequests, 3)
+	assert.Equal(t, "req-001", m.cursorID)
+	assert.Equal(t, 1, m.cursorIdx)
+	assert.Equal(t, 500, m.proxyRequests[1].StatusCode)
 }
 
 func TestViewModeSwitch(t *testing.T) {
@@ -594,4 +594,403 @@ func TestFormatProxyRequest_Padding(t *testing.T) {
 			assert.Contains(t, formatted, tt.wantDur, "duration padding")
 		})
 	}
+}
+
+// --- Requests-view cursor tests (C2 / D6-D11) ---
+
+// keyRune builds a rune KeyMsg for a single-character key.
+func keyRune(r rune) tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}}
+}
+
+// updateModel applies a message to a Model and returns the concrete result.
+func updateModel(m Model, msg tea.Msg) Model {
+	nm, _ := m.Update(msg)
+	return nm.(Model)
+}
+
+// newRequestsModel builds a Model in the requests view holding n requests
+// (IDs req-000..req-{n-1}, URLs /path/000..), with the viewport sized so its
+// content Height is viewportHeight (handleWindowSize subtracts the 6-row
+// header+footer margin). followMode starts true, so the cursor begins pinned
+// to the newest row.
+func newRequestsModel(n, viewportHeight int) Model {
+	m := newTestModel()
+	m.viewMode = ViewModeRequests
+	m.proxyRequests = makeTestRequests(n)
+	return updateModel(m, tea.WindowSizeMsg{Width: 120, Height: viewportHeight + 6})
+}
+
+// makeTestRequests builds n proxy request records with the shared fixture
+// convention (IDs req-000.., URLs /path/000.., monotonic timestamps). Shared by
+// both the Model and ClientModel requests-view test constructors.
+func makeTestRequests(n int) []proxy.RequestRecord {
+	reqs := make([]proxy.RequestRecord, n)
+	base := time.Unix(0, 0)
+	for i := 0; i < n; i++ {
+		reqs[i] = proxy.RequestRecord{
+			ID:         fmt.Sprintf("req-%03d", i),
+			Timestamp:  base.Add(time.Duration(i) * time.Second),
+			Method:     "GET",
+			URL:        fmt.Sprintf("/path/%03d", i),
+			StatusCode: 200,
+			Duration:   5 * time.Millisecond,
+		}
+	}
+	return reqs
+}
+
+// cursorVisible reports whether the cursor row is within the viewport window.
+func cursorVisible(m Model) bool {
+	yo := m.viewport.YOffset
+	return m.cursorIdx >= yo && m.cursorIdx < yo+m.viewport.Height
+}
+
+func newArrival(id, url string) proxy.RequestRecord {
+	return proxy.RequestRecord{ID: id, Timestamp: time.Now(), Method: "GET", URL: url, StatusCode: 200}
+}
+
+func TestRequestsCursor_Movement(t *testing.T) {
+	m := newRequestsModel(10, 5)
+	assert.Equal(t, 9, m.cursorIdx, "follow pins the cursor to the newest row")
+
+	m = updateModel(m, keyRune('k'))
+	assert.Equal(t, 8, m.cursorIdx)
+	assert.False(t, m.followMode, "k disengages follow")
+
+	m = updateModel(m, keyRune('k'))
+	assert.Equal(t, 7, m.cursorIdx)
+
+	m = updateModel(m, keyRune('g'))
+	assert.Equal(t, 0, m.cursorIdx)
+	assert.False(t, m.followMode)
+
+	// Clamp at the top.
+	m = updateModel(m, keyRune('k'))
+	assert.Equal(t, 0, m.cursorIdx)
+
+	// Half-page paging: step = Height/2 = 5/2 = 2.
+	m = updateModel(m, tea.KeyMsg{Type: tea.KeyPgDown})
+	assert.Equal(t, 2, m.cursorIdx)
+	m = updateModel(m, tea.KeyMsg{Type: tea.KeyPgUp})
+	assert.Equal(t, 0, m.cursorIdx)
+	assert.False(t, m.followMode)
+
+	m = updateModel(m, keyRune('G'))
+	assert.Equal(t, 9, m.cursorIdx)
+	assert.True(t, m.followMode, "G re-engages follow")
+
+	// Clamp at the bottom.
+	m = updateModel(m, keyRune('j'))
+	assert.Equal(t, 9, m.cursorIdx)
+}
+
+func TestRequestsCursor_VisibilityKeyboardJumps(t *testing.T) {
+	m := newRequestsModel(30, 5)
+
+	m = updateModel(m, keyRune('g'))
+	assert.Equal(t, 0, m.cursorIdx)
+	assert.Equal(t, 0, m.viewport.YOffset)
+	assert.True(t, cursorVisible(m))
+
+	// Walk the cursor down; it must stay on-screen with minimal scrolling.
+	for i := 1; i <= 20; i++ {
+		m = updateModel(m, keyRune('j'))
+		assert.Equal(t, i, m.cursorIdx)
+		assert.True(t, cursorVisible(m),
+			"cursor %d must be visible (YOffset %d, height %d)", i, m.viewport.YOffset, m.viewport.Height)
+	}
+
+	m = updateModel(m, keyRune('G'))
+	assert.Equal(t, 29, m.cursorIdx)
+	assert.True(t, cursorVisible(m))
+
+	m = updateModel(m, keyRune('g'))
+	assert.Equal(t, 0, m.cursorIdx)
+	assert.Equal(t, 0, m.viewport.YOffset)
+}
+
+// TestRequestsCursor_VisibilityTabIn covers the invariant across a tab-in from a
+// scrolled logs view: the shared viewport retains the logs YOffset, and the
+// requests branch of updateViewport must scroll it so the cursor is visible.
+func TestRequestsCursor_VisibilityTabIn(t *testing.T) {
+	m := newTestModel()
+	m = updateModel(m, tea.WindowSizeMsg{Width: 120, Height: 11}) // viewport height 5
+
+	// Fill logs and requests while in the logs view.
+	for i := 0; i < 30; i++ {
+		m = updateModel(m, LogEntryMsg(domain.LogEntry{Timestamp: time.Now(), Process: "p", Line: fmt.Sprintf("log %d", i)}))
+	}
+	for i := 0; i < 30; i++ {
+		m = updateModel(m, ProxyRequestMsg(newArrival(fmt.Sprintf("req-%03d", i), fmt.Sprintf("/path/%03d", i))))
+	}
+
+	// Scroll the logs viewport up (disengages follow) so YOffset is large.
+	m = updateModel(m, keyRune('k'))
+	require.Greater(t, m.viewport.YOffset, 5, "logs viewport should be scrolled well down")
+	require.False(t, m.followMode)
+
+	// Tab into the requests view: cursor resolves to row 0 (follow off, no prior
+	// cursor) and the viewport must scroll up to show it.
+	m = updateModel(m, tea.KeyMsg{Type: tea.KeyTab})
+	assert.Equal(t, ViewModeRequests, m.viewMode)
+	assert.Equal(t, 0, m.cursorIdx)
+	assert.Equal(t, 0, m.viewport.YOffset, "tab-in must reveal the cursor row")
+}
+
+func TestRequestsCursor_VisibilityResize(t *testing.T) {
+	m := newRequestsModel(40, 10)
+	m = updateModel(m, keyRune('g')) // follow off, cursor 0
+	for i := 0; i < 20; i++ {
+		m = updateModel(m, keyRune('j'))
+	}
+	require.Equal(t, 20, m.cursorIdx)
+	assert.True(t, cursorVisible(m))
+
+	// Shrink the window: cursor must stay visible.
+	m = updateModel(m, tea.WindowSizeMsg{Width: 120, Height: 5 + 6})
+	assert.Equal(t, 20, m.cursorIdx)
+	assert.True(t, cursorVisible(m))
+
+	// Grow it back: still visible, and the viewport must not be left scrolled
+	// past the true bottom (a grown window shrinks the valid max YOffset —
+	// blank overscroll would report the cursor "visible" while showing gaps).
+	m = updateModel(m, tea.WindowSizeMsg{Width: 120, Height: 30 + 6})
+	assert.Equal(t, 20, m.cursorIdx)
+	assert.True(t, cursorVisible(m))
+	maxOffset := m.viewport.TotalLineCount() - m.viewport.Height
+	if maxOffset < 0 {
+		maxOffset = 0
+	}
+	assert.LessOrEqual(t, m.viewport.YOffset, maxOffset,
+		"viewport must not overscroll past the last valid offset after a grow-resize")
+}
+
+func TestRequestsCursor_VisibilityFilterClear(t *testing.T) {
+	m := newRequestsModel(40, 5)
+	// Narrow to rows /path/030../path/039 (10 rows), follow off.
+	m.searchPattern = "/path/03"
+	m.followMode = false
+	m.updateViewport()
+
+	m = updateModel(m, keyRune('g')) // filtered row 0 = req-030
+	m = updateModel(m, keyRune('j')) // req-031
+	m = updateModel(m, keyRune('j')) // req-032
+	require.Equal(t, "req-032", m.cursorID)
+	require.False(t, m.followMode)
+
+	// esc clears the filter; the cursor's row (req-032, full-list index 32) must
+	// remain and be scrolled on-screen.
+	m = updateModel(m, tea.KeyMsg{Type: tea.KeyEscape})
+	assert.Empty(t, m.searchPattern)
+	assert.Equal(t, "req-032", m.cursorID)
+	assert.Equal(t, 32, m.cursorIdx)
+	assert.True(t, cursorVisible(m))
+}
+
+func TestRequestsCursor_VisibilityDetailReturn(t *testing.T) {
+	m := newRequestsModel(30, 5)
+	m = updateModel(m, keyRune('g'))
+	for i := 0; i < 15; i++ {
+		m = updateModel(m, keyRune('j'))
+	}
+	require.Equal(t, "req-015", m.cursorID)
+
+	m = updateModel(m, tea.KeyMsg{Type: tea.KeyEnter})
+	require.Equal(t, ViewModeRequestDetail, m.viewMode)
+
+	// esc back to the list: the cursor must be restored and visible.
+	m = updateModel(m, tea.KeyMsg{Type: tea.KeyEscape})
+	assert.Equal(t, ViewModeRequests, m.viewMode)
+	assert.Equal(t, "req-015", m.cursorID)
+	assert.True(t, cursorVisible(m))
+}
+
+// TestRequestsCursor_ArrivalDoesNotMoveShortList pins the CodeRabbit M1 trap:
+// with a short list that fits the viewport, AtBottom() is always true, so an
+// isNearBottom-based follow check would re-engage follow and yank the cursor on
+// every arrival. Arrivals must leave a user-positioned cursor untouched.
+func TestRequestsCursor_ArrivalDoesNotMoveShortList(t *testing.T) {
+	m := newRequestsModel(3, 20) // fits the viewport
+	m = updateModel(m, keyRune('k'))
+	require.Equal(t, 1, m.cursorIdx)
+	require.False(t, m.followMode)
+	require.True(t, m.viewport.AtBottom(), "precondition: a short list is always AtBottom")
+
+	m = updateModel(m, ProxyRequestMsg(newArrival("req-new", "/new")))
+	assert.Len(t, m.proxyRequests, 4)
+	assert.Equal(t, "req-001", m.cursorID, "arrival must not move the cursor")
+	assert.Equal(t, 1, m.cursorIdx)
+	assert.False(t, m.followMode, "arrival must not re-engage follow")
+}
+
+func TestRequestsCursor_JOntoLastRowReengagesFollow(t *testing.T) {
+	m := newRequestsModel(5, 20)
+	m = updateModel(m, keyRune('g'))
+	require.False(t, m.followMode)
+
+	for i := 1; i <= 3; i++ {
+		m = updateModel(m, keyRune('j'))
+		assert.False(t, m.followMode, "follow stays off until the cursor lands on the last row (idx %d)", m.cursorIdx)
+	}
+	require.Equal(t, 3, m.cursorIdx)
+
+	m = updateModel(m, keyRune('j')) // onto the last row
+	assert.Equal(t, 4, m.cursorIdx)
+	assert.True(t, m.followMode, "j onto the newest row re-engages follow")
+}
+
+func TestRequestsCursor_GAndFReengageFollow(t *testing.T) {
+	m := newRequestsModel(10, 5)
+	m = updateModel(m, keyRune('k'))
+	require.False(t, m.followMode)
+
+	m = updateModel(m, keyRune('G'))
+	assert.True(t, m.followMode)
+	assert.Equal(t, 9, m.cursorIdx)
+
+	m = updateModel(m, keyRune('g')) // follow off, cursor 0
+	require.False(t, m.followMode)
+	m = updateModel(m, keyRune('F')) // toggle on -> pins to newest
+	assert.True(t, m.followMode)
+	assert.Equal(t, 9, m.cursorIdx)
+	m = updateModel(m, keyRune('F')) // toggle off
+	assert.False(t, m.followMode)
+	assert.Equal(t, 9, m.cursorIdx)
+}
+
+func TestRequestsCursor_FollowArrivalPinsNewest(t *testing.T) {
+	m := newRequestsModel(5, 20)
+	require.True(t, m.followMode)
+	require.Equal(t, 4, m.cursorIdx)
+
+	m = updateModel(m, ProxyRequestMsg(newArrival("req-new", "/new")))
+	assert.Len(t, m.proxyRequests, 6)
+	assert.Equal(t, 5, m.cursorIdx, "follow pins the cursor to the newest row")
+	assert.Equal(t, "req-new", m.cursorID)
+	assert.True(t, m.viewport.AtBottom(), "follow keeps the viewport at the bottom")
+}
+
+func TestRequestsCursor_AppendTrimMidList(t *testing.T) {
+	m := newRequestsModel(maxProxyRequests, 5) // exactly full
+	m.followMode = false
+	m.setRequestCursor(m.filteredProxyRequests(), 500)
+	m.updateViewport()
+	require.Equal(t, "req-500", m.cursorID)
+
+	// A new arrival appends and trims the oldest row; the ID-anchored cursor
+	// rides down one index onto its still-present row.
+	m = updateModel(m, ProxyRequestMsg(newArrival("req-new", "/new")))
+	assert.Len(t, m.proxyRequests, maxProxyRequests)
+	assert.Equal(t, "req-500", m.cursorID)
+	assert.Equal(t, 499, m.cursorIdx)
+}
+
+func TestRequestsCursor_TrimmedRowClamps(t *testing.T) {
+	m := newRequestsModel(maxProxyRequests, 5)
+	m.followMode = false
+	m.setRequestCursor(m.filteredProxyRequests(), 0) // cursor on the oldest row
+	m.updateViewport()
+	require.Equal(t, "req-000", m.cursorID)
+
+	// The arrival trims req-000 away; the cursor clamps to the row now at idx 0.
+	m = updateModel(m, ProxyRequestMsg(newArrival("req-new", "/new")))
+	assert.Len(t, m.proxyRequests, maxProxyRequests)
+	assert.Equal(t, 0, m.cursorIdx)
+	assert.Equal(t, "req-001", m.cursorID, "cursor re-anchors to the row now at its index")
+}
+
+func TestRequestsCursor_EmptyToNonEmptyFollowOn(t *testing.T) {
+	m := newTestModel()
+	m.viewMode = ViewModeRequests
+	m = updateModel(m, tea.WindowSizeMsg{Width: 120, Height: 11})
+	require.True(t, m.followMode)
+	require.Equal(t, -1, m.cursorIdx, "empty list is the no-cursor sentinel")
+
+	m = updateModel(m, ProxyRequestMsg(newArrival("req-x", "/x")))
+	assert.Equal(t, 0, m.cursorIdx)
+	assert.Equal(t, "req-x", m.cursorID, "follow pins the first arrival")
+}
+
+func TestRequestsCursor_EmptyToNonEmptyFollowOff(t *testing.T) {
+	m := newTestModel()
+	m.viewMode = ViewModeRequests
+	m.followMode = false
+	m = updateModel(m, tea.WindowSizeMsg{Width: 120, Height: 11})
+	require.Equal(t, -1, m.cursorIdx)
+
+	m = updateModel(m, ProxyRequestMsg(newArrival("req-x", "/x")))
+	assert.Equal(t, 0, m.cursorIdx, "follow off lands the cursor on row 0")
+	assert.Equal(t, "req-x", m.cursorID)
+}
+
+func TestRequestsCursor_EnterOpensCursorRow(t *testing.T) {
+	m := newRequestsModel(10, 5)
+	m = updateModel(m, keyRune('g'))
+	for i := 0; i < 4; i++ {
+		m = updateModel(m, keyRune('j'))
+	}
+	require.Equal(t, "req-004", m.cursorID)
+
+	m = updateModel(m, tea.KeyMsg{Type: tea.KeyEnter})
+	assert.Equal(t, ViewModeRequestDetail, m.viewMode)
+	assert.Equal(t, "req-004", m.selectedRequestID)
+	if assert.NotNil(t, m.requestDetail) {
+		assert.Equal(t, "req-004", m.requestDetail.ID)
+	}
+}
+
+func TestRequestsCursor_EnterGotoTop(t *testing.T) {
+	m := newRequestsModel(30, 5) // follow on -> cursor deep, viewport scrolled down
+	require.Greater(t, m.viewport.YOffset, 0)
+
+	m = updateModel(m, tea.KeyMsg{Type: tea.KeyEnter})
+	assert.Equal(t, ViewModeRequestDetail, m.viewMode)
+	assert.Equal(t, 0, m.viewport.YOffset, "entering the detail view starts at the top")
+}
+
+func TestRequestsCursor_EmptyListEnterNoop(t *testing.T) {
+	m := newTestModel()
+	m.viewMode = ViewModeRequests
+	m = updateModel(m, tea.WindowSizeMsg{Width: 120, Height: 11})
+
+	m = updateModel(m, tea.KeyMsg{Type: tea.KeyEnter})
+	assert.Equal(t, ViewModeRequests, m.viewMode, "Enter on an empty list is a no-op")
+	assert.Empty(t, m.selectedRequestID)
+}
+
+// TestRequestsCursor_DetailArrivalNoScroll pins the m4 scroll-yank guard: while
+// a detail view is open, an arriving proxy request updates only the list data
+// and must not scroll the detail viewport out from under the reader.
+func TestRequestsCursor_DetailArrivalNoScroll(t *testing.T) {
+	m := newRequestsModel(10, 2) // tiny viewport so the detail scrolls
+	m = updateModel(m, tea.KeyMsg{Type: tea.KeyEnter})
+	require.Equal(t, ViewModeRequestDetail, m.viewMode)
+
+	// Reader scrolls down inside the detail.
+	m.viewport.SetYOffset(3)
+	require.Equal(t, 3, m.viewport.YOffset, "precondition: detail content taller than the viewport")
+
+	m = updateModel(m, ProxyRequestMsg(newArrival("req-new", "/new")))
+	assert.Equal(t, 3, m.viewport.YOffset, "arrival must not scroll the open detail view")
+	assert.Len(t, m.proxyRequests, 11, "list data is still updated")
+}
+
+func TestRequestsCursor_MarkerOnCursorRow(t *testing.T) {
+	m := newRequestsModel(5, 20) // all rows visible
+	m = updateModel(m, keyRune('g'))
+	m = updateModel(m, keyRune('j')) // cursor on row 1 (req-001, /path/001)
+	require.Equal(t, 1, m.cursorIdx)
+
+	view := m.viewport.View()
+	markerCount := 0
+	var markerLine string
+	for _, line := range strings.Split(view, "\n") {
+		if strings.Contains(line, "❯") {
+			markerCount++
+			markerLine = line
+		}
+	}
+	assert.Equal(t, 1, markerCount, "exactly one cursor marker is rendered")
+	assert.Contains(t, markerLine, "/path/001", "the marker sits on the cursor row")
 }

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1277,3 +1277,127 @@ func TestRequestsSearch_SingleMatchNextPrevNoop(t *testing.T) {
 	assert.Equal(t, 2, m.cursorIdx, "N with a sole match is a no-op")
 	assert.Equal(t, "req-002", m.cursorID)
 }
+
+// newInFlightDetailModel opens the detail view (local mode) for a single
+// in-flight request, viewport sized so its content Height is viewportHeight,
+// and returns the model with the detail already rendered from the top.
+func newInFlightDetailModel(t *testing.T, id string, viewportHeight int) Model {
+	t.Helper()
+	inFlight := proxy.RequestRecord{
+		ID: id, Timestamp: time.Now(), Method: "GET", URL: "/x", InFlight: true,
+	}
+	m := newSearchModel(viewportHeight, []proxy.RequestRecord{inFlight})
+	m = updateModel(m, tea.KeyMsg{Type: tea.KeyEnter})
+	require.Equal(t, ViewModeRequestDetail, m.viewMode)
+	require.NotNil(t, m.requestDetail)
+	require.True(t, m.requestDetail.InFlight)
+	return m
+}
+
+// finalRecordFor builds the completed (non-in-flight) record that would
+// arrive as the matching final ProxyRequestMsg for an in-flight row with the
+// given id, carrying Details so the refresh has something visible to render.
+func finalRecordFor(id string) proxy.RequestRecord {
+	return proxy.RequestRecord{
+		ID:         id,
+		Timestamp:  time.Now(),
+		Method:     "GET",
+		URL:        "/x",
+		StatusCode: 200,
+		Duration:   42 * time.Millisecond,
+		InFlight:   false,
+		Details: &proxy.RequestDetails{
+			RequestHeaders: map[string][]string{"X-Test": {"yes"}},
+		},
+	}
+}
+
+// TestModel_DetailLiveRefresh_LocalMatchingFinalRefreshesInPlace pins D15:
+// completing an in-flight request whose detail is open refreshes the view in
+// place — Details render, the "(in flight)" note disappears, and the
+// reader's scroll position is preserved (detail content only grows on
+// completion, and SetContent never resets YOffset on growth).
+func TestModel_DetailLiveRefresh_LocalMatchingFinalRefreshesInPlace(t *testing.T) {
+	m := newInFlightDetailModel(t, "req-1", 5)
+	assert.Contains(t, strings.Join(m.formatRequestDetail(), "\n"), "in flight")
+
+	m.viewport.SetYOffset(2)
+	require.Equal(t, 2, m.viewport.YOffset, "precondition: reader scrolled mid-read")
+
+	m = updateModel(m, ProxyRequestMsg(finalRecordFor("req-1")))
+
+	require.NotNil(t, m.requestDetail)
+	assert.False(t, m.requestDetail.InFlight)
+	assert.Equal(t, int64(42), m.requestDetail.DurationMs)
+	assert.Equal(t, 2, m.viewport.YOffset, "reader's scroll position is preserved")
+	rendered := strings.Join(m.formatRequestDetail(), "\n")
+	assert.NotContains(t, rendered, "in flight")
+	assert.Contains(t, rendered, "X-Test", "Details render after the refresh")
+}
+
+// TestModel_DetailLiveRefresh_NonMatchingIDNoRefresh pins that a final record
+// for a DIFFERENT request than the one open in the detail view leaves the
+// displayed snapshot untouched (the list still updates independently).
+func TestModel_DetailLiveRefresh_NonMatchingIDNoRefresh(t *testing.T) {
+	m := newInFlightDetailModel(t, "req-1", 5)
+
+	m = updateModel(m, ProxyRequestMsg(finalRecordFor("req-other")))
+
+	assert.True(t, m.requestDetail.InFlight, "the open detail is unaffected by another row's completion")
+	assert.Len(t, m.proxyRequests, 2, "the list still gains the new row")
+}
+
+// TestModel_DetailLiveRefresh_StillInFlightNoRefresh pins that a duplicate
+// in-flight message for the OPEN request (record.InFlight still true) does
+// not trigger a refresh — only a final (!InFlight) record does.
+func TestModel_DetailLiveRefresh_StillInFlightNoRefresh(t *testing.T) {
+	m := newInFlightDetailModel(t, "req-1", 5)
+
+	stillInFlight := proxy.RequestRecord{
+		ID: "req-1", Timestamp: time.Now(), Method: "GET", URL: "/x", InFlight: true,
+	}
+	m = updateModel(m, ProxyRequestMsg(stillInFlight))
+
+	assert.True(t, m.requestDetail.InFlight, "a still-in-flight duplicate must not be treated as the refresh")
+}
+
+// TestModel_DetailLiveRefresh_NotInDetailViewNoRefresh pins the list-only
+// path: a final ProxyRequestMsg arriving while the requests view (not the
+// detail view) is showing must not populate requestDetail — refresh only
+// applies to an OPEN detail view.
+func TestModel_DetailLiveRefresh_NotInDetailViewNoRefresh(t *testing.T) {
+	inFlight := proxy.RequestRecord{
+		ID: "req-1", Timestamp: time.Now(), Method: "GET", URL: "/x", InFlight: true,
+	}
+	m := newSearchModel(5, []proxy.RequestRecord{inFlight})
+	require.Equal(t, ViewModeRequests, m.viewMode)
+	require.Nil(t, m.requestDetail)
+
+	m = updateModel(m, ProxyRequestMsg(finalRecordFor("req-1")))
+
+	assert.Equal(t, ViewModeRequests, m.viewMode)
+	assert.Nil(t, m.requestDetail, "no detail view is open, so nothing is populated")
+}
+
+func TestModel_DetailLiveRefresh_ShrinkingContentClamps(t *testing.T) {
+	// A capture-disabled final detail is SHORTER than the in-flight view it
+	// replaces (the two in-flight note lines vanish and no header/body
+	// sections take their place). A bottom-scrolled reader must be pulled
+	// back to the last valid offset, not left on blank overscroll.
+	m := newInFlightDetailModel(t, "req-1", 3)
+	m.viewport.GotoBottom()
+	require.Positive(t, m.viewport.YOffset, "test needs a scrolled-down detail view")
+
+	final := finalRecordFor("req-1")
+	final.Details = nil // capture disabled: no headers/bodies arrive
+	m = updateModel(m, ProxyRequestMsg(final))
+
+	require.NotNil(t, m.requestDetail)
+	assert.False(t, m.requestDetail.InFlight)
+	maxOffset := m.viewport.TotalLineCount() - m.viewport.Height
+	if maxOffset < 0 {
+		maxOffset = 0
+	}
+	assert.LessOrEqual(t, m.viewport.YOffset, maxOffset,
+		"refresh onto shorter content must clamp the viewport offset")
+}

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -171,24 +172,6 @@ func TestContainsIgnoreCase(t *testing.T) {
 		got := containsIgnoreCase(tt.s, tt.substr)
 		assert.Equal(t, tt.want, got, "containsIgnoreCase(%q, %q)", tt.s, tt.substr)
 	}
-}
-
-func TestUpdateSearchMatches(t *testing.T) {
-	model := newTestModel()
-
-	model.logEntries = []domain.LogEntry{
-		{Line: "error: something failed"},
-		{Line: "info: all good"},
-		{Line: "error: another failure"},
-		{Line: "debug: test message"},
-	}
-
-	model.searchPattern = "error"
-	model.updateSearchMatches()
-
-	assert.Len(t, model.searchMatches, 2)
-	assert.Equal(t, 0, model.searchMatches[0])
-	assert.Equal(t, 2, model.searchMatches[1])
 }
 
 func TestFollowModeDefaults(t *testing.T) {
@@ -615,10 +598,7 @@ func updateModel(m Model, msg tea.Msg) Model {
 // header+footer margin). followMode starts true, so the cursor begins pinned
 // to the newest row.
 func newRequestsModel(n, viewportHeight int) Model {
-	m := newTestModel()
-	m.viewMode = ViewModeRequests
-	m.proxyRequests = makeTestRequests(n)
-	return updateModel(m, tea.WindowSizeMsg{Width: 120, Height: viewportHeight + 6})
+	return newSearchModel(viewportHeight, makeTestRequests(n))
 }
 
 // makeTestRequests builds n proxy request records with the shared fixture
@@ -993,4 +973,307 @@ func TestRequestsCursor_MarkerOnCursorRow(t *testing.T) {
 	}
 	assert.Equal(t, 1, markerCount, "exactly one cursor marker is rendered")
 	assert.Contains(t, markerLine, "/path/001", "the marker sits on the cursor row")
+}
+
+// --- Requests-view search navigation tests (C3 / D12-D13) ---
+
+// newSearchModel builds a Model in the requests view holding the given request
+// records, viewport sized to viewportHeight, follow-mode default (true) so the
+// cursor starts pinned to the newest row.
+func newSearchModel(viewportHeight int, reqs []proxy.RequestRecord) Model {
+	m := newTestModel()
+	m.viewMode = ViewModeRequests
+	m.proxyRequests = reqs
+	return updateModel(m, tea.WindowSizeMsg{Width: 120, Height: viewportHeight + 6})
+}
+
+// commitSearch drives the `/`-search flow: enter search mode, set the query,
+// and press Enter. handleSearchKey's enter case routes the commit itself
+// (jump in the requests view, filter in the logs view) based on m.viewMode,
+// so one driver helper serves both views.
+func commitSearch(m Model, query string) Model {
+	m = updateModel(m, keyRune('/'))
+	m.textInput.SetValue(query)
+	return updateModel(m, tea.KeyMsg{Type: tea.KeyEnter})
+}
+
+// searchFixture builds requests where /alpha matches rows 0 and 2 (with a POST
+// at row 3 and /beta rows between), for at-or-after and n/N tests.
+func searchFixture() []proxy.RequestRecord {
+	base := time.Unix(0, 0)
+	specs := []struct {
+		id, method, url string
+	}{
+		{"r0", "GET", "/alpha"},
+		{"r1", "GET", "/beta"},
+		{"r2", "GET", "/alpha/2"},
+		{"r3", "POST", "/gamma"},
+	}
+	reqs := make([]proxy.RequestRecord, len(specs))
+	for i, s := range specs {
+		reqs[i] = proxy.RequestRecord{
+			ID: s.id, Timestamp: base.Add(time.Duration(i) * time.Second),
+			Method: s.method, URL: s.url, StatusCode: 200, Duration: 5 * time.Millisecond,
+		}
+	}
+	return reqs
+}
+
+func TestRequestsSearch_JumpAtOrAfterAndWrap(t *testing.T) {
+	m := newSearchModel(20, searchFixture())
+	m = updateModel(m, keyRune('g')) // cursor row 0 (/alpha), follow off
+	require.Equal(t, "r0", m.cursorID)
+
+	// Cursor already sits on a match: at-or-after leaves it in place.
+	m = commitSearch(m, "alpha")
+	assert.Equal(t, "alpha", m.requestSearchQuery)
+	assert.Equal(t, "r0", m.cursorID, "at-or-after stays on a cursor that already matches")
+
+	// From row 1 (/beta, no match), the next match at-or-after is row 2.
+	m = updateModel(m, keyRune('g'))
+	m = updateModel(m, keyRune('j')) // row 1
+	require.Equal(t, "r1", m.cursorID)
+	m = commitSearch(m, "alpha")
+	assert.Equal(t, "r2", m.cursorID, "jumps forward to the next match")
+
+	// From row 3 (/gamma, no match), at-or-after wraps to row 0.
+	m = updateModel(m, keyRune('j')) // row 3 (last)
+	require.Equal(t, "r3", m.cursorID)
+	m = commitSearch(m, "alpha")
+	assert.Equal(t, "r0", m.cursorID, "at-or-after wraps around to the first match")
+}
+
+func TestRequestsSearch_NextPrevWrap(t *testing.T) {
+	m := newSearchModel(20, searchFixture())
+	m = updateModel(m, keyRune('g')) // row 0
+	m = commitSearch(m, "alpha")
+	require.Equal(t, "r0", m.cursorID)
+
+	m = updateModel(m, keyRune('n'))
+	assert.Equal(t, "r2", m.cursorID, "n advances to the next match")
+	m = updateModel(m, keyRune('n'))
+	assert.Equal(t, "r0", m.cursorID, "n wraps to the first match")
+
+	m = updateModel(m, keyRune('N'))
+	assert.Equal(t, "r2", m.cursorID, "N wraps backward to the last match")
+	m = updateModel(m, keyRune('N'))
+	assert.Equal(t, "r0", m.cursorID, "N retreats to the previous match")
+}
+
+func TestRequestsSearch_OffScreenScrollsMinimally(t *testing.T) {
+	reqs := makeTestRequests(30)
+	reqs[2].URL = "/target/a"
+	reqs[25].URL = "/target/b"
+	m := newSearchModel(5, reqs) // viewport height 5
+	m = updateModel(m, keyRune('g'))
+	require.Equal(t, 0, m.viewport.YOffset)
+
+	// Jump to the first match (row 2), already on-screen: no scroll.
+	m = commitSearch(m, "target")
+	assert.Equal(t, 2, m.cursorIdx)
+	assert.True(t, cursorVisible(m))
+
+	// n jumps down to row 25 off-screen: scroll the minimum (YOffset = 25-5+1).
+	m = updateModel(m, keyRune('n'))
+	assert.Equal(t, 25, m.cursorIdx)
+	assert.True(t, cursorVisible(m))
+	assert.Equal(t, 21, m.viewport.YOffset, "downward jump scrolls minimally")
+
+	// N jumps back up to row 2 off-screen: scroll up to place it at the top.
+	m = updateModel(m, keyRune('N'))
+	assert.Equal(t, 2, m.cursorIdx)
+	assert.True(t, cursorVisible(m))
+	assert.Equal(t, 2, m.viewport.YOffset, "upward jump scrolls minimally")
+}
+
+func TestRequestsSearch_ComposesWithFilter(t *testing.T) {
+	reqs := makeTestRequests(20)
+	for i := range reqs {
+		if i%2 == 0 {
+			reqs[i].Subdomain = "api"
+		} else {
+			reqs[i].Subdomain = "web"
+		}
+	}
+	reqs[4].URL = "/match/a"  // api  -> in the filtered list
+	reqs[5].URL = "/match/b"  // web  -> filtered OUT, must never be selected
+	reqs[12].URL = "/match/c" // api  -> in the filtered list
+
+	m := newSearchModel(40, reqs)
+	m.searchPattern = "api" // active `s` filter: only the 10 api rows remain
+	m.followMode = false
+	m.updateViewport()
+	m = updateModel(m, keyRune('g'))
+
+	// Matches are computed over the FILTERED list, so /match/b (web) is skipped.
+	m = commitSearch(m, "match")
+	assert.Equal(t, "req-004", m.cursorID, "search over the filtered list finds the first api match")
+	m = updateModel(m, keyRune('n'))
+	assert.Equal(t, "req-012", m.cursorID)
+	m = updateModel(m, keyRune('n'))
+	assert.Equal(t, "req-004", m.cursorID, "wraps over api matches only, skipping the filtered-out web row")
+	assert.Equal(t, "api", m.searchPattern, "the `s` filter is untouched")
+}
+
+func TestRequestsSearch_DoesNotFilter(t *testing.T) {
+	reqs := makeTestRequests(10)
+	reqs[3].URL = "/needle"
+	m := newSearchModel(20, reqs)
+	before := len(m.filteredProxyRequests())
+
+	m = commitSearch(m, "needle")
+	assert.Empty(t, m.searchPattern, "/ in the requests view must not touch the `s` filter")
+	assert.Equal(t, "needle", m.requestSearchQuery)
+	assert.Len(t, m.filteredProxyRequests(), before, "/ navigates; it must not hide rows")
+	assert.Len(t, m.proxyRequests, 10)
+}
+
+func TestRequestsSearch_NoMatch(t *testing.T) {
+	reqs := makeTestRequests(10)
+	m := newSearchModel(20, reqs)
+	m = updateModel(m, keyRune('g'))
+	m = updateModel(m, keyRune('j')) // row 1
+	require.Equal(t, 1, m.cursorIdx)
+
+	m = commitSearch(m, "zzz-nomatch")
+	assert.Equal(t, 1, m.cursorIdx, "a query with no match leaves the cursor unmoved")
+	assert.Equal(t, "req-001", m.cursorID)
+
+	// n/N are also no-ops when nothing matches.
+	m = updateModel(m, keyRune('n'))
+	assert.Equal(t, 1, m.cursorIdx)
+
+	bar := m.statusBar("")
+	assert.Contains(t, bar, "/zzz-nomatch (0 matches)", "status shows the 0-match form")
+}
+
+func TestRequestsSearch_EscClearsQuery(t *testing.T) {
+	reqs := makeTestRequests(10)
+	reqs[3].URL = "/needle"
+	m := newSearchModel(20, reqs)
+	m = commitSearch(m, "needle")
+	require.Equal(t, "needle", m.requestSearchQuery)
+
+	m = updateModel(m, tea.KeyMsg{Type: tea.KeyEscape})
+	assert.Empty(t, m.requestSearchQuery, "esc clears the requests-view search query")
+}
+
+func TestLogsSearch_SlashStillFilters(t *testing.T) {
+	m := newTestModel()
+	m = updateModel(m, tea.WindowSizeMsg{Width: 120, Height: 20})
+	m.logEntries = []domain.LogEntry{
+		{Process: "p", Line: "keep me"},
+		{Process: "p", Line: "drop it"},
+		{Process: "p", Line: "keep this too"},
+	}
+	require.Equal(t, ViewModeLogs, m.viewMode)
+
+	m = commitSearch(m, "keep")
+	assert.Equal(t, "keep", m.searchPattern, "logs-view / commits the substring filter (unchanged)")
+	assert.Empty(t, m.requestSearchQuery, "logs-view / must not set the requests query")
+	assert.Len(t, m.filteredEntries(), 2, "logs-view / hides non-matching lines")
+}
+
+func TestRequestsSearch_StatusPrecedence(t *testing.T) {
+	reqs := makeTestRequests(10)
+	reqs[3].URL = "/path/needle" // matches both the `path` filter and the search
+	m := newSearchModel(40, reqs)
+	m.soloProcess = "web" // a logs concept: must NOT appear in the requests view
+	m.searchPattern = "path"
+	m.followMode = false
+	m.updateViewport()
+	m = updateModel(m, keyRune('g'))
+
+	m = commitSearch(m, "needle")
+	bar := m.statusBar("")
+	assert.Contains(t, bar, "/needle (1/1)", "search indicator wins, with the cursor's match position")
+	assert.Contains(t, bar, "filter: path", "the active `s` filter is appended")
+	assert.NotContains(t, bar, "Showing:", "solo is never shown in the requests view")
+
+	// Prompt precedence: while typing a search, the input prompt wins over the
+	// committed indicator.
+	m2 := updateModel(m, keyRune('/'))
+	assert.Contains(t, m2.statusBar(""), "Search:", "the mode prompt takes precedence")
+}
+
+func TestRequestsSearch_UnicodeStatusWidth(t *testing.T) {
+	m := newSearchModel(40, makeTestRequests(5))
+	m.width = 120
+
+	m.requestSearchQuery = "日本語テスト"
+	unicodeBar := m.statusBar("")
+
+	// The layout is measured in display columns, not bytes: an ASCII query of
+	// the same DISPLAY width must produce a bar of the same rendered width.
+	// Scope note: this guards layout stability for wide-rune queries (the
+	// left side, laid out by lipgloss). It cannot catch a regression of the
+	// right side's lipgloss.Width back to len — the right side is
+	// structurally ASCII, so no assertion can distinguish them there.
+	m.requestSearchQuery = strings.Repeat("x", lipgloss.Width("日本語テスト"))
+	asciiBar := m.statusBar("")
+	assert.Equal(t, lipgloss.Width(asciiBar), lipgloss.Width(unicodeBar),
+		"a Unicode query must not change the status-bar layout width")
+}
+
+func TestRequestsSearch_WrapToNewestNoFollow(t *testing.T) {
+	reqs := makeTestRequests(6)
+	reqs[0].URL = "/hit/a"
+	reqs[5].URL = "/hit/b" // the newest (last) row also matches
+	m := newSearchModel(20, reqs)
+	m = updateModel(m, keyRune('g')) // cursor row 0, follow off
+	require.False(t, m.followMode)
+
+	m = commitSearch(m, "hit")
+	require.Equal(t, 0, m.cursorIdx)
+	require.False(t, m.followMode)
+
+	// n wraps forward onto the newest row. Unlike `j`, a search jump is
+	// positioning, not scrolling intent: it must NOT re-engage follow.
+	m = updateModel(m, keyRune('n'))
+	assert.Equal(t, 5, m.cursorIdx)
+	assert.Equal(t, "req-005", m.cursorID)
+	assert.False(t, m.followMode, "a search jump onto the newest row must not re-engage follow")
+}
+
+func TestRequestsSearch_FollowPreservedOnNewestRowMatch(t *testing.T) {
+	// Follow on, cursor pinned to the newest row, which matches the query: the
+	// jump lands where the cursor already is, so follow must stay engaged —
+	// disengaging would silently stop auto-follow after a no-op jump.
+	reqs := makeTestRequests(6)
+	reqs[5].URL = "/hit/newest"
+	m := newSearchModel(20, reqs)
+	require.True(t, m.followMode)
+	require.Equal(t, 5, m.cursorIdx, "follow pins the cursor to the newest row")
+
+	m = commitSearch(m, "hit")
+	assert.Equal(t, 5, m.cursorIdx)
+	assert.True(t, m.followMode, "a jump landing on the newest row must preserve follow")
+
+	// A jump that MOVES the cursor off the newest row must disengage follow,
+	// or resolveRequestCursor's pin-to-newest would immediately undo it.
+	reqs2 := makeTestRequests(6)
+	reqs2[2].URL = "/hit/mid"
+	m2 := newSearchModel(20, reqs2)
+	require.True(t, m2.followMode)
+	m2 = commitSearch(m2, "hit")
+	assert.Equal(t, 2, m2.cursorIdx, "the jump must stick")
+	assert.Equal(t, "req-002", m2.cursorID)
+	assert.False(t, m2.followMode, "jumping off the newest row must disengage follow")
+}
+
+func TestRequestsSearch_SingleMatchNextPrevNoop(t *testing.T) {
+	// n/N scan strictly past the cursor and never revisit its own row, so with
+	// the sole match under the cursor they are documented no-ops.
+	reqs := makeTestRequests(5)
+	reqs[2].URL = "/only/hit"
+	m := newSearchModel(20, reqs)
+	m = updateModel(m, keyRune('g'))
+	m = commitSearch(m, "hit")
+	require.Equal(t, 2, m.cursorIdx)
+
+	m = updateModel(m, keyRune('n'))
+	assert.Equal(t, 2, m.cursorIdx, "n with a sole match is a no-op")
+	m = updateModel(m, keyRune('N'))
+	assert.Equal(t, 2, m.cursorIdx, "N with a sole match is a no-op")
+	assert.Equal(t, "req-002", m.cursorID)
 }

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -101,6 +101,16 @@ var (
 	httpErrorStyle = lipgloss.NewStyle().
 			Foreground(errorColor)
 
+	// Cursor marker style for the selected row in the requests view. Bold +
+	// magenta accent (from the process palette, and distinct from the HTTP
+	// status colors) so the "❯ " marker reads clearly against the row's own
+	// dim/colored segments. Only the marker is styled, never the whole row:
+	// each row is a concatenation of individually styled segments whose ANSI
+	// resets would terminate an outer attribute mid-line (see D10).
+	cursorStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("13")).
+			Bold(true)
+
 	// Process colors for log lines
 	processColors []lipgloss.Style
 )

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -33,7 +33,21 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.handleLogEntry(domain.LogEntry(msg))
 
 	case ProxyRequestMsg:
-		m.handleProxyRequest(proxy.RequestRecord(msg))
+		record := proxy.RequestRecord(msg)
+		m.handleProxyRequest(record)
+		// Live-refresh an open detail view once its request completes (D15).
+		// Local records carry full Details already (no fetch needed, unlike
+		// attach mode); Upsert's monotonic in-flight->final state machine
+		// guarantees at most one matching final message per ID, so this
+		// fires once. updateViewport never resets YOffset on its own, so the
+		// reader's scroll position is preserved; the clamp covers the one
+		// case where the final content is SHORTER than the in-flight view
+		// (capture disabled: the note lines vanish, nothing replaces them).
+		if m.viewMode == ViewModeRequestDetail && m.selectedRequestID == record.ID && !record.InFlight {
+			m.requestDetail = convertRequestRecordToDetail(record)
+			m.updateViewport()
+			m.clampViewportToContent()
+		}
 
 	case ProcessesMsg:
 		m.processes = m.supervisor.Processes()

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -118,7 +118,7 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 						break
 					}
 				}
-				m.updateViewport()
+				m.renderDetailFromTop()
 			}
 		}
 		return m, nil


### PR DESCRIPTION
Implements #55, #47, and #54 (plan 007, panel-reviewed by Codex + GLM 5.2 + CodeRabbit). Closes #55, closes #47, closes #54.

## What changed

### #55 — daemon crash-restart 409 self-heal (`61bd1de`, daemon-side)
A `kill -9`'d `prox up` left a stale registration that 409'd an immediate restart until the 30s sweep. The daemon now detects a same-dir conflict whose holder PID is dead (signal-0) and replaces the registration inline: typed `ProjectConflictError` from `Registry.Register` (holder PID captured under the detecting lock), PID-guarded removal (purging the dead generation's records + body files, closing its listeners), one retried registration, brief bind retry on the replace path (kernel can hold a just-closed port a few ms). A live holder still 409s — the message now names the holding PID.

Correctness structure: a new `Server.lifecycleMu` serializes lifecycle transactions end-to-end (a sweep tick racing a self-heal could previously close the new generation's listeners or purge its records — registry mutation and physical cleanup were separate steps); shutdown-on-empty is a shared graced helper (`scheduleShutdownWhenEmpty`, injectable delay) used by deregister, the sweep, and register rollbacks (a rollback that emptied the registry used to strand an idle daemon forever), with epoch-guarded timers and a `SHUTTING_DOWN` 503 so a register queued behind a shutdown decision can't get a false 200. `pid > 0` is now validated at registration.

**⚠️ The user-facing fix requires a daemon restart; the exact-match version gate makes the old daemon refuse new clients loudly (unchanged behavior).**

### #47 — TUI requests-view cursor + search navigation (`73d98e3`, `fc11719`)
- Explicit ID-anchored cursor ("❯ " marker) decoupled from scroll; Enter opens exactly the cursor row (both local and attach modes); j/k/g/G + half-page pgup/pgdown; cursor rides its row across in-place completion updates and append+trim.
- Follow mode pins the cursor to the newest row; re-engagement is cursor-based (the old `isNearBottom` check is always true for a short list — arrivals would have yanked the cursor); disengage on upward movement, re-engage via G/F or moving onto the newest row.
- `/` now navigates instead of accidentally double-filtering: jumps to the first match at-or-after the cursor, n/N cycle with wraparound, derived match state (nothing stored, nothing to go stale), status-bar match indicator; `s` remains the filter and composes with search.
- Arrivals while a detail view is open no longer `GotoBottom`-yank it (pre-existing wart).
- Docs/help overlays reconciled with reality — the logs-view `/` regex/highlight/n-N claims described behavior that never existed; corrected, and #56 filed for actually adding logs-view match navigation.

### #54 — detail live-refresh (`874bd23`, builds on #47)
- Local mode: a matching final record re-converts the open detail in place (scroll preserved, clamped if the final content is shorter).
- Attach mode: completion triggers a background re-fetch guarded by a fetch sequence — stale-ID/superseded responses (success and error) are dropped entirely (previously `detailLoading` was mutated before the ID guard), plus a content guard so an in-flight payload can't overwrite a displayed final.
- A failed refresh keeps the snapshot and shows "(live refresh failed — press esc and re-enter to reload)" instead of silently promising details forever.

## Verification

- Per-commit gate: `make lint && make test && make test-race && make build`, green ×4.
- Per-commit codex correctness reviews (C1 adversarial): 6 findings across the four commits, all fixed in their commits (each commit message carries its dispositions); one dispositioned as pre-existing/accepted (register vs `prox proxy stop --force` teardown race — predates this change).
- New tests: ~26 daemon-side (typed error, self-heal lifecycle/e2e with a real DynamicProxy + real TCP listeners proving close/rebind and routed traffic, register-vs-sweep concurrency under `-race`, graced-shutdown helper both ways, epoch stand-down, SHUTTING_DOWN refusal) and ~45 TUI-side (cursor movement/visibility/follow/ID-stability/transitions, search jump/cycle/status, detail-refresh guard matrix incl. per-branch drops), plus the first ClientModel test harness (stub TUIClient).
- **Live pass** (isolated HOME, real binary, daemon topology — transcript in the plan artifacts): kill -9 → immediate restart (~9ms later) registered successfully and the first proxied request returned 200; daemon log shows "replacing stale registration"; a direct-socket register against the live healed instance 409s naming the holder PID; teardown clean. TUI verified by unit tests only (pinned scope, as plans 005/006).

## Notes for review
- Dependency/privacy/secret impact: none (no new dependencies, no wire-format changes, no new endpoints).
- Accepted risks (plan §9): PID-reuse blindness (pre-existing, same as the sweep); `lifecycleMu` serializes cert generation with deregisters (dev-tool tradeoff); brief port-unbound window during a replace (owner was dead); per-keypress O(n≤1000) re-render for cursor moves; mouse input remains disabled program-wide (wheel scrolling never worked; future work); failed attach refresh needs esc+re-enter (no auto-retry).
- Observed while live-testing, out of scope: a kill -9'd supervisor's orphaned backend can wedge holding its port (502 until cleaned) — supervisor territory, noted in the verification transcript.

<details>
<summary>Plan 007 (full text, including panel dispositions and verification record)</summary>

```markdown
# 007 — Crash-restart 409 self-heal (#55) + TUI requests cursor/search (#47) + detail live-refresh (#54)

Status: panel-reviewed (Codex + GLM 5.2 + CodeRabbit, 2026-07-18)
Repo: /Users/charliek/projects/prox (single-repo scope)
Baseline: main @ b31163c
Branch: feature/plan-007-selfheal-tui-cursor
Artifacts: ~/.claude/plans/prox/007-selfheal-tui-cursor/
Issues: #55 (daemon, first), #47 (TUI cursor+search), #54 (TUI detail refresh)
— one PR. Fallback pinned by the user: #55 is daemon-side and fully
independent of #47/#54; if the TUI work proves deeper than planned, ship C1
(#55) alone and re-plan #47/#54 — the commit ordering keeps that split clean.

Panel corrections incorporated (dispositions in §10):
- Server lifecycle mutex serializing register/deregister/stale-removal —
  the sweep's finishRemoval runs outside the registry lock, so the original
  compose-of-primitives flow could race a concurrent sweep tick into
  PORT_BIND_FAILED or purge the new generation's records (Codex critical).
- Typed conflict error from Registry.Register (kind + existing PID captured
  under the same lock) replaces the TOCTOU accessor inference (Codex
  critical; CodeRabbit m1).
- scheduleShutdownWhenEmpty helper (injectable delay, tested) used by
  deregister, sweep, and register-rollback — rollback after a self-heal
  replace could otherwise strand an idle daemon forever (CodeRabbit M2/M3;
  Codex; GLM M1).
- Requests-view follow re-engagement is cursor-based, not isNearBottom-based
  — with a short list AtBottom() is always true and every arrival would
  yank the cursor (CodeRabbit M1); effective follow state computed before
  render (Codex).
- Cursor visibility is an updateViewport invariant (covers tab-in, resize,
  filter changes, trim, detail-return), not a per-keypress afterthought;
  single setRequestCursor helper owns cursorID+cursorIdx (Codex).
- Mouse input is not enabled in the program at all (no WithMouse option,
  verified) — all wheel-scroll language dropped; future work (Codex).
- Attach detail refresh guarded by a fetch sequence token (error
  attribution across overlapping fetches) plus the in-flight-vs-final
  content check; loading/error mutations move inside the ID guard —
  today they mutate state for stale IDs (Codex, verified client.go:117/:125);
  refresh failure surfaces a note instead of silently keeping the
  "(in flight)" promise (Codex; CodeRabbit m3).
- C1 self-heal e2e must run a real DynamicProxy with real listeners —
  the registry-only socket scaffold cannot prove close/rebind (Codex
  critical); body-file purge asserted (Codex).

## 1. Problem / motivation

1. **#55 — crash-restart 409.** If a `prox up` process dies without
   deregistering (kill -9, terminal crash), its daemon registration survives
   until the 30s stale-PID sweep. Restarting `prox up` inside that window
   fails hard with `failed to register with proxy daemon: project <dir> is
   already registered; deregister first`, and the user's only recourse is to
   wait or `prox proxy stop --force`. Pre-existing wart noted in plans
   005/006 §9.
2. **#47 — no cursor in the requests view.** "Selected" is implicitly the
   top viewport row (`getSelectedRequest` reads `viewport.YOffset`); users
   can't see what Enter will open. `/` (ModeSearch) only indexes log
   entries; the computed `searchMatches` are consumed nowhere; docs claim
   n/N match navigation that does not exist anywhere in the code.
3. **#54 — stale detail snapshot.** A detail view opened on an in-flight
   request keeps showing "(in flight)" after the request completes; the
   user must close and reopen. Documented behavior today; CodeRabbit
   follow-up from PR #52.

## 2. Current state (verified this session)

Daemon registration (#55):
- Same-dir conflict originates at registry.go:79-81 — the
  `projects[req.ProjectDir]` existence check is the FIRST check in
  `Register` (route-level conflicts at registry.go:126-131 can only involve
  OTHER projects' routes). All Register errors map to HTTP 409
  `REGISTRATION_CONFLICT` at server.go:158-164; the client discards the
  code and surfaces the message (client.go:236-244), and `tryDaemonProxy`
  hard-fails on it with no retry (up.go:819-822, startProxy up.go:775-777).
- `Registry.mu` guards routes/projects/listeners; `Register` is one
  check-then-commit critical section (registry.go:74-190).
  `DeregisterIfPID` (registry.go:206-216) re-checks `proj.PID == pid` under
  the same lock acquisition that removes — the sweep-vs-reregister race
  guard, pinned by `TestServer_RemoveStaleProject_SkipsReRegistered`
  (server_lifecycle_test.go:97-128). **But**: registry mutation and
  physical cleanup are NOT one atomic unit — `removeStaleProject`
  (server.go:276-287) = `DeregisterIfPID` (locked) THEN `finishRemoval`
  (unlocked: listener close + `PurgeByProject`, server.go:292-304). Two
  concurrent removal/registration flows for the same dir can interleave
  registry state and physical cleanup.
- There is no generation concept; PID is the generation
  (ProjectRegistration fields registry.go:34-41). `PurgeByProject` is
  scoped by dir only, not PID.
- Liveness primitive: `daemon.ProcessExists(pid)` — signal-0, EPERM counts
  as alive (internal/daemon/pidfile.go:143-153). Already used by
  `Registry.StalePIDs` (registry.go:313-323). server.go does not yet import
  internal/daemon.
- Sweep: every 30s (daemon.go:33, loop daemon.go:198-227):
  `StalePIDs()` → `removeStaleProject` per stale entry → **immediate**
  `RequestShutdown()` when `len(stale) > 0 && registry.IsEmpty()`
  (daemon.go:206-224). Contrast: `handleDeregister` shuts down only after a
  5s re-check grace for rapid down/up cycles (server.go:245-254).
- handleRegister rollback paths (cert failure, port-bind failure) use
  unguarded `registry.Deregister` (server.go:171, :192) and schedule no
  shutdown check.
- Existing test scaffolding: `newLifecycleServer()`
  (server_lifecycle_test.go:19-25) — registry + RequestManager, NO
  DynamicProxy/listeners; dead-PID pattern via a reaped
  `exec.Command("true")` child (TestServer_StalePIDSweep_PurgesRecords
  :64-91); "always-alive" pattern via PID 1
  (TestServer_RemoveStaleProject_SkipsReRegistered :97-128); full
  socket-level client/server tests in client_server_test.go (registry-only
  scaffold, startTestServer :20). `TestRegistry_DuplicateProject`
  (registry_test.go:234-250) pins the same-dir conflict using fixed PID
  12345 (newTestRequest, registry_test.go:7-17) — registry-level, no
  liveness involved, so it stays valid under this plan (liveness lives at
  the server level).

TUI requests view (#47):
- `formatProxyRequest` (base.go:690-738) emits exactly ONE line per
  request; `updateViewport` (base.go:421-443) joins lines and is the ONLY
  `SetContent` call site — the single choke point every list mutation
  already flows through. The bubbles viewport does not wrap; long lines
  clip. No highlight/selection styling exists anywhere.
- **Mouse input is not enabled**: both `tea.NewProgram` calls pass only
  `tea.WithAltScreen()` (app.go:25, :123) — no `WithMouse*` option, so no
  MouseMsg ever arrives and `viewport.Update` (update.go:59, client.go:138)
  is a no-op for scrolling in practice. All navigation is keyboard, via
  `handleNavigationKey` (base.go:283-395), because `tea.KeyMsg` returns
  early from Update (update.go:25-26).
- `getSelectedRequest` (base.go:668-687): `viewport.YOffset` indexed into
  `filteredProxyRequests()`. Two call sites, both Enter handlers:
  update.go:107-124 (Model, converts locally) and client.go:184-198
  (ClientModel, async `fetchRequestDetail`). Neither Enter path resets the
  viewport, so a detail opened from deep in the list inherits a large
  YOffset.
- Follow mode: `handleProxyRequest` (base.go:155-187) checks
  `isNearBottom()` BEFORE mutating and re-enables follow when true.
  **When the list fits in the viewport, `viewport.AtBottom()` is always
  true**, so every arrival re-engages follow. It also calls
  `updateViewport` before setting followMode, and runs unconditionally in
  every view mode — including ViewModeRequestDetail, where its
  `GotoBottom()` yanks the detail viewport while the user reads.
  Upsert scans newest→oldest, replaces in place, else append +
  trim-to-1000 (trim only on the append path).
- Filter vs search: `s` (ModeStringFilter) live-writes `searchPattern`
  (base.go:246-269); `filteredProxyRequests` (base.go:648-666) filters on
  it over URL/Method/Subdomain. `/` (ModeSearch, base.go:308-314) ALSO
  commits to `searchPattern` (base.go:224-243) — in the requests view it
  acts as a second filter today. In the logs view both `/` and `s` are
  case-insensitive substring filters over the line; `/` commits on Enter,
  `s` applies live per keystroke; nothing is regex despite the help
  overlay's "(regex)" claim (base.go:910). `updateSearchMatches`
  (base.go:397-410) scans `logEntries` only; `searchMatches` is written,
  cleared on esc (base.go:354), and read nowhere — dead state. No n/N
  handling exists anywhere ("n" only appears as select-none in ModeFilter,
  base.go:210).
- statusBar (base.go:792-853): left side prioritizes mode prompts, then
  soloProcess, then searchPattern — regardless of view; width math uses
  byte `len(right)` (base.go:844).
- Tests (direct-call style, no PTY): `TestModel_ProxyRequestMsg_SelectionStable`
  (model_test.go:396-425) pins YOffset-selection stability across in-place
  update — must be migrated to cursor semantics.
  `TestModel_ProxyRequestMsg` (:322-390) pins upsert-not-duplicate;
  `TestProxyRequestBufferLimit` (:302-320) pins trim; format tests
  (:444-597); `TestUpdateSearchMatches` (:173-189) pins the dead logs
  match indexing. No ClientModel tests exist at all.

Detail view (#54):
- State: `selectedRequestID`, `requestDetail *RequestDetailData`,
  `detailLoading`, `detailError` on BaseModel (base.go:68-71). Local mode
  converts synchronously via `convertRequestRecordToDetail`
  (update.go:114-120; converter base.go:992-1024 copies InFlight). Attach
  mode fetches via `fetchRequestDetail` → `GetProxyRequest(id, true)`
  (client.go:210-245; `GET /api/v1/proxy/requests/{id}?include=body`).
- `RequestDetailMsg`/`RequestDetailErrorMsg` handled only in
  ClientModel.Update (client.go:116-129). **Both set
  `detailLoading = false` BEFORE the `msg.ID == m.selectedRequestID`
  guard** (client.go:117, :125) — a stale response for request A clears
  the loading state shown for newly selected request B. The guard also
  cannot distinguish an in-flight payload arriving after a final one for
  the same ID, nor attribute an error to the fetch that produced it.
- Local-mode ProxyRequestMsg carries the full record including Details
  (app.go:96-108). Attach-mode reconstruction (app.go:222-231) never sets
  Details — attach MUST re-fetch. Upsert semantics (requests.go:204-254,
  plan 006 D1: records transition absent→in-flight→final monotonically,
  duplicates are silent no-ops) guarantee a matching final ProxyRequestMsg
  arrives at most once.
- Docs: docs/reference/tui.md:117-121 documents "Detail views do not
  live-update — reopen the request..."; tui.md:84-85 and :155 document
  logs-view `/` highlight + n/N navigation that DOES NOT EXIST in code
  (pre-existing doc error); requests-view key table at tui.md:89-95.

Gate (Makefile, plans 004-006 convention):
`make lint && make test && make test-race && make build` (~3min).

## 3. Design decisions (PINNED)

### WS1 — #55 crash-restart self-heal

**D1. Typed conflict error from `Registry.Register`.** `Register`'s
same-dir branch returns a typed error, e.g.
`*ProjectConflictError{Dir string, PID int}` (satisfying `error`,
matched via `errors.As`), with the existing registration's PID captured
under the SAME lock acquisition that detected the conflict — no separate
accessor, no TOCTOU inference. All other Register errors (route conflict,
port/protocol validation) stay plain and are never retried. The
live-conflict message is upgraded to name the holder: `project %s is
already registered by a running prox up (PID %d); stop it or run 'prox
proxy stop --force'` (tests asserting the old string updated).
`handleRegister` additionally validates `req.PID > 0` → 400 BAD_REQUEST
(`ProcessExists(0)`/negative PIDs have signal-broadcast semantics and
would read as permanently alive).

**D2. Server lifecycle mutex.** New `Server.lifecycleMu sync.Mutex`
serializing every control-plane lifecycle transaction end-to-end
(registry mutation + physical listener add/remove + record purge):
- `handleRegister`'s whole register-through-listener-start flow
  (acquired after decode/validation, released before writing the
  response), including its rollback paths;
- `removeProject` (explicit deregister) and `removeStaleProject` (sweep),
  which become thin locked wrappers over lock-held internals so
  `handleRegister` can invoke the stale-removal internal while already
  holding the mutex (no self-deadlock).
Rationale: registry mutation and physical cleanup are today two separate
steps (§2), so a sweep tick racing a self-heal register could close the
new generation's listener, fail the retry with PORT_BIND_FAILED, or
purge the new generation's records (PurgeByProject is dir-scoped, not
generation-scoped). Serializing the control plane excludes the whole
class structurally; the data plane (route Lookup, proxying, SSE) never
touches this mutex. These operations are rare and fast; the one slow
holder is cert generation on first HTTPS registration — accepted for a
dev tool (noted §9). The existing `DeregisterIfPID` PID guard stays as
defense in depth (and `TestServer_RemoveStaleProject_SkipsReRegistered`
stays green).

**D3. Inline stale-registration replace in `handleRegister`.** Under
`lifecycleMu`:
1. `registry.Register(req)`; success → cert/listener phase as today.
2. On error: `errors.As` → `*ProjectConflictError`? If not → 409
   REGISTRATION_CONFLICT, exactly today (no retry for route/validation
   conflicts).
3. If yes and `daemon.ProcessExists(conflict.PID)` → 409 with the D1
   upgraded message (two concurrent `prox up`s is a real error).
4. If the PID is dead: `s.logger.Warn("replacing stale registration",
   ...)`; run the stale-removal internal (PID-guarded, purges the dead
   generation's records + body files, closes its listeners); retry
   `registry.Register(req)` exactly once. Success → cert/listener phase;
   failure → 409. Under the mutex the retry cannot lose a race — the
   single-retry is a correctness guarantee, not a heuristic.
Why not one registry-level critical section instead: an in-registry
replace would delete the dead registration's listener bookkeeping and
immediately re-mark those ports as "needed" while the physical listeners
are still bound, making `AddListener` fail into rollback. Close-then-
rebind under the lifecycle mutex is correct; the brief unbound window is
harmless (the project was dead — no live traffic).
Implementation amendment (C1, kept): the same-port close-then-rebind can
transiently fail because the OS briefly holds a just-closed listening
port; the REPLACE path (only) binds via a brief retry
(`addListenerWithBriefRetry`, 10×20ms ≈200ms cap) so the self-heal
promise doesn't fail intermittently. Normal registrations keep the
single-shot bind.

**D4. `scheduleShutdownWhenEmpty` helper.** Extract the deregister
grace pattern (server.go:247-253) into
`Server.scheduleShutdownWhenEmpty()` — goroutine, delay (field on
Server, default 5s, injectable for tests), re-check `registry.IsEmpty()`,
then `RequestShutdown()`. Used by: `handleDeregister` (replacing its
inline copy), the sweep's shutdown branch (replacing the immediate
shutdown at daemon.go:220-224 — closes the removal→retry window: the
re-check sees the self-heal's completed registration), and
`handleRegister`'s rollback paths (today a rollback that empties the
registry strands an idle daemon forever — after D3 that includes the
crash-restart path, so the rollback schedules the same graced check).
Tested directly at the lifecycle-scaffold level with a short injected
delay: empty-after-delay → shutdown requested; registration lands during
the delay → no shutdown.

**D5. No client/wire changes.** The client keeps discarding the error
code; no retry loop client-side; `RegisterRequest` unchanged. The 30s
sweep stays as the backstop for dirs never re-registered. Version gate
unchanged — the fix is daemon-side; the user's real daemon needs a loud
restart (§9).

### WS2 — #47 explicit cursor + search navigation

**D6. Cursor state: ID-anchored, resolved at the render choke point,
mutated only through one helper.** New BaseModel fields
`cursorID string` + `cursorIdx int`, owned by a single
`setRequestCursor(requests []proxy.RequestRecord, idx int)` helper that
clamps idx into `[0, len-1]` (`-1`/`""` when empty) and updates BOTH
fields together — every mover (nav keys, search jumps, resolution) goes
through it, so the pair can never disagree. `updateViewport`'s
ViewModeRequests branch runs `resolveRequestCursor(requests)` before
formatting: follow mode → pin to the LAST (newest) row; else if
`cursorID` present in the filtered list → its index (in-place upsert and
appends never move the cursor off its row); else clamp the stale
`cursorIdx` (trim/filter removed the row) and re-anchor to the row now
at that index. Covers every mutation source — upsert, append+trim, live
filter keystrokes, esc clear — because they all already funnel through
`updateViewport`. Empty→non-empty transition: follow-mode pinning wins
(cursor to newest); with follow off, the clamp re-anchors at row 0.
Enter opens by `cursorID`, never by index. Production record IDs are
always non-empty (both proxy paths mint them — plan 006); `""` is the
explicit no-cursor sentinel, pinned by comment.

**D7. Cursor visibility is an updateViewport invariant.** Immediately
after `SetContent` in the requests branch: follow mode → `GotoBottom()`;
else `ensureCursorVisible()` — minimal scroll: `cursorIdx < YOffset` →
`SetYOffset(cursorIdx)`; `cursorIdx >= YOffset+Height` →
`SetYOffset(cursorIdx - Height + 1)`. Because the invariant lives in the
choke point rather than per-keypress, the marker is on-screen after every
transition: tab-in from logs (whose YOffset the shared viewport
retains), window resize, appends/trims, filter edits, detail-return.
`handleProxyRequest`'s own GotoBottom handling is subsumed for the
requests view.

**D8. Follow-mode/cursor interplay — cursor-based re-engagement.** In
ViewModeRequests, `handleProxyRequest` no longer consults
`isNearBottom()` (with a short list `AtBottom()` is ALWAYS true — every
arrival would re-engage follow and yank the cursor off the row the user
navigated to). Instead: effective follow = `followMode` unchanged by
arrivals; follow is DISENGAGED by upward cursor movement (`k`/`up`,
`pgup`, `g`) and RE-ENGAGED only by explicit `G`/`end`/`F`, or by the
user moving the cursor onto the last row (`j` onto the newest row
re-engages — the cursor analog of "scrolled back to bottom"). The
effective follow state is computed/settled BEFORE `updateViewport`
renders, so the marker and the scroll agree within a single message
(no render-then-flip). Logs view keeps today's isNearBottom semantics
untouched. In ViewModeRequestDetail, `handleProxyRequest` updates the
LIST data only and does not touch viewport scroll or follow at all
(today it GotoBottom-yanks the detail view on every arrival —
pre-existing wart, fixed here because live-refresh makes the detail view
a place users linger).

**D9. Requests-view navigation keys move the cursor.** In
`handleNavigationKey`, branching on `viewMode == ViewModeRequests`:
up/k → cursor-1 (follow off); down/j → cursor+1 (re-engages follow only
when landing on the last row); pgup/pgdown → cursor ∓ max(1, Height/2)
(half-page, matching the logs view's HalfView semantics; pgup follow
off; pgdown re-engages follow when it lands on the last row, mirroring j
— C2 implementation reading of D8's landing-on-last-row rule, kept); g/home → cursor 0 (follow off); G/end → cursor last (follow on);
F → toggle (on → cursor pins to last). Each handler mutates via
`setRequestCursor` then calls `updateViewport` (highlight is baked into
content; D7 handles scroll). Logs and detail views keep today's
raw-viewport behavior. Entering the detail view (`enter`) calls
`viewport.GotoTop()` (a detail opened from deep in the list otherwise
inherits the list's YOffset); returning (esc) re-enters the requests
branch where D7 restores cursor visibility. Mouse input remains
disabled program-wide (§2) — enabling it is future work, out of scope.

**D10. Cursor rendering: marker prefix.** `updateViewport` prefixes the
cursor row with `"❯ "` (new `cursorStyle` in styles.go — bold +
accent foreground) and every other row with two spaces, keeping columns
aligned. `formatProxyRequest` is untouched (its format tests stay
green). A row-wide style was rejected: the row is a concatenation of
individually styled segments whose ANSI resets terminate any outer
attribute mid-line (bold included), so a wrapping style renders
inconsistently. Per-keypress O(n≤1000) re-render through updateViewport
is accepted (§9). One line per request is verified (§2); no wrapping
work (the viewport clips long URLs — unchanged, non-goal).

**D11. `getSelectedRequest` becomes cursor-backed.** Same name and
signature (returns `cursorID`, `""` outside ViewModeRequests or on an
empty list); both Enter call sites work unchanged. The YOffset-based
scheme is deleted. `TestModel_ProxyRequestMsg_SelectionStable` is
rewritten to pin the new invariant: cursor (ID and index) survives an
in-place upsert of another row AND of its own row, and survives
append+trim while anchored to a still-present row.

**D12. `/` search in the requests view: navigation, not filtration.**
New BaseModel field `requestSearchQuery string`, deliberately separate
from `searchPattern` (which remains the `s` filter). `handleSearchKey`'s
enter branch: when `viewMode == ViewModeRequests`, commit the input to
`requestSearchQuery` (leaving `searchPattern` untouched) and jump the
cursor to the first match at-or-after the current cursor (wrapping).
"At-or-after" (vs vim's strictly-after) is deliberate: on a fresh search
the cursor may already sit on the best match; n exists for advancing.
Matching: case-insensitive substring over URL, Method, Subdomain — the
same fields the `s` filter uses — evaluated against the FILTERED list
(search composes with an active filter). This deliberately changes
today's accidental behavior where `/` in the requests view acted as a
second filter; documented. Logs-view `/` behavior is untouched, but its
dead byproduct is removed: `searchMatches`/`updateSearchMatches` (and
their esc-clear and test) are deleted — computed, cleared, read nowhere.

**D13. Match state is derived, never stored.** No stored match list or
pointer: `n` jumps the cursor to the next matching row strictly after
`cursorIdx` (wrapping), `N` to the previous (wrapping), via an O(n) scan
of the filtered list at keypress time. No-ops when `requestSearchQuery`
is empty or nothing matches; n/N are requests-view normal-mode keys only.
Search jumps (including `/`-enter) never RE-ENGAGE follow (a wrapped n
landing on the newest row does not re-engage it, unlike j/pgdown), and
disengage it only when the jump moves the cursor OFF the newest row — a
jump must stick against follow's pin-to-newest, but a match landing on
the newest row leaves follow untouched (C3 codex-review refinement of
the earlier "never change followMode" wording, which would have let
pin-to-newest instantly undo every jump or silently killed follow on
no-op jumps; test-pinned both ways). n/N with the sole match under the
cursor are documented no-ops (strictly-past scan never revisits the
cursor's own row).
Status bar (requests view; precedence pinned): mode prompts first (as
today); else when `requestSearchQuery` is set, `/<query> (i/k)` with i
the cursor's 1-based position among matches when the cursor is on a
match, or `/<query> (k matches)` when it isn't (0 included) — combined
with the filter indicator when `searchPattern` is also set (`filter:
<pattern>` appended); else the existing filter/solo/default lines
(soloProcess is a logs-view concept and is no longer shown in the
requests view). Status-bar width math for the new right/left strings
uses `lipgloss.Width`, not byte `len` (Unicode queries would misalign).
esc in normal mode clears `requestSearchQuery` alongside today's filter
clears. No per-row match highlighting (non-goal; cursor highlight only).

**D14. Docs reconciled with reality.** tui.md requests-view table gains
cursor keys, `/`, n/N; the requests-view help overlay likewise. The
logs-view claims of match highlighting and n/N navigation (tui.md:84-85,
:155) and the help overlay's "`/` Pattern filter (regex)" (base.go:910)
are corrected to the actual semantics: both `/` and `s` are
case-insensitive substring filters in the logs view — `/` commits on
Enter, `s` applies live. Logs-view match navigation stays out of scope;
a follow-up issue WILL be filed in Phase 6 (not deferred silently).

### WS3 — #54 detail live-refresh

**D15. Local mode: re-convert on the matching final ProxyRequestMsg.**
In `Model.Update`'s ProxyRequestMsg case, after `handleProxyRequest`: if
`viewMode == ViewModeRequestDetail && selectedRequestID == record.ID &&
!record.InFlight`, set `requestDetail =
convertRequestRecordToDetail(record)` and `updateViewport()`, preserving
the current detail YOffset (the user may be mid-read; content only
grows). Local records carry full Details (§2); Upsert's monotonic state
machine guarantees at most one such final message; the conversion is the
same one Enter uses — cheap, race-free (single update loop), idempotent.

**D16. Attach mode: re-fetch with a fetch-sequence guard.** In
`ClientModel.Update`'s ProxyRequestMsg case, after `handleProxyRequest`:
same condition as D15 → return `m.fetchRequestDetail(record.ID)`
(streamed attach records carry no Details — §2), WITHOUT setting
`detailLoading` (the in-flight snapshot stays on screen; no flicker).
Guard machinery:
- New `detailFetchSeq int` on ClientModel, incremented by every
  `fetchRequestDetail` call; the closure captures its seq;
  `RequestDetailMsg`/`RequestDetailErrorMsg` gain a `Seq int` field.
- Handler discipline (both messages): ALL state mutations — including
  `detailLoading = false`, today mutated before the ID check
  (client.go:117/:125) — move inside a guard requiring
  `msg.ID == selectedRequestID && msg.Seq == detailFetchSeq`. Stale-ID
  and superseded-fetch results (success or error) are dropped entirely.
- Defense in depth (belt-and-braces per the brief): additionally drop a
  `RequestDetailMsg` whose payload is in-flight while the displayed
  `requestDetail` is final.
- Error handling: a current-seq error with a displayed `requestDetail`
  keeps the snapshot and sets a new `detailRefreshFailed bool` instead of
  rendering the error screen; `formatRequestDetail` then replaces the
  "(request in flight — details arrive on completion)" note with
  "(live refresh failed — press esc and re-enter to reload)" so a failed
  refresh can't silently promise details forever. A current-seq error
  with NOTHING displayed renders the error view (today's initial-failure
  behavior). `detailRefreshFailed` clears on any successful detail apply
  and on leaving the detail view.

**D17. Docs.** tui.md:117-121's "Detail views do not live-update —
reopen the request…" sentence is replaced with the live-refresh behavior
(local re-convert; attach re-fetch; the refresh-failed note). cli.md is
not touched (no CLI surface changes). Plan 006's pinned "no live-update"
was scope deferral (per issue #54's framing), superseded here.

## 4. Deviations / non-goals

- #53 (staleness reaper), #49 (quotas), #50 items: out of scope (pinned).
- No client-side registration retry loop; no wire-format changes (D5).
- No logs-view search navigation/highlighting (D14 — docs corrected,
  issue filed in Phase 6); no per-row match highlighting; no line
  wrapping/truncation work; no mouse enablement (D9 — future work).
- No registration generation counter — the lifecycle mutex (D2) makes
  dir+PID sufficient; generations remain the fallback design if the
  control plane ever needs to go concurrent.
- TUI verified by direct-call unit tests only (no PTY automation) — same
  accepted limit as plans 005/006.
- PR left open for user review; no release/deploy; no auto-merge.

## 5. Work breakdown (gated commits)

Gate per commit: `make lint && make test && make test-race && make build`.
C1 first — the #55/#47+#54 split point falls right after it.

- **C1 (opus) — #55 daemon crash-restart self-heal.** D1-D5: typed
  conflict error; lifecycle mutex; inline replace; shutdown helper with
  injectable delay; PID>0 validation; upgraded conflict message;
  `internal/daemon` import in server.go. Tests:
  - registry: typed error carries dir+PID of the existing registration;
    after re-register under a new PID the error carries the NEW pid;
    non-same-dir conflicts stay untyped; existing
    TestRegistry_DuplicateProject updated for the typed error/message.
  - lifecycle scaffold: same-dir dead-PID re-register succeeds (200),
    old generation's records purged INCLUDING body files (eviction
    callback wired, old files removed), other projects' registrations
    and records untouched; same-dir LIVE-PID (PID 1/self) still 409
    REGISTRATION_CONFLICT with the upgraded message; different-project
    route conflict unchanged 409, never retried; PID<=0 → 400.
  - e2e with a REAL DynamicProxy and real TCP listeners
    (client_server_test style, extended scaffold): dead-PID self-heal
    re-register on the same port → listener closed and rebound, a
    proxied request round-trips through the new registration (the
    registry-only scaffold cannot prove close/rebind).
  - concurrency (-race): registration attempts racing the sweep's
    removeStaleProject on the same dead dir — every outcome is either a
    successful self-heal with routable listeners or a clean 409; no
    PORT_BIND_FAILED, no lost new-generation records (bounded loop).
  - scheduleShutdownWhenEmpty (short injected delay): stays-empty →
    shutdown requested; registration during delay → no shutdown; wired
    from deregister, sweep, and register-rollback (rollback path test:
    self-heal replace whose listener bind fails → registry empty →
    shutdown scheduled → daemon doesn't idle forever).
  - existing TestServer_RemoveStaleProject_SkipsReRegistered and sweep
    tests stay green.
  Docs: grep docs/ for the 30s-sweep / "already registered" behavior and
  update if described.
- **C2 (opus) — #47 cursor.** D6-D11: cursor fields + setRequestCursor +
  resolve + visibility invariant + marker + cursorStyle; requests-view
  nav-key branch (half-page paging); cursor-based follow re-engagement +
  detail-view scroll-yank guard (the guard lands here with the follow
  rework, not C4); GotoTop on detail enter; both Enter call sites via
  cursor-backed getSelectedRequest. Also introduces the stub-TUIClient
  test harness (shared deliverable — C4 reuses it). Tests
  (model_test.go style): cursor moves j/k/g/G/pgup/pgdown with clamping;
  visibility invariant — YOffset assertions for keyboard jumps AND
  transitions (tab-in from a scrolled logs view, resize, filter
  clear, detail-return); follow: arrivals never move a
  user-positioned cursor (short list that fits the viewport — the
  AtBottom trap), k disengages, j-onto-last-row re-engages, G/F
  re-engage, follow-mode arrival pins cursor to newest and stays at
  bottom; ID-stability across in-place upsert of the cursor row/other
  rows, append+trim with cursor mid-list, cursor-row trimmed → clamp;
  empty→non-empty (follow on → newest; off → row 0); Enter opens the
  cursor row (Model local; ClientModel via stub asserting the fetched
  ID) and GotoTop on entry; empty-list Enter no-op; detail-view arrivals
  don't scroll the detail viewport; marker present exactly on the cursor
  row; rewritten SelectionStable test.
- **C3 (opus) — #47 search navigation.** D12-D14: requestSearchQuery,
  handleSearchKey requests branch, n/N, status-bar precedence + match
  indicator (lipgloss.Width), esc clear, dead searchMatches state
  deleted, help overlays + tui.md (logs-view corrections included).
  Tests: `/`+enter jumps to first match at-or-after cursor (incl. cursor
  already on a match → stays) and wraps; n/N advance/retreat with
  wraparound; off-screen jumps scroll minimally (YOffset assertions both
  directions); search composes with active `s` filter (matches over
  filtered list); searchPattern untouched by `/` in requests view (row
  count unchanged — not filtered); no-match → cursor unmoved, status
  shows 0; esc clears query; logs-view `/` filter behavior unchanged;
  status precedence (prompt > search+filter combined > filter; solo not
  shown in requests view); unicode query width. TestUpdateSearchMatches
  removed with the dead code.
- **C4 (sonnet) — #54 detail live-refresh.** D15-D17. Tests: local —
  open in-flight detail, matching final ProxyRequestMsg refreshes in
  place (Details rendered, no "(in flight)", YOffset preserved);
  non-matching ID / still-in-flight msg / not-in-detail-view → no
  refresh. Attach (stub TUIClient) — matching final msg returns a fetch
  cmd and detailLoading stays false; per-guard-branch tests: stale-ID
  result dropped WITHOUT clearing detailLoading for the current fetch;
  superseded-seq success and error both dropped; in-flight payload after
  displayed final dropped (content guard); final-after-in-flight
  applies and clears detailRefreshFailed; current-seq error with
  displayed detail → snapshot kept + refresh-failed note rendered
  (formatRequestDetail assertion); current-seq error with nothing
  displayed → error view (existing behavior). Docs: tui.md sentence
  (D17).

Order: C1 (#55 complete; split point) → C2 → C3 (#47 complete) → C4.
(C4 depends on C2 only for the shared stub harness and the detail-view
scroll guard; its logic keys off selectedRequestID, not the cursor —
noted for fallback flexibility.)

## 6. File map (indicative)

- internal/proxyd/registry.go, server.go, daemon.go (+ registry_test.go,
  server_lifecycle_test.go, client_server_test.go) — C1
- internal/tui/base.go, update.go, client.go, model.go, styles.go
  (+ model_test.go, new client_model_test.go) — C2, C3
- internal/tui/update.go, client.go, model.go — C4
- docs/reference/tui.md — C3, C4
- docs/ (daemon lifecycle text, if any describes the 30s wait) — C1

## 7. Acceptance criteria

#55:
- kill -9 a registered `prox up`; an immediate re-`prox up` (well inside
  the 30s window) registers successfully, routes resolve and serve
  traffic, and the dead generation's records/body files are purged.
- While a `prox up` is LIVE, a second `prox up` in the same dir still
  fails with a 409 naming the holding PID.
- Different-project conflicts behave exactly as today (no retry).
- Lifecycle transactions are serialized: a sweep tick concurrent with a
  self-heal register can produce only "self-heal succeeded with working
  listeners" or "clean 409" — never PORT_BIND_FAILED, never a purge of
  the new generation's records (pinned by the -race test).
- An emptied registry always gets a graced shutdown check (deregister,
  sweep, and register-rollback paths), verified at the helper level; the
  re-check sees a registration that landed during the grace and stands
  down.

#47:
- The requests list shows a visible cursor row at all times (keyboard
  jumps AND view transitions); Enter opens exactly that row in both
  modes; j/k/g/G/pgup/pgdown move the cursor with minimal scrolling.
- Arrivals never move a user-positioned cursor (including when the list
  fits in the viewport); follow mode pins the cursor to the newest row;
  k disengages follow; j onto the last row, G, or F re-engage it.
- The cursor stays on its row (by ID) across in-place completion updates
  and append+trim; when its row is filtered/trimmed away it clamps to
  the nearest position instead of vanishing.
- `/` + enter jumps to the first match at-or-after the cursor; n/N cycle
  matches with wraparound over the filtered list; the status bar shows
  the pinned indicator; `/` no longer filters the requests list; `s`
  filtering is unchanged; logs-view behavior is unchanged.
- Docs and help overlays match shipped behavior, including the corrected
  logs-view search description (substring, not regex; no n/N there).

#54:
- A detail view open on an in-flight request updates in place on
  completion: local mode renders final duration/headers/bodies from the
  streamed record; attach mode re-fetches and renders them; the reader's
  scroll position is preserved.
- A stale or superseded fetch result (success OR error, wrong ID or
  wrong seq) mutates nothing — including detailLoading.
- A failed refresh keeps the snapshot and visibly says the refresh
  failed (never a silent eternal "(in flight)", never an error screen
  replacing a useful snapshot).
- tui.md no longer claims detail views don't live-update.

All: gate green per commit.

## 8. Verification plan

- #55 — beyond unit/socket/e2e tests, a live pass with the real binary
  in daemon mode under an ISOLATED HOME (never the user's real daemon),
  artifacts to ~/.claude/plans/prox/007-selfheal-tui-cursor/: scratch
  project; `prox up` (daemon topology); kill -9 the `prox up` process;
  immediately re-run `prox up` (well inside the 30s window) →
  registration succeeds and a proxied request round-trips; then, with
  that instance live, a second `prox up` for the same dir → still fails
  with the 409 message naming the PID. Daemon log shows the "replacing
  stale registration" warn.
- #47/#54 — direct-call unit tests only (no PTY automation), per the
  pinned scope. No extra live TUI pass.

## 9. Risks / open items

- PID reuse can defeat the dead-PID check (a recycled PID looks alive →
  409 until the 30s sweep, which has the same blindness) — pre-existing
  sweep limitation, unchanged, accepted (plan 005 §9).
- `lifecycleMu` serializes cert generation (EnsureDomain on first HTTPS
  registration) with deregisters/sweeps — a slow cert gen briefly delays
  them. Accepted for a dev tool; the data plane is unaffected.
- The dead registration's ports are briefly unbound during replace
  (close → rebind). Harmless: the owner was dead, no live traffic.
- Per-keypress O(n≤1000) re-render for cursor moves (D10). Accepted; if
  it ever feels sluggish, cache formatted lines and re-prefix only the
  two changed rows.
- Requests-view `/` semantics change from (accidental) filter to
  navigation — deliberate (D12), documented; `s` remains the filter.
- Mouse input remains disabled program-wide — wheel scrolling neither
  works today nor is added; future work with `WithMouseCellMotion` +
  cursor integration.
- A failed attach refresh requires esc+re-enter to retry (no auto-retry)
  — accepted; the note makes it visible (D16).
- User's real daemon needs a restart to pick up #55; the exact-match
  version gate keeps that loud (unchanged).

## § Verified (2026-07-18, post-implementation)

All 4 commits landed on feature/plan-007-selfheal-tui-cursor
(61bd1de..874bd23), each through the full gate (lint, test, test-race,
build). Per-commit codex reviews: C1 adversarial (3 findings, all fixed —
epoch-guarded lifecycleMu-synchronized grace timers, SHUTTING_DOWN 503
for a register queued behind a shutdown decision, concurrency-test
hardening; register-vs-forced-stop teardown race dispositioned as
pre-existing/accepted), C2 (1 fixed — ensureCursorVisible overscroll
reclamp on grow-resize), C3 (1 fixed — search jumps no longer
unconditionally disengage follow; landing rules refined in D13 and
test-pinned, plus single-match n/N no-op and unicode-test scope-note
gaps), C4 (1 fixed — viewport clamp when a capture-disabled final detail
is shorter than the in-flight view). Simplify passes: C1 (test dedup),
C2 (3 dedups incl. moveRequestCursor/renderDetailFromTop helpers), C3
(3 dedups), C4 skipped (small single-concern diff).

Beyond automated tests, a live pass ran the real binary in daemon mode
under an isolated HOME (details in
007-selfheal-tui-cursor/verification-transcript.md): kill -9 of a
registered prox up followed by an immediate restart (~9ms later, well
inside the 30s sweep window) registered successfully with the first
post-restart proxied request returning 200; the daemon log showed the
"replacing stale registration" warn; a direct-socket register against
the live healed instance returned 409 REGISTRATION_CONFLICT naming the
holder's PID; a second `prox up` from the project dir was refused by the
project pidfile guard in front of that 409; teardown left no
isolated-HOME processes.

Known-unexercised live (accepted): sweep-vs-register interleavings,
rollback shutdown scheduling, epoch stand-down, and SHUTTING_DOWN
refusal are covered at the unit/e2e seams under -race only; TUI cursor/
search/detail-refresh verified by direct-call unit tests (no PTY
automation, pinned scope). Observed pre-existing wart (out of scope,
noted in the transcript): a kill -9'd supervisor's orphaned backend can
wedge holding its port, 502ing the healed route until cleaned —
supervisor territory, not registration.

## 10. Panel dispositions (summary)

Adopted (Codex): lifecycle mutex for atomic lifecycle transactions
(critical — finishRemoval runs outside the registry lock); typed
conflict error under the detecting lock (critical — TOCTOU); rollback
paths join the serialized flow + graced shutdown; shutdown helper with
injected delay + both-way tests; PID>0 validation; effective-follow
computed before render; visibility as an updateViewport invariant +
transition tests; setRequestCursor single ownership; GotoTop on detail
enter; all wheel language dropped (mouse not enabled — verified);
status-bar precedence pinned; lipgloss.Width for status widths; logs
docs corrected to exact substring/live-vs-enter semantics; fetch-seq
token + all mutations inside the guard (verified detailLoading bug at
client.go:117/:125) + stale-ID/superseded test matrix; refresh-failure
surfaced in the detail view; detail YOffset preservation; real
DynamicProxy e2e for close/rebind; body-file purge assertion; -race
register-vs-sweep test.
Adopted (CodeRabbit): M1 cursor-based follow re-engagement (the
AtBottom-always-true trap — test pinned); M2/M3 scheduleShutdownWhenEmpty
across deregister/sweep/rollback; m1 (via typed error); m2 §2 corrected
(PID 12345, not self-PID); m3 refresh-failed note; m4 detail-view
scroll-yank guard (landed in C2 with the follow rework); m5 half-page
paging parity; m6 O(n) note in §9; m7 help-overlay regex claim; m8 dead
searchMatches state deleted; m9 empty→non-empty pinned (follow wins);
m10 conflict message names the PID.
Adopted (GLM): M1 (via D4 helper — though the 5s-budget fragility
argument was off: the re-check needs only the registry commit, not
certs/listeners); M3 RegisteredPID-style accessor tests recast as
typed-error tests incl. new-PID-after-reregister; M4 status indicator
made unambiguous (i only when cursor on a match); L1 at-or-after
rationale noted in D12; L2 logs-view nav issue WILL be filed in Phase 6;
L3 per-guard-branch tests pinned; L4 stub harness pinned as shared C2
deliverable; L5 C4-independence noted at §5.
Adapted: GLM M2 cursor visual — louder marker (`❯ ` styled) adopted,
but the row-wide-bold claim was rejected as technically wrong (segment
ANSI resets terminate outer bold mid-line; D10 records the rationale).
Skipped: Codex "remove opus/sonnet labels" and "reduce plan-005/006
references" (gauntlet execution convention, kept as in plans 005/006 —
load-bearing invariants are restated inline where they matter); Codex
detail-scroll "reasonable offset" beyond YOffset preservation (content
only grows; preserved offset suffices).
Contradictions requiring user arbitration: none (the only true conflict
— marker vs row-wide styling — was resolved by verifying the ANSI
behavior directly).
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgMgg6eo4LgLTCkfYSARcH


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upgraded the Requests view with cursor-ID navigation, improved follow-mode visibility, and clearer `/` (jump) vs `s` (filter) behavior.
  * Request detail views now live-refresh more reliably, with clearer “refresh failed” feedback.
  * Enhanced self-healing so stale routes can be safely replaced after crashes.
* **Bug Fixes**
  * Prevented outdated or overlapping request-detail results from overwriting newer details.
  * Improved listener rebinding, conflict handling, and graced shutdown timing when idle.
* **Documentation**
  * Refined TUI control/search semantics and expanded guidance on stale route cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->