### PR TITLE
plan 009 PR-B: TUI logs-view search navigation + highlighting (#56)

### DIFF
--- a/docs/reference/tui.md
+++ b/docs/reference/tui.md
@@ -81,7 +81,8 @@ A request whose response is still streaming shows its real header-time status bu
 | --- | ------ |
 | `1-9` | Solo process (press again for all) |
 | `f` | Open process filter (multi-select) |
-| `/` | Substring filter, committed on `Enter` (hides non-matching) |
+| `/` | Search lines — jumps the cursor to a match (does not filter) |
+| `n` / `N` | Jump the cursor to the next/previous match (wraps) |
 | `s` | Substring filter, applied live (hides non-matching) |
 | `r` | Restart the soloed process (select with `1`-`9` first) |
 
@@ -180,10 +181,13 @@ Press `f` to open the multi-select process filter:
 Press `/` to enter search mode. An input field appears at the bottom; the
 behavior depends on the active view:
 
-- **Logs view:** `/` is a case-insensitive substring filter committed on
-  `Enter` — matching lines are kept and non-matching ones hidden (the same
-  effect as `s`, which applies live instead of on `Enter`). There is no match
-  highlighting and no `n`/`N` navigation in the logs view.
+- **Logs view:** `/` is case-insensitive substring *navigation* over the log
+  line text. On `Enter` the cursor jumps to the first match at-or-after its
+  current position (wrapping); `n`/`N` then jump to the next and previous
+  matches (wrapping). No lines are hidden, so search composes with an active
+  `s` filter — the cursor row is marked with `❯` and the matched substring is
+  highlighted, and the status bar shows the match indicator (`/<query> (i/k)`
+  or `/<query> (k matches)`). Use `s` — not `/` — to hide non-matching lines.
 - **Requests view:** `/` is case-insensitive substring *navigation* over
   URL/method/subdomain. On `Enter` the cursor jumps to the first match
   at-or-after its current row (wrapping); `n`/`N` then jump to the next and

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/go-chi/chi/v5 v5.2.4
 	github.com/joho/godotenv v1.5.1
+	github.com/muesli/termenv v0.16.0
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/sys v0.36.0
@@ -32,7 +33,6 @@ require (
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
-	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect

--- a/internal/domain/log.go
+++ b/internal/domain/log.go
@@ -21,6 +21,14 @@ type LogEntry struct {
 	Process   string    `json:"process"`
 	Stream    Stream    `json:"stream"`
 	Line      string    `json:"line"`
+	// Seq is a TUI-session-local monotonic sequence number assigned on ingest
+	// (BaseModel.handleLogEntry). It anchors the logs-view `/`-search cursor
+	// across the 1000-entry front-eviction ring, where a bare slice index would
+	// drift as old entries are dropped. It is deliberately json:"-": session-
+	// local UI state that must NOT ride the socket wire to the attach client
+	// (which stamps its own on ingest). The wire itself carries LogEntry only
+	// via api.LogEntryResponse, which has no Seq field.
+	Seq int64 `json:"-"`
 }
 
 // LogFilter defines criteria for filtering log entries

--- a/internal/tui/base.go
+++ b/internal/tui/base.go
@@ -63,6 +63,30 @@ type BaseModel struct {
 	// the filtered list at keypress time (D12/D13).
 	requestSearchQuery string
 
+	// logSearchQuery is the logs-view `/` search term. Like requestSearchQuery
+	// (and unlike searchPattern, the `s` filter) it NAVIGATES rather than
+	// filters: `/` jumps the logs cursor to the first matching line and n/N
+	// cycle, leaving every line visible. Match state is never stored; the seek
+	// helpers rescan filteredEntries() at keypress time (D6-D8).
+	logSearchQuery string
+
+	// logSeq is a session-local monotonic counter stamped onto each ingested
+	// LogEntry.Seq. The logs cursor is anchored by Seq, not index, so it rides
+	// the 1000-entry front-eviction ring without drifting (a bare index would
+	// shift when old entries are dropped — see LogEntry.Seq) (D7).
+	logSeq int64
+
+	// Logs-view search cursor (Seq-anchored). logCursorSeq names the line the
+	// cursor sits on; logCursorIdx is its index in the filtered list. Both are
+	// mutated ONLY through setLogCursor so they can never disagree. logCursorSeq
+	// 0 is the explicit no-cursor sentinel (ingested Seqs are always >= 1), and
+	// logCursorIdx -1 pairs with it. Unlike the requests cursor, this one exists
+	// only while a `/`-search is active and is not scroll-coupled: j/k keep
+	// scrolling the viewport, and resolveLogCursor only re-derives the marker
+	// index — the scroll-to-match is a one-shot from the /,n,N handlers (D8/D9).
+	logCursorSeq int64
+	logCursorIdx int
+
 	// Auto-scroll
 	followMode bool // Auto-scroll to bottom on new logs
 
@@ -116,6 +140,7 @@ func newBaseModel(helpConfig HelpConfig) BaseModel {
 		viewMode:        ViewModeLogs,
 		filterProcesses: make(map[string]bool),
 		followMode:      true,
+		logCursorIdx:    -1, // no-cursor sentinel (pairs with logCursorSeq 0)
 		helpConfig:      helpConfig,
 	}
 }
@@ -149,6 +174,10 @@ func (b *BaseModel) handleLogEntry(entry domain.LogEntry) {
 	// Check if we're at/near bottom BEFORE adding new content
 	wasNearBottom := b.isNearBottom()
 
+	// Stamp a session-local monotonic Seq so the logs search cursor can anchor
+	// to this line's identity across the front-eviction ring below (D7).
+	b.logSeq++
+	entry.Seq = b.logSeq
 	b.logEntries = append(b.logEntries, entry)
 	// Keep only last entries - create new slice to release memory from old entries
 	if len(b.logEntries) > maxLogEntries {
@@ -158,8 +187,15 @@ func (b *BaseModel) handleLogEntry(entry domain.LogEntry) {
 	}
 	b.updateViewport()
 
-	// If user was at bottom, re-enable follow mode and stay at bottom
-	if wasNearBottom {
+	// If user was at bottom, re-enable follow mode and stay at bottom — UNLESS an
+	// active logs search has parked the cursor off the newest row. landLogSearchJump
+	// deliberately disengages follow on an off-newest match; with a short/full
+	// viewport that match is still "near bottom", so a streaming arrival would
+	// otherwise silently flip follow back on and let resolveLogCursor drag the ❯
+	// marker off the match (search position lost mid-stream). While a search is
+	// parked (query set, follow off), leave follow disengaged.
+	searchParked := b.logSearchQuery != "" && !b.followMode
+	if wasNearBottom && !searchParked {
 		b.followMode = true
 		b.viewport.GotoBottom()
 	} else if b.followMode {
@@ -279,9 +315,17 @@ func (b *BaseModel) handleSearchKey(msg tea.KeyMsg) (bool, tea.Cmd) {
 			b.updateViewport()
 			return true, nil
 		}
-		// Logs view: `/` is a substring filter committed on Enter (D14).
-		b.searchPattern = b.textInput.Value()
+		// Logs view: `/` is navigation, not filtration (D6/D8) — it mirrors the
+		// requests view. Commit the query to logSearchQuery (searchPattern — the
+		// `s` filter — is untouched) and jump the cursor to the first match
+		// at-or-after the current position, wrapping. The scroll-to-match is a
+		// one-shot here rather than wired into updateViewport, which also runs on
+		// streaming arrivals and free j/k scroll where re-scrolling would fight
+		// the reader.
+		b.logSearchQuery = b.textInput.Value()
+		b.seekLogSearchMatch(0)
 		b.updateViewport()
+		b.ensureLogCursorVisible()
 		return true, nil
 	}
 
@@ -370,16 +414,25 @@ func (b *BaseModel) handleNavigationKey(msg tea.KeyMsg) bool {
 		return true
 
 	case "n", "N":
-		// Requests-view search navigation only: n jumps to the next match
-		// strictly after the cursor, N to the previous, both wrapping (D13).
-		// No-op (and unhandled elsewhere) outside the requests view.
-		if b.viewMode == ViewModeRequests {
-			dir := 1
-			if msg.String() == "N" {
-				dir = -1
-			}
+		// Search navigation: n jumps to the next match strictly after the
+		// cursor, N to the previous, both wrapping. Handled in the requests view
+		// (D13) and the logs view (D8); a no-op query in either view leaves the
+		// cursor put. Unhandled in the detail view.
+		dir := 1
+		if msg.String() == "N" {
+			dir = -1
+		}
+		switch b.viewMode {
+		case ViewModeRequests:
 			b.cycleRequestSearchMatch(dir)
 			b.updateViewport()
+			return true
+		case ViewModeLogs:
+			// One-shot scroll to the landed match, after the re-render (updateViewport
+			// deliberately never scrolls the logs viewport — see seekLogSearchMatch).
+			b.seekLogSearchMatch(dir)
+			b.updateViewport()
+			b.ensureLogCursorVisible()
 			return true
 		}
 		return false
@@ -412,10 +465,15 @@ func (b *BaseModel) handleNavigationKey(msg tea.KeyMsg) bool {
 			b.updateViewport()
 			return true
 		}
-		// Clear filters (and the requests-view search query — D13).
+		// Clear filters and both views' search queries (D13/D8). Resetting the
+		// logs cursor to the no-cursor sentinel makes the next `/` seed its
+		// origin from the viewport again rather than the stale prior match.
 		b.soloProcess = ""
 		b.searchPattern = ""
 		b.requestSearchQuery = ""
+		b.logSearchQuery = ""
+		b.logCursorSeq = 0
+		b.logCursorIdx = -1
 		b.updateViewport()
 		return true
 
@@ -624,6 +682,189 @@ func (b *BaseModel) requestSearchMatchInfo(requests []proxy.RequestRecord) (posi
 	return position, total
 }
 
+// logMatchesSearch reports whether a log line matches the logs-view `/` query:
+// a case-insensitive substring over the line text (D8).
+func logMatchesSearch(entry domain.LogEntry, query string) bool {
+	return containsIgnoreCase(entry.Line, query)
+}
+
+// seekLogSearchMatch scans the filtered log entries for a matching line and
+// moves the logs cursor to it. dir 0 = at-or-after the origin (the `/`-commit
+// jump, includes the origin row); dir +1/-1 = strictly next/previous (n/N),
+// wrapping. Mirrors seekRequestSearchMatch: derived at keypress time, no match
+// list is ever stored (D8).
+func (b *BaseModel) seekLogSearchMatch(dir int) {
+	if b.logSearchQuery == "" {
+		return
+	}
+	entries := b.filteredEntries()
+	n := len(entries)
+	if n == 0 {
+		return
+	}
+	start := b.logSearchOriginIdx(entries)
+	if dir == 0 {
+		// At-or-after: offsets 0..n-1 forward, origin row first.
+		for i := 0; i < n; i++ {
+			idx := (start + i) % n
+			if logMatchesSearch(entries[idx], b.logSearchQuery) {
+				b.landLogSearchJump(entries, idx, n)
+				return
+			}
+		}
+		return
+	}
+	// Strictly past the cursor: offsets 1..n-1 in dir, wrapping. The origin row
+	// is never revisited, so n/N are no-ops when it is the sole match.
+	for i := 1; i < n; i++ {
+		idx := ((start+dir*i)%n + n) % n
+		if logMatchesSearch(entries[idx], b.logSearchQuery) {
+			b.landLogSearchJump(entries, idx, n)
+			return
+		}
+	}
+}
+
+// logSearchOriginIdx returns the index in entries from which a seek should
+// begin. With a cursor already anchored (logCursorSeq set), it re-resolves that
+// Seq to its current index — surviving the eviction ring — and clamps the
+// last-known index when the anchored line has been evicted. On the FIRST search
+// (no cursor yet), it seeds from what the user is looking at: the newest row
+// under follow, else the top visible row derived from the viewport offset, so
+// `/` searches from the region on screen (D8).
+func (b *BaseModel) logSearchOriginIdx(entries []domain.LogEntry) int {
+	n := len(entries)
+	if b.logCursorSeq != 0 {
+		for i, e := range entries {
+			if e.Seq == b.logCursorSeq {
+				return i
+			}
+		}
+		// Anchored line evicted: fall back to the clamped last-known index.
+		return clampIndex(b.logCursorIdx, n)
+	}
+	if b.followMode {
+		return n - 1
+	}
+	return clampIndex(b.viewport.YOffset, n)
+}
+
+// clampIndex clamps idx into [0, n-1] for a non-empty n (callers guard n > 0).
+func clampIndex(idx, n int) int {
+	if idx < 0 {
+		return 0
+	}
+	if idx > n-1 {
+		return n - 1
+	}
+	return idx
+}
+
+// landLogSearchJump places the logs cursor on a search match. Mirrors
+// landSearchJump: follow is disengaged only when the jump moves the cursor off
+// the newest row — a jump must stick against resolveLogCursor's pin-to-newest
+// and handleLogEntry's auto-GotoBottom, but a match landing ON the newest row
+// leaves follow untouched (never re-engaged; a search jump is positioning, not
+// scrolling intent).
+func (b *BaseModel) landLogSearchJump(entries []domain.LogEntry, idx, n int) {
+	if idx != n-1 {
+		b.followMode = false
+	}
+	b.setLogCursor(entries, idx)
+}
+
+// setLogCursor is the SOLE mutator of the logs-view search cursor. It clamps
+// idx into [0, len(entries)-1] and updates logCursorIdx and logCursorSeq
+// together so the pair can never disagree; an empty list resets to the
+// no-cursor sentinel (logCursorIdx -1, logCursorSeq 0). Mirrors setRequestCursor.
+func (b *BaseModel) setLogCursor(entries []domain.LogEntry, idx int) {
+	if len(entries) == 0 {
+		b.logCursorIdx = -1
+		b.logCursorSeq = 0
+		return
+	}
+	idx = clampIndex(idx, len(entries))
+	b.logCursorIdx = idx
+	b.logCursorSeq = entries[idx].Seq
+}
+
+// resolveLogCursor re-anchors the logs search cursor against the current
+// filtered list at render time (called from updateViewport only while a search
+// is active), so the row marker stays on the searched-to line as entries stream
+// in and the eviction ring shifts indices. Mirrors resolveRequestCursor but
+// anchors by Seq (logs have no ID) and NEVER scrolls — the logs viewport scroll
+// stays owned by j/k, follow, and the one-shot ensureLogCursorVisible.
+//
+// Unlike the requests cursor (which always exists), the logs cursor is
+// search-scoped: logCursorSeq 0 means no jump has landed (fresh search with no
+// match, or a cleared one), so there is NO marker — we return the sentinel
+// rather than manufacturing a row-0 cursor. Precedence when a cursor DOES exist:
+//   - follow mode pins the cursor to the newest (last) row;
+//   - else if logCursorSeq is still present, its current index;
+//   - else the stale logCursorIdx is clamped and re-anchored (line evicted).
+func (b *BaseModel) resolveLogCursor(entries []domain.LogEntry) {
+	if b.logCursorSeq == 0 {
+		b.logCursorIdx = -1 // no active cursor: sentinel, no marker
+		return
+	}
+	if len(entries) == 0 {
+		b.setLogCursor(entries, 0) // resets to the no-cursor sentinel
+		return
+	}
+	if b.followMode {
+		b.setLogCursor(entries, len(entries)-1)
+		return
+	}
+	for i, e := range entries {
+		if e.Seq == b.logCursorSeq {
+			b.setLogCursor(entries, i)
+			return
+		}
+	}
+	// Anchored line evicted: clamp the last-known index and re-anchor.
+	b.setLogCursor(entries, b.logCursorIdx)
+}
+
+// ensureLogCursorVisible scrolls the logs viewport the minimum amount needed to
+// bring the cursor row on-screen. Called ONLY from the /,n,N handlers as a
+// one-shot (mirrors ensureCursorVisible but is deliberately NOT wired into
+// updateViewport, so streaming re-renders and free j/k scroll are never yanked).
+func (b *BaseModel) ensureLogCursorVisible() {
+	if b.logCursorIdx < 0 {
+		return // no-cursor sentinel (empty list or no active search)
+	}
+	// A grown viewport (or shrunk list) can leave YOffset past the last valid
+	// offset. Reclamp before the minimal-scroll branches.
+	if maxOffset := b.viewport.TotalLineCount() - b.viewport.Height; b.viewport.YOffset > maxOffset {
+		b.viewport.SetYOffset(max(0, maxOffset))
+	}
+	if b.logCursorIdx < b.viewport.YOffset {
+		b.viewport.SetYOffset(b.logCursorIdx)
+	} else if b.logCursorIdx >= b.viewport.YOffset+b.viewport.Height {
+		b.viewport.SetYOffset(b.logCursorIdx - b.viewport.Height + 1)
+	}
+}
+
+// logSearchMatchInfo derives the status-bar match indicator for the current
+// logSearchQuery over entries (the filtered list): total match count and the
+// cursor's 1-based position among matches (0 when the cursor is off any match).
+// Mirrors requestSearchMatchInfo; entries is passed in so statusBar shares one
+// filteredEntries() scan with the visible/total count (D10).
+func (b *BaseModel) logSearchMatchInfo(entries []domain.LogEntry) (position, total int) {
+	if b.logSearchQuery == "" {
+		return 0, 0
+	}
+	for i, entry := range entries {
+		if logMatchesSearch(entry, b.logSearchQuery) {
+			total++
+			if i == b.logCursorIdx {
+				position = total
+			}
+		}
+	}
+	return position, total
+}
+
 // isNearBottom checks if the viewport is at or near the bottom
 func (b *BaseModel) isNearBottom() bool {
 	if b.viewport.AtBottom() {
@@ -742,8 +983,24 @@ func (b *BaseModel) updateViewport() {
 		}
 	default: // ViewModeLogs
 		entries := b.filteredEntries()
-		for _, entry := range entries {
+		// A `/`-search adds a cursor row marker (mirroring the requests block).
+		// Resolve the Seq-anchored cursor against the just-computed list BEFORE
+		// formatting so the marker index and formatLogEntry's inline highlight
+		// agree within this single render. No cursor/marker without a search:
+		// the marker prefix would otherwise shift every log line for no reason.
+		searching := b.logSearchQuery != ""
+		if searching {
+			b.resolveLogCursor(entries)
+		}
+		for i, entry := range entries {
 			line := b.formatLogEntry(entry)
+			if searching {
+				marker := "  "
+				if i == b.logCursorIdx {
+					marker = cursorStyle.Render("❯ ")
+				}
+				line = marker + line
+			}
 			lines = append(lines, line)
 		}
 	}
@@ -1088,7 +1345,47 @@ func (b *BaseModel) formatLogEntry(entry domain.LogEntry) string {
 		streamIndicator = errorStyle.Render(" ERR ")
 	}
 
-	return fmt.Sprintf("%s %s%s %s", timestamp, prefix, streamIndicator, entry.Line)
+	return fmt.Sprintf("%s %s%s %s", timestamp, prefix, streamIndicator, b.highlightLogLine(entry.Line))
+}
+
+// highlightLogLine wraps the first case-insensitive match of the active
+// logSearchQuery in line with searchHighlightStyle (D9). It highlights only
+// when BOTH the query and the WHOLE line are plain ASCII with no ESC byte:
+// case-folding an ASCII line preserves byte offsets (so the styled run lands
+// exactly on the match), and excluding ESC keeps a digit query from matching
+// inside an ANSI escape sequence. Any other line (unicode, or one already
+// carrying escape codes) falls back to the unstyled text — the row marker alone
+// signals the match. Returns line unchanged when no search is active or nothing
+// matches.
+func (b *BaseModel) highlightLogLine(line string) string {
+	q := b.logSearchQuery
+	if q == "" {
+		return line
+	}
+	if !isASCIINoESC(q) || !isASCIINoESC(line) {
+		return line
+	}
+	// Both sides are ASCII, so ToLower does not shift byte offsets: the index
+	// found in the lowered line is valid in the original.
+	idx := strings.Index(strings.ToLower(line), strings.ToLower(q))
+	if idx < 0 {
+		return line
+	}
+	end := idx + len(q)
+	return line[:idx] + searchHighlightStyle.Render(line[idx:end]) + line[end:]
+}
+
+// isASCIINoESC reports whether s is pure ASCII (every byte < 0x80) and contains
+// no ESC byte (0x1b). It gates the inline search highlight: non-ASCII text
+// breaks the byte-offset-preserving case fold, and an embedded ESC means a
+// match could split an ANSI escape sequence (see highlightLogLine).
+func isASCIINoESC(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] >= 0x80 || s[i] == 0x1b {
+			return false
+		}
+	}
+	return true
 }
 
 // processPanel renders the process status header
@@ -1127,9 +1424,12 @@ func (b *BaseModel) processPanel() string {
 //     the cursor is on a match, else "/<query> (k matches)" (0 included) — with
 //     "| filter: <pattern>" appended when the `s` filter is also active. soloProcess
 //     is a logs-view concept and is never shown here.
-//   - Logs view: today's precedence — solo wins, then the `s` filter.
+//   - Logs view: the `/` search indicator wins when a query is set —
+//     "/<query> (i/k)" (cursor on match i of k) or "/<query> (k matches)" when
+//     the cursor is off any match — then solo, then the `s` filter (D10). The
+//     `s` filter and search compose (search navigates within the filtered set).
 //   - Otherwise (either view): the `s` filter line, then the default hint.
-func (b *BaseModel) statusLeftDefault(extraInfo string, requests []proxy.RequestRecord) string {
+func (b *BaseModel) statusLeftDefault(extraInfo string, requests []proxy.RequestRecord, entries []domain.LogEntry) string {
 	if b.viewMode == ViewModeRequests && b.requestSearchQuery != "" {
 		position, total := b.requestSearchMatchInfo(requests)
 		var indicator string
@@ -1142,6 +1442,13 @@ func (b *BaseModel) statusLeftDefault(extraInfo string, requests []proxy.Request
 			indicator += fmt.Sprintf(" | filter: %s", b.searchPattern)
 		}
 		return indicator
+	}
+	if b.viewMode == ViewModeLogs && b.logSearchQuery != "" {
+		position, total := b.logSearchMatchInfo(entries)
+		if position > 0 {
+			return fmt.Sprintf("/%s (%d/%d)", b.logSearchQuery, position, total)
+		}
+		return fmt.Sprintf("/%s (%d matches)", b.logSearchQuery, total)
 	}
 	if b.viewMode != ViewModeRequests && b.soloProcess != "" {
 		return fmt.Sprintf("Showing: %s (ESC to clear)", b.soloProcess)
@@ -1175,12 +1482,15 @@ func (b *BaseModel) statusBar(extraInfo string) string {
 		viewIndicator = "[Request Detail]"
 	}
 
-	// Requests-view filtered list, computed once and shared below between the
-	// left-side search indicator and the right-side visible count so a single
-	// render doesn't rescan b.proxyRequests twice.
+	// Filtered lists, each computed once and shared below between the left-side
+	// search indicator and the right-side visible count so a single render never
+	// rescans the underlying slice twice. Only the active view's list is built.
 	var requests []proxy.RequestRecord
+	var entries []domain.LogEntry
 	if b.viewMode == ViewModeRequests {
 		requests = b.filteredProxyRequests()
+	} else {
+		entries = b.filteredEntries()
 	}
 
 	// Left side: mode/filter info
@@ -1192,7 +1502,7 @@ func (b *BaseModel) statusBar(extraInfo string) string {
 	case ModeStringFilter:
 		left = "String filter: " + b.textInput.View()
 	default:
-		left = b.statusLeftDefault(extraInfo, requests)
+		left = b.statusLeftDefault(extraInfo, requests, entries)
 	}
 
 	// Right side: follow mode and count
@@ -1203,7 +1513,7 @@ func (b *BaseModel) statusBar(extraInfo string) string {
 		total = len(b.proxyRequests)
 		label = "requests"
 	} else {
-		visible = len(b.filteredEntries())
+		visible = len(entries)
 		total = len(b.logEntries)
 		label = "lines"
 	}
@@ -1280,12 +1590,15 @@ Navigation:
   PgUp/PgDn  Page up/down
   F          Toggle auto-follow mode
 
+Search (jumps the cursor, does NOT filter):
+  /          Search lines (jump to match at/after the current position)
+  n/N        Jump to next/previous match (wraps)
+
 Filtering:
   1-9        Solo process (toggle)
   f          Filter mode (process selection)
-  /          Substring filter (hide non-matching, commit on Enter)
   s          Substring filter (hide non-matching, applied live)
-  ESC        Clear filters
+  ESC        Clear filters and search
 
 Other:
   r          Restart selected process (1-9 to select)

--- a/internal/tui/base.go
+++ b/internal/tui/base.go
@@ -712,6 +712,10 @@ func (b *BaseModel) seekLogSearchMatch(dir int) {
 				return
 			}
 		}
+		// No match: clear any cursor a PRIOR search left, so a stale ❯ marker
+		// doesn't linger on a non-matching row while the status shows "(0 matches)"
+		// (CodeRabbit). setLogCursor(nil, ...) resets to the no-cursor sentinel.
+		b.setLogCursor(nil, 0)
 		return
 	}
 	// Strictly past the cursor: offsets 1..n-1 in dir, wrapping. The origin row

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1286,6 +1286,21 @@ func TestLogsSearch_NoMatch(t *testing.T) {
 	assert.Contains(t, bar, "/zzz (0 matches)", "status shows the 0-match form")
 }
 
+func TestLogsSearch_NoMatchAfterPriorMatchClearsCursor(t *testing.T) {
+	// Regression (CodeRabbit): a `/`-search with NO match must clear a cursor left
+	// by a PRIOR match, so no stale ❯ marker lingers on a non-matching row while
+	// the status shows "(0 matches)".
+	m := newLogsModel(20, []string{"alpha", "hit here", "gamma"})
+	m = commitSearch(m, "hit")
+	require.Equal(t, "hit here", logCursorLine(t, m))
+
+	m = commitSearch(m, "zzz") // no match — must clear the prior cursor
+	assert.Equal(t, "zzz", m.logSearchQuery)
+	assert.Equal(t, -1, m.logCursorIdx, "a no-match search clears the prior cursor index")
+	assert.Equal(t, int64(0), m.logCursorSeq, "and its Seq anchor")
+	assert.Contains(t, m.statusBar(""), "/zzz (0 matches)")
+}
+
 func TestLogsSearch_EscClears(t *testing.T) {
 	m := newLogsModel(20, []string{"aaa", "needle", "bbb"})
 	m = updateModel(m, keyRune('g'))

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -8,6 +8,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -1158,20 +1159,318 @@ func TestRequestsSearch_EscClearsQuery(t *testing.T) {
 	assert.Empty(t, m.requestSearchQuery, "esc clears the requests-view search query")
 }
 
-func TestLogsSearch_SlashStillFilters(t *testing.T) {
-	m := newTestModel()
-	m = updateModel(m, tea.WindowSizeMsg{Width: 120, Height: 20})
-	m.logEntries = []domain.LogEntry{
-		{Process: "p", Line: "keep me"},
-		{Process: "p", Line: "drop it"},
-		{Process: "p", Line: "keep this too"},
-	}
-	require.Equal(t, ViewModeLogs, m.viewMode)
+// --- Logs-view search navigation tests (C4 / D6-D10) ---
 
-	m = commitSearch(m, "keep")
-	assert.Equal(t, "keep", m.searchPattern, "logs-view / commits the substring filter (unchanged)")
+// newLogsModel builds a Model in the (default) logs view, viewport sized so its
+// content height is viewportHeight (handleWindowSize subtracts the 6-row
+// margin), then streams the given lines through handleLogEntry so each entry is
+// stamped with a unique non-zero Seq — the logs search cursor anchors by Seq, so
+// a zero Seq would break the anchor. followMode starts true (default), pinning
+// the cursor to the newest line until a jump or scroll disengages it.
+func newLogsModel(viewportHeight int, lines []string) Model {
+	m := newTestModel()
+	m = updateModel(m, tea.WindowSizeMsg{Width: 120, Height: viewportHeight + 6})
+	base := time.Unix(0, 0)
+	for i, line := range lines {
+		m = updateModel(m, LogEntryMsg(domain.LogEntry{
+			Timestamp: base.Add(time.Duration(i) * time.Second),
+			Process:   "p",
+			Line:      line,
+		}))
+	}
+	return m
+}
+
+// logCursorLine returns the line the logs search cursor currently sits on
+// (resolved against the filtered list), for assertions that care about which
+// line was landed rather than its shifting index.
+func logCursorLine(t *testing.T, m Model) string {
+	t.Helper()
+	fe := m.filteredEntries()
+	require.GreaterOrEqual(t, m.logCursorIdx, 0)
+	require.Less(t, m.logCursorIdx, len(fe))
+	return fe[m.logCursorIdx].Line
+}
+
+// TestLogsSearch_SlashNavigates replaces the old TestLogsSearch_SlashStillFilters:
+// logs `/` no longer filters — it navigates (jumps the cursor) and leaves every
+// line visible, mirroring the requests view (D6).
+func TestLogsSearch_SlashNavigates(t *testing.T) {
+	m := newLogsModel(20, []string{"keep me", "drop it", "keep this too"})
+	require.Equal(t, ViewModeLogs, m.viewMode)
+	before := len(m.filteredEntries())
+
+	m = commitSearch(m, "drop")
+	assert.Equal(t, "drop", m.logSearchQuery, "logs-view / commits the navigation query")
+	assert.Empty(t, m.searchPattern, "logs-view / must not touch the `s` filter")
 	assert.Empty(t, m.requestSearchQuery, "logs-view / must not set the requests query")
-	assert.Len(t, m.filteredEntries(), 2, "logs-view / hides non-matching lines")
+	assert.Len(t, m.filteredEntries(), before, "logs-view / navigates; it must not hide lines")
+	assert.Equal(t, "drop it", logCursorLine(t, m), "the cursor lands on the matching line")
+}
+
+func TestLogsSearch_JumpAtOrAfterAndWrap(t *testing.T) {
+	// "needle" matches rows 0 and 2; rows 1 and 3 do not.
+	m := newLogsModel(20, []string{"needle a", "x", "needle b", "z"})
+	m = updateModel(m, keyRune('g')) // top of viewport, follow off; origin -> row 0
+	require.False(t, m.followMode)
+
+	// At-or-after from the top: row 0 already matches, so the cursor stays put.
+	m = commitSearch(m, "needle")
+	assert.Equal(t, "needle", m.logSearchQuery)
+	assert.Equal(t, 0, m.logCursorIdx, "at-or-after stays on a matching origin")
+
+	// Park the cursor on the last row (row 3, no "needle") via a throwaway query,
+	// then a fresh "needle" at-or-after finds nothing to the end and WRAPS to row 0.
+	m = commitSearch(m, "z")
+	require.Equal(t, 3, m.logCursorIdx)
+	m = commitSearch(m, "needle")
+	assert.Equal(t, 0, m.logCursorIdx, "at-or-after wraps around to the first match")
+
+	// Park on row 1 (no match), then at-or-after jumps FORWARD to the next match (row 2).
+	m = commitSearch(m, "x")
+	require.Equal(t, 1, m.logCursorIdx)
+	m = commitSearch(m, "needle")
+	assert.Equal(t, 2, m.logCursorIdx, "at-or-after jumps forward to the next match")
+}
+
+func TestLogsSearch_NextPrevWrap(t *testing.T) {
+	m := newLogsModel(20, []string{"needle a", "x", "needle b", "z"})
+	m = updateModel(m, keyRune('g'))
+	m = commitSearch(m, "needle")
+	require.Equal(t, 0, m.logCursorIdx)
+
+	m = updateModel(m, keyRune('n'))
+	assert.Equal(t, 2, m.logCursorIdx, "n advances to the next match")
+	m = updateModel(m, keyRune('n'))
+	assert.Equal(t, 0, m.logCursorIdx, "n wraps to the first match")
+
+	m = updateModel(m, keyRune('N'))
+	assert.Equal(t, 2, m.logCursorIdx, "N wraps backward to the last match")
+	m = updateModel(m, keyRune('N'))
+	assert.Equal(t, 0, m.logCursorIdx, "N retreats to the previous match")
+}
+
+func TestLogsSearch_ComposesWithFilter(t *testing.T) {
+	// The `s` filter keeps only "keep" lines; search then navigates WITHIN that
+	// filtered set, never selecting a hidden "drop" row.
+	m := newLogsModel(20, []string{
+		"keep needle a", "drop needle b", "keep plain", "keep needle c", "drop needle d",
+	})
+	m.searchPattern = "keep" // active `s` filter -> rows 0,2,3 survive
+	m.followMode = false
+	m.updateViewport()
+	m = updateModel(m, keyRune('g')) // origin -> top of the filtered list
+
+	m = commitSearch(m, "needle")
+	assert.Equal(t, "keep needle a", logCursorLine(t, m), "search starts within the `s`-filtered set")
+	m = updateModel(m, keyRune('n'))
+	assert.Equal(t, "keep needle c", logCursorLine(t, m), "n skips the filtered-out drop rows")
+	m = updateModel(m, keyRune('n'))
+	assert.Equal(t, "keep needle a", logCursorLine(t, m), "wraps over the filtered matches only")
+	assert.Equal(t, "keep", m.searchPattern, "the `s` filter is untouched")
+}
+
+func TestLogsSearch_NoMatch(t *testing.T) {
+	m := newLogsModel(20, []string{"aaa", "bbb", "ccc"})
+	m = updateModel(m, keyRune('g'))
+
+	m = commitSearch(m, "zzz")
+	assert.Equal(t, "zzz", m.logSearchQuery)
+	assert.Equal(t, -1, m.logCursorIdx, "a query with no match leaves no cursor")
+
+	// n/N are also no-ops when nothing matches.
+	m = updateModel(m, keyRune('n'))
+	assert.Equal(t, -1, m.logCursorIdx)
+
+	bar := m.statusBar("")
+	assert.Contains(t, bar, "/zzz (0 matches)", "status shows the 0-match form")
+}
+
+func TestLogsSearch_EscClears(t *testing.T) {
+	m := newLogsModel(20, []string{"aaa", "needle", "bbb"})
+	m = updateModel(m, keyRune('g'))
+	m = commitSearch(m, "needle")
+	require.Equal(t, "needle", m.logSearchQuery)
+	require.NotEqual(t, -1, m.logCursorIdx)
+
+	m = updateModel(m, tea.KeyMsg{Type: tea.KeyEscape})
+	assert.Empty(t, m.logSearchQuery, "esc clears the logs-view search query")
+	assert.Equal(t, int64(0), m.logCursorSeq, "esc resets the logs cursor anchor")
+	assert.Equal(t, -1, m.logCursorIdx, "esc resets the logs cursor index")
+}
+
+func TestLogsSearch_StatusIndicator(t *testing.T) {
+	m := newLogsModel(20, []string{"needle a", "x", "needle b"})
+	m = updateModel(m, keyRune('g'))
+	m = commitSearch(m, "needle")
+	require.Equal(t, 0, m.logCursorIdx)
+
+	assert.Contains(t, m.statusBar(""), "/needle (1/2)", "shows the cursor's match position of the total")
+	m = updateModel(m, keyRune('n'))
+	assert.Contains(t, m.statusBar(""), "/needle (2/2)", "advancing updates the position")
+}
+
+func TestLogsSearch_FollowPreservedOnNewestRowMatch(t *testing.T) {
+	// Follow on, cursor pinned to the newest line which matches: the jump lands
+	// where the cursor already is, so follow must stay engaged.
+	m := newLogsModel(20, []string{"a", "b", "c", "hit newest"})
+	require.True(t, m.followMode)
+	m = commitSearch(m, "hit")
+	assert.Equal(t, 3, m.logCursorIdx, "the newest line matches")
+	assert.True(t, m.followMode, "a jump landing on the newest line preserves follow")
+
+	// A jump that MOVES the cursor off the newest line must disengage follow, or
+	// resolveLogCursor's pin-to-newest would immediately undo the jump.
+	m2 := newLogsModel(20, []string{"a", "hit mid", "c", "d"})
+	require.True(t, m2.followMode)
+	m2 = commitSearch(m2, "hit")
+	assert.Equal(t, 1, m2.logCursorIdx, "the jump sticks off the newest line")
+	assert.False(t, m2.followMode, "jumping off the newest line disengages follow")
+}
+
+func TestLogsSearch_OffNewestJumpSurvivesLogArrival(t *testing.T) {
+	// Regression (codex review): after a jump parks the cursor off the newest row
+	// (follow disengaged), a streaming log arrival must NOT silently re-engage
+	// follow and drag the ❯ marker off the match — even with a short/full viewport
+	// where the match is still "near bottom".
+	m := newLogsModel(20, []string{"a", "hit mid", "c", "d"})
+	m = commitSearch(m, "hit")
+	require.Equal(t, "hit mid", logCursorLine(t, m))
+	require.False(t, m.followMode)
+	require.Contains(t, m.statusBar(""), "/hit (1/1)")
+
+	// A new log line arrives while the search is parked off-newest.
+	m = updateModel(m, LogEntryMsg(domain.LogEntry{
+		Timestamp: time.Unix(10, 0),
+		Process:   "p",
+		Line:      "e newest",
+	}))
+
+	assert.False(t, m.followMode, "a streaming arrival must not re-engage follow while a search is parked")
+	assert.Equal(t, "hit mid", logCursorLine(t, m), "the cursor stays on the match, not yanked to the new newest row")
+	assert.Contains(t, m.statusBar(""), "/hit (1/1)", "match position is preserved across the arrival")
+}
+
+func TestLogsSearch_EvictionAnchorSurvives(t *testing.T) {
+	m := newTestModel()
+	m = updateModel(m, tea.WindowSizeMsg{Width: 120, Height: 11}) // viewport height 5
+	feed := func(line string) {
+		m.handleLogEntry(domain.LogEntry{Timestamp: time.Unix(0, 0), Process: "p", Line: line})
+	}
+
+	// Fill the ring with a lone match parked in the MIDDLE, so scrolling to it on
+	// commit does not leave the viewport near the bottom (which would re-engage
+	// follow on later arrivals and pin the cursor to the newest row instead).
+	for i := 0; i < 500; i++ {
+		feed(fmt.Sprintf("log %04d", i))
+	}
+	feed("NEEDLE row")
+	for i := 0; i < 500; i++ {
+		feed(fmt.Sprintf("log %04d", 500+i))
+	}
+	require.Len(t, m.logEntries, maxLogEntries, "the front-eviction ring is full")
+
+	// Search with follow off so the cursor stays Seq-anchored to NEEDLE as the
+	// ring shifts, rather than being pinned to the newest line.
+	m = updateModel(m, keyRune('g')) // GotoTop, follow off
+	m = commitSearch(m, "NEEDLE")
+	require.False(t, m.followMode)
+	require.Contains(t, m.logEntries[m.logCursorIdx].Line, "NEEDLE")
+	needleSeq := m.logCursorSeq
+	require.NotZero(t, needleSeq)
+	idxBefore := m.logCursorIdx
+
+	// Push more: front eviction shifts NEEDLE's index down, but its Seq survives,
+	// so resolveLogCursor re-resolves the cursor onto it (index changes, line same).
+	for i := 0; i < 10; i++ {
+		feed(fmt.Sprintf("extra %d", i))
+	}
+	assert.Equal(t, needleSeq, m.logCursorSeq, "the Seq anchor is unchanged by eviction")
+	assert.Contains(t, m.logEntries[m.logCursorIdx].Line, "NEEDLE", "cursor rides the Seq across the ring")
+	assert.Less(t, m.logCursorIdx, idxBefore, "the anchored index shifted down as the ring evicted")
+
+	// Now evict NEEDLE outright; the cursor must CLAMP into range, never go stale
+	// or panic.
+	for i := 0; i < 1100; i++ {
+		feed(fmt.Sprintf("flood %d", i))
+	}
+	for _, e := range m.logEntries {
+		require.NotEqual(t, needleSeq, e.Seq, "NEEDLE has been evicted")
+	}
+	assert.GreaterOrEqual(t, m.logCursorIdx, 0, "the evicted cursor clamps in range")
+	assert.Less(t, m.logCursorIdx, len(m.logEntries), "the evicted cursor clamps in range")
+}
+
+func TestLogsSearch_FirstSearchAfterManualScroll(t *testing.T) {
+	// A match sits both ABOVE the visible region (row 2) and inside/after it
+	// (row 20). A first search must seed from what the user is looking at (the
+	// top visible row), landing on row 20 rather than the earlier row 2.
+	lines := make([]string, 30)
+	for i := range lines {
+		lines[i] = fmt.Sprintf("line %02d", i)
+	}
+	lines[2] = "target above"
+	lines[20] = "target below"
+	m := newLogsModel(5, lines) // viewport height 5, follow on, parked at the bottom
+
+	m = updateModel(m, keyRune('k')) // disengage follow
+	require.False(t, m.followMode)
+	m.viewport.SetYOffset(15) // top visible row is now 15
+	require.Equal(t, 15, m.viewport.YOffset)
+
+	m = commitSearch(m, "target")
+	assert.Equal(t, 20, m.logCursorIdx, "first search starts from the visible region, not row 0")
+}
+
+func TestLogsSearch_HighlightGuard(t *testing.T) {
+	// The default test renderer is Ascii (no color), which would make a
+	// highlighted and an unhighlighted line byte-identical. Force a color profile
+	// so the inline highlight actually emits detectable ANSI, and restore it.
+	prev := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.ANSI)
+	defer lipgloss.SetColorProfile(prev)
+
+	m := newLogsModel(20, []string{"plain"})
+
+	// ASCII line + ASCII query: the matched run is wrapped in searchHighlightStyle.
+	m.logSearchQuery = "match"
+	ascii := m.highlightLogLine("hello match world")
+	assert.NotEqual(t, "hello match world", ascii, "an ASCII match is inline-highlighted")
+	assert.Contains(t, ascii, searchHighlightStyle.Render("match"), "the matched run is styled")
+	assert.Contains(t, ascii, "hello ")
+	assert.Contains(t, ascii, " world")
+
+	// Unicode line: case-folding would shift byte offsets, so the guard trips and
+	// the line falls back to no inline highlight (row marker alone) — unchanged.
+	uni := "日本語 match テスト"
+	assert.Equal(t, uni, m.highlightLogLine(uni), "a unicode line falls back to no highlight")
+
+	// ESC-bearing line: a digit query can match inside the ANSI escape, so the
+	// guard trips and the escape is left intact rather than split.
+	m.logSearchQuery = "31"
+	ansiLine := "x \x1b[31mred\x1b[0m match"
+	assert.Equal(t, ansiLine, m.highlightLogLine(ansiLine), "an ESC-bearing line falls back, escape intact")
+}
+
+func TestLogsSearch_UnicodeAndAnsiRenderSafely(t *testing.T) {
+	// End-to-end: a unicode line and a line already carrying ANSI escapes. The
+	// search must not panic or split the escape, and the row marker still lands
+	// on the matched row.
+	m := newLogsModel(20, []string{"before", "cafe \x1b[31mMATCH\x1b[0m after", "café résumé MATCH"})
+	m = updateModel(m, keyRune('g'))
+	m = commitSearch(m, "MATCH")
+	require.Equal(t, 1, m.logCursorIdx, "the first match at/after the top is the ANSI row")
+
+	view := m.viewport.View()
+	assert.Contains(t, view, "❯", "the cursor marker renders on the matched row")
+	assert.Contains(t, view, "\x1b[31mMATCH\x1b[0m", "the source line's escape survives intact (not split by a highlight)")
+}
+
+func TestLogsSearch_IsASCIINoESC(t *testing.T) {
+	assert.True(t, isASCIINoESC("plain ascii 123"))
+	assert.True(t, isASCIINoESC(""))
+	assert.False(t, isASCIINoESC("café"), "non-ASCII bytes fail")
+	assert.False(t, isASCIINoESC("has\x1b[0mesc"), "an ESC byte fails even though it is ASCII")
 }
 
 func TestRequestsSearch_StatusPrecedence(t *testing.T) {

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -111,6 +111,18 @@ var (
 			Foreground(lipgloss.Color("13")).
 			Bold(true)
 
+	// Search highlight style for the matched substring of a logs-view line
+	// during `/`-search (D9). An accent background (yellow) with black text so
+	// the hit stands out against the line's own coloring. Applied only to the
+	// exact matched run, and only when the query and the whole line are plain
+	// ASCII with no ESC byte — otherwise case-folding could shift byte offsets
+	// or the run could land inside an ANSI escape, so formatLogEntry falls back
+	// to the row marker alone (see isASCIINoESC).
+	searchHighlightStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("0")).
+				Background(lipgloss.Color("11")).
+				Bold(true)
+
 	// Process colors for log lines
 	processColors []lipgloss.Style
 )


### PR DESCRIPTION
Plan 009 (post-plan-008 Tier-1 follow-ups), **PR-B of 3** — the TUI logs-view search feature. Sibling PRs: PR-A #63 (daemon lifecycle + infra), PR-C (supervisor orphan reap, opened separately). The panel-reviewed plan lives outside the repo (`~/.claude/plans/prox/009-plan008-followups.md`); its substance is below.

## What changed — `feat(tui): logs-view search-match navigation (n/N) + highlighting` (Closes #56)

Plan 007 corrected the docs to admit the logs view had only a substring filter — no n/N, no highlighting. This brings it up to what the requests view got in plan 007:

- **Logs `/` now NAVIGATES** (jumps the cursor to matches; non-matching lines stay visible) with **`n`/`N`** cycling (wrapping). `s` remains the live substring filter; `j`/`k` remain viewport scroll. **User-visible change:** logs `/` no longer hides non-matching lines (use `s` for that).
- **Stable cursor anchor:** logs have no ID (unlike `proxy.RequestRecord`), and the buffer is a 1000-entry **front-eviction ring**, so a bare index would drift during streaming. A session-local monotonic `domain.LogEntry.Seq` (`json:"-"`, stamped at TUI ingestion) anchors the cursor so it survives eviction — mirroring the requests view's ID-anchored cursor. Match state is derived at keypress, never stored.
- First search seeds from the current viewport (newest under follow, else the top visible row). A jump off the newest row disengages follow; scroll-to-match is a one-shot on `/`/`n`/`N` (not a per-render invariant, which would fight streaming).
- **Match highlighting:** the matched span is wrapped in `searchHighlightStyle`, but **only when the query AND the whole line are ASCII with no ESC byte** (else the byte offsets from case-folding could split a rune, or a digit query could match inside an ANSI escape) — otherwise the cursor-row `❯` marker alone.
- Status `/<query> (<i>/<n>)`; logs help overlay + `docs/reference/tui.md` updated (removed the "no highlighting / no n/N" note).

## Verification
- **Gate green** on macOS: `make lint && make test && make test-race && make build` (tui under `-race`).
- **14 `TestLogsSearch_*` tests** drive the real `Update()` keystroke→state loop: `/`-navigate (not filter), jump-at-or-after + wrap, n/N wrap, compose-with-`s`-filter, no-match, Esc clears, status indicator, **eviction-anchor survives** (~2100 entries → ring evicts), follow-preserved-on-newest + disengage-off-newest, **off-newest-jump-survives-a-log-arrival** (the codex-found regression), first-search-after-manual-scroll, highlight guard (unicode + ANSI fall back to marker-only), and `isASCIINoESC`.
- **Simplify:** no changes (helpers already extracted; cross-view dedup would touch committed requests code). **Codex review:** found one UX bug — a streaming arrival re-engaged follow via the "near bottom" check and dragged the marker off an off-newest match; **fixed** (suppress re-engage while a search is parked) + regression test.
- An interactive terminal pass was not automated (no PTY harness); the unit suite exercises the same event loop that keystrokes drive.

## Dependency / privacy / secret impact
`go.mod`: `termenv` promoted indirect→direct — a highlight test forces a color profile via `lipgloss.SetColorProfile(termenv.ANSI)` to assert real ANSI output (the dep was already transitive; `go mod tidy` moved it to the direct block; go.sum unchanged). No secrets, no data collection. `Seq` is `json:"-"` so the socket wire contract to the attach client is unchanged.

## Note on CI
This branch is cut from `main` and does not carry PR-A's macOS CI matrix (that lands with #63). Rebasing on top of #63 (or after it merges) will add macOS coverage here too.

<details>
<summary>Plan 009 — PR-B sections (C4 design, D6–D10)</summary>

See `~/.claude/plans/prox/009-plan008-followups.md` §D6–D10, §7 (acceptance), §9 (risks), §10 (panel). Panel corrections incorporated for this commit: `Seq json:"-"`; stamp at `handleLogEntry` (not the nonexistent `addLogEntry`); replace the invalidated `TestLogsSearch_SlashStillFilters` with `TestLogsSearch_SlashNavigates`; scroll-to-match one-shot (not a render invariant); first-search origin from the viewport; whole-line-ASCII+no-ESC highlight guard; `j`/`k` stay scroll.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgMgg6eo4LgLTCkfYSARcH


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In the Logs view, `/` now navigates to the next matching line/text instead of filtering out non-matching lines.
  * The matching substring is highlighted (when supported), and the status bar shows match position/total.
  * Added `n`/`N` to jump between matches with wraparound.
  * `/` composes with the existing `s` filter, and follow-mode behavior is preserved when appropriate.
* **Documentation**
  * Updated Logs view and Search mode help/reference to reflect the new `/` navigation, highlighting, and `n`/`N` behavior.
* **Tests**
  * Added comprehensive Logs search navigation, highlighting, no-match, and follow-mode coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->