### PR TITLE
plan 009 PR-C: supervisor orphan-reap on startup after kill -9 (#59)

### DIFF
--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -261,6 +261,19 @@ func runUp(cmd *cobra.Command, args []string) error {
 		_ = pidFile.Release()
 	}()
 
+	// Reap any orphaned backend process GROUPS left by a previous generation that
+	// was killed with SIGKILL: its graceful shutdown never ran, so its supervised
+	// child groups outlived it and may still hold ports (#59). The per-project
+	// PID-file lock acquired above serializes this across concurrent `prox up`
+	// invocations. Only groups positively identified as belonging to the prior
+	// generation are signaled; unverifiable leftovers are left for the operator.
+	reapLogger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	if reaped, skipped, rerr := supervisor.ReapOrphans(daemon.StateDir(cwd), reapLogger); rerr != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to reap orphaned child groups: %v\n", rerr)
+	} else if len(reaped) > 0 || len(skipped) > 0 {
+		fmt.Fprintf(os.Stderr, "Reaped %d orphaned child group(s) from a previous run; skipped %d (unverifiable or not confirmed gone)\n", len(reaped), len(skipped))
+	}
+
 	// Create log manager
 	logMgr := logs.NewManager(logs.ManagerConfig{
 		BufferSize:         1000,
@@ -282,6 +295,10 @@ func runUp(cmd *cobra.Command, args []string) error {
 	// The absolute config path lets an API-driven (re)start re-read prox.yaml and
 	// apply the target process's current config (#33, D3).
 	supConfig.ConfigPath = absConfigPath
+	// The state dir lets the supervisor persist the orphan-reaping ownership
+	// ledger on every launch, so a later `prox up` can reap groups a SIGKILL'd
+	// generation orphaned (#59). ReapOrphans (above) reads it from the same path.
+	supConfig.StateDir = daemon.StateDir(cwd)
 	// cfg.ShutdownTimeout was already validated by config.Load above, so this
 	// only errors for a hand-built Config bypassing Load/Validate.
 	// ShutdownTimeoutDuration's error is already field-prefixed

--- a/internal/cli/up_test.go
+++ b/internal/cli/up_test.go
@@ -49,6 +49,9 @@ func newFakeStopProcess(pid int, survivor bool) *fakeStopProcess {
 
 func (p *fakeStopProcess) PID() int { return p.pid }
 
+func (p *fakeStopProcess) PGID() int         { return p.pid }
+func (p *fakeStopProcess) StartToken() int64 { return int64(p.pid) }
+
 func (p *fakeStopProcess) Wait() error {
 	<-p.waitCh
 	return nil

--- a/internal/daemon/state.go
+++ b/internal/daemon/state.go
@@ -13,6 +13,11 @@ const (
 	StateDirName = ".prox"
 	// StateFileName is the name of the state file
 	StateFileName = "prox.state"
+	// ChildrenFileName is the name of the supervised-child ownership ledger,
+	// recording the process GROUPS a running prox generation supervises so a
+	// later `prox up` can reap any that a SIGKILL'd generation orphaned (its
+	// graceful Stop never ran). See internal/supervisor/orphans.go.
+	ChildrenFileName = "prox.children"
 	// PIDFileName is the name of the PID file
 	PIDFileName = "prox.pid"
 	// LogFileName is the name of the daemon log file

--- a/internal/supervisor/fake_runner_test.go
+++ b/internal/supervisor/fake_runner_test.go
@@ -26,6 +26,14 @@ import (
 // (c) an unreapable group whose leader dies but whose group never does.
 type fakeProcess struct {
 	pid int
+	// pgid overrides the value PGID() reports. Zero (the default) means PGID()
+	// returns pid, mirroring the real runner where the group leader's PID IS the
+	// PGID. A test that needs a PID/PGID mismatch (e.g. to exercise the reaper's
+	// corrupt-record guard) sets this explicitly.
+	pgid int
+	// startToken overrides StartToken(). Zero (the default) means StartToken()
+	// returns int64(pid), a non-zero stand-in for the launch-captured token.
+	startToken int64
 
 	mu         sync.Mutex
 	alive      bool
@@ -69,6 +77,20 @@ func newFakeProcess(pid int) *fakeProcess {
 }
 
 func (fp *fakeProcess) PID() int { return fp.pid }
+
+func (fp *fakeProcess) PGID() int {
+	if fp.pgid != 0 {
+		return fp.pgid
+	}
+	return fp.pid
+}
+
+func (fp *fakeProcess) StartToken() int64 {
+	if fp.startToken != 0 {
+		return fp.startToken
+	}
+	return int64(fp.pid) // non-zero fake token by default (mirrors a captured token)
+}
 
 func (fp *fakeProcess) Wait() error {
 	<-fp.waitCh

--- a/internal/supervisor/orphans.go
+++ b/internal/supervisor/orphans.go
@@ -1,0 +1,337 @@
+package supervisor
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/charliek/prox/internal/daemon"
+)
+
+// Orphan reaping (plan 009 D11-D13, issue #59).
+//
+// The graceful shutdown path (ManagedProcess.Stop) already escalates SIGTERM ->
+// SIGKILL over the whole process group and reaps stubborn grandchildren. But
+// SIGKILL is uncatchable: when a `prox up` generation is killed with `kill -9`,
+// its graceful Stop never runs, so the backend process GROUPS it supervised
+// orphan and keep holding their ports -- the next `prox up` then hits EADDRINUSE
+// / 502s.
+//
+// To close that gap the running supervisor persists an ownership ledger of the
+// group-leader PIDs it supervises (see Supervisor.persistChildren). On the next
+// startup, ReapOrphans reads that ledger and reaps any group still positively
+// identifiable as belonging to the prior generation. The ledger is the ONLY
+// record that survives a SIGKILL, since PGIDs are otherwise held only in memory.
+//
+// Safety bias: the reaper never signals a group it cannot positively identify as
+// ours. Identity is verified ONCE, up front, via a strict start-token match
+// (sameGeneration); everything else is skipped and left for the operator.
+
+const (
+	// reapGraceWindow is how long ReapOrphans waits for a positively-identified
+	// group to exit after SIGTERM before escalating to SIGKILL.
+	reapGraceWindow = 2 * time.Second
+	// reapPollInterval is how often the grace window re-probes group liveness.
+	reapPollInterval = 50 * time.Millisecond
+)
+
+// ChildRecord is one entry in the ownership ledger: a process GROUP the running
+// generation supervises.
+type ChildRecord struct {
+	Name       string `json:"name"`
+	PID        int    `json:"pid"`         // group leader PID; == PGID by construction
+	PGID       int    `json:"pgid"`        // == PID (Setpgid, no explicit Pgid)
+	StartToken int64  `json:"start_token"` // daemon.ProcessStartTime(PID)
+}
+
+// WriteChildren marshals recs to JSON and writes them to
+// <stateDir>/prox.children via a temp file + atomic rename (0600). The rename
+// is atomic so a torn ledger read at the next startup can never mis-drive the
+// reap.
+func WriteChildren(stateDir string, recs []ChildRecord) error {
+	if err := os.MkdirAll(stateDir, 0700); err != nil {
+		return fmt.Errorf("creating state directory: %w", err)
+	}
+
+	data, err := json.MarshalIndent(recs, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling children ledger: %w", err)
+	}
+
+	tmp, err := os.CreateTemp(stateDir, daemon.ChildrenFileName+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("creating temp children ledger: %w", err)
+	}
+	tmpName := tmp.Name()
+	// Best-effort cleanup: after a successful rename tmpName no longer exists and
+	// this Remove is a harmless no-op; on any failure below it removes the stray.
+	defer func() { _ = os.Remove(tmpName) }()
+
+	if err := tmp.Chmod(0600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("chmod temp children ledger: %w", err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("writing children ledger: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("syncing children ledger: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("closing children ledger: %w", err)
+	}
+
+	if err := os.Rename(tmpName, filepath.Join(stateDir, daemon.ChildrenFileName)); err != nil {
+		return fmt.Errorf("renaming children ledger: %w", err)
+	}
+	return nil
+}
+
+// LoadChildren reads the ownership ledger from <stateDir>/prox.children. A
+// missing ledger is not an error: it returns (nil, nil).
+func LoadChildren(stateDir string) ([]ChildRecord, error) {
+	data, err := os.ReadFile(filepath.Join(stateDir, daemon.ChildrenFileName))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading children ledger: %w", err)
+	}
+
+	var recs []ChildRecord
+	if err := json.Unmarshal(data, &recs); err != nil {
+		return nil, fmt.Errorf("unmarshaling children ledger: %w", err)
+	}
+	return recs, nil
+}
+
+// RemoveChildren deletes the ownership ledger. A missing ledger is tolerated.
+func RemoveChildren(stateDir string) error {
+	if err := os.Remove(filepath.Join(stateDir, daemon.ChildrenFileName)); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("removing children ledger: %w", err)
+	}
+	return nil
+}
+
+// sameGeneration is the STRICT positive identity predicate for a ledger record:
+// it reports true only when pid still names the SAME process generation that
+// recorded token. It biases hard toward NOT killing -- a non-positive pid, a
+// zero (never-captured) token, an unreadable current token, or any mismatch all
+// return false. This is the single gate that decides whether the reaper is
+// allowed to signal a group at all.
+//
+// Accepted residual (plan §9), Linux-only: daemon.ProcessStartTime is boot-scoped
+// on Linux (clock ticks since boot), while the ledger can survive a reboot. After
+// a reboot the recorded orphans are already dead (nothing survives a reboot), so
+// the reap has no upside; but an unrelated process that reused both the PID AND
+// the same boot-relative start tick would collide here and be signaled. Darwin
+// tokens are wall-clock microseconds (P_starttime) and so are cross-boot-unique --
+// no collision. Persisting a boot marker to discard a cross-boot ledger is a
+// recommended follow-up.
+func sameGeneration(pid int, token int64) bool {
+	return sameGenerationWith(daemon.ProcessStartTime, pid, token)
+}
+
+// sameGenerationWith is sameGeneration with an injectable start-token reader so
+// the reaper (and its tests) can verify identity without touching real PIDs.
+func sameGenerationWith(startTime func(pid int) (int64, bool), pid int, token int64) bool {
+	if pid <= 0 || token == 0 {
+		return false
+	}
+	cur, ok := startTime(pid)
+	return ok && cur == token
+}
+
+// reaper performs the ledger-driven orphan reap. Its signal/liveness/identity
+// operations are injectable function fields so unit tests can drive the full
+// escalation WITHOUT ever signaling the test runner's own process group.
+type reaper struct {
+	// killpg signals the process group led by pgid. The real implementation is
+	// syscall.Kill(-pgid, sig).
+	killpg func(pgid int, sig syscall.Signal) error
+	// groupAlive reports whether any member of the group led by pgid is still
+	// alive (signal-0 probe; conservative "alive" on ambiguous errors).
+	groupAlive func(pgid int) bool
+	// startTime reads a process's opaque generation token.
+	startTime func(pid int) (int64, bool)
+
+	grace  time.Duration
+	poll   time.Duration
+	logger *slog.Logger
+}
+
+// newReaper returns a reaper wired to the real syscalls and daemon token reader.
+func newReaper(logger *slog.Logger) *reaper {
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
+	return &reaper{
+		killpg:     func(pgid int, sig syscall.Signal) error { return syscall.Kill(-pgid, sig) },
+		groupAlive: realGroupAlive,
+		startTime:  daemon.ProcessStartTime,
+		grace:      reapGraceWindow,
+		poll:       reapPollInterval,
+		logger:     logger,
+	}
+}
+
+// realGroupAlive probes the group led by pgid with signal 0. It mirrors
+// execProcess.GroupAlive's mapping: ESRCH => gone, anything else (including
+// EPERM and transient errors) => conservatively alive so a probe failure never
+// masquerades as a confirmed reap.
+func realGroupAlive(pgid int) bool {
+	if pgid <= 0 {
+		return false
+	}
+	err := syscall.Kill(-pgid, syscall.Signal(0))
+	switch {
+	case err == nil:
+		return true
+	case errors.Is(err, syscall.ESRCH):
+		return false
+	default:
+		return true
+	}
+}
+
+// reap processes every ledger record, returning the groups it confirmed reaped
+// and the ones it did NOT reap ("skipped"). A skipped record is EITHER one that
+// was never signaled (not positively identified as belonging to the prior
+// generation) OR one that was positively ours but could not be confirmed gone
+// after the SIGTERM->SIGKILL escalation (a rare wedged survivor). It never
+// signals a group that is not positively identified.
+func (r *reaper) reap(recs []ChildRecord) (reaped, skipped []ChildRecord) {
+	for _, rec := range recs {
+		// Reject corrupt/planted records before any signal. PGID must equal the
+		// leader PID by construction (Setpgid without an explicit Pgid), so a
+		// record whose PGID != PID -- or whose PID is non-positive -- is untrusted
+		// and never signaled. PGID > 0 alone is INSUFFICIENT.
+		if rec.PID <= 0 || rec.PGID != rec.PID {
+			r.logger.Warn("skipping corrupt child ledger record; not reaping",
+				"name", rec.Name, "pid", rec.PID, "pgid", rec.PGID)
+			skipped = append(skipped, rec)
+			continue
+		}
+
+		// Verify identity ONCE, immediately before the first signal. If it does
+		// not positively match, skip -- we never signal a group we cannot prove is
+		// ours.
+		if !sameGenerationWith(r.startTime, rec.PID, rec.StartToken) {
+			r.logger.Warn("leftover child could not be positively identified; not reaping — if a port is wedged, kill it manually",
+				"name", rec.Name, "pid", rec.PID)
+			skipped = append(skipped, rec)
+			continue
+		}
+
+		// Positively ours: escalate SIGTERM -> (grace) -> SIGKILL over the group.
+		// We deliberately do NOT re-verify sameGeneration before SIGKILL: the
+		// stubborn-grandchild leader EXITS on SIGTERM, making its token
+		// unverifiable, so re-verifying would skip the SIGKILL and leave the port
+		// wedged. Ownership rests on this ONE up-front identity check plus the
+		// group's continued liveness through the escalation -- exactly how the
+		// graceful ManagedProcess.Stop already escalates. Accepted residual (plan
+		// §9): liveness is SAMPLED, so if the owned group fully exits and an
+		// unrelated process reuses the exact PGID within a grace-window gap, the
+		// escalation could signal the replacement. This is the same unavoidable
+		// user-space check-to-signal TOCTOU as the graceful path; the strict
+		// up-front identity check minimizes but cannot eliminate it.
+		if r.reapGroup(rec) {
+			reaped = append(reaped, rec)
+		} else {
+			// Escalation did not confirm the group gone (e.g. SIGKILL errored and
+			// the group is still present). Do NOT report it reaped or drop it
+			// silently -- surface it as skipped so the operator and the up.go count
+			// see that a port-holding orphan may remain.
+			skipped = append(skipped, rec)
+		}
+	}
+	return reaped, skipped
+}
+
+// reapGroup runs the SIGTERM -> SIGKILL escalation for one positively-identified
+// group. If the whole group disappears during the grace window it stops without
+// SIGKILL. It returns true iff the group was CONFIRMED gone -- callers must treat
+// a false return as "the orphan may still be holding its port" (not reaped).
+func (r *reaper) reapGroup(rec ChildRecord) bool {
+	if err := r.killpg(rec.PGID, syscall.SIGTERM); err != nil {
+		r.logger.Warn("SIGTERM to leftover child group failed",
+			"name", rec.Name, "pgid", rec.PGID, "err", err)
+	}
+
+	if r.waitGroupGone(rec.PGID) {
+		r.logger.Info("reaped leftover child group (exited on SIGTERM)",
+			"name", rec.Name, "pgid", rec.PGID)
+		return true
+	}
+
+	if err := r.killpg(rec.PGID, syscall.SIGKILL); err != nil {
+		r.logger.Warn("SIGKILL to leftover child group failed",
+			"name", rec.Name, "pgid", rec.PGID, "err", err)
+	}
+	// Confirm the group is actually gone (SIGKILL is uncatchable, so this returns
+	// promptly) before the caller removes the ledger and the new generation
+	// launches -- otherwise a still-dying group could still hold a port the
+	// replacement needs to rebind.
+	if r.waitGroupGone(rec.PGID) {
+		r.logger.Info("reaped leftover child group (escalated to SIGKILL)",
+			"name", rec.Name, "pgid", rec.PGID)
+		return true
+	}
+	r.logger.Warn("leftover child group still present after SIGKILL",
+		"name", rec.Name, "pgid", rec.PGID)
+	return false
+}
+
+// waitGroupGone polls group liveness on r.poll until the group is gone or the
+// grace window passes. It returns true iff the group is gone.
+func (r *reaper) waitGroupGone(pgid int) bool {
+	deadline := time.Now().Add(r.grace)
+	for {
+		if !r.groupAlive(pgid) {
+			return true
+		}
+		if !time.Now().Before(deadline) {
+			return false
+		}
+		time.Sleep(r.poll)
+	}
+}
+
+// ReapOrphans loads the ownership ledger written by the previous prox generation
+// and reaps any process group still positively identifiable as belonging to it
+// (see the package doc above). It returns the reaped and skipped records. The
+// ledger is removed after the pass regardless of outcome: it has served its
+// purpose, and the new generation rewrites it from its first successful launch.
+//
+// This must be called AFTER the per-project PID-file lock is held and BEFORE the
+// supervisor starts, so concurrent `prox up` invocations are serialized by that
+// lock.
+func ReapOrphans(stateDir string, logger *slog.Logger) (reaped, skipped []ChildRecord, err error) {
+	recs, err := LoadChildren(stateDir)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	r := newReaper(logger)
+	reaped, skipped = r.reap(recs)
+
+	// Remove the old ledger after the pass (tolerates a missing file). A removal
+	// failure is RETURNED to the caller (up.go logs it non-fatally) rather than
+	// swallowed: a readable-but-unremovable ledger would otherwise drive a spurious
+	// reap pass on every subsequent startup with no signal (codex review). The
+	// reaped/skipped classification is still valid, so it is returned alongside.
+	if rmErr := RemoveChildren(stateDir); rmErr != nil {
+		r.logger.Warn("failed to remove children ledger after reap", "err", rmErr)
+		return reaped, skipped, rmErr
+	}
+
+	return reaped, skipped, nil
+}

--- a/internal/supervisor/orphans_test.go
+++ b/internal/supervisor/orphans_test.go
@@ -1,0 +1,380 @@
+package supervisor
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/charliek/prox/internal/config"
+	"github.com/charliek/prox/internal/daemon"
+	"github.com/charliek/prox/internal/logs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// discardLogger is a slog logger that drops everything, so the reaper's WARN/INFO
+// lines never pollute test output.
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// deadPID returns a PID that is guaranteed dead: it runs `true` to completion and
+// returns its (now-exited) PID. ProcessStartTime for it returns (0, false), so it
+// can never be positively identified by sameGeneration.
+func deadPID(t *testing.T) int {
+	t.Helper()
+	cmd := exec.Command("true")
+	require.NoError(t, cmd.Run(), "running true")
+	return cmd.Process.Pid
+}
+
+// killpgRecorder captures the (pgid, sig) of every killpg call so a test can
+// assert the escalation order without touching a real process group.
+type killpgRecorder struct {
+	mu    sync.Mutex
+	calls []syscall.Signal
+}
+
+func (k *killpgRecorder) killpg(_ int, sig syscall.Signal) error {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	k.calls = append(k.calls, sig)
+	return nil
+}
+
+func (k *killpgRecorder) signals() []syscall.Signal {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	out := make([]syscall.Signal, len(k.calls))
+	copy(out, k.calls)
+	return out
+}
+
+// --- sameGeneration truth table ---------------------------------------------
+
+func TestSameGeneration_TruthTable(t *testing.T) {
+	self := os.Getpid()
+	selfToken, ok := daemon.ProcessStartTime(self)
+	require.True(t, ok, "reading self start token")
+
+	t.Run("token zero is never positive", func(t *testing.T) {
+		assert.False(t, sameGeneration(self, 0), "a zero (never-captured) token must never match")
+	})
+
+	t.Run("non-positive pid is never positive", func(t *testing.T) {
+		assert.False(t, sameGeneration(0, selfToken))
+		assert.False(t, sameGeneration(-1, selfToken))
+	})
+
+	t.Run("dead pid is never positive", func(t *testing.T) {
+		assert.False(t, sameGeneration(deadPID(t), selfToken),
+			"a dead pid has no readable token, so identity cannot be confirmed")
+	})
+
+	t.Run("live self with matching token is positive", func(t *testing.T) {
+		assert.True(t, sameGeneration(self, selfToken),
+			"the live self with its own captured token must match")
+	})
+
+	t.Run("live self with mismatched token is not positive", func(t *testing.T) {
+		assert.False(t, sameGeneration(self, selfToken+1),
+			"a token that does not match the current generation must be rejected")
+	})
+}
+
+// --- ledger round-trip -------------------------------------------------------
+
+func TestWriteLoadChildren_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	recs := []ChildRecord{
+		{Name: "web", PID: 4321, PGID: 4321, StartToken: 111},
+		{Name: "worker", PID: 8765, PGID: 8765, StartToken: 222},
+	}
+	require.NoError(t, WriteChildren(dir, recs))
+
+	// The ledger is written 0600.
+	info, err := os.Stat(filepath.Join(dir, daemon.ChildrenFileName))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm(), "ledger must be 0600")
+
+	loaded, err := LoadChildren(dir)
+	require.NoError(t, err)
+	assert.Equal(t, recs, loaded, "round-trip must preserve every record")
+}
+
+func TestLoadChildren_MissingIsNil(t *testing.T) {
+	loaded, err := LoadChildren(t.TempDir())
+	require.NoError(t, err, "a missing ledger must not error")
+	assert.Nil(t, loaded, "a missing ledger loads as nil")
+}
+
+func TestRemoveChildren_MissingTolerated(t *testing.T) {
+	assert.NoError(t, RemoveChildren(t.TempDir()), "removing a missing ledger must be tolerated")
+}
+
+// --- reaper escalation via injected seams ------------------------------------
+
+// newTestReaper builds a reaper wired to the given seams with a short, fast grace
+// window so escalation tests run quickly and NEVER signal a real process group.
+func newTestReaper(killpg func(int, syscall.Signal) error, groupAlive func(int) bool, startTime func(int) (int64, bool)) *reaper {
+	return &reaper{
+		killpg:     killpg,
+		groupAlive: groupAlive,
+		startTime:  startTime,
+		grace:      40 * time.Millisecond,
+		poll:       5 * time.Millisecond,
+		logger:     discardLogger(),
+	}
+}
+
+// alwaysStartTime returns a startTime seam that reports token for pid == wantPID
+// (positively identifying it) and (0,false) for anything else.
+func alwaysStartTime(wantPID int, token int64) func(int) (int64, bool) {
+	return func(pid int) (int64, bool) {
+		if pid == wantPID {
+			return token, true
+		}
+		return 0, false
+	}
+}
+
+func TestReaper_EscalatesToSigkill_WhenGroupSurvivesSigterm(t *testing.T) {
+	rec := ChildRecord{Name: "worker", PID: 12345, PGID: 12345, StartToken: 999}
+	rk := &killpgRecorder{}
+
+	// The stubborn shape: the leader "exits" on SIGTERM (unverifiable afterward)
+	// and the group survives the grace window, so the reaper must escalate to
+	// SIGKILL; the group then dies on SIGKILL (uncatchable). groupAlive stays true
+	// until SIGKILL is sent, then false. reap runs synchronously in this goroutine,
+	// so a plain bool needs no synchronization.
+	sigkilled := false
+	killpg := func(pgid int, sig syscall.Signal) error {
+		if sig == syscall.SIGKILL {
+			sigkilled = true
+		}
+		return rk.killpg(pgid, sig)
+	}
+	groupAlive := func(int) bool { return !sigkilled }
+	r := newTestReaper(killpg, groupAlive, alwaysStartTime(rec.PID, rec.StartToken))
+
+	reaped, skipped := r.reap([]ChildRecord{rec})
+
+	assert.Equal(t, []ChildRecord{rec}, reaped, "a group confirmed gone after SIGKILL is reaped")
+	assert.Empty(t, skipped)
+	assert.Equal(t, []syscall.Signal{syscall.SIGTERM, syscall.SIGKILL}, rk.signals(),
+		"escalation must send SIGTERM then, when the group survives the grace window, SIGKILL")
+}
+
+func TestReaper_SurvivorNotReported_WhenGroupPersistsAfterSigkill(t *testing.T) {
+	// Codex review: a group that CANNOT be confirmed gone (e.g. SIGKILL errored, or
+	// the group is wedged in uninterruptible sleep) must be reported SKIPPED, never
+	// reaped — otherwise ReapOrphans drops the still-port-holding orphan from the
+	// ledger and up.go prints a false reaped count.
+	rec := ChildRecord{Name: "wedged", PID: 32100, PGID: 32100, StartToken: 999}
+	rk := &killpgRecorder{}
+	groupAlive := func(int) bool { return true } // never confirmed gone, even after SIGKILL
+	r := newTestReaper(rk.killpg, groupAlive, alwaysStartTime(rec.PID, rec.StartToken))
+
+	reaped, skipped := r.reap([]ChildRecord{rec})
+
+	assert.Empty(t, reaped, "a group not confirmed gone must NOT be reported reaped")
+	assert.Equal(t, []ChildRecord{rec}, skipped, "an unconfirmed survivor is surfaced as skipped")
+	assert.Equal(t, []syscall.Signal{syscall.SIGTERM, syscall.SIGKILL}, rk.signals(),
+		"escalation still sent both signals before giving up")
+}
+
+func TestReaper_NoSigkill_WhenGroupExitsOnSigterm(t *testing.T) {
+	rec := ChildRecord{Name: "worker", PID: 22222, PGID: 22222, StartToken: 999}
+	rk := &killpgRecorder{}
+
+	// Well-behaved group: gone immediately after SIGTERM.
+	groupAlive := func(int) bool { return false }
+	r := newTestReaper(rk.killpg, groupAlive, alwaysStartTime(rec.PID, rec.StartToken))
+
+	reaped, skipped := r.reap([]ChildRecord{rec})
+
+	assert.Equal(t, []ChildRecord{rec}, reaped)
+	assert.Empty(t, skipped)
+	assert.Equal(t, []syscall.Signal{syscall.SIGTERM}, rk.signals(),
+		"a group gone after SIGTERM must NOT be SIGKILLed")
+}
+
+func TestReaper_SkipsCorruptRecord_PidPgidMismatch(t *testing.T) {
+	// PGID != PID: corrupt/planted -- must be skipped before any signal, even
+	// though PGID > 0.
+	rec := ChildRecord{Name: "evil", PID: 100, PGID: 200, StartToken: 999}
+	rk := &killpgRecorder{}
+	// startTime would positively identify it if it were ever consulted -- it must
+	// not be.
+	r := newTestReaper(rk.killpg, func(int) bool { return true }, alwaysStartTime(100, 999))
+
+	reaped, skipped := r.reap([]ChildRecord{rec})
+
+	assert.Empty(t, reaped)
+	assert.Equal(t, []ChildRecord{rec}, skipped)
+	assert.Empty(t, rk.signals(), "a corrupt record must never be signaled")
+}
+
+func TestReaper_SkipsUnidentifiable(t *testing.T) {
+	rk := &killpgRecorder{}
+	// startTime that can never positively identify anything (models a stale ledger
+	// whose leaders are all gone / tokens unreadable).
+	deadStartTime := func(int) (int64, bool) { return 0, false }
+	r := newTestReaper(rk.killpg, func(int) bool { return true }, deadStartTime)
+
+	recs := []ChildRecord{
+		{Name: "zero-token", PID: 300, PGID: 300, StartToken: 0},   // token 0
+		{Name: "unreadable", PID: 400, PGID: 400, StartToken: 777}, // startTime !ok
+	}
+	reaped, skipped := r.reap(recs)
+
+	assert.Empty(t, reaped)
+	assert.ElementsMatch(t, recs, skipped, "unverifiable records are skipped")
+	assert.Empty(t, rk.signals(), "no unverifiable record may be signaled (no SIGKILL of a stale group)")
+}
+
+func TestReaper_SkipsMismatchedToken(t *testing.T) {
+	rec := ChildRecord{Name: "worker", PID: 555, PGID: 555, StartToken: 111}
+	rk := &killpgRecorder{}
+	// Current token differs from the recorded one (PID reuse) -> not our generation.
+	r := newTestReaper(rk.killpg, func(int) bool { return true }, alwaysStartTime(555, 222))
+
+	reaped, skipped := r.reap([]ChildRecord{rec})
+
+	assert.Empty(t, reaped)
+	assert.Equal(t, []ChildRecord{rec}, skipped)
+	assert.Empty(t, rk.signals())
+}
+
+// --- ReapOrphans (real syscalls, never signals: all records unidentifiable) ---
+
+func TestReapOrphans_MissingLedgerIsNoOp(t *testing.T) {
+	reaped, skipped, err := ReapOrphans(t.TempDir(), discardLogger())
+	require.NoError(t, err)
+	assert.Nil(t, reaped)
+	assert.Nil(t, skipped)
+}
+
+func TestReapOrphans_StaleLedger_SkipsAndRemoves(t *testing.T) {
+	dir := t.TempDir()
+	// A well-formed but stale record: PID==PGID, but the pid is dead, so it can
+	// never be positively identified and ReapOrphans (real syscalls) never signals
+	// anything -- a clean no-op with NO SIGKILL.
+	dp := deadPID(t)
+	require.NoError(t, WriteChildren(dir, []ChildRecord{
+		{Name: "gone", PID: dp, PGID: dp, StartToken: 123456789},
+	}))
+
+	reaped, skipped, err := ReapOrphans(dir, discardLogger())
+	require.NoError(t, err)
+	assert.Empty(t, reaped, "a stale group must not be reaped")
+	assert.Len(t, skipped, 1, "the stale record is skipped")
+
+	// The old ledger is removed after the pass.
+	_, statErr := os.Stat(filepath.Join(dir, daemon.ChildrenFileName))
+	assert.True(t, os.IsNotExist(statErr), "the ledger must be removed after the reap pass")
+}
+
+// --- persistence concurrency -------------------------------------------------
+
+// newPersistSupervisor builds a supervisor over n graceful fake processes with a
+// real StateDir so launches persist the ownership ledger.
+func newPersistSupervisor(t *testing.T, n int, runner ProcessRunner) (*Supervisor, string, []string) {
+	t.Helper()
+	logMgr := logs.NewManager(logs.ManagerConfig{BufferSize: 1000})
+	t.Cleanup(func() { logMgr.Close() })
+
+	procs := make(map[string]config.ProcessConfig, n)
+	names := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		name := fmt.Sprintf("proc%d", i)
+		procs[name] = config.ProcessConfig{Cmd: "irrelevant", StopTimeout: "5s"}
+		names = append(names, name)
+	}
+	cfg := &config.Config{
+		API:       config.APIConfig{Port: 5599, Host: "127.0.0.1"},
+		Processes: procs,
+	}
+	stateDir := t.TempDir()
+	supCfg := DefaultSupervisorConfig()
+	supCfg.StateDir = stateDir
+	return New(cfg, logMgr, runner, supCfg), stateDir, names
+}
+
+// TestPersistChildren_ConcurrentLaunches drives the persist callback from the
+// parallel initial-start goroutines and asserts the final ledger has every live
+// child exactly once (last-writer-correctness under childrenMu + the s.mu
+// snapshot).
+func TestPersistChildren_ConcurrentLaunches(t *testing.T) {
+	const n = 8
+	// Distinct pids per launch; graceful so a later Stop reaps them cleanly.
+	runner := newFakeRunner(func(call int) *fakeProcess { return newGracefulFake(20000 + call) })
+	sup, stateDir, names := newPersistSupervisor(t, n, runner)
+
+	result, err := sup.Start(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, result.Failed, "all fake processes should start")
+
+	// Assert the ledger BEFORE Stop (a clean Stop removes it).
+	recs, err := LoadChildren(stateDir)
+	require.NoError(t, err)
+	require.Len(t, recs, n, "the final ledger must record every live child exactly once")
+
+	gotNames := make([]string, 0, len(recs))
+	seenPID := make(map[int]bool)
+	for _, r := range recs {
+		gotNames = append(gotNames, r.Name)
+		assert.Greater(t, r.PID, 0, "each record must carry a positive pid")
+		assert.Equal(t, r.PID, r.PGID, "PGID must equal the leader PID by construction")
+		assert.False(t, seenPID[r.PID], "no pid may appear twice in the ledger")
+		seenPID[r.PID] = true
+	}
+	sort.Strings(gotNames)
+	sort.Strings(names)
+	assert.Equal(t, names, gotNames, "every configured process must appear exactly once")
+
+	// A clean full Stop reaps the graceful fakes and removes the ledger.
+	require.NoError(t, sup.Stop(context.Background()))
+	_, statErr := os.Stat(filepath.Join(stateDir, daemon.ChildrenFileName))
+	assert.True(t, os.IsNotExist(statErr), "a clean Stop must remove the ledger")
+}
+
+// TestPersistChildren_SkippedAfterRefuseLaunches pins the fix for the codex
+// finding that a launch reaching the persist callback LATE (after Stop began
+// managing the ledger) could clobber a RETAINED ledger (dropping a surviving
+// group) or recreate a removed one. Once launches are refused, persistChildren
+// must no-op.
+func TestPersistChildren_SkippedAfterRefuseLaunches(t *testing.T) {
+	runner := newFakeRunner(func(call int) *fakeProcess { return newGracefulFake(21000 + call) })
+	sup, stateDir, _ := newPersistSupervisor(t, 1, runner)
+
+	retained := []ChildRecord{{Name: "survivor", PID: 40000, PGID: 40000, StartToken: 123}}
+
+	// Positive control: with launches OPEN, persistChildren rewrites the ledger
+	// (no child is running yet, so it writes an empty set). This proves the no-op
+	// below is due to the gate, not some other reason.
+	require.NoError(t, WriteChildren(stateDir, retained))
+	sup.launchable.Store(true)
+	sup.persistChildren()
+	open, err := LoadChildren(stateDir)
+	require.NoError(t, err)
+	assert.Empty(t, open, "with launches open, persistChildren rewrites the ledger (no live children -> empty)")
+
+	// Shutdown has begun: launches refused, Stop owns the ledger. A late callback
+	// must NOT touch the retained ledger.
+	require.NoError(t, WriteChildren(stateDir, retained))
+	sup.RefuseLaunches()
+	sup.persistChildren()
+	got, err := LoadChildren(stateDir)
+	require.NoError(t, err)
+	assert.Equal(t, retained, got, "after RefuseLaunches, persistChildren must not clobber the retained ledger")
+}

--- a/internal/supervisor/process.go
+++ b/internal/supervisor/process.go
@@ -147,6 +147,16 @@ type ManagedProcess struct {
 	// NewManagedProcess construction in tests) means "always allow".
 	launchGate func() error
 
+	// onLaunched, when set, is invoked by startWithConfig AFTER a successful launch
+	// and AFTER p.mu is released. It persists the supervisor's orphan-reaping
+	// ledger (see Supervisor.persistChildren / orphans.go). It is deliberately
+	// called outside the p.mu critical section: persistChildren takes s.mu, and the
+	// verified s.mu -> p.mu order would AB-BA if it ran while p.mu was held.
+	// supervisor.createManagedProcess injects it; nil (direct construction in
+	// tests) means "no persistence". Set once before publication, so it is read
+	// lock-free (like launchGate).
+	onLaunched func()
+
 	// stopBarrier is a test-only seam (nil in production). Stop invokes it,
 	// unlocked, at interleaving-sensitive points identified by phase:
 	//
@@ -264,24 +274,71 @@ func (p *ManagedProcess) StopTimeout() time.Duration {
 	return p.shutdownTimeout
 }
 
+// childRecord returns a ledger record for this process's currently-running
+// group, and ok=false when there is nothing live to record. Only a process in
+// the Running state with a live current instance is recorded: its leader is
+// still alive, so its start token is readable and the reap's up-front identity
+// check can positively match it on the next startup. A Stopping/Stopped/Crashed
+// process is deliberately excluded -- its leader has been (or is being) reaped,
+// so it could never be positively identified anyway.
+//
+// The start token comes from Process.StartToken (captured at spawn), so no
+// per-process syscall runs here and the recorded token cannot be a reused PID's.
+func (p *ManagedProcess) childRecord() (ChildRecord, bool) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if p.state != domain.ProcessStateRunning || p.current == nil || p.current.proc == nil {
+		return ChildRecord{}, false
+	}
+	pid := p.current.proc.PID()
+	pgid := p.current.proc.PGID()
+	if pid <= 0 {
+		return ChildRecord{}, false
+	}
+	// The start token is the one CAPTURED AT SPAWN (Process.StartToken), not re-read
+	// here: the monitor's Wait() reaps the leader (freeing its PID) BEFORE it takes
+	// p.mu to leave Running, so state can be Running while the PID is already
+	// reusable. Re-reading daemon.ProcessStartTime(pid) here could therefore stamp
+	// an unrelated reused-PID process's token onto this record, which the reaper
+	// would later positively match and signal (codex review).
+	return ChildRecord{Name: p.name, PID: pid, PGID: pgid, StartToken: p.current.proc.StartToken()}, true
+}
+
 // Start starts the process with its currently-stored config.
 func (p *ManagedProcess) Start(ctx context.Context) error {
 	return p.startWithConfig(ctx, nil)
 }
 
-// startWithConfig starts the process, optionally swapping in a freshly-reloaded
-// config first. When pending is non-nil the swap (config, env loader, effective
-// stop budget) happens inside this locked critical section, AFTER both
-// early-return guards (already-running state check, surviving-previous-group
-// check) pass and BEFORE the runner launches -- so a concurrent Start that wins
-// the race starts the old config and the loser returns ErrProcessAlreadyRunning
-// WITHOUT applying the swap. The stored config therefore always matches the
-// running process (#33, D3).
+// startWithConfig starts the process (see startWithConfigLocked for the launch
+// semantics) and, on success, persists the orphan-reaping ledger via onLaunched.
+//
+// The persist is invoked HERE -- after startWithConfigLocked has returned and
+// fully released p.mu -- rather than inside the locked section, because
+// persistChildren takes s.mu and the verified s.mu -> p.mu order would AB-BA if
+// it ran while p.mu was held. Every launch path funnels through this wrapper
+// (Start, Restart, and the supervisor's direct startWithConfig calls), so no
+// path can forget to persist and a future path inherits it for free.
+func (p *ManagedProcess) startWithConfig(ctx context.Context, pending *pendingConfig) error {
+	err := p.startWithConfigLocked(ctx, pending)
+	if err == nil && p.onLaunched != nil {
+		p.onLaunched()
+	}
+	return err
+}
+
+// startWithConfigLocked starts the process, optionally swapping in a
+// freshly-reloaded config first. When pending is non-nil the swap (config, env
+// loader, effective stop budget) happens inside this locked critical section,
+// AFTER both early-return guards (already-running state check,
+// surviving-previous-group check) pass and BEFORE the runner launches -- so a
+// concurrent Start that wins the race starts the old config and the loser
+// returns ErrProcessAlreadyRunning WITHOUT applying the swap. The stored config
+// therefore always matches the running process (#33, D3).
 //
 // If the runner (or the post-swap env reload) fails AFTER the swap was applied,
 // the new config stays in place (state Crashed; the next start uses it) -- "the
 // file is the truth".
-func (p *ManagedProcess) startWithConfig(ctx context.Context, pending *pendingConfig) error {
+func (p *ManagedProcess) startWithConfigLocked(ctx context.Context, pending *pendingConfig) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 

--- a/internal/supervisor/runner.go
+++ b/internal/supervisor/runner.go
@@ -18,6 +18,7 @@ import (
 	"os/exec"
 	"syscall"
 
+	"github.com/charliek/prox/internal/daemon"
 	"github.com/charliek/prox/internal/domain"
 )
 
@@ -29,6 +30,20 @@ type ProcessRunner interface {
 // Process represents a running process
 type Process interface {
 	PID() int
+	// PGID returns the process group ID captured at launch (== leader PID by
+	// construction, since the runner Setpgid's without an explicit Pgid). A value
+	// <= 0 means the group is unknown. It is used to persist the orphan-reaping
+	// ledger (see orphans.go) so a later `prox up` can reap a group left behind by
+	// a SIGKILL'd generation whose graceful Stop never ran.
+	PGID() int
+	// StartToken returns the leader's opaque process start token
+	// (daemon.ProcessStartTime), CAPTURED AT LAUNCH when the PID is definitively
+	// this process. The orphan-reaping ledger records it so the next `prox up` can
+	// verify a leftover group still names the same generation. It is captured at
+	// spawn (not re-read later) because re-reading a PID after Wait() reaps the
+	// leader could stamp an unrelated reused-PID process's token. 0 means the token
+	// was unreadable at launch (the reaper then never reaps that record).
+	StartToken() int64
 	Wait() error
 	Signal(sig os.Signal) error
 	// GroupAlive reports whether any member of the process group is still
@@ -114,20 +129,28 @@ func (r *ExecRunner) Start(ctx context.Context, config domain.ProcessConfig, env
 	// leader). We record the leader PID directly rather than calling
 	// syscall.Getpgid: the leader PID is authoritative and this avoids a race
 	// where the leader has already exited by the time we'd query it.
+	//
+	// Capture the start token here too, while cmd.Process.Pid is DEFINITIVELY this
+	// freshly-forked child: we have not Wait()ed it, so even an immediate exit only
+	// zombifies it (we hold the reap), keeping the PID un-reusable. Reading the
+	// token later (after Wait reaps the leader) could stamp a reused PID's token.
+	startToken, _ := daemon.ProcessStartTime(cmd.Process.Pid)
 	return &execProcess{
-		cmd:    cmd,
-		pgid:   cmd.Process.Pid,
-		stdout: stdoutR,
-		stderr: stderrR,
+		cmd:        cmd,
+		pgid:       cmd.Process.Pid,
+		startToken: startToken,
+		stdout:     stdoutR,
+		stderr:     stderrR,
 	}, nil
 }
 
 // execProcess wraps exec.Cmd to implement Process interface
 type execProcess struct {
-	cmd    *exec.Cmd
-	pgid   int // process group ID captured at launch (== leader PID); <= 0 means unknown
-	stdout io.Reader
-	stderr io.Reader
+	cmd        *exec.Cmd
+	pgid       int   // process group ID captured at launch (== leader PID); <= 0 means unknown
+	startToken int64 // leader start token captured at launch; 0 means unreadable
+	stdout     io.Reader
+	stderr     io.Reader
 }
 
 func (p *execProcess) PID() int {
@@ -135,6 +158,18 @@ func (p *execProcess) PID() int {
 		return 0
 	}
 	return p.cmd.Process.Pid
+}
+
+// PGID returns the process group ID captured at launch (== leader PID). See the
+// Process interface for how it is used by the orphan-reaping ledger.
+func (p *execProcess) PGID() int {
+	return p.pgid
+}
+
+// StartToken returns the leader's start token captured at launch. See the Process
+// interface for why it is captured at spawn rather than re-read later.
+func (p *execProcess) StartToken() int64 {
+	return p.startToken
 }
 
 func (p *execProcess) Wait() error {

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -35,6 +35,12 @@ type SupervisorConfig struct {
 	// reload entirely (tests that construct a Supervisor directly), preserving
 	// back-compat: the up-time config is used as-is.
 	ConfigPath string
+	// StateDir is the absolute path to this project's .prox state directory. When
+	// set, every successful launch persists the orphan-reaping ownership ledger
+	// (<StateDir>/prox.children) so a later `prox up` can reap groups a SIGKILL'd
+	// generation orphaned (plan 009 D11-D13, #59). Empty disables persistence
+	// (tests that construct a Supervisor directly), a clean no-op.
+	StateDir string
 }
 
 // DefaultSupervisorConfig returns default configuration
@@ -90,6 +96,14 @@ type Supervisor struct {
 	eventMu sync.RWMutex
 	// eventSubs holds channels for subscribers to supervisor events
 	eventSubs []chan SupervisorEvent
+
+	// childrenMu serializes writes to the orphan-reaping ownership ledger
+	// (<supConfig.StateDir>/prox.children). Holding it across BOTH the s.mu
+	// snapshot and the file write gives last-writer-correctness under the parallel
+	// launches: each serialized persist snapshots the CURRENT live set, so the
+	// final write reflects reality even when starts race. Lock order is
+	// childrenMu -> s.mu (persistChildren); no path takes them the other way.
+	childrenMu sync.Mutex
 }
 
 // SupervisorEvent represents a supervisor event
@@ -223,6 +237,12 @@ func (s *Supervisor) createManagedProcess(name string, procConfig config.Process
 		}
 		return nil
 	}
+	// Persist the orphan-reaping ledger after every successful launch (plan 009
+	// D11-D13, #59). startWithConfig invokes this AFTER releasing p.mu, so
+	// persistChildren's childrenMu -> s.mu ordering is safe. Wiring it here (on
+	// every managed process) means all launch paths persist and a future one
+	// cannot forget.
+	mp.onLaunched = s.persistChildren
 
 	return mp, nil
 }
@@ -373,6 +393,111 @@ func (s *Supervisor) startProcessesConcurrently(result *StartResult) {
 	wg.Wait()
 }
 
+// persistChildren rewrites the orphan-reaping ownership ledger to reflect every
+// currently-live child (plan 009 D11-D13, #59). It is invoked by every
+// successful startWithConfig (via ManagedProcess.onLaunched), OUTSIDE any p.mu
+// critical section.
+//
+// It holds childrenMu across BOTH the s.mu snapshot and the file write so the
+// serialized persists each capture the up-to-date live set -- the final write
+// therefore reflects reality even when launches race (last-writer-correctness).
+// The write itself is temp+rename (file-atomicity), so a concurrent LoadChildren
+// never sees a torn ledger.
+//
+// Persistence-failure policy (best-effort, loud): a write failure is logged
+// prominently and swallowed -- the just-started child is NOT failed or killed
+// over an unwritable ledger.
+func (s *Supervisor) persistChildren() {
+	if s.supConfig.StateDir == "" {
+		return
+	}
+
+	s.childrenMu.Lock()
+	defer s.childrenMu.Unlock()
+
+	recs := s.snapshotChildren()
+
+	// Gate AFTER the snapshot, not before. Once launches are refused, Stop owns the
+	// ledger (removes it after a clean reap, or RETAINS it on
+	// ErrProcessGroupNotReaped). A launch that got past the launch gate and reaches
+	// this callback late must NOT rewrite the ledger, or it could clobber a
+	// retained ledger (dropping a surviving group) or recreate one after removal
+	// (codex review). Stop flips launchable false BEFORE it stops any process, and
+	// the p.mu the snapshot takes to read a process's (Crashed) state
+	// synchronizes-with that flip -- so any snapshot that could OMIT a
+	// being-stopped survivor is guaranteed to observe launchable==false here and
+	// abort. Checking BEFORE the snapshot left a window where a callback read
+	// launchable==true, then Stop flipped it and Crashed the survivor, then the
+	// stale snapshot wrote an incomplete ledger.
+	//
+	// Accepted residual (plan §9, codex): this gate trades the clobber-a-retained-
+	// ledger bug for a narrower completeness gap. If a callback snapshots BEFORE a
+	// concurrent launch B, writes while launchable is still true, and B's own
+	// callback then aborts at this gate during shutdown, a B that SURVIVES Stop can
+	// be left out of the ledger. This is NOT a safety issue (it can only fail to
+	// reap, never signal an innocent group) and is ultra-narrow (needs a
+	// SIGKILL-surviving group AND an API launch landing exactly at shutdown); worst
+	// case the operator kills that one group manually, as before #59. Fully closing
+	// it (Stop authoritatively rewriting the survivor set) is a recommended
+	// follow-up, bounded anyway by the pre-existing launch/stop race (#36 D4).
+	if !s.launchable.Load() {
+		return
+	}
+
+	if err := WriteChildren(s.supConfig.StateDir, recs); err != nil {
+		s.systemErrorf("ERROR: failed to persist child ownership ledger: %v", err)
+	}
+}
+
+// systemErrorf writes an ERROR-level system log line to stderr. It is the stderr
+// sibling of SystemLog, used for the best-effort ledger-persistence failures that
+// are logged loudly but swallowed (see persistChildren / removeChildrenLedger).
+func (s *Supervisor) systemErrorf(format string, args ...interface{}) {
+	s.logManager.Write(domain.LogEntry{
+		Timestamp: time.Now(),
+		Process:   "system",
+		Stream:    domain.StreamStderr,
+		Line:      fmt.Sprintf(format, args...),
+	})
+}
+
+// snapshotChildren returns a ledger record for every currently-live child. It
+// collects the managed-process pointers under s.mu (correct s.mu -> p.mu order),
+// then reads each record via childRecord (which takes its own p.mu and reads the
+// start token UNDER it, so the token matches the captured pid's generation), so
+// no per-process syscall runs while s.mu is held.
+func (s *Supervisor) snapshotChildren() []ChildRecord {
+	s.mu.RLock()
+	procs := make([]*ManagedProcess, 0, len(s.processes))
+	for _, mp := range s.processes {
+		procs = append(procs, mp)
+	}
+	s.mu.RUnlock()
+
+	recs := make([]ChildRecord, 0, len(procs))
+	for _, mp := range procs {
+		if rec, ok := mp.childRecord(); ok {
+			recs = append(recs, rec)
+		}
+	}
+	return recs
+}
+
+// removeChildrenLedger deletes the ownership ledger under childrenMu. It is
+// called from Stop ONLY when every group was confirmed reaped -- a clean
+// shutdown leaves no orphans to reap, so the ledger must not linger and drive a
+// spurious reap on the next startup. A no-op when persistence is disabled.
+func (s *Supervisor) removeChildrenLedger() {
+	if s.supConfig.StateDir == "" {
+		return
+	}
+	s.childrenMu.Lock()
+	defer s.childrenMu.Unlock()
+	if err := RemoveChildren(s.supConfig.StateDir); err != nil {
+		s.systemErrorf("ERROR: failed to remove child ownership ledger: %v", err)
+	}
+}
+
 // stopEvent maps a per-process Stop result to the event that Supervisor.Stop and
 // StopProcess both emit, so the event semantics stay uniform across the two paths
 // by construction (#36, D3): a clean stop (or already-not-running) is
@@ -501,6 +626,11 @@ func (s *Supervisor) Stop(ctx context.Context) error {
 	})
 
 	if len(failures) == 0 {
+		// Every group was confirmed reaped -- there are no orphans for a later
+		// `prox up` to reap, so drop the ownership ledger. It is RETAINED below
+		// when a group survived (ErrProcessGroupNotReaped), so the next startup can
+		// still reap whatever this stop could not.
+		s.removeChildrenLedger()
 		// Return a literal nil, never a typed-nil *ProcessStopError (which would be
 		// a non-nil error interface).
 		return nil

--- a/test/integration/reap_orphans_test.go
+++ b/test/integration/reap_orphans_test.go
@@ -1,0 +1,108 @@
+package integration
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// TestReap_OrphanedGrandchildAfterKill (issue #59) proves the ownership-ledger
+// orphan reap end to end through the real binary:
+//
+//  1. Generation 1 starts the stubborn fixture (a leader shell whose backgrounded
+//     python grandchild ignores SIGTERM and holds a real TCP port).
+//  2. Generation 1 is killed with SIGKILL -- its graceful shutdown NEVER runs, so
+//     the supervised child group orphans and keeps holding the port (the classic
+//     EADDRINUSE-on-next-up scenario).
+//  3. Generation 2 starts in the same project dir. On startup it reads the ledger
+//     the SIGKILL'd generation left behind and reaps the orphaned group, so its
+//     own worker rebinds the same port (SO_REUSEADDR is deliberately off in the
+//     fixture, so a successful rebind proves the orphan genuinely released it).
+//
+// This is the core acceptance for C5: first-generation group GONE + port REBINDS,
+// with no EADDRINUSE crashloop.
+func TestReap_OrphanedGrandchildAfterKill(t *testing.T) {
+	skipShort(t)
+
+	binary := buildBinary(t)
+	addr := stubbornAPIAddr
+
+	var firstGrandchildPID, secondGrandchildPID int
+	t.Cleanup(func() {
+		// Never leak a stubborn listener into CI, and remove the ledger so it
+		// cannot drive a reap in a later test sharing this project dir.
+		killIfAlive(secondGrandchildPID)
+		killIfAlive(firstGrandchildPID)
+		_ = os.Remove(filepath.Join(projectRoot(t), ".prox", "prox.children"))
+	})
+
+	// --- Generation 1 -------------------------------------------------------
+	first := startProxWithOutput(t, binary, "up", "-c", configPath("stubborn"))
+	// If an assertion below aborts before gen-1 is SIGKILL'd, make sure it dies.
+	firstKilled := false
+	defer func() {
+		if !firstKilled {
+			killProx(first.cmd)
+		}
+	}()
+
+	waitForAPI(t, addr, 10*time.Second)
+
+	pidStr := waitForMarkerValue(t, addr, "worker", "GRANDCHILD_PID=", "", 5*time.Second)
+	pid, err := strconv.Atoi(pidStr)
+	requireNoError(t, err, "parsing first GRANDCHILD_PID")
+	firstGrandchildPID = pid
+	waitForMarkerValue(t, addr, "worker", "LISTENING=", "", 5*time.Second)
+
+	// SIGKILL the prox process. Its child group is in its own PGID, so SIGKILL does
+	// NOT cascade to it -- the leader shell + grandchild orphan and keep running.
+	killProx(first.cmd)
+	firstKilled = true
+
+	// The orphaned grandchild survived and still holds the port.
+	if !processAlive(firstGrandchildPID) {
+		t.Fatalf("grandchild pid %d should survive prox SIGKILL (orphaned), but it is gone", firstGrandchildPID)
+	}
+	// The port is genuinely held: a fresh bind (SO_REUSEADDR off in the fixture)
+	// must fail with the orphan still listening.
+	if ln, bindErr := net.Listen("tcp", net.JoinHostPort("127.0.0.1", stubbornListenerPort)); bindErr == nil {
+		_ = ln.Close()
+		t.Fatalf("expected port %s to be held by the orphaned grandchild, but it was free", stubbornListenerPort)
+	}
+
+	// --- Generation 2: reaps the orphan on startup, then rebinds the port ----
+	second := startProxWithOutput(t, binary, "up", "-c", configPath("stubborn"))
+	defer killProx(second.cmd)
+
+	// Startup includes the reap grace window (~2s) before the supervisor starts.
+	waitForAPI(t, addr, 20*time.Second)
+
+	// The first generation's orphaned group must be gone -- reaped from the ledger
+	// during gen-2 startup.
+	if !waitForPIDGone(firstGrandchildPID, 15*time.Second) {
+		t.Fatalf("first-generation grandchild pid %d still alive after generation-2 startup reap", firstGrandchildPID)
+	}
+
+	// The port rebinds: gen-2's worker launches a NEW grandchild that binds the
+	// same port. The marker only prints after a successful bind+listen, so its mere
+	// presence proves the rebind succeeded (a failed rebind would crash the python
+	// script before printing GRANDCHILD_PID/LISTENING).
+	newPIDStr := waitForMarkerValue(t, addr, "worker", "GRANDCHILD_PID=", pidStr, 15*time.Second)
+	newPID, err := strconv.Atoi(newPIDStr)
+	requireNoError(t, err, "parsing second GRANDCHILD_PID")
+	secondGrandchildPID = newPID
+	if newPID == firstGrandchildPID {
+		t.Fatalf("expected a new grandchild pid distinct from %d, got the same pid", firstGrandchildPID)
+	}
+
+	listeningPort := waitForMarkerValue(t, addr, "worker", "LISTENING=", "", 5*time.Second)
+	if listeningPort != stubbornListenerPort {
+		t.Fatalf("expected the rebound grandchild to listen on port %s, got %q", stubbornListenerPort, listeningPort)
+	}
+
+	// The replacement worker should be running (not crashed on EADDRINUSE).
+	waitForProcessState(t, addr, "worker", "running", 5*time.Second)
+}


### PR DESCRIPTION
Plan 009 (post-plan-008 Tier-1 follow-ups), **PR-C of 3** — the supervisor orphan-reap. Sibling PRs: PR-A #63 (daemon lifecycle + infra), PR-B #64 (TUI logs search). The panel-reviewed plan lives outside the repo (`~/.claude/plans/prox/009-plan008-followups.md`); its substance is below.

## What changed — `feat(supervisor): reap orphaned child groups on startup after kill -9` (Closes #59)

When a `prox up` is killed with `kill -9`, its graceful `Stop` never runs (SIGKILL is uncatchable), so the backend process **groups** it supervised orphan and keep holding their ports — the next `prox up` then hits EADDRINUSE / 502s. The `setpgid`+`killpg` escalation already existed for the graceful path; the gap was that PGIDs live only in memory.

**Discovery correction:** the brief assumed the fix was "add setpgid + killpg" — but discovery found those already implemented. The real gap (and the fix) is persisting the group identities and reaping them on the next startup.

- **Ownership ledger** (`.prox/prox.children`, temp+rename atomic): records each supervised group leader's `{name, pid, pgid(==pid), start_token}`. The **start token is captured AT SPAWN** (`Process.StartToken`, when the PID is definitively ours) — not re-read later, which could stamp a reused PID's token. Rewritten on every successful launch via one `startWithConfig` callback (covers initial + API start/restart); best-effort (a write error is logged, never fails the child). Owned by `Stop`: removed on a clean reap, **retained** on `ErrProcessGroupNotReaped`, and deliberately **not** folded into `CleanupStateDir`/`CleanupStaleFiles` (which run before the reap).
- **Startup reap** (`ReapOrphans`, after the PID-file lock, before the supervisor starts): reaps each leftover group that **strictly positively** matches its recorded generation — `sameGeneration` (`pid>0 && token!=0 && current token == recorded`), deliberately **not** the alive-*biased* `daemon.IsProcessAlive` (whose bias is inverted, and lethal, for a `killpg`). Corrupt records (`pid!=pgid`) are never signaled. Identity is verified **once** up front, then `SIGTERM→(grace)→SIGKILL` escalates on group liveness; a group not confirmed gone is reported **skipped**, never a false "reaped". Signal/liveness/token seams are injectable so unit tests never signal the test runner's own group.

## Verification
- **Gate green** on macOS: `make lint && make test && make test-race && make build` (supervisor + integration under `-race`, no data races).
- **Unit** (`orphans_test.go`): `sameGeneration` truth table; write/load round-trip; reaper escalation; corrupt/unverifiable/mismatched **skips**; **survivor-not-reported**; concurrent-launch ledger correctness; **persist-gate after RefuseLaunches**. **Integration** (`reap_orphans_test.go`): kill-9-then-restart port rebind.
- **Simplify:** two safe logging-only cleanups (a nil-guard, a duplicated log block → `systemErrorf`).
- **Codex adversarial review** (three rounds on this lethal-`killpg` code) drove: spawn-time token capture (was re-read, racing `Wait()`); `reapGroup` confirmed-gone verdict (was false-reporting survivors); persist gate after the snapshot (was clobbering a retained ledger); surfacing the ledger-removal error.
- **Live isolated pass** (`live-reap.sh`): a `kill -9`'d `prox up` left a stubborn backend (ignores SIGTERM) orphaned holding port 18099; the ledger survived the kill-9; the next `prox up` logged `reaped leftover child group (escalated to SIGKILL)` + `Reaped 1 orphaned child group(s)`, the old orphan was **gone**, and gen2's **new** backend (a different PID) rebound 18099 — **no wedged port**. Isolated HOME + temp project; the user's real daemon and `:5555` were untouched.

## Accepted residuals (dispositioned; documented in code + §9)
- **verify→`killpg` / escalation-grace TOCTOU:** fundamental to user-space `check→signal`; minimized by the strict up-front identity check; no worse than the existing graceful `Stop` escalation. (Innocent-kill *safety* is otherwise fully closed: spawn-captured token + strict `sameGeneration` + `pid==pgid`.)
- **Linux-only cross-boot token collision:** `ProcessStartTime` is boot-relative on Linux; the ledger can survive a reboot (after which the orphans are already dead). Darwin tokens are wall-clock (`P_starttime`) so are cross-boot-unique. Follow-up: persist a boot marker.
- **Ultra-narrow persist gap:** a concurrent API launch racing a shutdown-with-surviving-group can leave that group unrecorded — a *completeness* gap (fails to reap next startup; manual kill, as before #59), not a safety issue, bounded by the pre-existing launch/stop race (#36 D4).

## Dependency / privacy / secret impact
None (no new deps). No secrets, no data collection. Unix-only (`syscall.Kill`); Windows is a non-target (`.goreleaser.yaml` builds linux+darwin only), so no platform split.

## Note on CI
Cut from `main`, so it doesn't carry PR-A's macOS CI matrix (lands with #63); rebasing on #63 (or after merge) adds macOS coverage here.

<details>
<summary>Plan 009 — PR-C sections (C5 design, D11–D13)</summary>

See `~/.claude/plans/prox/009-plan008-followups.md` §D11–D13, §7 (acceptance), §9 (risks), §10 (panel). The panel (Codex/GLM/CodeRabbit) established H1 (strict `sameGeneration`, not the alive-biased `IsProcessAlive`) and the verify-once-then-escalate design; per-commit Codex review then hardened the implementation as above.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgMgg6eo4LgLTCkfYSARcH


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically cleans up orphaned backend process groups when starting a project after an interrupted shutdown.
  * Safely verifies process ownership before terminating leftovers and reports reaped or skipped groups.
  * Releases previously occupied ports so services can restart successfully.

* **Bug Fixes**
  * Prevents stale backend processes from causing restart failures or port conflicts.

* **Tests**
  * Added coverage for orphan cleanup, interrupted launches, process identity checks, and service recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->