### PR TITLE
fix(proxyd): registration/lifecycle bugfixes — HTTPS cert join (#58), forced-stop teardown race (#60), PID-reuse liveness (#61)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/sys v0.36.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -36,6 +37,5 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
-	golang.org/x/sys v0.36.0 // indirect
 	golang.org/x/text v0.3.8 // indirect
 )

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -805,6 +805,13 @@ func tryDaemonProxy(cfg *config.Config, cwd string, ctx context.Context, handler
 		services[name] = proxyd.ServiceTarget{Host: svc.Host, Port: svc.Port}
 	}
 
+	// Read our own process start token so the daemon can tell a genuine
+	// same-dir conflict from a crashed generation whose PID has been reused.
+	startToken, ok := daemon.ProcessStartTime(os.Getpid())
+	if !ok {
+		fmt.Fprintln(os.Stderr, "Warning: could not read process start token; proxy PID-reuse protection is degraded to bare-PID")
+	}
+
 	req := proxyd.RegisterRequest{
 		ProjectDir:     cwd,
 		PID:            os.Getpid(),
@@ -814,6 +821,7 @@ func tryDaemonProxy(cfg *config.Config, cwd string, ctx context.Context, handler
 		HTTPPort:       cfg.Proxy.HTTPPort,
 		HTTPSPort:      cfg.Proxy.HTTPSPort,
 		CaptureEnabled: cfg.Proxy.Capture != nil && cfg.Proxy.Capture.Enabled,
+		StartTime:      startToken,
 	}
 
 	resp, err := client.Register(req)

--- a/internal/daemon/liveness.go
+++ b/internal/daemon/liveness.go
@@ -1,0 +1,23 @@
+package daemon
+
+// IsProcessAlive reports whether pid still names the same process generation
+// that recorded startTime. Semantics are "process identity still exists," not
+// "running": like ProcessExists it treats a zombie as existing (reaping zombies
+// is a non-goal). Fallbacks bias toward "alive" so a live process is never
+// falsely reaped:
+//
+//	startTime == 0          -> bare ProcessExists (no token captured)
+//	current token unreadable -> bare ProcessExists (can't disprove identity)
+func IsProcessAlive(pid int, startTime int64) bool {
+	if !ProcessExists(pid) {
+		return false
+	}
+	if startTime == 0 {
+		return true
+	}
+	cur, ok := ProcessStartTime(pid)
+	if !ok {
+		return true
+	}
+	return cur == startTime
+}

--- a/internal/daemon/liveness_test.go
+++ b/internal/daemon/liveness_test.go
@@ -1,0 +1,78 @@
+//go:build darwin || linux
+
+package daemon
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+)
+
+// deadPIDLocal runs a process to completion and returns its (now reaped) PID —
+// guaranteed not to name a live process. Mirrors the proxyd package helper but
+// kept local to daemon.
+func deadPIDLocal(t *testing.T) int {
+	t.Helper()
+	cmd := exec.Command("true")
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("running true: %v", err)
+	}
+	return cmd.Process.Pid
+}
+
+func TestProcessStartTime_Self(t *testing.T) {
+	first, ok := ProcessStartTime(os.Getpid())
+	if !ok {
+		t.Fatal("ProcessStartTime(self) ok = false, want true")
+	}
+	if first <= 0 {
+		t.Errorf("ProcessStartTime(self) = %d, want > 0", first)
+	}
+	// A process's start token is a fixed generation discriminator — stable
+	// across reads for the life of the process.
+	second, ok := ProcessStartTime(os.Getpid())
+	if !ok || second != first {
+		t.Errorf("second read = (%d, %v), want (%d, true) — token must be stable", second, ok, first)
+	}
+}
+
+func TestProcessStartTime_DeadPID(t *testing.T) {
+	if _, ok := ProcessStartTime(deadPIDLocal(t)); ok {
+		t.Error("ProcessStartTime(dead) ok = true, want false")
+	}
+}
+
+func TestProcessStartTime_NonPositive(t *testing.T) {
+	if _, ok := ProcessStartTime(0); ok {
+		t.Error("ProcessStartTime(0) ok = true, want false")
+	}
+	if _, ok := ProcessStartTime(-1); ok {
+		t.Error("ProcessStartTime(-1) ok = true, want false")
+	}
+}
+
+func TestIsProcessAlive(t *testing.T) {
+	self := os.Getpid()
+	token, ok := ProcessStartTime(self)
+	if !ok {
+		t.Fatal("could not read self start token")
+	}
+
+	if !IsProcessAlive(self, token) {
+		t.Error("IsProcessAlive(self, matching token) = false, want true")
+	}
+	if IsProcessAlive(self, token+1) {
+		t.Error("IsProcessAlive(self, mismatched token) = true, want false")
+	}
+	// startTime == 0 falls back to bare ProcessExists, which is true for self.
+	if !IsProcessAlive(self, 0) {
+		t.Error("IsProcessAlive(self, 0) = false, want true (bare-PID fallback)")
+	}
+	// A dead PID is dead regardless of the stored token.
+	if IsProcessAlive(deadPIDLocal(t), token) {
+		t.Error("IsProcessAlive(dead, token) = true, want false")
+	}
+	// The "current token unreadable -> alive" fallback in IsProcessAlive cannot
+	// be forced deterministically for a live PID on darwin/linux without a
+	// contrived seam; it is covered by inspection.
+}

--- a/internal/daemon/process_darwin.go
+++ b/internal/daemon/process_darwin.go
@@ -2,13 +2,20 @@
 
 package daemon
 
