### PR TITLE
plan 009 PR-A: daemon lifecycle + infra (#61 sweep guard, cert-lock refactor, macOS CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,17 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    # Matrix over Linux + macOS so the darwin-tagged process code
+    # (internal/daemon/process_darwin.go) and the process-start-token liveness
+    # path are exercised in CI on every change, not just cross-built by the
+    # release pipeline. macos-latest (Apple Silicon) runs the full suite,
+    # including test/integration; fail-fast:false keeps the ubuntu leg's results
+    # visible if the macOS leg flakes.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6

--- a/internal/proxyd/cert_lock_test.go
+++ b/internal/proxyd/cert_lock_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -61,11 +62,29 @@ func TestMultiDomainCertManager_SlowGenerateDoesNotBlockOtherDomain(t *testing.T
 	<-bStarted
 
 	// While B is provably still blocked, GetCertificate for an A host must return
-	// A's cert. This assertion completes BEFORE bRelease is closed below, so A's
-	// handshake path deterministically did not wait on B's generation.
-	gotA, err := m.GetCertificate(&tls.ClientHelloInfo{ServerName: "x.a.test"})
-	require.NoError(t, err)
-	require.Same(t, certA, gotA, "A's host must serve A's cert while B is blocked")
+	// A's cert. Run it in a goroutine bounded by a generous deadline: a lock
+	// regression (generation holding m.mu across mkcert) would block this lookup,
+	// and we want it to FAIL PROMPTLY here instead of hanging until the
+	// suite-level timeout. The deadline is a deadlock guard, not a timing
+	// assertion — a correct impl returns in microseconds.
+	type aResult struct {
+		cert *tls.Certificate
+		err  error
+	}
+	aDone := make(chan aResult, 1)
+	go func() {
+		c, e := m.GetCertificate(&tls.ClientHelloInfo{ServerName: "x.a.test"})
+		aDone <- aResult{c, e}
+	}()
+	select {
+	case got := <-aDone:
+		require.NoError(t, got.err)
+		require.Same(t, certA, got.cert, "A's host must serve A's cert while B is blocked")
+	case <-time.After(2 * time.Second):
+		close(bRelease) // unblock B so its goroutine can finish and not leak
+		<-bErr
+		t.Fatal("GetCertificate(A) blocked while B was generating — cert generation is holding the cache lock")
+	}
 
 	// Unblock B; its EnsureDomain must succeed and publish B's cert.
 	close(bRelease)

--- a/internal/proxyd/cert_lock_test.go
+++ b/internal/proxyd/cert_lock_test.go
@@ -1,0 +1,98 @@
+package proxyd
+
+import (
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMultiDomainCertManager_SlowGenerateDoesNotBlockOtherDomain is the D3/D4
+// lock-discipline regression: a slow first-time generation for domain B must NOT
+// block GetCertificate for the already-loaded domain A. It proves the refactor's
+// core property — EnsureDomain runs the generator OUTSIDE m.mu — by overriding
+// m.generate (white-box, same package) with an in-memory fake instead of shelling
+// mkcert.
+//
+// Coverage boundary (intentional): overriding m.generate bypasses the real
+// generateViaMkcert, so this does not exercise the production mkcert/LoadX509KeyPair
+// path itself. Testing that path's lock discipline directly would require mkcert on
+// the runner or a deeper inner seam (out of scope). The real generateViaMkcert body
+// holds m.mu only via managerFor's brief map-lock; because that lock is NOT
+// reentrant, a regression that wrapped the whole generator in m.mu.Lock would
+// deadlock rather than silently stall — the structural backstop for this boundary.
+func TestMultiDomainCertManager_SlowGenerateDoesNotBlockOtherDomain(t *testing.T) {
+	m := NewMultiDomainCertManager(t.TempDir())
+
+	certA, err := generateWildcardCert("a.test")
+	require.NoError(t, err)
+	certB, err := generateWildcardCert("b.test")
+	require.NoError(t, err)
+
+	// bStarted signals that generate("b.test") has been entered (so B is provably
+	// blocked with NO cache lock held); bRelease unblocks it. A returns
+	// immediately; any other domain is unexpected.
+	bStarted := make(chan struct{})
+	bRelease := make(chan struct{})
+	m.generate = func(domain string) (*tls.Certificate, error) {
+		switch domain {
+		case "a.test":
+			return certA, nil
+		case "b.test":
+			close(bStarted)
+			<-bRelease
+			return certB, nil
+		default:
+			return nil, fmt.Errorf("unexpected domain %s", domain)
+		}
+	}
+
+	// Preload A so m.loaded["a.test"] is set (fast path, no blocking).
+	require.NoError(t, m.EnsureDomain("a.test"))
+
+	// Start B's generation; it blocks inside generate until bRelease is closed.
+	bErr := make(chan error, 1)
+	go func() { bErr <- m.EnsureDomain("b.test") }()
+
+	// Confirm B is inside generate (blocked on bRelease, holding no lock).
+	<-bStarted
+
+	// While B is provably still blocked, GetCertificate for an A host must return
+	// A's cert. This assertion completes BEFORE bRelease is closed below, so A's
+	// handshake path deterministically did not wait on B's generation.
+	gotA, err := m.GetCertificate(&tls.ClientHelloInfo{ServerName: "x.a.test"})
+	require.NoError(t, err)
+	require.Same(t, certA, gotA, "A's host must serve A's cert while B is blocked")
+
+	// Unblock B; its EnsureDomain must succeed and publish B's cert.
+	close(bRelease)
+	require.NoError(t, <-bErr)
+
+	gotB, err := m.GetCertificate(&tls.ClientHelloInfo{ServerName: "svc.b.test"})
+	require.NoError(t, err)
+	require.Same(t, certB, gotB, "B's host must serve B's cert once generation completes")
+}
+
+// TestMultiDomainCertManager_GenerateError_PublishesNothing pins the rollback
+// contract: when generate fails, EnsureDomain returns that error unchanged and
+// publishes nothing (m.loaded still lacks the domain), so register() can map it
+// to CERT_GENERATION_FAILED and roll back cleanly.
+func TestMultiDomainCertManager_GenerateError_PublishesNothing(t *testing.T) {
+	m := NewMultiDomainCertManager(t.TempDir())
+
+	wantErr := errors.New("forced generate failure")
+	m.generate = func(domain string) (*tls.Certificate, error) {
+		return nil, wantErr
+	}
+
+	err := m.EnsureDomain("fail.test")
+	require.Same(t, wantErr, err, "EnsureDomain must return the generate error unchanged")
+
+	m.mu.RLock()
+	_, ok := m.loaded["fail.test"]
+	m.mu.RUnlock()
+	assert.False(t, ok, "a failed generation must publish nothing")
+}

--- a/internal/proxyd/certs.go
+++ b/internal/proxyd/certs.go
@@ -17,49 +17,97 @@ type MultiDomainCertManager struct {
 	certsDir string
 	managers map[string]*certs.Manager   // base domain -> cert manager
 	loaded   map[string]*tls.Certificate // base domain -> loaded cert
+
+	// generate loads (managerFor + mkcert EnsureCerts + LoadX509KeyPair) a cert
+	// for a base domain, holding NO cache lock across mkcert/file I/O. Set once
+	// in the constructor; overridable in tests ONLY (do not mutate
+	// post-construction).
+	generate func(domain string) (*tls.Certificate, error)
 }
 
 // NewMultiDomainCertManager creates a new multi-domain cert manager.
 func NewMultiDomainCertManager(certsDir string) *MultiDomainCertManager {
-	return &MultiDomainCertManager{
+	m := &MultiDomainCertManager{
 		certsDir: certsDir,
 		managers: make(map[string]*certs.Manager),
 		loaded:   make(map[string]*tls.Certificate),
 	}
+	m.generate = m.generateViaMkcert
+	return m
 }
 
-// EnsureDomain ensures a wildcard certificate exists for the given base domain.
-// It generates one via mkcert if it doesn't exist yet.
+// EnsureDomain ensures a wildcard certificate exists for the given base domain,
+// generating one via mkcert if it isn't loaded yet. Generation (mkcert + file
+// load) now runs OUTSIDE m.mu — only a brief RLock (fast path) and a brief Lock
+// (publish) touch the cache — so a joining domain's first-time generation never
+// stalls GetCertificate's RLock and thus never blocks TLS handshakes for OTHER
+// domains on the shared HTTPS listener.
+//
+// The sole caller, register(), is serialized under lifecycleMu, so there is no
+// concurrent EnsureDomain for the same domain and a per-domain single-flight is
+// unnecessary. IF a future non-register caller is added, a per-domain
+// single-flight MUST be reintroduced: two concurrent EnsureCerts on the same
+// *certs.Manager would race on the cert files.
 func (m *MultiDomainCertManager) EnsureDomain(domain string) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	// Already loaded
-	if _, ok := m.loaded[domain]; ok {
+	// Fast path: already loaded — RLock only, never blocks on generation.
+	m.mu.RLock()
+	_, ok := m.loaded[domain]
+	m.mu.RUnlock()
+	if ok {
 		return nil
 	}
 
-	// Create or reuse manager for this domain
+	// Generate with NO cache lock held (m.generate wraps managerFor +
+	// EnsureCerts(mkcert) + LoadX509KeyPair; only managerFor briefly locks
+	// m.mu for the managers map). GetCertificate's RLock is therefore never
+	// blocked by mkcert — the whole point of the refactor.
+	cert, err := m.generate(domain)
+	if err != nil {
+		return err // already wrapped by m.generate
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.loaded[domain]; ok { // double-check: a concurrent caller won
+		return nil
+	}
+	m.loaded[domain] = cert
+	return nil
+}
+
+// generateViaMkcert loads a cert for a base domain: it resolves the domain's
+// certs.Manager, shells to mkcert to generate the cert files if needed, then
+// loads the key pair. It holds NO m.mu except via managerFor's brief lock on the
+// managers map — never across mkcert or file I/O.
+func (m *MultiDomainCertManager) generateViaMkcert(domain string) (*tls.Certificate, error) {
+	mgr := m.managerFor(domain)
+
+	// Ensure certs exist (generate via mkcert if needed).
+	paths, err := mgr.EnsureCerts()
+	if err != nil {
+		return nil, fmt.Errorf("ensuring certs for %s: %w", domain, err)
+	}
+
+	// Load the certificate.
+	cert, err := tls.LoadX509KeyPair(paths.CertFile, paths.KeyFile)
+	if err != nil {
+		return nil, fmt.Errorf("loading cert for %s: %w", domain, err)
+	}
+	return &cert, nil
+}
+
+// managerFor returns the certs.Manager for a base domain, creating and caching
+// it on first use. It briefly locks m.mu for the managers map only; it never
+// runs mkcert.
+func (m *MultiDomainCertManager) managerFor(domain string) *certs.Manager {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	mgr, ok := m.managers[domain]
 	if !ok {
 		mgr = certs.NewManager(m.certsDir, domain)
 		m.managers[domain] = mgr
 	}
-
-	// Ensure certs exist (generate if needed)
-	paths, err := mgr.EnsureCerts()
-	if err != nil {
-		return fmt.Errorf("ensuring certs for %s: %w", domain, err)
-	}
-
-	// Load the certificate
-	cert, err := tls.LoadX509KeyPair(paths.CertFile, paths.KeyFile)
-	if err != nil {
-		return fmt.Errorf("loading cert for %s: %w", domain, err)
-	}
-
-	m.loaded[domain] = &cert
-	return nil
+	return mgr
 }
 
 // GetCertificate is the TLS SNI callback. It selects the appropriate
@@ -83,6 +131,12 @@ func (m *MultiDomainCertManager) GetCertificate(hello *tls.ClientHelloInfo) (*tl
 
 // RemoveDomain removes a domain from the cache. Cert files are left on disk
 // for reuse if the domain is registered again later.
+//
+// Currently unused in production. It is NOT concurrency-safe with EnsureDomain's
+// out-of-lock generation: a RemoveDomain racing a concurrent generation could be
+// followed by that generation's publish, resurrecting the domain. Any future use
+// must serialize against in-flight EnsureDomain (e.g. under lifecycleMu) or
+// reintroduce a per-domain single-flight.
 func (m *MultiDomainCertManager) RemoveDomain(domain string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/proxyd/daemon.go
+++ b/internal/proxyd/daemon.go
@@ -205,7 +205,7 @@ func RunDaemon(ctx context.Context) error {
 			case <-ticker.C:
 				stale := registry.StalePIDs()
 				for _, sp := range stale {
-					removed, hostnames, emptyPorts := server.removeStaleProject(sp.Dir, sp.PID)
+					removed, hostnames, emptyPorts := server.removeStaleProject(sp.Dir, sp.PID, sp.StartTime)
 					if !removed {
 						// Re-registered with a live PID between detection and
 						// removal — leave the new registration alone.

--- a/internal/proxyd/daemon.go
+++ b/internal/proxyd/daemon.go
@@ -214,6 +214,7 @@ func RunDaemon(ctx context.Context) error {
 					logger.Warn("cleaned stale project registration",
 						"project", sp.Dir,
 						"pid", sp.PID,
+						"start_time", sp.StartTime,
 						"removed_hostnames", hostnames,
 						"closed_ports", emptyPorts,
 					)

--- a/internal/proxyd/registry.go
+++ b/internal/proxyd/registry.go
@@ -353,7 +353,7 @@ type StaleProject struct {
 // StalePIDs returns the registered projects whose owning process generation is
 // no longer running. Liveness is keyed on (PID, start token) so a reused PID
 // naming a different process reads as dead (see daemon.IsProcessAlive). It only
-// detects — removal goes through the consolidated removeProject path
+// detects — removal goes through the consolidated removeStaleProject path
 // (identity-guarded via DeregisterIfIdentity) so the crash path purges captured
 // records and body files the same way an explicit deregister does, without
 // racing a concurrent re-registration.

--- a/internal/proxyd/registry.go
+++ b/internal/proxyd/registry.go
@@ -230,18 +230,25 @@ func (r *Registry) Deregister(projectDir string) (removedHostnames []string, emp
 	return r.deregisterLocked(projectDir)
 }
 
-// DeregisterIfPID removes a project's routes only if its CURRENT registration
-// still carries pid. The check and removal happen under one lock acquisition,
-// closing the race where the stale-PID sweep detects a dead generation, the
-// project re-registers with a live PID, and the sweep would otherwise tear
-// down the new live registration. Returns removed=false when the project is
-// gone or has re-registered under a different PID.
-func (r *Registry) DeregisterIfPID(projectDir string, pid int) (removed bool, removedHostnames []string, emptyPorts []int) {
+// DeregisterIfIdentity removes a project's routes only if its CURRENT
+// registration matches BOTH pid and startTime. The check and removal happen
+// under one lock acquisition, closing the reused-PID teardown race: the
+// stale-PID sweep detects a dead generation, the project re-registers with a
+// live process that reused the crashed PID, and a PID-only guard would tear
+// down that new live registration. Keying on the start token as well as the PID
+// makes the reused-PID restart read as a different identity, so it survives.
+// Returns removed=false when the project is gone or has re-registered under a
+// different pid or start token.
+//
+// When startTime is 0 (the holder could not read its start token) the guard
+// degrades to PID-only, so exact-PID reuse can still reap a live restart — the
+// accepted bare-PID fallback (see daemon.IsProcessAlive).
+func (r *Registry) DeregisterIfIdentity(projectDir string, pid int, startTime int64) (removed bool, removedHostnames []string, emptyPorts []int) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	proj, ok := r.projects[projectDir]
-	if !ok || proj.PID != pid {
+	if !ok || proj.PID != pid || proj.StartTime != startTime {
 		return false, nil, nil
 	}
 	removedHostnames, emptyPorts = r.deregisterLocked(projectDir)
@@ -336,15 +343,20 @@ func (r *Registry) IsEmpty() bool {
 type StaleProject struct {
 	Dir string
 	PID int
+	// StartTime is the dead generation's opaque process start token (see
+	// daemon.ProcessStartTime), carried through to the removal guard so a
+	// restart that reused the crashed PID is not torn down. 0 means the holder
+	// could not read it, so the guard degrades to bare-PID.
+	StartTime int64
 }
 
 // StalePIDs returns the registered projects whose owning process generation is
 // no longer running. Liveness is keyed on (PID, start token) so a reused PID
 // naming a different process reads as dead (see daemon.IsProcessAlive). It only
 // detects — removal goes through the consolidated removeProject path
-// (PID-guarded via DeregisterIfPID) so the crash path purges captured records
-// and body files the same way an explicit deregister does, without racing a
-// concurrent re-registration.
+// (identity-guarded via DeregisterIfIdentity) so the crash path purges captured
+// records and body files the same way an explicit deregister does, without
+// racing a concurrent re-registration.
 //
 // The candidate set is snapshotted under RLock and the lock is RELEASED before
 // any liveness check runs: daemon.IsProcessAlive does OS reads (procfs /
@@ -365,7 +377,7 @@ func (r *Registry) StalePIDs() []StaleProject {
 	var stale []StaleProject
 	for _, c := range candidates {
 		if !daemon.IsProcessAlive(c.pid, c.token) {
-			stale = append(stale, StaleProject{Dir: c.dir, PID: c.pid})
+			stale = append(stale, StaleProject{Dir: c.dir, PID: c.pid, StartTime: c.token})
 		}
 	}
 	return stale

--- a/internal/proxyd/registry_test.go
+++ b/internal/proxyd/registry_test.go
@@ -233,6 +233,71 @@ func TestRegistry_DeregisterLeavesOtherProjects(t *testing.T) {
 	}
 }
 
+// TestRegistry_DeregisterIfIdentity pins the reused-PID teardown guard (#61):
+// removal happens only when the CURRENT registration matches BOTH the pid and
+// the start token, so a restart that reused a crashed PID under a new token is
+// never torn down.
+func TestRegistry_DeregisterIfIdentity(t *testing.T) {
+	t.Run("pid and token match removes", func(t *testing.T) {
+		reg := NewRegistry()
+		req := newTestRequest("/projects/a", "local.dev",
+			map[string]ServiceTarget{"api": {Host: "localhost", Port: 3000}}, 0, 443)
+		req.PID = 111
+		req.StartTime = 424242
+		if _, _, err := reg.Register(req); err != nil {
+			t.Fatalf("Register: %v", err)
+		}
+
+		removed, hostnames, emptyPorts := reg.DeregisterIfIdentity("/projects/a", 111, 424242)
+		if !removed {
+			t.Fatal("removed = false, want true when pid and token match")
+		}
+		if len(hostnames) != 1 || hostnames[0] != "api.local.dev" {
+			t.Errorf("hostnames = %v, want [api.local.dev]", hostnames)
+		}
+		if len(emptyPorts) != 1 || emptyPorts[0] != 443 {
+			t.Errorf("emptyPorts = %v, want [443]", emptyPorts)
+		}
+		if !reg.IsEmpty() {
+			t.Error("registry should be empty after a matching identity removal")
+		}
+	})
+
+	t.Run("token mismatch leaves registration intact", func(t *testing.T) {
+		reg := NewRegistry()
+		req := newTestRequest("/projects/a", "local.dev",
+			map[string]ServiceTarget{"api": {Host: "localhost", Port: 3000}}, 0, 443)
+		req.PID = 111
+		req.StartTime = 424242
+		if _, _, err := reg.Register(req); err != nil {
+			t.Fatalf("Register: %v", err)
+		}
+
+		// Same PID reused by a restart under a different token — must not remove.
+		removed, hostnames, emptyPorts := reg.DeregisterIfIdentity("/projects/a", 111, 424243)
+		if removed {
+			t.Fatal("removed = true, want false when the start token differs")
+		}
+		if hostnames != nil || emptyPorts != nil {
+			t.Errorf("expected nil results on skip, got hostnames=%v emptyPorts=%v", hostnames, emptyPorts)
+		}
+		if _, ok := reg.Lookup("api.local.dev", 443); !ok {
+			t.Error("registration must survive a token mismatch")
+		}
+	})
+
+	t.Run("missing project is a no-op", func(t *testing.T) {
+		reg := NewRegistry()
+		removed, hostnames, emptyPorts := reg.DeregisterIfIdentity("/projects/missing", 111, 424242)
+		if removed {
+			t.Fatal("removed = true, want false for a missing project")
+		}
+		if hostnames != nil || emptyPorts != nil {
+			t.Errorf("expected nil results, got hostnames=%v emptyPorts=%v", hostnames, emptyPorts)
+		}
+	})
+}
+
 func TestRegistry_DuplicateProject(t *testing.T) {
 	reg := NewRegistry()
 

--- a/internal/proxyd/selfheal_test.go
+++ b/internal/proxyd/selfheal_test.go
@@ -158,7 +158,10 @@ func TestSelfHeal_Concurrency_RegisterVsSweep(t *testing.T) {
 		}()
 		go func() {
 			defer wg.Done()
-			s.removeStaleProject("/projects/dead", dead)
+			// The dead fixture registers without a start token, so the sweep
+			// guard degrades to bare-PID; reReq below uses os.Getpid() != dead,
+			// so the identity guard skips the live restart exactly as before.
+			s.removeStaleProject("/projects/dead", dead, 0)
 		}()
 		wg.Wait()
 
@@ -180,7 +183,7 @@ func TestSelfHeal_Concurrency_RegisterVsSweep(t *testing.T) {
 			// generation's route or records.
 			recID := fmt.Sprintf("newgen-%d", i)
 			s.requestManager.Record(proxy.RequestRecord{ID: recID, ProjectDir: "/projects/dead", Method: "GET", URL: "/n", Details: &proxy.RequestDetails{}})
-			removed, _, _ := s.removeStaleProject("/projects/dead", dead)
+			removed, _, _ := s.removeStaleProject("/projects/dead", dead, 0)
 			assert.False(t, removed, "iteration %d: late sweep must skip the live generation", i)
 			_, ok = s.registry.Lookup("api.local.dev", port)
 			assert.True(t, ok, "iteration %d: live route must survive a late sweep", i)

--- a/internal/proxyd/server.go
+++ b/internal/proxyd/server.go
@@ -253,7 +253,7 @@ func (s *Server) register(req RegisterRequest) (int, any) {
 		// closes its listeners) and retry once. Under lifecycleMu the retry
 		// cannot lose a race, so a single retry is a correctness guarantee.
 		s.logger.Warn("replacing stale registration", "project", conflict.Dir, "pid", conflict.PID)
-		s.removeStaleProjectLocked(conflict.Dir, conflict.PID)
+		s.removeStaleProjectLocked(conflict.Dir, conflict.PID, conflict.StartTime)
 		hostnames, newPorts, err = s.registry.Register(req)
 		if err != nil {
 			return http.StatusConflict, ErrorResponse{Error: err.Error(), Code: "REGISTRATION_CONFLICT"}
@@ -405,9 +405,10 @@ func (s *Server) removeProjectLocked(projectDir string) (removedHostnames []stri
 }
 
 // removeStaleProject is removeProject for the crash-recovery sweep: removal is
-// guarded on the registration still carrying the detected dead PID, so a
-// project that re-registered between detection and removal is left alone.
-func (s *Server) removeStaleProject(projectDir string, pid int) (removed bool, removedHostnames []string, emptyPorts []int) {
+// guarded on the registration still carrying the detected dead PID AND start
+// token, so a restart that reused the crashed PID between detection and removal
+// is left alone.
+func (s *Server) removeStaleProject(projectDir string, pid int, startTime int64) (removed bool, removedHostnames []string, emptyPorts []int) {
 	s.lifecycleMu.Lock()
 	defer s.lifecycleMu.Unlock()
 	// Once teardown has begun, physical cleanup is the exiting daemon's job:
@@ -417,16 +418,16 @@ func (s *Server) removeStaleProject(projectDir string, pid int) (removed bool, r
 	if s.isShuttingDown() {
 		return false, nil, nil
 	}
-	return s.removeStaleProjectLocked(projectDir, pid)
+	return s.removeStaleProjectLocked(projectDir, pid, startTime)
 }
 
 // removeStaleProjectLocked is removeStaleProject's body; lifecycleMu must be
 // held. register calls it to replace a crashed generation inline.
-func (s *Server) removeStaleProjectLocked(projectDir string, pid int) (removed bool, removedHostnames []string, emptyPorts []int) {
+func (s *Server) removeStaleProjectLocked(projectDir string, pid int, startTime int64) (removed bool, removedHostnames []string, emptyPorts []int) {
 	if s.registry == nil {
 		return false, nil, nil
 	}
-	removed, removedHostnames, emptyPorts = s.registry.DeregisterIfPID(projectDir, pid)
+	removed, removedHostnames, emptyPorts = s.registry.DeregisterIfIdentity(projectDir, pid, startTime)
 	if !removed {
 		return false, nil, nil
 	}

--- a/internal/proxyd/server.go
+++ b/internal/proxyd/server.go
@@ -252,7 +252,7 @@ func (s *Server) register(req RegisterRequest) (int, any) {
 		// registration inline (PID-guarded; purges its records + body files and
 		// closes its listeners) and retry once. Under lifecycleMu the retry
 		// cannot lose a race, so a single retry is a correctness guarantee.
-		s.logger.Warn("replacing stale registration", "project", conflict.Dir, "pid", conflict.PID)
+		s.logger.Warn("replacing stale registration", "project", conflict.Dir, "pid", conflict.PID, "start_time", conflict.StartTime)
 		s.removeStaleProjectLocked(conflict.Dir, conflict.PID, conflict.StartTime)
 		hostnames, newPorts, err = s.registry.Register(req)
 		if err != nil {

--- a/internal/proxyd/server_lifecycle_test.go
+++ b/internal/proxyd/server_lifecycle_test.go
@@ -85,7 +85,7 @@ func TestServer_StalePIDSweep_PurgesRecords(t *testing.T) {
 	stale := s.registry.StalePIDs()
 	require.Equal(t, []StaleProject{{Dir: "/projects/dead", PID: dead}}, stale)
 	for _, sp := range stale {
-		removed, _, _ := s.removeStaleProject(sp.Dir, sp.PID)
+		removed, _, _ := s.removeStaleProject(sp.Dir, sp.PID, sp.StartTime)
 		assert.True(t, removed)
 	}
 
@@ -119,11 +119,61 @@ func TestServer_RemoveStaleProject_SkipsReRegistered(t *testing.T) {
 	require.NoError(t, err)
 	s.requestManager.Record(proxy.RequestRecord{ID: "x1", Method: "GET", URL: "/x", ProjectDir: "/projects/x"})
 
-	removed, _, _ := s.removeStaleProject(stale[0].Dir, stale[0].PID)
+	removed, _, _ := s.removeStaleProject(stale[0].Dir, stale[0].PID, stale[0].StartTime)
 	assert.False(t, removed, "guarded removal must skip the re-registered project")
 	_, ok := s.registry.Lookup("api.local.dev", 443)
 	assert.True(t, ok, "live registration's route must survive")
 	assert.Equal(t, 1, s.requestManager.Count(), "live registration's records must survive")
+}
+
+// TestServer_RemoveStaleProject_SkipsReusedPID pins the reused-PID teardown fix
+// (#61): the sweep snapshots a dead generation's identity (PID + start token),
+// but a restart reuses the crashed PID under a NEW start token before removal.
+// The identity guard must key on the token too, so the delayed sweep removal
+// leaves the live restart — same PID, different token — alone.
+func TestServer_RemoveStaleProject_SkipsReusedPID(t *testing.T) {
+	s := newLifecycleServer()
+
+	const (
+		t1 int64 = 424242 // dead generation's start token
+		t2       = t1 + 1 // restart's start token (same PID, new generation)
+	)
+
+	// Dead generation {D, deadP, T1}: a non-zero token so the guard does not
+	// degrade to bare-PID. The dead PID makes StalePIDs detect it.
+	deadP := deadPID(t)
+	req := newTestRequest("/projects/x", "local.dev",
+		map[string]ServiceTarget{"api": {Host: "localhost", Port: 3000}}, 0, 443)
+	req.PID = deadP
+	req.StartTime = t1
+	_, _, err := s.registry.Register(req)
+	require.NoError(t, err)
+
+	// Token-propagation half: the snapshot carries the dead generation's token.
+	stale := s.registry.StalePIDs()
+	require.Len(t, stale, 1)
+	assert.Equal(t, deadP, stale[0].PID)
+	assert.Equal(t, t1, stale[0].StartTime, "snapshot must carry the dead generation's start token")
+
+	// Restart reuses the crashed PID under a new start token before the sweep
+	// removal fires.
+	s.registry.Deregister("/projects/x")
+	reReq := newTestRequest("/projects/x", "local.dev",
+		map[string]ServiceTarget{"api": {Host: "localhost", Port: 3000}}, 0, 443)
+	reReq.PID = deadP // same PID reused by the restart
+	reReq.StartTime = t2
+	_, _, err = s.registry.Register(reReq)
+	require.NoError(t, err)
+	s.requestManager.Record(proxy.RequestRecord{ID: "x1", Method: "GET", URL: "/x", ProjectDir: "/projects/x"})
+
+	// Guard half: the delayed sweep removal targets the dead generation's
+	// identity (deadP, T1), but the current registration carries T2 — the
+	// identity guard must skip it regardless of the shared PID.
+	removed, _, _ := s.removeStaleProject(stale[0].Dir, stale[0].PID, stale[0].StartTime)
+	assert.False(t, removed, "reused-PID restart under a new token must survive the sweep")
+	_, ok := s.registry.Lookup("api.local.dev", 443)
+	assert.True(t, ok, "live restart's route must survive")
+	assert.Equal(t, 1, s.requestManager.Count(), "live restart's records must survive")
 }
 
 // TestHandleRegister_RejectsEmptyProjectDir pins the identity requirement:
@@ -531,7 +581,7 @@ func TestRemoveProject_NoOpsWhileShuttingDown(t *testing.T) {
 
 		s.RequestShutdown()
 
-		removed, hostnames, emptyPorts := s.removeStaleProject("/projects/a", os.Getpid())
+		removed, hostnames, emptyPorts := s.removeStaleProject("/projects/a", os.Getpid(), 0)
 		assert.False(t, removed, "removeStaleProject must no-op while shutting down")
 		assert.Nil(t, hostnames)
 		assert.Nil(t, emptyPorts)


### PR DESCRIPTION
Plan 009 (post-plan-008 Tier-1 follow-ups), **PR-A of 3** — the cohesive daemon/infra items. Sibling PRs (opened separately): PR-B TUI logs search (#56), PR-C supervisor orphan reap (#59).

The plan lives outside the repo (`~/.claude/plans/prox/009-plan008-followups.md`), panel-reviewed by Codex + GLM 5.2 + CodeRabbit; its substance is reproduced below.

## What changed

### C1 — `fix(proxyd): make stale-PID sweep removal token-aware` (Closes #61)
Plan 008 made stale-PID **detection** token-aware but left the sweep's **removal** guard `DeregisterIfPID` PID-only, so under exact-PID reuse the sweep could tear down a **live** restart: old gen `{D,P,T1}` crashes → `StalePIDs` detects it stale but discarded the token → the restart self-heals as `{D,P,T2}` reusing PID `P` → the delayed sweep's `removeStaleProject(D,P)` matched on PID alone and closed the live restart's listeners / purged its records.
- `StaleProject` carries `StartTime`; `StalePIDs` stops discarding the token.
- Replaced `DeregisterIfPID` with token-aware `DeregisterIfIdentity(dir, pid, startTime)` (removes only when the current registration matches **both** pid and token). Self-heal passes `conflict.StartTime` (exact under `lifecycleMu`); the sweep passes `sp.StartTime`.
- Token 0 (holder couldn't read its start token) degrades to the accepted bare-PID fallback, unchanged from plan 008.

### C2 — `refactor(proxyd): run cert generation outside the cache lock`
`EnsureDomain` held `m.mu.Lock()` across the mkcert subprocess + `tls.LoadX509KeyPair`, while `GetCertificate` needs `m.mu.RLock()` per handshake — so a joining domain's first-time generation stalled TLS handshakes for **all** domains on the shared HTTPS listener (the accepted-risk stall from plan 008 §9, widened by #58).
- mkcert/file I/O now runs with **no** cache lock held (via an `m.generate` seam); publish happens under a brief double-checked `Lock`.
- No per-domain single-flight (the sole caller `register()` is serialized under `lifecycleMu`); documented, with a future-caller caveat.
- Idempotency + `CERT_GENERATION_FAILED` rollback preserved. Documented behavior change: a `GetCertificate(B)` racing B's first generation now fails fast instead of blocking-then-succeeding.

### C3 — `ci: run the test job on macOS as well as Linux`
Matrix the `test` job over `[ubuntu-latest, macos-latest]` (`fail-fast: false`) so the darwin-tagged `process_darwin.go` + the #61 start-token liveness path run in CI, not just cross-built. `lint`/`release-snapshot` stay ubuntu-only.

## Verification
- **Per-commit gate green** on macOS: `make lint && make test && make test-race && make build` (incl. `test/integration`, no data races).
- **C1:** new `TestServer_RemoveStaleProject_SkipsReusedPID` (a live `{D,P,T2}` survives a sweep snapshot for `{D,P,T1}`, asserting token propagation) + `TestRegistry_DeregisterIfIdentity`; pinned `_StalePIDSweep_PurgesRecords` / `_SkipsReRegistered` stay green. Codex adversarial review: **no correctness findings**.
- **C2:** deterministic `cert_lock_test.go` (a slow generate for B does not block `GetCertificate(A)`, channel-synchronized; a generate error publishes nothing). Codex review: production refactor correct; one test-coverage finding dispositioned (documented coverage boundary — the seam bypasses the real `generateViaMkcert`, whose lock discipline would need mkcert-in-test or a deeper seam; a lock wrapped around the whole generator would deadlock via non-reentrant `managerFor`).
- **C3:** this PR's own CI run on `macos-latest` is the acceptance signal.
- A live isolated-HOME/project daemon pass for #61 + the cert-lock refactor is being run separately and will be posted as a comment.

## Dependency / privacy / secret impact
None. No new dependencies (the per-domain single-flight was deliberately avoided, so no `golang.org/x/sync`). No secrets, no data-collection, no wire-format change.

## Accepted risks (dispositioned in the plan)
- **#61 token-0 residual:** with a zero/unreadable token the identity guard degrades to PID-only (accepted bare-PID fallback; tokens are available on both shipped platforms). Documented on `DeregisterIfIdentity`.
- **C2 behavior change:** the fail-fast `GetCertificate(B)` during B's first generation (above) — unreachable in normal flow (register returns 200 only after publish), documented.
- **macOS CI cost/flakiness:** the matrix doubles the `test` job; `fail-fast: false` preserves ubuntu visibility; a narrowing fallback is noted if integration flakes on macOS.

<details>
<summary>Plan 009 — PR-A sections (C1/C2/C3 design, D1–D5)</summary>

See `~/.claude/plans/prox/009-plan008-followups.md` §D1–D5, §7 (acceptance), §9 (risks), §10 (panel dispositions). Key pinned decisions:
- #61: chose the token-threading guard (option b) over re-verifying `IsProcessAlive` inside the shared `removeStaleProjectLocked` (option a), which would regress the self-heal path on a transiently-unreadable token.
- Cert-lock: double-checked publish, **no** mutex map — panel confirmed the sole caller is serialized, so a single-flight would be dead weight + a per-domain leak.
- macOS CI: matrix the `test` job; keep `lint`/`release-snapshot` ubuntu-only.

Panel (Codex + GLM 5.2 + CodeRabbit) corrections incorporated for these commits: all 5 `removeStaleProject` test call sites updated (compile break), assert token propagation in the reused-PID test, drop the mutex map, document the cert-lock behavior change + `RemoveDomain` note.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgMgg6eo4LgLTCkfYSARcH


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved certificate handling so one domain’s generation no longer blocks access to other domains.
  - Improved resilience so failed certificate generation doesn’t leave partial domain state.
  - Hardened stale project cleanup so deregistration happens only for the intended process (PID + start-time identity).
  - Enhanced stale-cleanup warnings with start time, removed hostnames, and closed/empty ports.

- **Tests**
  - Expanded CI to run the full test suite on both Linux and macOS.
  - Added regression coverage for certificate concurrency and generation failures, plus identity-guarded stale deregistration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->