-import "golang.org/x/sys/unix"
+import (
+	"math"
+
+	"golang.org/x/sys/unix"
+)
 
 // ProcessStartTime returns an opaque, host-and-boot-local generation token for
 // pid (Darwin: kinfo_proc P_starttime, process creation time in microseconds).
 // ok=false when unreadable. See IsProcessAlive for how it is used.
 func ProcessStartTime(pid int) (int64, bool) {
-	if pid <= 0 {
+	// SysctlKinfoProc and the P_pid guard below narrow pid to int32; a value
+	// outside the signed 32-bit range would wrap and could alias a different
+	// process. Reject it up front (real PIDs are well within range).
+	if pid <= 0 || pid > math.MaxInt32 {
 		return 0, false
 	}
 	kp, err := unix.SysctlKinfoProc("kern.proc.pid", pid)

--- a/internal/daemon/process_darwin.go
+++ b/internal/daemon/process_darwin.go
@@ -1,0 +1,32 @@
+//go:build darwin
+
+package daemon
+
+import "golang.org/x/sys/unix"
+
+// ProcessStartTime returns an opaque, host-and-boot-local generation token for
+// pid (Darwin: kinfo_proc P_starttime, process creation time in microseconds).
+// ok=false when unreadable. See IsProcessAlive for how it is used.
+func ProcessStartTime(pid int) (int64, bool) {
+	if pid <= 0 {
+		return 0, false
+	}
+	kp, err := unix.SysctlKinfoProc("kern.proc.pid", pid)
+	if err != nil || kp == nil {
+		return 0, false
+	}
+	// Defend against a stale/empty kinfo naming a different process.
+	if kp.Proc.P_pid != int32(pid) {
+		return 0, false
+	}
+	sec := int64(kp.Proc.P_starttime.Sec)
+	usec := int64(kp.Proc.P_starttime.Usec)
+	if sec <= 0 || usec < 0 || usec >= 1_000_000 {
+		return 0, false
+	}
+	token := sec*1_000_000 + usec
+	if token <= 0 {
+		return 0, false
+	}
+	return token, true
+}

--- a/internal/daemon/process_linux.go
+++ b/internal/daemon/process_linux.go
@@ -1,0 +1,47 @@
+//go:build linux
+
+package daemon
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// ProcessStartTime returns an opaque, host-and-boot-local generation token for
+// pid (Linux: /proc/<pid>/stat field 22, starttime in clock ticks since boot).
+// ok=false when unreadable. See IsProcessAlive for how it is used.
+func ProcessStartTime(pid int) (int64, bool) {
+	if pid <= 0 {
+		return 0, false
+	}
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		return 0, false
+	}
+	return parseProcStatStartTime(data)
+}
+
+// parseProcStatStartTime extracts stat field 22 (starttime). comm (field 2) is
+// parenthesized and may itself contain spaces and ')'; parse AFTER the LAST ')'
+// so it can't shift the fields. In that remainder the tokens start at field 3
+// (state), so starttime (field 22) is index 19.
+func parseProcStatStartTime(data []byte) (int64, bool) {
+	i := bytes.LastIndexByte(data, ')')
+	if i < 0 {
+		return 0, false
+	}
+	fields := strings.Fields(string(data[i+1:]))
+	const startTimeIdx = 19 // stat field 22 == index 19 after the trailing ')'
+	if len(fields) <= startTimeIdx {
+		return 0, false
+	}
+	v, err := strconv.ParseUint(fields[startTimeIdx], 10, 64)
+	if err != nil || v == 0 || v > math.MaxInt64 {
+		return 0, false
+	}
+	return int64(v), true
+}

--- a/internal/daemon/process_linux_test.go
+++ b/internal/daemon/process_linux_test.go
@@ -1,0 +1,75 @@
+//go:build linux
+
+package daemon
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// buildStat renders a /proc/<pid>/stat line whose comm field is `prefix`
+// (already wrapped in parens, e.g. "1234 (bash)") followed by 20 tokens where
+// index 19 — stat field 22, starttime, once parsing resumes after the LAST ')'
+// — is `startTime`. Extra trailing tokens model the real file's remaining
+// fields.
+func buildStat(prefix, startTime string) []byte {
+	fields := make([]string, 20)
+	for i := range fields {
+		fields[i] = "0"
+	}
+	fields[19] = startTime
+	return []byte(prefix + " " + strings.Join(fields, " ") + " 0 0 0\n")
+}
+
+func TestParseProcStatStartTime(t *testing.T) {
+	cases := []struct {
+		name   string
+		data   []byte
+		want   int64
+		wantOK bool
+	}{
+		{name: "normal", data: buildStat("1234 (bash)", "8425"), want: 8425, wantOK: true},
+		{name: "comm with spaces", data: buildStat("1234 (my proc)", "999"), want: 999, wantOK: true},
+		{name: "comm with open paren", data: buildStat("1234 (a(b)", "111"), want: 111, wantOK: true},
+		// comm literally contains a ')': the field is "(weird):)"; the LAST ')'
+		// is its closing paren, so a naive first-')' parse would misalign.
+		{name: "comm with close paren", data: buildStat("1234 (weird):)", "777"), want: 777, wantOK: true},
+		{name: "truncated too few fields", data: []byte("1234 (bash) R 1 1 1\n"), wantOK: false},
+		{name: "no closing paren", data: []byte("1234 malformed line\n"), wantOK: false},
+		{name: "non-numeric starttime", data: buildStat("1234 (bash)", "abc"), wantOK: false},
+		{name: "zero starttime", data: buildStat("1234 (bash)", "0"), wantOK: false},
+		// MaxInt64 + 1: parses as uint64 but exceeds int64 range.
+		{name: "overflow", data: buildStat("1234 (bash)", "9223372036854775808"), wantOK: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := parseProcStatStartTime(tc.data)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v (data=%q)", ok, tc.wantOK, tc.data)
+			}
+			if ok && got != tc.want {
+				t.Errorf("token = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestProcessStartTime_Self_Linux(t *testing.T) {
+	got, ok := ProcessStartTime(os.Getpid())
+	if !ok {
+		t.Fatal("ProcessStartTime(self) ok = false, want true")
+	}
+	if got <= 0 {
+		t.Errorf("ProcessStartTime(self) = %d, want > 0", got)
+	}
+	// The parsed value should equal what we get parsing the file directly.
+	data, err := os.ReadFile("/proc/" + strconv.Itoa(os.Getpid()) + "/stat")
+	if err == nil {
+		if want, wok := parseProcStatStartTime(data); wok && want != got {
+			t.Errorf("ProcessStartTime = %d, direct parse = %d", got, want)
+		}
+	}
+}

--- a/internal/daemon/process_other.go
+++ b/internal/daemon/process_other.go
@@ -1,0 +1,7 @@
+//go:build !darwin && !linux
+
+package daemon
+
+// ProcessStartTime has no portable implementation on this platform; returning
+// ok=false makes IsProcessAlive fall back to bare-PID liveness.
+func ProcessStartTime(pid int) (int64, bool) { return 0, false }

--- a/internal/proxyd/cert_registration_test.go
+++ b/internal/proxyd/cert_registration_test.go
@@ -306,8 +306,8 @@ func TestCertRegistration_NilCertMgr_HTTPSNoPanic(t *testing.T) {
 	}, "an HTTPS register with no cert manager must not panic")
 
 	require.NotEqual(t, http.StatusOK, status, "HTTPS register with no cert manager must fail: %v", body)
-	if errResp, ok := body.(ErrorResponse); ok {
-		assert.Equal(t, "PORT_BIND_FAILED", errResp.Code)
-		assert.Contains(t, errResp.Error, "no certificate manager")
-	}
+	errResp, ok := body.(ErrorResponse)
+	require.True(t, ok, "failure body should be an ErrorResponse, got %T", body)
+	assert.Equal(t, "PORT_BIND_FAILED", errResp.Code)
+	assert.Contains(t, errResp.Error, "no certificate manager")
 }

--- a/internal/proxyd/cert_registration_test.go
+++ b/internal/proxyd/cert_registration_test.go
@@ -1,0 +1,313 @@
+package proxyd
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"io"
+	"log/slog"
+	"math/big"
+	"net/http"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/charliek/prox/internal/proxy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeCertManager is an in-memory certManager for deterministic tests. It
+// mirrors MultiDomainCertManager's SNI selection (keyed by extractBaseDomain)
+// but generates self-signed certs in-process instead of shelling out to mkcert,
+// and records which domains were EnsureDomain'd so tests can assert the register
+// flow's cert gating.
+type fakeCertManager struct {
+	mu      sync.Mutex
+	certs   map[string]*tls.Certificate // base domain -> cert
+	ensured map[string]int              // domain -> EnsureDomain call count
+	failFor map[string]error            // domain -> forced EnsureDomain error
+}
+
+func newFakeCertManager() *fakeCertManager {
+	return &fakeCertManager{
+		certs:   make(map[string]*tls.Certificate),
+		ensured: make(map[string]int),
+		failFor: make(map[string]error),
+	}
+}
+
+// failDomain configures EnsureDomain to fail for the given domain.
+func (f *fakeCertManager) failDomain(domain string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.failFor[domain] = fmt.Errorf("forced cert failure for %s", domain)
+}
+
+// ensureCount reports how many times EnsureDomain was called for a domain.
+func (f *fakeCertManager) ensureCount(domain string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.ensured[domain]
+}
+
+// EnsureDomain generates and caches a self-signed wildcard cert for domain,
+// recording the call. It is idempotent (one cert per domain) like the real one.
+func (f *fakeCertManager) EnsureDomain(domain string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.ensured[domain]++
+
+	if err, ok := f.failFor[domain]; ok {
+		return err
+	}
+	if _, ok := f.certs[domain]; ok {
+		return nil
+	}
+
+	cert, err := generateWildcardCert(domain)
+	if err != nil {
+		return err
+	}
+	f.certs[domain] = cert
+	return nil
+}
+
+// GetCertificate is the SNI callback: it selects a cert by the ClientHello's
+// base domain using the same extractBaseDomain logic as the real manager.
+func (f *fakeCertManager) GetCertificate(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	if hello.ServerName == "" {
+		return nil, fmt.Errorf("no SNI server name provided")
+	}
+	domain := extractBaseDomain(hello.ServerName)
+
+	f.mu.Lock()
+	cert, ok := f.certs[domain]
+	f.mu.Unlock()
+
+	if !ok {
+		return nil, fmt.Errorf("no certificate for domain %s (from %s)", domain, hello.ServerName)
+	}
+	return cert, nil
+}
+
+// generateWildcardCert builds an in-memory self-signed leaf cert covering both
+// "*.<domain>" and "<domain>" with an ECDSA P-256 key.
+func generateWildcardCert(domain string) (*tls.Certificate, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, err
+	}
+	tmpl := x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: domain},
+		DNSNames:              []string{"*." + domain, domain},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &key.PublicKey, key)
+	if err != nil {
+		return nil, err
+	}
+	leaf, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, err
+	}
+	return &tls.Certificate{
+		Certificate: [][]byte{der},
+		PrivateKey:  key,
+		Leaf:        leaf,
+	}, nil
+}
+
+// backendTarget returns a syntactically valid, unbound host:port for a
+// RegisterRequest's ServiceTarget. These tests only exercise the cert gate and
+// the TLS handshake against the proxy's own listener (via dialTLSVerify) —
+// never a proxied HTTP round trip to the backend — so the target need not be a
+// live server.
+func backendTarget(t *testing.T) (host string, port int) {
+	t.Helper()
+	return "127.0.0.1", freePort(t)
+}
+
+// newProxyServerWithCertMgr mirrors newProxyServer but wires the DynamicProxy to
+// a caller-supplied certManager so HTTPS registrations exercise the real cert
+// gate and SNI cert selection.
+func newProxyServerWithCertMgr(t *testing.T, cm certManager) *Server {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
+	s := NewServer(ServerConfig{SocketPath: "", Logger: logger, Version: "test"})
+	reg := NewRegistry()
+	rm := proxy.NewRequestManager(100)
+	dp := NewDynamicProxy(reg, cm, rm, nil, logger)
+	s.SetRegistry(reg)
+	s.SetProxy(dp)
+	s.SetRequestManager(rm)
+	t.Cleanup(func() { _ = dp.Shutdown(context.Background()) })
+	return s
+}
+
+// dialTLSVerify TLS-dials addr with the given SNI server name, retrying briefly
+// while the listener warms up, and asserts the served leaf cert verifies the
+// hostname. InsecureSkipVerify lets the handshake complete so we can inspect the
+// presented cert directly (the fake certs are self-signed).
+func dialTLSVerify(t *testing.T, addr, serverName string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		conn, err := tls.Dial("tcp", addr, &tls.Config{
+			ServerName:         serverName,
+			InsecureSkipVerify: true,
+		})
+		if err != nil {
+			lastErr = err
+			time.Sleep(20 * time.Millisecond)
+			continue
+		}
+		state := conn.ConnectionState()
+		_ = conn.Close()
+		require.NotEmpty(t, state.PeerCertificates,
+			"handshake produced no peer certificates for %s", serverName)
+		require.NoError(t, state.PeerCertificates[0].VerifyHostname(serverName),
+			"served cert must verify hostname %s", serverName)
+		return
+	}
+	t.Fatalf("TLS dial to %s (SNI %s) never succeeded: %v", addr, serverName, lastErr)
+}
+
+// TestCertRegistration_SharedHTTPSPort_BothDomainsServed is the #58 regression:
+// a second domain joining an already-bound shared HTTPS port must still get its
+// cert generated, so its SNI handshake succeeds. The old cert loop scanned only
+// NEW listener ports, so the joining domain (no new port) was skipped.
+func TestCertRegistration_SharedHTTPSPort_BothDomainsServed(t *testing.T) {
+	backendHost, backendPort := backendTarget(t)
+
+	fake := newFakeCertManager()
+	s := newProxyServerWithCertMgr(t, fake)
+	port := freePort(t)
+
+	reqA := RegisterRequest{
+		ProjectDir: "/projects/a", PID: os.Getpid(), Version: "test", Domain: "a.test",
+		Services:  map[string]ServiceTarget{"svc": {Host: backendHost, Port: backendPort}},
+		HTTPSPort: port,
+	}
+	registerOK(t, s, reqA)
+
+	// B shares A's already-bound HTTPS port: no new listener, so the old loop
+	// would have skipped B's cert.
+	reqB := RegisterRequest{
+		ProjectDir: "/projects/b", PID: os.Getpid(), Version: "test", Domain: "b.test",
+		Services:  map[string]ServiceTarget{"svc": {Host: backendHost, Port: backendPort}},
+		HTTPSPort: port,
+	}
+	registerOK(t, s, reqB)
+
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	dialTLSVerify(t, addr, "svc.a.test")
+	dialTLSVerify(t, addr, "svc.b.test")
+
+	assert.Positive(t, fake.ensureCount("a.test"), "A's domain must get a cert")
+	assert.Positive(t, fake.ensureCount("b.test"),
+		"B's domain must get a cert even though it joined an already-bound port")
+}
+
+// TestCertRegistration_JoiningCertFailureRollsBack pins that when a domain
+// joining a shared HTTPS port fails cert generation, its registration rolls back
+// cleanly while the shared listener and the incumbent domain survive intact.
+func TestCertRegistration_JoiningCertFailureRollsBack(t *testing.T) {
+	backendHost, backendPort := backendTarget(t)
+
+	fake := newFakeCertManager()
+	s := newProxyServerWithCertMgr(t, fake)
+	port := freePort(t)
+
+	reqA := RegisterRequest{
+		ProjectDir: "/projects/a", PID: os.Getpid(), Version: "test", Domain: "a.test",
+		Services:  map[string]ServiceTarget{"svc": {Host: backendHost, Port: backendPort}},
+		HTTPSPort: port,
+	}
+	registerOK(t, s, reqA)
+
+	fake.failDomain("b.test")
+	reqB := RegisterRequest{
+		ProjectDir: "/projects/b", PID: os.Getpid(), Version: "test", Domain: "b.test",
+		Services:  map[string]ServiceTarget{"svc": {Host: backendHost, Port: backendPort}},
+		HTTPSPort: port,
+	}
+	status, body := s.register(reqB)
+	require.Equal(t, http.StatusInternalServerError, status, "cert failure must fail the register: %v", body)
+	errResp, ok := body.(ErrorResponse)
+	require.True(t, ok, "failure body should be an ErrorResponse, got %T", body)
+	assert.Equal(t, "CERT_GENERATION_FAILED", errResp.Code)
+
+	// B's routes are gone; A's survive.
+	_, ok = s.registry.Lookup("svc.b.test", port)
+	assert.False(t, ok, "B's route must be rolled back")
+	_, ok = s.registry.Lookup("svc.a.test", port)
+	assert.True(t, ok, "A's route must survive B's rollback")
+
+	// The shared listener survives the rollback and still serves A.
+	dialTLSVerify(t, fmt.Sprintf("127.0.0.1:%d", port), "svc.a.test")
+}
+
+// TestCertRegistration_HTTPOnly_NoEnsureDomain verifies an HTTP-only
+// registration never triggers cert generation.
+func TestCertRegistration_HTTPOnly_NoEnsureDomain(t *testing.T) {
+	backendHost, backendPort := backendTarget(t)
+
+	fake := newFakeCertManager()
+	s := newProxyServerWithCertMgr(t, fake)
+
+	req := RegisterRequest{
+		ProjectDir: "/projects/http", PID: os.Getpid(), Version: "test", Domain: "http.test",
+		Services: map[string]ServiceTarget{"svc": {Host: backendHost, Port: backendPort}},
+		HTTPPort: freePort(t),
+	}
+	registerOK(t, s, req)
+
+	assert.Zero(t, fake.ensureCount("http.test"),
+		"an HTTP-only registration must not generate a cert")
+}
+
+// TestCertRegistration_NilCertMgr_HTTPSNoPanic pins that an HTTPS registration
+// against a proxy with no cert manager fails cleanly (via the explicit
+// AddListener guard) instead of panicking on a nil-interface method value.
+func TestCertRegistration_NilCertMgr_HTTPSNoPanic(t *testing.T) {
+	backendHost, backendPort := backendTarget(t)
+
+	// newProxyServer wires the DynamicProxy with a nil certMgr.
+	s := newProxyServer(t)
+
+	req := RegisterRequest{
+		ProjectDir: "/projects/nilcert", PID: os.Getpid(), Version: "test", Domain: "nil.test",
+		Services:  map[string]ServiceTarget{"svc": {Host: backendHost, Port: backendPort}},
+		HTTPSPort: freePort(t),
+	}
+
+	var status int
+	var body any
+	require.NotPanics(t, func() {
+		status, body = s.register(req)
+	}, "an HTTPS register with no cert manager must not panic")
+
+	require.NotEqual(t, http.StatusOK, status, "HTTPS register with no cert manager must fail: %v", body)
+	if errResp, ok := body.(ErrorResponse); ok {
+		assert.Equal(t, "PORT_BIND_FAILED", errResp.Code)
+		assert.Contains(t, errResp.Error, "no certificate manager")
+	}
+}

--- a/internal/proxyd/daemon.go
+++ b/internal/proxyd/daemon.go
@@ -238,7 +238,11 @@ func RunDaemon(ctx context.Context) error {
 		close(serverErr)
 	}()
 
-	// Wait for shutdown signal
+	// Wait for shutdown signal. Every branch falls THROUGH to the unconditional
+	// teardown below; a socket-server error records runErr and still tears down
+	// (an early return here used to skip dynamicProxy.Shutdown/requestMgr.Close/
+	// server.Shutdown entirely, leaking listeners and body files).
+	var runErr error
 	select {
 	case sig := <-sigCh:
 		logger.Info("received signal", "signal", sig)
@@ -247,11 +251,17 @@ func RunDaemon(ctx context.Context) error {
 	case err := <-serverErr:
 		if err != nil {
 			logger.Error("server error", "error", err)
-			return err
+			runErr = err
 		}
 	}
 
-	// Graceful shutdown
+	// Graceful shutdown. quiesceForTeardown sets the shutdown flag and takes
+	// lifecycleMu as a barrier, so teardown is serialized against any in-flight
+	// register/deregister/stale-removal: the one transaction already running when
+	// the flag was set completes atomically, and every later one self-gates to a
+	// no-op before we start closing listeners and records.
+	server.quiesceForTeardown()
+
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer shutdownCancel()
 
@@ -269,5 +279,5 @@ func RunDaemon(ctx context.Context) error {
 	}
 
 	logger.Info("proxy daemon stopped")
-	return nil
+	return runErr
 }

--- a/internal/proxyd/dynamic_proxy.go
+++ b/internal/proxyd/dynamic_proxy.go
@@ -19,6 +19,13 @@ import (
 	"github.com/charliek/prox/internal/proxy"
 )
 
+// certManager is the cert capability the dynamic proxy and register flow need:
+// per-domain cert generation plus SNI cert selection.
+type certManager interface {
+	EnsureDomain(domain string) error
+	GetCertificate(*tls.ClientHelloInfo) (*tls.Certificate, error)
+}
+
 // managedListener tracks a dynamically created port listener.
 type managedListener struct {
 	port     int
@@ -34,7 +41,7 @@ type DynamicProxy struct {
 	listeners      map[int]*managedListener
 	registry       *Registry
 	transport      *http.Transport
-	certMgr        *MultiDomainCertManager
+	certMgr        certManager
 	requestManager *proxy.RequestManager
 	captureManager *proxy.CaptureManager
 	logger         *slog.Logger
@@ -43,7 +50,12 @@ type DynamicProxy struct {
 // NewDynamicProxy creates a new dynamic proxy. captureManager may be nil, in
 // which case no request/response bodies are captured (metadata-only records);
 // when non-nil, capture is further gated per route via Route.CaptureEnabled.
-func NewDynamicProxy(registry *Registry, certMgr *MultiDomainCertManager, requestManager *proxy.RequestManager, captureManager *proxy.CaptureManager, logger *slog.Logger) *DynamicProxy {
+//
+// certMgr must be either a real *MultiDomainCertManager or the untyped nil
+// literal: the HTTPS bind path and the register flow gate on certMgr != nil, so
+// a typed nil such as (*MultiDomainCertManager)(nil) would slip past that guard
+// (a non-nil interface wrapping a nil pointer) and panic on the first HTTPS bind.
+func NewDynamicProxy(registry *Registry, certMgr certManager, requestManager *proxy.RequestManager, captureManager *proxy.CaptureManager, logger *slog.Logger) *DynamicProxy {
 	return &DynamicProxy{
 		listeners:      make(map[int]*managedListener),
 		registry:       registry,
@@ -79,6 +91,12 @@ func (dp *DynamicProxy) AddListener(port int, protocol string) error {
 	var err error
 
 	if protocol == "https" {
+		// Guard before dereferencing dp.certMgr: a nil interface here would
+		// otherwise produce a method-value panic when the TLS stack invokes
+		// GetCertificate on the first handshake.
+		if dp.certMgr == nil {
+			return fmt.Errorf("cannot start https listener on port %d: no certificate manager configured", port)
+		}
 		tlsCfg := &tls.Config{
 			GetCertificate: dp.certMgr.GetCertificate,
 			MinVersion:     tls.VersionTLS12,

--- a/internal/proxyd/registry.go
+++ b/internal/proxyd/registry.go
@@ -32,10 +32,14 @@ type Route struct {
 
 // ProjectRegistration tracks all routes belonging to a project.
 type ProjectRegistration struct {
-	Dir            string
-	PID            int
-	Domain         string
-	RouteKeys      []string // "hostname:port" keys into the routes map
+	Dir       string
+	PID       int
+	Domain    string
+	RouteKeys []string // "hostname:port" keys into the routes map
+	// StartTime is an opaque process start token (see daemon.ProcessStartTime):
+	// a generation discriminator, not a timestamp. 0 means the holder could not
+	// read it, so liveness falls back to bare-PID.
+	StartTime      int64
 	RegisteredAt   time.Time
 	CaptureEnabled bool
 }
@@ -78,6 +82,11 @@ func routeKey(hostname string, port int) string {
 type ProjectConflictError struct {
 	Dir string
 	PID int
+	// StartTime is the existing holder's opaque process start token (see
+	// daemon.ProcessStartTime): a generation discriminator, not a timestamp. It
+	// lets the self-heal liveness check distinguish a still-running holder from a
+	// crashed one whose PID has been reused. 0 means bare-PID fallback.
+	StartTime int64
 }
 
 func (e *ProjectConflictError) Error() string {
@@ -96,7 +105,11 @@ func (r *Registry) Register(req RegisterRequest) (hostnames []string, newPorts [
 
 	// Check if this project is already registered
 	if existing, exists := r.projects[req.ProjectDir]; exists {
-		return nil, nil, &ProjectConflictError{Dir: req.ProjectDir, PID: existing.PID}
+		return nil, nil, &ProjectConflictError{
+			Dir:       req.ProjectDir,
+			PID:       existing.PID,
+			StartTime: existing.StartTime,
+		}
 	}
 
 	// Reject same port for both HTTP and HTTPS
@@ -197,6 +210,7 @@ func (r *Registry) Register(req RegisterRequest) (hostnames []string, newPorts [
 		PID:            req.PID,
 		Domain:         req.Domain,
 		RouteKeys:      routeKeys,
+		StartTime:      req.StartTime,
 		RegisteredAt:   now,
 		CaptureEnabled: req.CaptureEnabled,
 	}
@@ -324,18 +338,34 @@ type StaleProject struct {
 	PID int
 }
 
-// StalePIDs returns the registered projects whose PID is no longer running.
-// It only detects — removal goes through the consolidated removeProject path
+// StalePIDs returns the registered projects whose owning process generation is
+// no longer running. Liveness is keyed on (PID, start token) so a reused PID
+// naming a different process reads as dead (see daemon.IsProcessAlive). It only
+// detects — removal goes through the consolidated removeProject path
 // (PID-guarded via DeregisterIfPID) so the crash path purges captured records
 // and body files the same way an explicit deregister does, without racing a
 // concurrent re-registration.
+//
+// The candidate set is snapshotted under RLock and the lock is RELEASED before
+// any liveness check runs: daemon.IsProcessAlive does OS reads (procfs /
+// sysctl) that must not block registry writers.
 func (r *Registry) StalePIDs() []StaleProject {
+	type candidate struct {
+		dir   string
+		pid   int
+		token int64
+	}
 	r.mu.RLock()
-	defer r.mu.RUnlock()
-	var stale []StaleProject
+	candidates := make([]candidate, 0, len(r.projects))
 	for dir, proj := range r.projects {
-		if !daemon.ProcessExists(proj.PID) {
-			stale = append(stale, StaleProject{Dir: dir, PID: proj.PID})
+		candidates = append(candidates, candidate{dir: dir, pid: proj.PID, token: proj.StartTime})
+	}
+	r.mu.RUnlock()
+
+	var stale []StaleProject
+	for _, c := range candidates {
+		if !daemon.IsProcessAlive(c.pid, c.token) {
+			stale = append(stale, StaleProject{Dir: c.dir, PID: c.pid})
 		}
 	}
 	return stale

--- a/internal/proxyd/registry_starttime_test.go
+++ b/internal/proxyd/registry_starttime_test.go
@@ -1,0 +1,126 @@
+package proxyd
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/charliek/prox/internal/daemon"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mustSelfToken reads the current process's start token, or skips the test
+// when the platform can't produce one (the process_other.go stub) — the
+// token-identity semantics under test aren't exercisable without a real token
+// to compare against.
+func mustSelfToken(t *testing.T) int64 {
+	t.Helper()
+	token, ok := daemon.ProcessStartTime(os.Getpid())
+	if !ok {
+		t.Skip("process start token unreadable on this platform; token-identity semantics not exercisable")
+	}
+	return token
+}
+
+// selfPIDRequest builds a RegisterRequest for dir on api.local.dev:443, owned
+// by the current process and carrying startTime as its stored token (pass 0
+// for the bare-PID fallback case).
+func selfPIDRequest(dir string, startTime int64) RegisterRequest {
+	req := newTestRequest(dir, "local.dev",
+		map[string]ServiceTarget{"api": {Host: "localhost", Port: 3000}}, 0, 443)
+	req.PID = os.Getpid()
+	req.StartTime = startTime
+	return req
+}
+
+// TestStalePIDs_TokenMismatchIsStale pins the #61 fix: a live PID whose stored
+// start token no longer matches the running generation reads as stale (its
+// original generation died and the PID was reused), while a live PID stored
+// with StartTime==0 (bare-PID fallback) is NOT stale.
+func TestStalePIDs_TokenMismatchIsStale(t *testing.T) {
+	realToken := mustSelfToken(t)
+
+	reg := NewRegistry()
+
+	// Live PID, but the stored token names a different (dead) generation.
+	mismatch := selfPIDRequest("/projects/mismatch", realToken+1)
+	_, _, err := reg.Register(mismatch)
+	require.NoError(t, err)
+
+	// Live PID with no token captured — bare-PID liveness keeps it alive.
+	bare := newTestRequest("/projects/barealive", "other.dev",
+		map[string]ServiceTarget{"api": {Host: "localhost", Port: 5000}}, 0, 8443)
+	bare.PID = os.Getpid()
+	bare.StartTime = 0
+	_, _, err = reg.Register(bare)
+	require.NoError(t, err)
+
+	stale := reg.StalePIDs()
+	require.Len(t, stale, 1, "only the token-mismatched project should be stale")
+	assert.Equal(t, "/projects/mismatch", stale[0].Dir)
+	assert.Equal(t, os.Getpid(), stale[0].PID)
+}
+
+// TestSelfHeal_TokenMatchStillConflicts pins that a same-dir conflict whose
+// stored holder is (PID=self, StartTime=realToken) — a genuinely live, matching
+// generation — still 409s rather than being silently replaced.
+func TestSelfHeal_TokenMatchStillConflicts(t *testing.T) {
+	realToken := mustSelfToken(t)
+
+	s := newLifecycleServer()
+	req := selfPIDRequest("/projects/live", realToken)
+	_, _, err := s.registry.Register(req)
+	require.NoError(t, err)
+
+	status, body := s.register(req)
+	require.Equal(t, http.StatusConflict, status, "live, token-matching holder must still conflict: %v", body)
+	errResp, ok := body.(ErrorResponse)
+	require.True(t, ok, "conflict body should be an ErrorResponse")
+	assert.Equal(t, "REGISTRATION_CONFLICT", errResp.Code)
+}
+
+// TestSelfHeal_TokenMismatchIsReplaced pins the #61 self-heal path: a same-dir
+// conflict whose stored holder is (PID=self, StartTime=realToken+1) is treated
+// as a crashed generation whose PID was reused, so the re-register replaces it
+// and returns 200.
+func TestSelfHeal_TokenMismatchIsReplaced(t *testing.T) {
+	realToken := mustSelfToken(t)
+
+	s := newLifecycleServer()
+
+	// Stored holder: live PID but a stale token (the reused-PID scenario).
+	stored := selfPIDRequest("/projects/reused", realToken+1)
+	_, _, err := s.registry.Register(stored)
+	require.NoError(t, err)
+
+	// The restart carries the real (current) token for the same live PID.
+	reReq := stored
+	reReq.StartTime = realToken
+	status, body := s.register(reReq)
+	require.Equal(t, http.StatusOK, status, "token mismatch must be treated as dead and self-healed: %v", body)
+
+	// The registration now carries the live generation's real token.
+	route, ok := s.registry.Lookup("api.local.dev", 443)
+	require.True(t, ok, "self-healed route must be registered")
+	assert.Equal(t, os.Getpid(), route.PID)
+}
+
+// TestRegisterRequest_StartTimeWire pins the JSON contract: a body without
+// "start_time" decodes to StartTime==0 (bare-PID fallback), and a zero
+// StartTime is omitted on the wire (omitempty), while a nonzero one round-trips.
+func TestRegisterRequest_StartTimeWire(t *testing.T) {
+	var req RegisterRequest
+	require.NoError(t, json.Unmarshal(
+		[]byte(`{"project_dir":"/p","pid":1,"domain":"d","services":{}}`), &req))
+	assert.Equal(t, int64(0), req.StartTime, "missing start_time must decode to 0")
+
+	zero, err := json.Marshal(RegisterRequest{ProjectDir: "/p", PID: 1})
+	require.NoError(t, err)
+	assert.NotContains(t, string(zero), "start_time", "zero StartTime must be omitted (omitempty)")
+
+	nonzero, err := json.Marshal(RegisterRequest{ProjectDir: "/p", PID: 1, StartTime: 42})
+	require.NoError(t, err)
+	assert.Contains(t, string(nonzero), `"start_time":42`, "nonzero StartTime must be serialized")
+}

--- a/internal/proxyd/registry_test.go
+++ b/internal/proxyd/registry_test.go
@@ -240,12 +240,13 @@ func TestRegistry_DuplicateProject(t *testing.T) {
 		map[string]ServiceTarget{"api": {Host: "localhost", Port: 3000}},
 		0, 443,
 	)
+	req.StartTime = 987654321 // opaque start token; the conflict must echo it back
 	if _, _, err := reg.Register(req); err != nil {
 		t.Fatalf("Register: %v", err)
 	}
 
 	// Try to register the same project again — a typed conflict carrying the
-	// existing registration's dir and PID.
+	// existing registration's dir, PID, and start token.
 	_, _, err := reg.Register(req)
 	if err == nil {
 		t.Fatal("expected duplicate project error, got nil")
@@ -259,6 +260,9 @@ func TestRegistry_DuplicateProject(t *testing.T) {
 	}
 	if conflict.PID != req.PID {
 		t.Errorf("conflict.PID = %d, want %d", conflict.PID, req.PID)
+	}
+	if conflict.StartTime != req.StartTime {
+		t.Errorf("conflict.StartTime = %d, want %d", conflict.StartTime, req.StartTime)
 	}
 	if !strings.Contains(err.Error(), "already registered by a running prox up") ||
 		!strings.Contains(err.Error(), "prox proxy stop --force") {

--- a/internal/proxyd/server.go
+++ b/internal/proxyd/server.go
@@ -244,7 +244,7 @@ func (s *Server) register(req RegisterRequest) (int, any) {
 			// Route/validation conflict — a real error, never retried.
 			return http.StatusConflict, ErrorResponse{Error: err.Error(), Code: "REGISTRATION_CONFLICT"}
 		}
-		if daemon.ProcessExists(conflict.PID) {
+		if daemon.IsProcessAlive(conflict.PID, conflict.StartTime) {
 			// A second live prox up in the same dir is a genuine conflict.
 			return http.StatusConflict, ErrorResponse{Error: err.Error(), Code: "REGISTRATION_CONFLICT"}
 		}

--- a/internal/proxyd/server.go
+++ b/internal/proxyd/server.go
@@ -243,18 +243,17 @@ func (s *Server) register(req RegisterRequest) (int, any) {
 		}
 	}
 
-	// Ensure certs exist for HTTPS domains before starting listeners
-	if s.proxy != nil && s.proxy.certMgr != nil {
-		for _, ps := range newPorts {
-			if ps.Protocol == "https" {
-				if err := s.proxy.certMgr.EnsureDomain(req.Domain); err != nil {
-					s.rollbackRegistration(req.ProjectDir)
-					return http.StatusInternalServerError, ErrorResponse{
-						Error: fmt.Sprintf("failed to generate certs for %s: %v", req.Domain, err),
-						Code:  "CERT_GENERATION_FAILED",
-					}
-				}
-				break // one EnsureDomain per domain is sufficient
+	// Ensure a cert exists for the registration's domain whenever it registers any
+	// HTTPS route. Gating on req.HTTPSPort > 0 (not on a NEW listener port) is the
+	// #58 fix: a domain joining an already-bound shared HTTPS port has no new port
+	// in newPorts, so the old loop skipped its cert and the SNI handshake failed.
+	// EnsureDomain is idempotent (one cert per base domain), so re-calls are cheap.
+	if s.proxy != nil && s.proxy.certMgr != nil && req.HTTPSPort > 0 {
+		if err := s.proxy.certMgr.EnsureDomain(req.Domain); err != nil {
+			s.rollbackRegistration(req.ProjectDir)
+			return http.StatusInternalServerError, ErrorResponse{
+				Error: fmt.Sprintf("failed to generate certs for %s: %v", req.Domain, err),
+				Code:  "CERT_GENERATION_FAILED",
 			}
 		}
 	}

--- a/internal/proxyd/server.go
+++ b/internal/proxyd/server.go
@@ -125,6 +125,23 @@ func (s *Server) RequestShutdown() {
 	}
 }
 
+// quiesceForTeardown makes daemon teardown mutually exclusive with lifecycle
+// transactions. It sets the shutdown flag FIRST (so every later register,
+// deregister, and stale-removal self-gates on isShuttingDown()), then takes
+// lifecycleMu once as a barrier so the single transaction that was already in
+// flight when the flag was set completes atomically before the caller tears down
+// listeners and records. Flag-before-lock is the contract; do not reorder.
+//
+// Lock ordering: RequestShutdown takes shutdownMu and releases it before this
+// method acquires lifecycleMu, so there is no shutdownMu<->lifecycleMu cycle with
+// the scheduleShutdownWhenEmpty timer (which takes lifecycleMu, then shutdownMu
+// via RequestShutdown, with no overlapping hold).
+func (s *Server) quiesceForTeardown() {
+	s.RequestShutdown()
+	s.lifecycleMu.Lock()
+	s.lifecycleMu.Unlock() //nolint:staticcheck // SA2001: intentional lifecycle barrier
+}
+
 func (s *Server) registerRoutes() {
 	// Health check — no prefix, lightweight
 	s.router.Get("/health", func(w http.ResponseWriter, r *http.Request) {
@@ -365,6 +382,13 @@ func (s *Server) scheduleShutdownWhenEmpty() {
 func (s *Server) removeProject(projectDir string) (removedHostnames []string, emptyPorts []int) {
 	s.lifecycleMu.Lock()
 	defer s.lifecycleMu.Unlock()
+	// Once teardown has begun, physical cleanup is the exiting daemon's job:
+	// dynamicProxy.Shutdown closes every listener and captureMgr.Cleanup removes
+	// all body files on exit. A deregister here would race that teardown for the
+	// listeners and the closing RequestManager, so no-op under the flag.
+	if s.isShuttingDown() {
+		return nil, nil
+	}
 	return s.removeProjectLocked(projectDir)
 }
 
@@ -386,6 +410,13 @@ func (s *Server) removeProjectLocked(projectDir string) (removedHostnames []stri
 func (s *Server) removeStaleProject(projectDir string, pid int) (removed bool, removedHostnames []string, emptyPorts []int) {
 	s.lifecycleMu.Lock()
 	defer s.lifecycleMu.Unlock()
+	// Once teardown has begun, physical cleanup is the exiting daemon's job:
+	// dynamicProxy.Shutdown closes every listener and captureMgr.Cleanup removes
+	// all body files on exit. A sweep removal here would race that teardown for
+	// the listeners and the closing RequestManager, so no-op under the flag.
+	if s.isShuttingDown() {
+		return false, nil, nil
+	}
 	return s.removeStaleProjectLocked(projectDir, pid)
 }
 
@@ -510,9 +541,12 @@ func (s *Server) handleShutdown(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.logger.Info("shutdown requested", "force", force)
+	// Set the flag synchronously BEFORE the response so the 200 is the shutdown
+	// linearization point: a register arriving after it observes isShuttingDown()
+	// and gets 503. server.Shutdown is graceful (it waits for this active handler),
+	// so the response still flushes.
+	s.RequestShutdown()
 	writeJSON(w, http.StatusOK, map[string]string{"status": "shutting down"})
-
-	go s.RequestShutdown()
 }
 
 func (s *Server) handleStreamRequests(w http.ResponseWriter, r *http.Request) {

--- a/internal/proxyd/server_lifecycle_test.go
+++ b/internal/proxyd/server_lifecycle_test.go
@@ -5,8 +5,10 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"testing"
 	"time"
@@ -433,6 +435,126 @@ func TestRegister_WhileShuttingDown_Returns503(t *testing.T) {
 	require.True(t, ok, "expected ErrorResponse, got %T", body)
 	assert.Equal(t, "SHUTTING_DOWN", er.Code)
 	assert.True(t, s.registry.IsEmpty(), "no registration may land after shutdown")
+}
+
+// TestQuiesceForTeardown_DrainsInFlightTransaction pins the teardown barrier
+// (#60): quiesceForTeardown sets the shutdown flag FIRST, then blocks on
+// lifecycleMu until the single transaction that was already in flight when the
+// flag was set completes. Modeling the in-flight transaction by holding
+// lifecycleMu directly lets the test assert the flag-before-lock half
+// deterministically (the flag closes while the lock is held) and the
+// barrier-waits half robustly (the return cannot happen until the lock frees).
+func TestQuiesceForTeardown_DrainsInFlightTransaction(t *testing.T) {
+	s := newLifecycleServer()
+
+	// Simulate a lifecycle transaction already in flight by holding the mutex.
+	s.lifecycleMu.Lock()
+
+	done := make(chan struct{})
+	go func() {
+		s.quiesceForTeardown()
+		close(done)
+	}()
+
+	// Flag-before-lock: the shutdown flag closes even while the in-flight
+	// transaction still holds lifecycleMu.
+	select {
+	case <-s.ShutdownCh():
+		// correct — flag set first
+	case <-time.After(2 * time.Second):
+		t.Fatal("quiesceForTeardown must set the shutdown flag before taking the barrier lock")
+	}
+
+	// The barrier must not return while the in-flight holder still owns
+	// lifecycleMu. "A goroutine is blocked on a mutex" is not directly
+	// observable in Go, so give the quiesce goroutine ample opportunity to run
+	// to completion: if the barrier lock were absent, quiesceForTeardown would be
+	// nothing but RequestShutdown and `done` would close within this window. With
+	// the barrier present, `done` stays open for as long as we hold the lock — no
+	// matter how slow the machine — so this assertion is robust in the correct
+	// direction and reliably fails a regression that drops the barrier.
+	for i := 0; i < 50; i++ {
+		runtime.Gosched()
+		time.Sleep(time.Millisecond)
+		select {
+		case <-done:
+			t.Fatal("quiesceForTeardown returned before the in-flight transaction released lifecycleMu")
+		default:
+		}
+	}
+
+	// Release the in-flight transaction; the barrier now completes.
+	s.lifecycleMu.Unlock()
+	select {
+	case <-done:
+		// correct — barrier drained the in-flight holder and returned
+	case <-time.After(2 * time.Second):
+		t.Fatal("quiesceForTeardown must return once the in-flight transaction releases lifecycleMu")
+	}
+}
+
+// TestRemoveProject_NoOpsWhileShuttingDown pins that once the shutdown flag is
+// set, the public removal entries no-op instead of racing the exiting daemon's
+// physical teardown (dynamicProxy.Shutdown / captureMgr.Cleanup). The route and
+// its records must be left intact for the exiting daemon to reap. The
+// register-after-flag → 503 counterpart is covered by
+// TestRegister_WhileShuttingDown_Returns503.
+func TestRemoveProject_NoOpsWhileShuttingDown(t *testing.T) {
+	t.Run("removeProject", func(t *testing.T) {
+		s := newLifecycleServer()
+		req := newTestRequest("/projects/a", "local.dev",
+			map[string]ServiceTarget{"api": {Host: "localhost", Port: 3000}}, 0, 443)
+		req.PID = os.Getpid()
+		_, _, err := s.registry.Register(req)
+		require.NoError(t, err)
+		s.requestManager.Record(proxy.RequestRecord{ID: "a1", Method: "GET", URL: "/a", ProjectDir: "/projects/a"})
+
+		s.RequestShutdown()
+
+		removed, emptyPorts := s.removeProject("/projects/a")
+		assert.Nil(t, removed, "removeProject must no-op while shutting down")
+		assert.Nil(t, emptyPorts)
+
+		_, ok := s.registry.Lookup("api.local.dev", 443)
+		assert.True(t, ok, "route must survive for the exiting daemon to reap")
+		assert.Equal(t, 1, s.requestManager.Count(), "records must not be purged mid-teardown")
+	})
+
+	t.Run("removeStaleProject", func(t *testing.T) {
+		s := newLifecycleServer()
+		req := newTestRequest("/projects/a", "local.dev",
+			map[string]ServiceTarget{"api": {Host: "localhost", Port: 3000}}, 0, 443)
+		req.PID = os.Getpid()
+		_, _, err := s.registry.Register(req)
+		require.NoError(t, err)
+		s.requestManager.Record(proxy.RequestRecord{ID: "a1", Method: "GET", URL: "/a", ProjectDir: "/projects/a"})
+
+		s.RequestShutdown()
+
+		removed, hostnames, emptyPorts := s.removeStaleProject("/projects/a", os.Getpid())
+		assert.False(t, removed, "removeStaleProject must no-op while shutting down")
+		assert.Nil(t, hostnames)
+		assert.Nil(t, emptyPorts)
+
+		_, ok := s.registry.Lookup("api.local.dev", 443)
+		assert.True(t, ok, "route must survive for the exiting daemon to reap")
+		assert.Equal(t, 1, s.requestManager.Count(), "records must not be purged mid-teardown")
+	})
+}
+
+// TestHandleShutdown_SetsFlagBeforeResponse pins that handleShutdown sets the
+// shutdown flag synchronously (before the response), so the 200 is the shutdown
+// linearization point rather than a later goroutine. A register racing the 200
+// then reliably observes isShuttingDown().
+func TestHandleShutdown_SetsFlagBeforeResponse(t *testing.T) {
+	s := newLifecycleServer() // empty registry — no ACTIVE_ROUTES gate
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/shutdown", nil)
+	rec := httptest.NewRecorder()
+	s.handleShutdown(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.True(t, s.isShuttingDown(), "flag must be set synchronously by the time handleShutdown returns")
 }
 
 // TestServer_RemoveProject_NilRequestManager guards the daemon-startup window

--- a/internal/proxyd/types.go
+++ b/internal/proxyd/types.go
@@ -23,6 +23,10 @@ type RegisterRequest struct {
 	HTTPPort       int                      `json:"http_port,omitempty"`
 	HTTPSPort      int                      `json:"https_port,omitempty"`
 	CaptureEnabled bool                     `json:"capture_enabled,omitempty"`
+	// StartTime is an opaque process start token (see daemon.ProcessStartTime):
+	// a generation discriminator, not a timestamp. 0 means the client could not
+	// read it, so the daemon falls back to bare-PID liveness for this holder.
+	StartTime int64 `json:"start_time,omitempty"`
 }
 
 // RegisterResponse is returned after a successful registration.


### PR DESCRIPTION
Three independent daemon-side bugfixes in the `internal/proxyd` registration/lifecycle subsystem, filed from the plan-007 session (PR #57) and implemented as plan 008. One commit each, in the order #58 → #60 → #61.

Closes #58. Closes #60. Advances #61 (see the **sweep-removal residual** below — #61 is intentionally left open pending your decision on a one-line follow-up).

## What changed, per issue

### C1 · #58 — HTTPS cert skipped for a domain joining an existing HTTPS listener (`085b9f5`)
`register()`'s cert phase iterated `newPorts` and called `EnsureDomain` only when a **new** HTTPS listener port was started. A project whose HTTPS port was already bound by another project had `newPorts` empty for that port, so its domain's cert was never generated and the shared TLS listener's SNI callback failed every handshake to the joining project's hostnames.

- Gate cert generation on `req.HTTPSPort > 0` (one idempotent `EnsureDomain` per HTTPS registration), keeping the `s.proxy`/`certMgr` nil guards and the `rollbackRegistration` + `CERT_GENERATION_FAILED` unwinding.
- Add a `certManager` interface and retype `DynamicProxy.certMgr` so the shared-port behavior can be tested with an in-memory-cert fake (no mkcert); `AddListener` now returns an explicit error for an HTTPS bind with a nil certMgr instead of nil-dereferencing.

### C2 · #60 — forced-stop teardown not serialized with lifecycle transactions (`10b4c9c`)
`handleShutdown`'s decision and `RunDaemon`'s teardown ran outside `lifecycleMu`, so a `prox proxy stop --force` racing a register could close a listener the register just added mid-flow or return 200 from an exiting daemon.

- `quiesceForTeardown()` sets the shutdown flag **first**, then takes `lifecycleMu` once as a barrier so the one in-flight transaction completes atomically before teardown; `removeProject`/`removeStaleProject` no-op under the flag; `handleShutdown` sets the flag synchronously before writing 200; `RunDaemon` captures a `serverErr` into `runErr` and runs teardown unconditionally (this also fixes a pre-existing bug where a socket-server error skipped teardown entirely).
- Forced-stop body-file cleanup (the issue's 2nd question): **verified no leak** — the deferred `captureMgr.Cleanup()` `RemoveAll` already reaps body files on exit. No code change.

### C3 · #61 — PID reuse can defeat dead-PID liveness checks (`4152549`)
Every liveness decision was bare-PID signal-0; a recycled PID made a dead registration look alive, reviving the #55 failure.

- New per-host, per-boot process **start token** (opaque generation discriminator, not a timestamp): platform-split `daemon.ProcessStartTime` (Linux `/proc/<pid>/stat` field 22 with an extracted, table-tested parser; Darwin `kinfo_proc` via `SysctlKinfoProc`; a `!darwin,!linux` stub) + `IsProcessAlive` with fallbacks that bias toward "alive" (token 0 or unreadable → bare-PID).
- `RegisterRequest`/`ProjectRegistration`/`*ProjectConflictError` gain `StartTime` (`json:"start_time,omitempty"`); the client captures its own token (warns on failure); `StalePIDs` snapshots under `RLock` then checks liveness outside the lock; the self-heal conflict check uses `IsProcessAlive`.
- Backward-compatible via the wire shape (additive `omitempty`; a missing field decodes to 0 → bare-PID fallback), **not** the version gate (dev builds all report `"dev"`).

## ⚠️ Sweep-removal residual — needs your call (why #61 is left open)

Flagged independently by CodeRabbit (plan review) **and** Codex (C3 review, rated Medium): `StalePIDs` detection is now start-token-aware, but the sweep's **removal** guard `DeregisterIfPID` stays PID-only per the brief's explicit "keep `DeregisterIfPID` intact" pin. So a narrow hole in #61's own class remains:

> old gen `{D,P,T1}` crashes → `StalePIDs` detects it stale but returns only `{Dir,P}` (token dropped) → the restart self-heals and registers `{D,P,T2}` reusing the same PID `P` → the delayed sweep's `removeStaleProject(D,P)` → `DeregisterIfPID(D,P)` matches on PID alone and **tears down the live restart** (closes its now-empty listeners, purges its records).

Trigger is narrow (exact-value PID reuse onto the crashed PID — more feasible on macOS's small PID space — **and** the sweep's removal running after the restart's self-heal within one 30s cycle). The brief pinned `DeregisterIfPID` intact and #61 minimal, and issue #61's stated rationale ("a re-registration changes the PID") is falsified under PID reuse. **Not fixed here** — I honored your explicit pin rather than override it while you were away. The one-line fix is to thread the snapshotted token into the sweep's removal guard (or re-verify `IsProcessAlive` on the current registration before removal); it keeps `TestServer_RemoveStaleProject_SkipsReRegistered` green. Say the word and I'll add it here or spin it into #53 / a new issue.

## Verification

- **Gate green per commit** on macOS: `make lint` (0 issues), `make test`, `make test-race`, `make build`; plus `GOOS=linux`/`GOOS=darwin` cross-compiles for the #61 platform split.
- **New tests**: #58 in-memory-cert TLS-handshake regression (two domains on one shared listener both handshake + `VerifyHostname`; joining-cert-failure rollback leaves the first project's listener intact; HTTP-only never generates; nil-certMgr no panic). #60 deterministic barrier/self-gate tests (channel-synced, not timing-window). #61 `parseProcStatStartTime` table tests + `IsProcessAlive`/`StalePIDs`/self-heal token cases + wire omitempty round-trip.
- **Per-commit review**: each commit ran a Codex correctness pass (C2 adversarial for the concurrency change). C1/C3 code clean; C2's one test-validity finding fixed; C3's one Medium finding is the sweep residual above.
- **#58 live pass** (isolated HOME, real binary, daemon mode): two projects with different domains sharing HTTPS port 19443 — the joining domain is served a SAN-valid, chain-valid cert (`openssl` SAN + `curl --cacert` `ssl_verify_result=0` + HTTP 200); a **baseline (pre-fix) build demonstrably fails** the joining domain's handshake (`tlsv1 alert internal error`, no cert generated). #60 is verified at the `-race` seam; a true PID-reuse for #61 is covered by the token simulation.

## Notes

- **Dependency**: `golang.org/x/sys` promoted from indirect to a direct require (already in the module graph; `go mod tidy`, no network fetch). No `go.sum` change.
- **CI gap**: darwin start-token code isn't exercised by CI (Linux-only); it was run locally (dev is on macOS). A `macos-latest` test job is a recommended follow-up.
- **Privacy/secrets**: none. No new external calls; the start token is a local, opaque, host-private value never logged as time.
- **Restart needed after merge**: all three change daemon behavior, so your real daemon needs its usual restart to pick them up (the exact-match version gate keeps that loud for released versions).

<details>
<summary>Plan 008 — design decisions & accepted risks (the plan file lives outside the repo)</summary>

**#58 (D1–D2):** gate cert generation on `req.HTTPSPort > 0` (idempotent, a strict superset of the old `newPorts` behavior); `certManager` interface seam for a mkcert-free TLS test; nil-safe HTTPS `AddListener`. Cert gen stays under `lifecycleMu` (accepted tradeoff).

**#60 (D3–D4):** flag-first teardown barrier + self-gated `removeProject`/`removeStaleProject` + synchronous flag in `handleShutdown` + unconditional `RunDaemon` teardown. Lock ordering is deadlock-free (`RequestShutdown` releases `shutdownMu` before `quiesceForTeardown` takes `lifecycleMu`; no `shutdownMu↔lifecycleMu` cycle with the grace timer). Body-file cleanup on forced stop is a verified non-change. Residual (accepted, bounded): a register that already passed its `isShuttingDown()` check completes and returns 200 just before exit → stranded client until restart.

**#61 (D5–D9):** `(PID, start token)` identity; token is an opaque per-host/per-boot generation discriminator; `IsProcessAlive` fallbacks bias toward "alive" so a live process is never falsely reaped; zombies are treated as existing ("identity exists," not "running" — reaping them is a non-goal). `DeregisterIfPID`/`StaleProject` stay PID-only (brief-pinned).

**Accepted risks:** #58 `EnsureDomain` holds the cert write lock across mkcert on first generation, briefly stalling TLS handshakes for existing domains on the shared listener (pre-existing; widened; future work = single-flight outside the cache lock). #60 last-register-vs-exit window (bounded). #61 sweep-removal residual (above), unreadable/zero-token fallback to bare-PID, token-granularity collision, PID-namespace-mismatched setups fall back to today's behavior.

**Out of scope (brief-pinned):** #53, #59, #49, #50, #56, #34; supervisor pidfile hardening; zombie reaping; the `EnsureDomain` lock refactor.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of stale registrations when process IDs are reused.
  * Prevented shutdown and teardown race conditions, ensuring consistent responses and cleanup.
  * Improved HTTPS domain registration, certificate provisioning, rollback behavior, and error handling.
  * Ensured daemon startup failures are reported while cleanup still completes reliably.

* **Tests**
  * Added coverage for process identity checks, registration conflicts, shutdown behavior, and HTTPS certificate handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->