### PR TITLE
Hardening: lifecycle signals, self-healing shared proxy, requests dependability (plan 010)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,142 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+A hardening pass on lifecycle signals and the requests pipeline: `prox up`/`prox status`/`prox stop` now give trustworthy exit codes and error messages instead of silently degrading, the shared proxy daemon self-heals and isolates projects from each other, and captured request/response bodies decode more content types. Plus a refreshed agent skill and docs.
+
+> **Upgrading:** as with v0.2.0, the shared daemon requires an exact version
+> match with its clients. After installing this release, stop the old daemon
+> and restart every project: `prox proxy stop --force`, then `prox up` in
+> each project — or just run `prox up` in one project and let the idle-daemon
+> auto-heal (below) replace it for you.
+
+### Breaking
+
+- **`prox status` exits 1 when the shared proxy is down** (#66). Previously
+  `prox status` only reflected the project supervisor's own process health,
+  so a dead shared proxy daemon could go unnoticed behind a clean-looking
+  status. It now probes the daemon and prints `Proxy: DOWN — shared proxy
+  daemon unreachable (proxied routes are dead). Check 'prox proxy status'.`,
+  exiting non-zero, even when every child process is healthy. Scripts that
+  treated `prox status`'s exit code as pure process health must account for
+  proxy health too.
+- **Client commands no longer fall back to `:5555`** (#66). `status`,
+  `logs`, `stop`, `start`, `restart`, `down`, `attach`, and `requests`
+  previously dialed the compiled-in `127.0.0.1:5555` default when they
+  couldn't discover a running instance from `.prox/prox.state` — silently
+  talking to nothing, or the wrong daemon. They now error with remediation
+  ("run from the project directory, or pass `--addr`") instead. Scripts
+  invoking these commands from outside the project directory must pass
+  `--addr` explicitly.
+- **`prox up -d` exit code is now truthful** (was always 0). The detach
+  parent used to print `prox started (pid N)` and exit 0 immediately after
+  forking, before the child had loaded its config, bound its ports, or
+  registered its routes — so a child that died during startup still reported
+  success. `prox up -d` now polls up to 15s for the child to become ready
+  (state file + `/health`) before exiting 0; it exits 1 with a
+  `.prox/prox.log` tail on early child death or a never-ready timeout
+  (killing the child on timeout).
+- **Orphan ledger format is a forward-incompatible envelope** (#67). The
+  supervisor's crash-recovery ledger (`.prox/prox.children`) is now
+  `{"boot_marker":"...","children":[...]}` instead of a bare array, so a
+  reboot can't let a PID/start-token collision reap an unrelated process
+  group. A pre-upgrade `prox` binary cannot parse the new envelope — it
+  fails to unmarshal and simply skips the reap (never unsafe, just less
+  helpful) until every project has been restarted on this version. Downgrade
+  from this version briefly loses crash-recovery reaping for the same
+  reason.
+- **New dependencies**: `github.com/klauspost/compress` (zstd decoding) and
+  `github.com/andybalholm/brotli` (brotli decoding), both pure Go.
+
+### Lifecycle
+
+- **Version-skew hard fail with idle-daemon auto-heal**. A shared proxy
+  daemon running a different version than the connecting `prox` used to
+  silently fall back to a proxy-less standalone start. Now a version
+  mismatch is a typed error: if the daemon still has registered projects,
+  `prox up` fails hard, naming both versions, every registered project
+  directory, and the exact remediation; if the daemon is idle, `prox up`
+  auto-replaces it with a fresh daemon of the current version and prints a
+  one-line notice. Standalone proxy create/start failures are likewise now
+  fatal when a proxy is configured (`--no-proxy` is the escape hatch)
+  instead of warn-and-continue — no code path starts a project with a
+  silently-disabled proxy anymore.
+- **Registration recovers from a draining daemon**. Registering during the
+  shared daemon's brief shutdown grace used to be a fatal `SHUTTING_DOWN`
+  error whose text said "retry" but nothing retried. `prox up` now polls for
+  the old daemon to finish draining (up to 10s), starts a fresh daemon, and
+  re-registers automatically; a second failure is still fatal.
+- **Forwarder self-heal after daemon death** (#66). When the shared daemon
+  dies, every registered project used to reconnect silently forever with no
+  path back. Projects now detect a prolonged (15s+) connection failure and
+  re-register with a fresh or recovered daemon automatically (damped to at
+  most once per 30s), worst case within ~45s — no `prox proxy stop --force`
+  required. The daemon's re-registration path was also made idempotent for a
+  live same-identity holder, closing a would-be `REGISTRATION_CONFLICT`
+  loop. Healing is suppressed while a project is itself shutting down, and a
+  version-mismatch failure surfaces as a status state rather than
+  restarting a daemon that might still be in use.
+- **Boot-marker guard for the orphan ledger** (#67). See Breaking above —
+  the ledger now discards itself across a reboot (and on Linux, when it
+  predates this marker) instead of risking a PID/start-token collision.
+
+### Requests
+
+- **`prox status` / `GET /status` surface shared-proxy health** (#66). A new
+  `proxy` block reports `mode` (`shared`/`standalone`/`disabled`),
+  `daemon_reachable`, `daemon_version`, reconnect/drop/backfill counters,
+  and `heal_state`. The CLI renders this as a `Proxy:` line (see Breaking).
+- **Stale flag for stuck in-flight requests** (#53). A request that has been
+  `in_flight` for more than 5 minutes now also carries `stale: true`
+  (`stale?` in the CLI/TUI) — the completion event may have been lost and
+  the outcome is unknown. Computed at serve time; no protocol or storage
+  change. Long-lived streams and large transfers can legitimately show
+  `stale?` while still live.
+- **Drop and degradation counters**. The request stream's subscriber
+  channels used to drop events silently on overflow. Dropped-event and
+  backfill-failure counts are now tracked (atomics) and exposed through the
+  `proxy` status block, so silent request loss becomes visible.
+- **More captured-body content types decoded** (#50). `deflate` (zlib with a
+  raw-deflate fallback), `zstd`, and `br` (brotli) captured bodies now
+  decode for display, joining `gzip`/`x-gzip`; all four are bounded by the
+  same 10MB decode cap. Chained or unrecognized encodings, truncated
+  captures, and corrupt streams still fall back to raw bytes.
+- **Hex preview for binary bodies in the TUI** (#50). The request detail
+  view renders binary bodies as a bounded `hexdump -C`-style preview (first
+  256 bytes, offset + hex + ASCII gutter) instead of an inert
+  `[binary data]` placeholder.
+- **Cursor pagination for `GET /proxy/requests`** (#50). A new `before_id`
+  parameter pages strictly older than the given record, returning
+  `next_before_id` (the oldest *scanned* record, so a fully-filtered page
+  still advances) for the next page. An unknown, evicted, or out-of-scope
+  cursor returns `410` with code `CURSOR_GONE`. `prox requests` (CLI) is
+  unchanged — this is an API-only capability for now.
+- **Per-project request rings and capture caps on the shared daemon**
+  (#49). The daemon's single global request ring and capture cap used to let
+  one chatty project evict another project's records and bodies, and a
+  per-project `capture.max_body_size` was silently ignored on the daemon.
+  Each registered project now gets its own full-capacity ring and its
+  `max_body_size` is enforced per request on the shared capture path — one
+  project flooding traffic cannot affect another's history or capture
+  quota.
+
+### Skill & Docs
+
+- **Agent skill refreshed to post-hardening reality**. `skills/prox/references/api.md`
+  and `SKILL.md` now document 12-char request IDs, `since`/`url_contains`,
+  `in_flight`/`stale`/`captured_size`/`content_encoding`/`unavailable_reason`,
+  the `before_id`/`next_before_id`/`CURSOR_GONE` cursor, the `proxy` status
+  block, the no-`:5555`-fallback rule, and the truthful `prox up -d` exit
+  code / version-mismatch behavior.
+- **README, architecture, and reference docs updated to match**: the HTTP
+  API table gains the `/proxy/requests` endpoints; `docs/development/architecture.md`
+  documents the shared proxy daemon, the capture pipeline, and the forwarder
+  bridge; `docs/reference/api.md`/`cli.md`/`configuration.md` document the
+  `proxy` status block, `stale`, cursor pagination, the decoder list, and
+  per-project `max_body_size`; `docs/guides/shared-proxy.md` documents
+  self-healing and version-mismatch behavior.
+
 ## v0.2.0
 
 The requests/capture overhaul: the shared proxy daemon now captures request and

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ For one-off installs without configuring the apt repo (CI runners, locked-down h
 
 ```bash
 ARCH=$(dpkg --print-architecture)        # amd64 or arm64
-VERSION=0.1.3                            # check https://github.com/charliek/prox/releases for the latest
+VERSION=0.2.0                            # check https://github.com/charliek/prox/releases for the latest
 curl -fLO "https://github.com/charliek/prox/releases/download/v${VERSION}/prox_${VERSION}_${ARCH}.deb"
 sudo apt install -y "./prox_${VERSION}_${ARCH}.deb"
 ```
@@ -182,6 +182,9 @@ By default, the API binds to a dynamic (auto-assigned) localhost port. Discover 
 | `/processes/{name}/restart` | POST | Restart a process |
 | `/logs` | GET | Retrieve logs |
 | `/logs/stream` | GET | Stream logs (SSE) |
+| `/proxy/requests` | GET | List proxied requests |
+| `/proxy/requests/{id}` | GET | Get proxied request details |
+| `/proxy/requests/stream` | GET | Stream proxied requests (SSE) |
 | `/shutdown` | POST | Shutdown supervisor |
 
 ## Security

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -132,49 +132,47 @@ The optional reverse proxy provides hostname-based routing to local services ove
 ### Proxy Architecture
 
 ```
-┌──────────────────────────────────────────────────────────────────┐
-│                   Shared HTTP/HTTPS Proxy                         │
-│                                                                    │
-│  Browser Request                                                   │
-│  http(s)://app.local.dev:port/api/users                           │
-│         │                                                          │
-│         ▼                                                          │
-│  ┌─────────────────────┐                                          │
-│  │  Hostname Router    │  Match full hostname                     │
-│  │  (extract + lookup) │                                          │
-│  └──────────┬──────────┘                                          │
-│             │                                                      │
-│             ▼                                                      │
-│  ┌─────────────────────┐     ┌─────────────────────┐              │
-│  │   Route Table       │────▶│   Request Manager   │              │
-│  │ app.local → :3000   │     │   (ring buffer)     │              │
-│  │ api.local → :8000   │     └─────────────────────┘              │
-│  └──────────┬──────────┘                                          │
-│             │                                                      │
-│             ▼                                                      │
-│  ┌─────────────────────┐                                          │
-│  │ httputil.ReverseProxy│                                         │
-│  │ → localhost:3000    │                                          │
-│  └─────────────────────┘                                          │
-└──────────────────────────────────────────────────────────────────┘
+┌───────────────────────┐                          ┌──────────────────────────────────────────┐
+│  Project A (prox up)  │                          │       Shared Proxy Daemon (proxyd)        │
+│  ┌─────────┐ ┌──────┐ │  register / heartbeat    │  singleton (flock'd ~/.prox/proxy.pid)    │
+│  │Forwarder│▶│Local │ │─────────────────────────▶│                                            │
+│  │ bridge  │ │  RM  │ │◀─────────────────────────│  ┌──────────┐    ┌──────────────────────┐ │
+│  └─────────┘ └──────┘ │  per-project SSE stream  │  │ Registry │    │  Hostname Router      │ │
+└───────────────────────┘  + snapshot backfill     │  │ refcounted│──▶│  (Host header / SNI)  │ │
+┌───────────────────────┐  over ~/.prox/proxy.sock │  │ listeners │   └──────────┬────────────┘ │
+│  Project B (prox up)  │◀─────────────────────────│  └────┬─────┘              │              │
+│    (forwarder + RM)   │─────────────────────────▶│       │        ┌───────────▼────────────┐ │
+└───────────────────────┘                          │       │        │ httputil.ReverseProxy  │ │
+                                                     │       ▼        │  → localhost:<port>   │ │
+                                                     │  ┌───────────────────────────────────┐ │ │
+                                                     │  │ map[projectDir]*RequestManager     │ │ │
+                                                     │  │ (one ring per registered project)  │ │ │
+                                                     │  └───────────────────────────────────┘ │ │
+                                                     │  stale-PID sweep (30s) reaps dead regs  │ │
+                                                     └──────────────────────────────────────────┘
 ```
+
+Each project keeps its own local `RequestManager` and API surface — `prox requests`, the HTTP API, and the TUI always read from the project's own process, never from the daemon directly. The forwarder bridge is what keeps a project's local copy in sync with the daemon when routing is shared.
 
 ### Package Structure
 
 ```
 internal/proxy/
 ├── proxy.go          # Standalone proxy service and request handling
-├── requests.go       # Request manager (ring buffer, subscriptions)
-├── capture.go        # Optional request/response body capture
+├── requests.go       # Request manager (ring buffer, subscriptions, cursor pagination)
+├── capture.go        # Request/response body capture (inline vs spilled, per-call caps)
+├── body.go           # Captured-body content decoders (gzip, deflate, zstd, brotli)
 ├── certs/
 │   └── certs.go      # mkcert integration for certificate management
 
 internal/proxyd/
-├── daemon.go         # Shared daemon lifecycle and auto-start
-├── dynamic_proxy.go  # Runtime listener and route management
-├── registry.go       # Project route registry and conflict checks
-├── server.go         # Unix-socket HTTP API for registration/control
-├── client.go         # Client used by project supervisors
+├── daemon.go         # Shared daemon lifecycle: singleton start, version check, stale-PID sweep
+├── dynamic_proxy.go  # Runtime listener and route management, per-project capture caps
+├── registry.go       # Project route registry, refcounted listeners, conflict/idempotent-reregister checks
+├── managers.go       # map[projectDir]*proxy.RequestManager — one ring per registered project
+├── server.go         # Unix-socket HTTP API for registration/control/request streaming
+├── forwarder.go      # Project-side bridge: SSE consumption, snapshot backfill, health sink, self-heal
+├── client.go         # Client used by project supervisors to talk to the daemon
 └── certs.go          # Multi-domain certificate management
 ```
 
@@ -185,8 +183,35 @@ internal/proxyd/
 3. Look up the full hostname in the route table
 4. Forward request via `httputil.ReverseProxy`
 5. Set `X-Forwarded-Proto` based on connection type (HTTP or HTTPS)
-6. Record request in RequestManager
+6. Record request (and, if capture is enabled for the owning project, its body) in that project's `RequestManager`
 7. Return response to client
+
+### Shared Proxy Daemon (proxyd)
+
+When more than one project needs the same proxy port, prox routes through a per-user shared daemon (`internal/proxyd`) instead of each project binding its own listener.
+
+- **Singleton.** The daemon locks `~/.prox/proxy.pid` via `flock`; only one instance can hold the lock at a time. `EnsureRunning` connects to the existing daemon's Unix socket (`~/.prox/proxy.sock`), or forks a new detached daemon process (`Setsid`) and polls until it answers `/health`. A version mismatch between the connecting client and a running daemon is a typed error (`VersionMismatchError`) — the client hard-fails when the daemon has registered projects, or auto-replaces an idle daemon.
+- **Unix-socket API.** All daemon communication — registration, deregistration, status, route listing, shutdown, and the per-project request stream — goes over the socket via a small HTTP API (`server.go`), never a network port.
+- **Registration and refcounted listeners.** Each project registers its hostnames and target ports (`registry.go`). Multiple projects can share one physical listener (e.g. `:443`) as long as their hostnames differ; the registry tracks how many projects reference a listener and only closes it when the last one deregisters. A same-PID re-register (a project reconnecting after a broken stream) is idempotent rather than a 409 conflict; a genuinely different live holder still is.
+- **Per-project request rings.** The daemon keeps one full-capacity `RequestManager` ring per registered project (`managers.go`), guarded independently of the daemon's lifecycle lock so the hot request path never contends with registration/deregistration. This bounds the blast radius of a chatty project: it can fill its own ring but cannot evict another project's history. A manager is closed (releasing any blocked SSE subscribers) and removed when its project deregisters or is swept as stale.
+- **Stale-PID sweep.** A periodic sweep (every 30s) checks each registered project's owning PID and start-token for liveness and reaps registrations left behind by a crashed or `kill -9`'d project, so a restart doesn't collide with a dead entry.
+- **Self-heal re-registration.** If a project's connection to the daemon breaks (daemon restart, transient crash), its forwarder re-establishes the daemon connection and re-registers automatically once the failure persists past a threshold — see the Forwarder Bridge below.
+
+### Capture Pipeline
+
+Request/response body capture (`internal/proxy/capture.go`, `body.go`) is optional per project (`proxy.capture.enabled` or `prox up --capture`) and works identically whether the proxy is standalone or routed through the shared daemon.
+
+- **Inline vs. spilled bodies.** Small captured bodies are kept inline with the request record; bodies larger than `DefaultCaptureInlineThreshold` (64KB) are spilled to a file under the capture directory and loaded lazily when `prox requests <id> --body` / `include=body` is requested.
+- **Per-project caps, one capture path.** The shared daemon has a single `CaptureManager` and capture directory, but each project's `max_body_size` (sent at registration) is enforced per call via limit-aware capture (`CaptureRequestWithLimit`/`WrapResponseWriterWithLimit`) rather than one `CaptureManager` per project — one shared cleanup path, per-project ceilings.
+- **Decoders.** Captured bodies store the raw wire bytes; `DecodeCapturedBody` decodes at serve time for `gzip`/`x-gzip`, `deflate` (zlib-wrapped, with a raw-deflate fallback), `zstd`, and `br` (brotli), bounded by `MaxDecodedBodySize` (10MB). Chained or unrecognized encodings, truncated captures, and corrupt streams fall back to serving the raw bytes as binary.
+
+### Forwarder Bridge
+
+Every project registered with the shared daemon runs a forwarder (`internal/proxyd/forwarder.go`) that bridges the daemon's per-project request stream into that project's own local `RequestManager`, so `prox requests`, the HTTP API, and the TUI behave identically whether the proxy is standalone or shared.
+
+- **SSE + snapshot backfill.** On every (re)connect, the forwarder concurrently fetches a snapshot of the daemon's current ring for this project and subscribes to its live SSE stream, so a reconnect after a gap backfills history instead of losing it. Monotonic same-ID upserts keep the two feeds from regressing a record.
+- **Health sink.** The forwarder tracks consecutive reconnect failures, last-successful-connect time, and dropped-event/backfill-failure counters (atomics), which feed directly into the `proxy` block of `GET /status` and the CLI's `Proxy:` line.
+- **Self-heal.** After the connection has been down continuously for about 15s, the forwarder invokes a heal callback — re-`EnsureRunning` plus re-`Register` — at most once every ~30s (damping against a flapping daemon). Healing is suppressed while the project itself is shutting down, and a version-mismatch failure is surfaced as a status state rather than forcing a restart of a daemon that might still be in use.
 
 ## Technologies
 

--- a/docs/guides/shared-proxy.md
+++ b/docs/guides/shared-proxy.md
@@ -79,6 +79,12 @@ auth.local.example.dev      443   https     localhost:3000  /projects/auth      
 app.local.example.dev       443   https     localhost:5173  /projects/app        12391
 ```
 
+## Health and Self-Healing
+
+`prox status` in each project reports the shared daemon's health, not just its own process health — see the `Proxy:` line in [`prox status`](../reference/cli.md#status). If the shared daemon dies (crash, `kill -9`, a bad upgrade), every project registered with it prints `Proxy: DOWN` and exits `1` from `prox status`, even though their own processes are still running.
+
+No operator action is required to recover: each project's forwarder detects the prolonged failure and re-registers with a fresh or recovered daemon automatically, worst case within about 45 seconds. Once healed, `prox status` goes back to `Proxy: shared (running, vX.Y.Z)` and exits `0`. Treat a brief `DOWN` reading as transient rather than something to page on.
+
 ## Constraints
 
 | Constraint | Behavior |
@@ -86,7 +92,7 @@ app.local.example.dev       443   https     localhost:5173  /projects/app       
 | Scope | The daemon is per-user and per-machine. State lives in `~/.prox/`. |
 | Hostname ownership | The same `hostname:port` cannot be registered by two projects. The second registration fails. |
 | Protocol ownership | A listener port is HTTP or HTTPS. Mixing protocols on the same port is rejected. |
-| Version matching | A project can join only when its `prox` version matches the running daemon. Use `prox proxy stop --force` to reset a stale daemon after upgrading. |
+| Version matching | A project can join only when its `prox` version matches the running daemon. After upgrading `prox`, the next `prox up` against an idle daemon of the old version replaces it automatically with a one-line notice. If the old daemon still has projects registered, `prox up` fails hard instead — run `prox proxy stop --force`, then `prox up` (or `prox restart`) in every project listed in the error. |
 | Fallback | If `~/.prox/` is unavailable, prox runs a standalone per-project proxy. Port sharing is not available in fallback mode. |
 
 ## Files

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -52,6 +52,7 @@ All errors return JSON:
 | `STREAMING_NOT_SUPPORTED` | The server cannot provide an SSE stream for this request |
 | `REQUEST_NOT_FOUND` | Proxy request ID does not exist in the request buffer |
 | `MISSING_REQUEST_ID` | Request detail endpoint was called without an ID |
+| `CURSOR_GONE` | A `before_id` cursor's anchor record is unknown, evicted, or out of scope for the current filters; restart pagination without a cursor |
 
 ## Endpoints
 
@@ -76,9 +77,34 @@ Supervisor status.
   "status": "running",
   "uptime_seconds": 7200,
   "config_file": "/path/to/prox.yaml",
-  "api_version": "v1"
+  "api_version": "v1",
+  "proxy": {
+    "mode": "shared",
+    "daemon_reachable": true,
+    "daemon_version": "0.2.0",
+    "consecutive_failures": 0,
+    "last_connected_at": "2025-01-19T10:32:01.123Z",
+    "dropped_events": 0,
+    "backfill_failures": 0,
+    "heal_state": "healthy"
+  }
 }
 ```
+
+`proxy` reports this project's shared-proxy health and is present whenever a proxy is configured (`mode` is `disabled` and the rest of the block is zero-valued when no proxy is configured):
+
+| Field | Description |
+|-------|-------------|
+| `mode` | `shared` (registered with the shared proxy daemon), `standalone` (this process runs its own in-process proxy listener), or `disabled` |
+| `daemon_reachable` | Result of a live `/health` probe against the shared daemon (500ms timeout, cached 2s); always `false` outside `shared` mode |
+| `daemon_version` | The shared daemon's reported version, when reachable |
+| `consecutive_failures` | The forwarder's current run of failed reconnects to the shared daemon |
+| `last_connected_at` | Last time the forwarder established an SSE stream to the shared daemon |
+| `dropped_events` | Request-stream events lost to a full subscriber channel |
+| `backfill_failures` | Post-connect ring snapshot fetch failures |
+| `heal_state` | `healthy`, `healing`, or `version_mismatch`; empty when not in shared mode |
+
+`prox status` (the CLI command) renders this block as a `Proxy:` line and, when `mode` is `shared` and `daemon_reachable` is `false`, prints `Proxy: DOWN — shared proxy daemon unreachable (proxied routes are dead). Check 'prox proxy status'.` and **exits with status 1** even though the project's own processes may be healthy. The project self-heals automatically (re-registers with a fresh or recovered daemon), worst case within ~45s — treat a brief `daemon_reachable: false` as transient rather than a hard failure. See [`prox status`](cli.md#status).
 
 ### GET /processes
 
@@ -267,6 +293,7 @@ endpoint stays free of duplicates.
 | `max_status` | int | — | Maximum status code |
 | `since` | string | — | RFC3339 timestamp; only requests recorded at or after this time |
 | `url_contains` | string | — | Case-insensitive substring match against the request URL (path+query only — never scheme/host) |
+| `before_id` | string | — | Cursor: page strictly older than this request ID (see [Cursor pagination](#cursor-pagination) below) |
 | `limit` | int | 100 | Max requests to return (max 1000) |
 
 **Response:**
@@ -287,7 +314,8 @@ endpoint stays free of duplicates.
     }
   ],
   "filtered_count": 50,
-  "total_count": 250
+  "total_count": 250,
+  "next_before_id": "9f8e7d6c5b4a"
 }
 ```
 
@@ -298,7 +326,29 @@ daemon-side record that predates this field).
 `in_flight` is `true` on a request whose response is still streaming (the
 backend has sent headers but the body hasn't finished); it is omitted
 entirely once the request completes. `duration_ms` stays `0` while
-`in_flight` is `true` — read it only once the field is gone.
+`in_flight` is `true` — read it only once the field is gone. A request that
+has been `in_flight` for more than 5 minutes also carries `"stale": true` —
+this means the completion event may have been lost and the true outcome is
+unknown, **not** that the request is broken: long-lived streams (SSE,
+WebSocket-over-HTTP) and large transfers can legitimately sit at
+`stale: true` for a long time while still live. `stale` is omitted once the
+request completes.
+
+#### Cursor pagination
+
+Pass the previous page's `next_before_id` as `before_id` to fetch the next
+older page. `next_before_id` is the ID of the *oldest scanned* record, not
+the oldest *returned* one — a page that gets filtered down to zero results
+still advances the cursor instead of stalling. It is omitted when the scan
+reached the end of the ring (no more history).
+
+Ring order is arrival order, not strict timestamp order (backfill and a
+completion re-appending after its in-flight record was evicted can both put
+a newer-by-timestamp record after an older one). An unknown, evicted, or
+out-of-scope `before_id` — including a record from a different
+`?subdomain=`/project scope — returns **`410 Gone`** with code
+`CURSOR_GONE`; on that response, restart pagination without a cursor rather
+than retrying the same one.
 
 **Example:**
 
@@ -314,6 +364,9 @@ curl "http://localhost:5555/api/v1/proxy/requests?min_status=500"
 
 # Filter by URL substring (path+query, case-insensitive)
 curl "http://localhost:5555/api/v1/proxy/requests?url_contains=/api/users"
+
+# Page backward through history
+curl "http://localhost:5555/api/v1/proxy/requests?before_id=9f8e7d6c5b4a"
 ```
 
 ### GET /proxy/requests/{id}
@@ -368,7 +421,7 @@ Body data is available only when capture was enabled with `prox up --capture` or
 | `data` | Body content (only with `include=body`): plain text for text bodies, base64 for binary |
 | `unavailable_reason` | Set (e.g. `evicted`) when `include=body` was requested but the body could no longer be loaded; `data` is absent |
 
-**Decoded-body semantics:** captured bodies store the raw wire bytes and are decoded at serve time. When `content_encoding` is `gzip` or `x-gzip` and the body was not truncated, the decoded bytes are served and `is_binary` reflects the decoded content (readable JSON/text decodes to `is_binary: false`). Unsupported encodings (`deflate`, `br`, `zstd`, chained values like `gzip, br`), truncated bodies, corrupt streams, and payloads whose decoded size would exceed the 10MB cap are served as the raw bytes, base64-encoded, with `is_binary: true` and `content_encoding` preserved. The stored (raw) binary classification and the served `is_binary` may therefore legitimately differ. The on-disk path of a spilled body is never exposed.
+**Decoded-body semantics:** captured bodies store the raw wire bytes and are decoded at serve time. Supported `content_encoding` values are `gzip`/`x-gzip`, `deflate` (zlib-wrapped per RFC 9110, with a fallback to raw deflate for servers that send it unwrapped), `zstd`, and `br` (brotli) — decoded automatically, capped at 10MB decoded size (`MaxDecodedBodySize`). When the body was not truncated and decodes cleanly, `is_binary` reflects the decoded content (readable JSON/text decodes to `is_binary: false`). Chained encodings (e.g. `gzip, br`), unrecognized tokens, truncated bodies, corrupt streams, and payloads whose decoded size would exceed the cap are served as the raw bytes, base64-encoded, with `is_binary: true` and `content_encoding` preserved. The stored (raw) binary classification and the served `is_binary` may therefore legitimately differ. The on-disk path of a spilled body is never exposed.
 
 **Examples:**
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -11,10 +11,12 @@ prox <command> [options]
 | Flag | Description |
 |------|-------------|
 | `--config, -c` | Config file path (default: `prox.yaml`) |
-| `--addr` | API address for client commands (auto-discovered from `.prox/prox.state`) |
+| `--addr` | API address for client commands. Used only when passed explicitly; otherwise auto-discovered from `.prox/prox.state` (or `prox.yaml` for a pinned `api.port`) |
 | `--detach, -d` | Run in background (daemon mode) |
 | `--verbose, -v` | Enable verbose output |
 | `--version` | Show version information |
+
+**No implicit `:5555` fallback.** Client commands (`status`, `logs`, `stop`, `start`, `restart`, `down`, `attach`, `requests`) discover the running instance from `.prox/prox.state` in the current directory. If no state file (or configured port) is found and `--addr` was not passed explicitly, the command errors instead of silently dialing the compiled-in `127.0.0.1:5555` default — run the command from the project directory, or pass `--addr host:port`. `version`, `up`, `proxy`, and `completion` are unaffected (they never need discovery).
 
 ## Commands
 
@@ -74,6 +76,10 @@ prox up --capture
 
 When no port is specified (via `--api-port` or `api.port` in config), prox automatically finds an available port. The port is stored in `.prox/prox.state` and auto-discovered by CLI commands.
 
+**`-d`/`--detach` readiness:** the parent process no longer exits `0` the instant it forks the child. It polls for up to 15s for the child to write a PID-matched `.prox/prox.state` and answer `GET /health`, then prints `prox started (pid N, api http://host:port)` and exits `0` — a truthful signal that the daemon is actually accepting requests. If the child dies during startup (bad config, port bind failure), `prox up -d` exits `1` and prints the last ~20 lines of `.prox/prox.log`. If the child never becomes ready within 15s, `prox up -d` prints the same diagnostics, sends SIGTERM to the child (SIGKILL after a 5s grace if it doesn't exit), and exits `1`.
+
+**Shared-proxy version mismatch:** when this project's proxy would join the per-user shared daemon and the daemon's version doesn't match this `prox` binary's version, `prox up` no longer falls back to a proxy-less standalone start. If the daemon still has registered projects, `prox up` fails hard, naming both versions and the registered project directories, with remediation (`prox proxy stop --force`, then `prox up`/`prox restart` in each listed project). If the daemon is idle, prox auto-replaces it with a fresh daemon of the current version and prints a one-line notice.
+
 ### status
 
 Show process status.
@@ -95,6 +101,8 @@ prox status
 # JSON output (for scripting)
 prox status --json
 ```
+
+**Proxy line and exit code:** when a proxy is configured, output includes a `Proxy:` line reporting the shared-proxy health tracked by [the `proxy` block of `GET /status`](api.md#get-status) — `Proxy: shared (running, vX.Y.Z)` when healthy, `Proxy: standalone` for an in-process proxy, or `Proxy: DOWN — shared proxy daemon unreachable (proxied routes are dead). Check 'prox proxy status'.` when the shared daemon is unreachable. In the `DOWN` case, `prox status` **exits 1** even though the project's own processes may all be healthy — this is a breaking change from earlier versions, where `prox status` never consulted the shared proxy and always reflected only process health. The project self-heals in the background (worst case ~45s), so a brief `DOWN` reading is often transient.
 
 ### logs
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -324,7 +324,7 @@ services:
 
 ### Request Capture
 
-Request capture records request and response headers and bodies for the `prox requests <id>` detail view. Bodies up to `proxy.capture.max_body_size` are retained; larger bodies are truncated.
+Request capture records request and response headers and bodies for the `prox requests <id>` detail view. Bodies up to `proxy.capture.max_body_size` are retained; larger bodies are truncated. This cap is enforced per project: when several projects share one proxy daemon, each project's `max_body_size` (sent to the daemon at registration) governs only that project's captures — one project cannot inflate or shrink another's capture limit.
 
 ```yaml
 proxy:

--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,13 @@ go 1.24.0
 toolchain go1.24.12
 
 require (
+	github.com/andybalholm/brotli v1.2.2
 	github.com/charmbracelet/bubbles v0.21.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/go-chi/chi/v5 v5.2.4
 	github.com/joho/godotenv v1.5.1
+	github.com/klauspost/compress v1.19.1
 	github.com/muesli/termenv v0.16.0
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/andybalholm/brotli v1.2.2 h1:HzTuoo2ErYQqf5qvcJInB8uvqSVxRttzkFexPWtnceM=
+github.com/andybalholm/brotli v1.2.2/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
@@ -27,6 +29,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
+github.com/klauspost/compress v1.19.1 h1:VsB4HPswih7mmZ8WleSFQ75c/Ui1M4trX5oAsJnhSlk=
+github.com/klauspost/compress v1.19.1/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
@@ -55,6 +59,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
+github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
+github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561 h1:MDc5xs78ZrZr3HMQugiXOAkSZtfTpbJLDr/lwfgO53E=
 golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -394,13 +394,25 @@ func (h *Handlers) GetProxyRequests(w http.ResponseWriter, r *http.Request) {
 
 	filter := parseProxyRequestParams(r)
 
-	requests := h.requestManager.Recent(filter)
+	requests, nextBeforeID, anchorFound := h.requestManager.RecentPage(filter)
+	if !anchorFound {
+		// filter.BeforeID named a record that's unknown, evicted, or out of
+		// scope. 410 (not 404): the cursor once pointed at a real ring
+		// position that has since aged out — the caller should restart
+		// pagination without a cursor rather than retry this one (D12, #50).
+		writeJSON(w, http.StatusGone, ErrorResponse{
+			Error: "cursor is gone: the before_id record is unknown, evicted, or out of scope",
+			Code:  domain.ErrCodeCursorGone,
+		})
+		return
+	}
 	total := h.requestManager.Count()
 
 	resp := ProxyRequestsResponse{
 		Requests:      make([]ProxyRequestResponse, len(requests)),
 		FilteredCount: len(requests),
 		TotalCount:    total,
+		NextBeforeID:  nextBeforeID,
 	}
 
 	for i, req := range requests {
@@ -610,6 +622,7 @@ func parseProxyRequestParams(r *http.Request) proxy.RequestFilter {
 	filter.Subdomain = r.URL.Query().Get("subdomain")
 	filter.Method = r.URL.Query().Get("method")
 	filter.URLContains = r.URL.Query().Get("url_contains")
+	filter.BeforeID = r.URL.Query().Get("before_id")
 
 	if minStatus := r.URL.Query().Get("min_status"); minStatus != "" {
 		if v, err := strconv.Atoi(minStatus); err == nil {

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -45,6 +45,7 @@ type Handlers struct {
 	captureManager *proxy.CaptureManager
 	configFile     string
 	shutdown       ShutdownController
+	proxyStatus    ProxyStatusProvider
 }
 
 // NewHandlers creates new HTTP handlers. shutdown may be nil in tests that never
@@ -76,6 +77,14 @@ func (h *Handlers) SetCaptureManager(cm *proxy.CaptureManager) {
 	h.captureManager = cm
 }
 
+// SetProxyStatusProvider injects the shared-proxy health provider (D5). A setter
+// (not a constructor arg) mirrors SetRequestManager: the proxy path resolves
+// after the handlers are built, and the provider (the cli's proxyRuntime) is
+// wired in then. When unset, GET /status omits the proxy block.
+func (h *Handlers) SetProxyStatusProvider(p ProxyStatusProvider) {
+	h.proxyStatus = p
+}
+
 // GetStatus handles GET /api/v1/status
 func (h *Handlers) GetStatus(w http.ResponseWriter, r *http.Request) {
 	status := h.supervisor.Status()
@@ -85,6 +94,9 @@ func (h *Handlers) GetStatus(w http.ResponseWriter, r *http.Request) {
 		UptimeSeconds: status.UptimeSeconds(),
 		ConfigFile:    h.configFile,
 		APIVersion:    "v1",
+	}
+	if h.proxyStatus != nil {
+		resp.Proxy = h.proxyStatus.ProxyStatus()
 	}
 
 	writeJSON(w, http.StatusOK, resp)

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -629,6 +629,99 @@ func TestGetProxyRequests(t *testing.T) {
 
 		assert.Len(t, resp.Requests, 2)
 	})
+
+	t.Run("plain first page carries next_before_id", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/v1/proxy/requests?limit=1", nil)
+		w := httptest.NewRecorder()
+
+		handlers.GetProxyRequests(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), `"next_before_id"`)
+
+		var resp ProxyRequestsResponse
+		err := json.NewDecoder(w.Body).Decode(&resp)
+		require.NoError(t, err)
+
+		require.Len(t, resp.Requests, 1)
+		assert.NotEmpty(t, resp.NextBeforeID)
+	})
+
+	t.Run("before_id pages strictly older records and last page omits cursor", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/v1/proxy/requests?limit=2", nil)
+		w := httptest.NewRecorder()
+		handlers.GetProxyRequests(w, req)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var first ProxyRequestsResponse
+		require.NoError(t, json.NewDecoder(w.Body).Decode(&first))
+		require.Len(t, first.Requests, 2)
+		require.NotEmpty(t, first.NextBeforeID, "partial page must carry a cursor")
+
+		req2 := httptest.NewRequest("GET", "/api/v1/proxy/requests?limit=2&before_id="+first.NextBeforeID, nil)
+		w2 := httptest.NewRecorder()
+		handlers.GetProxyRequests(w2, req2)
+		require.Equal(t, http.StatusOK, w2.Code)
+		assert.NotContains(t, w2.Body.String(), `"next_before_id"`, "last page omits the field entirely (omitempty)")
+
+		var second ProxyRequestsResponse
+		require.NoError(t, json.NewDecoder(w2.Body).Decode(&second))
+		require.Len(t, second.Requests, 1)
+		assert.Empty(t, second.NextBeforeID, "last page omits the cursor")
+
+		firstIDs := map[string]bool{}
+		for _, r := range first.Requests {
+			firstIDs[r.ID] = true
+		}
+		for _, r := range second.Requests {
+			assert.False(t, firstIDs[r.ID], "cursor page repeated a record already returned by the first page")
+		}
+	})
+}
+
+func TestGetProxyRequests_CursorGone(t *testing.T) {
+	logMgr := logs.NewManager(logs.ManagerConfig{BufferSize: 100})
+	defer logMgr.Close()
+
+	cfg := &config.Config{
+		API:       config.APIConfig{Port: 0},
+		Processes: map[string]config.ProcessConfig{},
+	}
+	sup := supervisor.New(cfg, logMgr, nil, supervisor.DefaultSupervisorConfig())
+	handlers := NewHandlers(sup, logMgr, "prox.yaml", nil)
+
+	// Capacity 2: recording a third record evicts "r1" from the ring.
+	rm := proxy.NewRequestManager(2)
+	handlers.SetRequestManager(rm)
+	rm.Record(proxy.RequestRecord{ID: "r1", Method: "GET", URL: "/a"})
+	rm.Record(proxy.RequestRecord{ID: "r2", Method: "GET", URL: "/b"})
+	rm.Record(proxy.RequestRecord{ID: "r3", Method: "GET", URL: "/c"})
+
+	t.Run("evicted anchor", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/v1/proxy/requests?before_id=r1", nil)
+		w := httptest.NewRecorder()
+
+		handlers.GetProxyRequests(w, req)
+
+		assert.Equal(t, http.StatusGone, w.Code)
+		var resp ErrorResponse
+		err := json.NewDecoder(w.Body).Decode(&resp)
+		require.NoError(t, err)
+		assert.Equal(t, domain.ErrCodeCursorGone, resp.Code)
+	})
+
+	t.Run("unknown anchor", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/v1/proxy/requests?before_id=does-not-exist", nil)
+		w := httptest.NewRecorder()
+
+		handlers.GetProxyRequests(w, req)
+
+		assert.Equal(t, http.StatusGone, w.Code)
+		var resp ErrorResponse
+		err := json.NewDecoder(w.Body).Decode(&resp)
+		require.NoError(t, err)
+		assert.Equal(t, domain.ErrCodeCursorGone, resp.Code)
+	})
 }
 
 func TestGetProxyRequests_ProxyNotEnabled(t *testing.T) {

--- a/internal/api/responses.go
+++ b/internal/api/responses.go
@@ -257,6 +257,12 @@ type ProxyRequestResponse struct {
 	// replaces this record (same ID). Omitted for completed records so their
 	// JSON stays byte-identical to the pre-in-flight wire format.
 	InFlight bool `json:"in_flight,omitempty"`
+	// Stale marks an in-flight record that has been in-flight for longer than
+	// constants.InFlightStaleAfter as of conversion time (D8, #53). It means
+	// "completion unknown" (the completion event may have been lost), not
+	// "broken" — long-lived streams and large transfers can legitimately stay
+	// in-flight this long. Always false (and omitted) for completed records.
+	Stale bool `json:"stale,omitempty"`
 }
 
 // ProxyRequestsResponse represents the response for GET /proxy/requests
@@ -266,7 +272,9 @@ type ProxyRequestsResponse struct {
 	TotalCount    int                    `json:"total_count"`
 }
 
-// ToProxyRequestResponse converts proxy.RequestRecord to ProxyRequestResponse
+// ToProxyRequestResponse converts proxy.RequestRecord to ProxyRequestResponse.
+// Staleness (D8) is computed here, at serve/conversion time, against the
+// current wall clock — there is no background reaper.
 func ToProxyRequestResponse(req proxy.RequestRecord) ProxyRequestResponse {
 	return ProxyRequestResponse{
 		ID:         req.ID,
@@ -279,6 +287,7 @@ func ToProxyRequestResponse(req proxy.RequestRecord) ProxyRequestResponse {
 		DurationMs: req.Duration.Milliseconds(),
 		RemoteAddr: req.RemoteAddr,
 		InFlight:   req.InFlight,
+		Stale:      req.StaleAt(time.Now()),
 	}
 }
 

--- a/internal/api/responses.go
+++ b/internal/api/responses.go
@@ -270,6 +270,12 @@ type ProxyRequestsResponse struct {
 	Requests      []ProxyRequestResponse `json:"requests"`
 	FilteredCount int                    `json:"filtered_count"`
 	TotalCount    int                    `json:"total_count"`
+	// NextBeforeID is the before_id to pass for the next older page
+	// (ring-position cursor pagination, D12/#50). Populated whenever the
+	// scan didn't reach the ring's oldest record — including on a plain
+	// first page (no before_id given), so pollers can start cursoring
+	// immediately. Omitted on the last page (scan reached the ring tail).
+	NextBeforeID string `json:"next_before_id,omitempty"`
 }
 
 // ToProxyRequestResponse converts proxy.RequestRecord to ProxyRequestResponse.

--- a/internal/api/responses.go
+++ b/internal/api/responses.go
@@ -29,6 +29,45 @@ type StatusResponse struct {
 	UptimeSeconds int64  `json:"uptime_seconds"`
 	ConfigFile    string `json:"config_file,omitempty"`
 	APIVersion    string `json:"api_version"`
+	// Proxy reports shared-proxy health (D5). Present whenever a
+	// ProxyStatusProvider was injected (the normal `prox up` path); omitted only
+	// where none is set (e.g. unit-test handlers), so those consumers see no
+	// change. The CLI omits the rendered line when Mode is "disabled".
+	Proxy *ProxyStatusResponse `json:"proxy,omitempty"`
+}
+
+// ProxyStatusResponse reports the health of this project's proxy path (D5),
+// surfaced under StatusResponse.proxy. It is the single source of truth `prox
+// status` renders for shared-proxy reachability and request-stream health.
+type ProxyStatusResponse struct {
+	// Mode is "shared", "standalone", or "disabled".
+	Mode string `json:"mode"`
+	// DaemonReachable is the result of a live /health probe against the shared
+	// daemon (shared mode only; always false otherwise).
+	DaemonReachable bool `json:"daemon_reachable"`
+	// DaemonVersion is the shared daemon's reported version when reachable.
+	DaemonVersion string `json:"daemon_version,omitempty"`
+	// ConsecutiveFailures is the forwarder's current run of failed reconnects.
+	ConsecutiveFailures int64 `json:"consecutive_failures"`
+	// LastConnectedAt is the last time the forwarder established an SSE stream.
+	LastConnectedAt *time.Time `json:"last_connected_at,omitempty"`
+	// DroppedEvents is the number of request-stream events lost to a full
+	// subscriber channel (D9), read from the project's local request manager.
+	DroppedEvents int64 `json:"dropped_events"`
+	// BackfillFailures counts post-connect ring snapshot fetch failures.
+	BackfillFailures int64 `json:"backfill_failures"`
+	// HealState is "healthy" when the shared daemon is reachable, "" otherwise
+	// (C5). C6 refines it to "healing"/"version_mismatch".
+	HealState string `json:"heal_state,omitempty"`
+}
+
+// ProxyStatusProvider supplies the proxy block for GET /status. The daemon
+// injects an implementation (the cli's proxyRuntime); it is defined here as a
+// narrow interface — following the ShutdownController precedent — so the api
+// package does not depend on internal/cli or internal/proxyd and tests can
+// drive GetStatus with a fake.
+type ProxyStatusProvider interface {
+	ProxyStatus() *ProxyStatusResponse
 }
 
 // ProcessListResponse represents the response for GET /processes

--- a/internal/api/responses_test.go
+++ b/internal/api/responses_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/charliek/prox/internal/constants"
 	"github.com/charliek/prox/internal/domain"
 	"github.com/charliek/prox/internal/proxy"
 )
@@ -466,5 +467,73 @@ func TestToProxyRequestResponse_InFlightPresentInJSONWhenTrue(t *testing.T) {
 	}
 	if !strings.Contains(string(data), `"in_flight":true`) {
 		t.Errorf("expected in_flight:true in JSON, got %s", data)
+	}
+}
+
+// TestToProxyRequestResponse_StaleInFlight verifies D8 (#53): an in-flight
+// record older than constants.InFlightStaleAfter converts with Stale true,
+// and the field is present in the JSON wire format.
+func TestToProxyRequestResponse_StaleInFlight(t *testing.T) {
+	rec := proxy.RequestRecord{
+		ID:        "abc1234",
+		URL:       "/api/stream",
+		InFlight:  true,
+		Timestamp: time.Now().Add(-constants.InFlightStaleAfter - time.Minute),
+	}
+
+	resp := ToProxyRequestResponse(rec)
+
+	if !resp.Stale {
+		t.Error("expected Stale to be true for an in-flight record past the staleness threshold")
+	}
+
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+	if !strings.Contains(string(data), `"stale":true`) {
+		t.Errorf("expected stale:true in JSON, got %s", data)
+	}
+}
+
+// TestToProxyRequestResponse_FreshInFlightNotStale verifies a recently
+// started in-flight record does not convert as stale (D8, #53).
+func TestToProxyRequestResponse_FreshInFlightNotStale(t *testing.T) {
+	rec := proxy.RequestRecord{
+		ID:        "abc1234",
+		URL:       "/api/stream",
+		InFlight:  true,
+		Timestamp: time.Now(),
+	}
+
+	resp := ToProxyRequestResponse(rec)
+
+	if resp.Stale {
+		t.Error("expected Stale to be false for a fresh in-flight record")
+	}
+
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+	if strings.Contains(string(data), "stale") {
+		t.Errorf("expected stale to be omitted from JSON when false, got %s", data)
+	}
+}
+
+// TestToProxyRequestResponse_FinalRecordNeverStale verifies a completed
+// (non-in-flight) record is never reported stale regardless of age (D8, #53).
+func TestToProxyRequestResponse_FinalRecordNeverStale(t *testing.T) {
+	rec := proxy.RequestRecord{
+		ID:         "abc1234",
+		URL:        "/api/users",
+		StatusCode: 200,
+		Timestamp:  time.Now().Add(-24 * time.Hour),
+	}
+
+	resp := ToProxyRequestResponse(rec)
+
+	if resp.Stale {
+		t.Error("expected Stale to be false for a completed record")
 	}
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/subtle"
 	"fmt"
+	"net"
 	"net/http"
 	"strings"
 	"sync"
@@ -241,13 +242,25 @@ func (s *Server) registerRoutes() {
 	})
 }
 
-// Start starts the HTTP server
-func (s *Server) Start() error {
+// Listen binds the server's TCP listener synchronously so callers can treat
+// a bind failure as fatal instead of losing it inside a background serve
+// goroutine. Without this, a child whose API port is already taken keeps
+// running with no control surface — and, worse, whatever process holds the
+// port answers /health and can fool the `prox up -d` readiness poll (D2).
+func (s *Server) Listen() (net.Listener, error) {
 	addr := fmt.Sprintf("%s:%d", s.config.Host, s.config.Port)
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("binding API server on %s: %w", addr, err)
+	}
+	return ln, nil
+}
 
+// Serve serves HTTP on ln, blocking until Shutdown or a serve error.
+func (s *Server) Serve(ln net.Listener) error {
 	s.mu.Lock()
 	s.httpServer = &http.Server{
-		Addr:         addr,
+		Addr:         ln.Addr().String(),
 		Handler:      s.router,
 		ReadTimeout:  15 * time.Second,
 		WriteTimeout: 0, // Disable for SSE
@@ -256,7 +269,16 @@ func (s *Server) Start() error {
 	server := s.httpServer
 	s.mu.Unlock()
 
-	return server.ListenAndServe()
+	return server.Serve(ln)
+}
+
+// Start binds and serves in one call (Listen + Serve).
+func (s *Server) Start() error {
+	ln, err := s.Listen()
+	if err != nil {
+		return err
+	}
+	return s.Serve(ln)
 }
 
 // Shutdown gracefully shuts down the server

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -48,6 +48,12 @@ func runStatus(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to get processes: %w", err)
 	}
 
+	// A shared proxy that is down makes `prox status` exit non-zero even when
+	// every child process is healthy (D5, breaking change): the proxied routes
+	// are dead, so a green table alone would mislead. Computed here so both the
+	// JSON and table paths honor it.
+	proxyDown := sharedProxyDown(status.Proxy)
+
 	if statusJSON {
 		output := map[string]interface{}{
 			"status":    status,
@@ -55,6 +61,9 @@ func runStatus(cmd *cobra.Command, args []string) error {
 		}
 		if err := json.NewEncoder(os.Stdout).Encode(output); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: failed to encode output: %v\n", err)
+		}
+		if proxyDown {
+			return errSharedProxyDown
 		}
 		return nil
 	}
@@ -76,7 +85,46 @@ func runStatus(cmd *cobra.Command, args []string) error {
 			p.Name, p.Status, p.PID, uptime, p.Restarts, p.Health)
 	}
 	w.Flush()
+
+	// Proxy line (D5). Printed after the table so the process status is always
+	// visible even when the shared proxy is down (which then forces exit 1).
+	renderProxyStatus(status.Proxy)
+	if proxyDown {
+		return errSharedProxyDown
+	}
 	return nil
+}
+
+// errSharedProxyDown is returned by runStatus when the shared proxy daemon is
+// unreachable, so `prox status` exits non-zero (D5). The message has already
+// been printed to the user; rootCmd sets SilenceErrors, so cobra does not
+// reprint it — the error only drives the exit code.
+var errSharedProxyDown = fmt.Errorf("shared proxy daemon is unreachable")
+
+// sharedProxyDown is the single "down" predicate behind both the DOWN line and
+// the exit-1 contract (D5): a shared proxy whose daemon is unreachable. Sourcing
+// it once keeps the rendered message and the exit code from drifting apart. A
+// nil block (pre-D5 daemons, test handlers) is never down.
+func sharedProxyDown(p *api.ProxyStatusResponse) bool {
+	return p != nil && p.Mode == proxyModeShared && !p.DaemonReachable
+}
+
+// renderProxyStatus prints the Proxy line for `prox status` (D5). Disabled mode
+// (and an absent block, for pre-D5 daemons) prints nothing.
+func renderProxyStatus(p *api.ProxyStatusResponse) {
+	if p == nil {
+		return
+	}
+	switch p.Mode {
+	case proxyModeShared:
+		if sharedProxyDown(p) {
+			fmt.Println("\nProxy: DOWN — shared proxy daemon unreachable (proxied routes are dead). Check 'prox proxy status'.")
+		} else {
+			fmt.Printf("\nProxy: shared (running, v%s)\n", p.DaemonVersion)
+		}
+	case proxyModeStandalone:
+		fmt.Println("\nProxy: standalone")
+	}
 }
 
 // Logs command flags

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -585,6 +585,12 @@ func runRequests(cmd *cobra.Command, args []string) error {
 				duration := fmt.Sprintf("%dms", req.DurationMs)
 				if req.InFlight {
 					duration = "..."
+					if req.Stale {
+						// Completion event may have been lost; true outcome
+						// unknown (D8, #53). Long-lived streams/transfers can
+						// legitimately still be live past this point.
+						duration = "stale?"
+					}
 				}
 				fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%s\t%s\n",
 					req.ID, timeStr, req.Method, req.StatusCode, duration, req.URL)
@@ -621,9 +627,12 @@ func showRequestDetail(client *Client, id string, includeBody, jsonOutput bool) 
 	fmt.Printf("Method:  %s\n", resp.Method)
 	fmt.Printf("URL:     %s\n", resp.URL)
 	fmt.Printf("Status:  %d\n", resp.StatusCode)
-	if resp.InFlight {
+	switch {
+	case resp.InFlight && resp.Stale:
+		fmt.Printf("Duration: (in flight, stale?)\n")
+	case resp.InFlight:
 		fmt.Printf("Duration: (in flight)\n")
-	} else {
+	default:
 		fmt.Printf("Duration: %dms\n", resp.DurationMs)
 	}
 	fmt.Printf("Remote:  %s\n", resp.RemoteAddr)
@@ -650,6 +659,8 @@ func showRequestDetail(client *Client, id string, includeBody, jsonOutput bool) 
 		if resp.Details.ResponseBody != nil {
 			printCapturedBody("Response Body", resp.Details.ResponseBody, includeBody)
 		}
+	} else if resp.InFlight && resp.Stale {
+		fmt.Println("\n(request in flight, stale? — the completion event may have been lost; true outcome unknown)")
 	} else if resp.InFlight {
 		fmt.Println("\n(request in flight — details arrive on completion)")
 	} else {
@@ -754,6 +765,9 @@ func printProxyRequest(req api.ProxyRequestResponse) {
 	duration := fmt.Sprintf("(%dms)", req.DurationMs)
 	if req.InFlight {
 		duration = "(in flight)"
+		if req.Stale {
+			duration = "(in flight, stale?)"
+		}
 	}
 	fmt.Printf("%s %s %s%d%s %s %s\n",
 		req.ID, timeStr, statusColor, req.StatusCode, resetColor, req.Method, duration)

--- a/internal/cli/commands_test.go
+++ b/internal/cli/commands_test.go
@@ -965,3 +965,106 @@ func TestRunFullStop_CleanVerdictPollTimeout(t *testing.T) {
 		t.Errorf("expected a Warning about the daemon still finishing, got stderr %q", stderr)
 	}
 }
+
+// statusServerWithProxy starts a fake API server that returns a status response
+// carrying the given proxy block (nil = no block) plus a minimal process list,
+// and points apiAddr at it for the duration of the test.
+func statusServerWithProxy(t *testing.T, proxy *api.ProxyStatusResponse) {
+	t.Helper()
+	originalApiAddr := apiAddr
+	t.Cleanup(func() { apiAddr = originalApiAddr })
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/status":
+			_ = json.NewEncoder(w).Encode(api.StatusResponse{
+				Status:        "running",
+				UptimeSeconds: 10,
+				ConfigFile:    "prox.yaml",
+				APIVersion:    "v1",
+				Proxy:         proxy,
+			})
+		case "/api/v1/processes":
+			_ = json.NewEncoder(w).Encode(api.ProcessListResponse{
+				Processes: []api.ProcessResponse{
+					{Name: "web", Status: "running", PID: 1234, UptimeSeconds: 5, Health: "healthy"},
+				},
+			})
+		}
+	}))
+	t.Cleanup(server.Close)
+	apiAddr = server.URL
+}
+
+// TestRunStatus_SharedProxyDownExits1 pins D5: when the status block reports a
+// shared proxy that is unreachable, runStatus prints the DOWN line and returns a
+// non-nil error (exit 1) even though the child process is healthy.
+func TestRunStatus_SharedProxyDownExits1(t *testing.T) {
+	statusServerWithProxy(t, &api.ProxyStatusResponse{
+		Mode:            proxyModeShared,
+		DaemonReachable: false,
+	})
+
+	var runErr error
+	stdout, _ := captureOutput(t, func() {
+		runErr = runStatus(statusCmd, []string{})
+	})
+
+	if runErr == nil {
+		t.Fatal("runStatus returned nil, want a non-nil error (exit 1) when the shared proxy is down")
+	}
+	if !strings.Contains(stdout, "Proxy: DOWN") {
+		t.Errorf("stdout missing the DOWN line; got:\n%s", stdout)
+	}
+	// The process table must still have printed first.
+	if !strings.Contains(stdout, "web") {
+		t.Errorf("stdout missing the process table; got:\n%s", stdout)
+	}
+}
+
+// TestRunStatus_SharedProxyUpNoError pins that a reachable shared proxy renders
+// the running line and returns nil (exit 0).
+func TestRunStatus_SharedProxyUpNoError(t *testing.T) {
+	statusServerWithProxy(t, &api.ProxyStatusResponse{
+		Mode:            proxyModeShared,
+		DaemonReachable: true,
+		DaemonVersion:   "1.2.3",
+	})
+
+	var runErr error
+	stdout, _ := captureOutput(t, func() {
+		runErr = runStatus(statusCmd, []string{})
+	})
+
+	if runErr != nil {
+		t.Fatalf("runStatus returned %v, want nil when the shared proxy is up", runErr)
+	}
+	if !strings.Contains(stdout, "Proxy: shared (running, v1.2.3)") {
+		t.Errorf("stdout missing the running proxy line; got:\n%s", stdout)
+	}
+}
+
+// TestRunStatus_SharedProxyDownJSONExits1 pins that JSON mode also exits 1 when
+// the shared proxy is down (the block is emitted verbatim; scripts parsing JSON
+// still get the failure signal).
+func TestRunStatus_SharedProxyDownJSONExits1(t *testing.T) {
+	statusServerWithProxy(t, &api.ProxyStatusResponse{
+		Mode:            proxyModeShared,
+		DaemonReachable: false,
+	})
+	statusJSON = true
+	t.Cleanup(func() { statusJSON = false })
+
+	var runErr error
+	stdout, _ := captureOutput(t, func() {
+		runErr = runStatus(statusCmd, []string{})
+	})
+
+	if runErr == nil {
+		t.Fatal("runStatus (JSON) returned nil, want a non-nil error when the shared proxy is down")
+	}
+	if !strings.Contains(stdout, "\"daemon_reachable\":false") {
+		t.Errorf("JSON output missing the proxy block; got:\n%s", stdout)
+	}
+}

--- a/internal/cli/commands_test.go
+++ b/internal/cli/commands_test.go
@@ -644,6 +644,56 @@ func TestRunRequests_TableRendersInFlightDuration(t *testing.T) {
 	}
 }
 
+// TestRunRequests_TableRendersStale verifies the list table's DURATION
+// column shows "stale?" instead of "..." for an in-flight row the server
+// reports as stale (D8, #53).
+func TestRunRequests_TableRendersStale(t *testing.T) {
+	origFollow := requestsFollow
+	origJSON := requestsJSON
+	defer func() {
+		requestsFollow = origFollow
+		requestsJSON = origJSON
+	}()
+
+	originalApiAddr := apiAddr
+	defer func() { apiAddr = originalApiAddr }()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(api.ProxyRequestsResponse{
+			Requests: []api.ProxyRequestResponse{
+				{
+					ID:         "stale1",
+					Timestamp:  time.Now().Add(-10 * time.Minute).Format(time.RFC3339Nano),
+					Method:     "GET",
+					URL:        "/stream",
+					StatusCode: 200,
+					DurationMs: 0,
+					InFlight:   true,
+					Stale:      true,
+				},
+			},
+			FilteredCount: 1,
+			TotalCount:    1,
+		})
+	}))
+	defer server.Close()
+	apiAddr = server.URL
+
+	requestsFollow = false
+	requestsJSON = false
+
+	stdout, _ := captureOutput(t, func() {
+		if err := runRequests(requestsCmd, []string{}); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(stdout, "stale?") {
+		t.Errorf("expected DURATION column to render 'stale?' for a stale in-flight row, got:\n%s", stdout)
+	}
+}
+
 // TestPrintProxyRequest_InFlight verifies follow-mode prints "(in flight)"
 // instead of a fake "(0ms)" for an in-flight streamed record (D10).
 func TestPrintProxyRequest_InFlight(t *testing.T) {
@@ -706,6 +756,44 @@ func TestShowRequestDetail_InFlight(t *testing.T) {
 	}
 	if strings.Contains(stdout, "capture not enabled") {
 		t.Errorf("expected the misleading capture-not-enabled hint to be suppressed, got:\n%s", stdout)
+	}
+}
+
+// TestShowRequestDetail_Stale verifies the detail view indicates staleness
+// for a stale in-flight request (D8, #53): the Duration line and the
+// in-flight note both call out "stale?" instead of the ordinary in-flight
+// wording.
+func TestShowRequestDetail_Stale(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(api.ProxyRequestDetailResponse{
+			ProxyRequestResponse: api.ProxyRequestResponse{
+				ID:         "stale1",
+				Timestamp:  time.Now().Add(-10 * time.Minute).Format(time.RFC3339Nano),
+				Method:     "GET",
+				URL:        "/stream",
+				StatusCode: 200,
+				DurationMs: 0,
+				InFlight:   true,
+				Stale:      true,
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+
+	stdout, _ := captureOutput(t, func() {
+		if err := showRequestDetail(client, "stale1", false, false); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(stdout, "Duration: (in flight, stale?)") {
+		t.Errorf("expected 'Duration: (in flight, stale?)', got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "stale?") {
+		t.Errorf("expected a stale note in the output, got:\n%s", stdout)
 	}
 }
 

--- a/internal/cli/daemon_startup.go
+++ b/internal/cli/daemon_startup.go
@@ -1,0 +1,240 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/charliek/prox/internal/constants"
+	"github.com/charliek/prox/internal/daemon"
+)
+
+// daemonChild is the parent's handle on the detached daemon process. The real
+// implementation (execChild) wraps *exec.Cmd; tests supply a fake so the
+// poll/wait/report logic runs without spawning a real process.
+type daemonChild interface {
+	// Pid is the child's process ID (used to match the state file, staleness guard).
+	Pid() int
+	// Wait blocks until the child exits and returns its exit status. It is called
+	// exactly once, from the reaping goroutine, so the direct child never zombies.
+	Wait() error
+	// Signal delivers sig to the child (SIGTERM/SIGKILL on the timeout path).
+	Signal(sig os.Signal) error
+}
+
+// execChild adapts a started *exec.Cmd to daemonChild.
+type execChild struct{ cmd *exec.Cmd }
+
+func (c *execChild) Pid() int                   { return c.cmd.Process.Pid }
+func (c *execChild) Wait() error                { return c.cmd.Wait() }
+func (c *execChild) Signal(sig os.Signal) error { return c.cmd.Process.Signal(sig) }
+
+// daemonStartupOps bundles the injectable operations and timings the parent's
+// wait-and-report loop (D2) needs so awaitDaemonStartup can be unit-tested with
+// a fake child and fake probes — no real sockets or wall-clock waits. Mirrors
+// the skewOps pattern (version_skew.go). defaultDaemonStartupOps wires the
+// production implementations.
+type daemonStartupOps struct {
+	// loadState reads the child's state file for the project dir.
+	loadState func(dir string) (*daemon.State, error)
+	// healthOK reports whether GET /health on the state's address (host:port) succeeds.
+	healthOK func(addr string) bool
+	// logTail returns the last n lines of the child's daemon log for diagnostics.
+	logTail func(dir string, n int) string
+
+	sleep func(time.Duration)
+
+	readyTimeout time.Duration // total budget for the child to become ready
+	pollInterval time.Duration // interval between readiness polls
+	killGrace    time.Duration // grace after SIGTERM before escalating to SIGKILL
+}
+
+// killWaitBound caps how long the parent waits for the post-SIGKILL reap
+// before giving up so the `prox up -d` exit contract stays bounded.
+const killWaitBound = 2 * time.Second
+
+// defaultDaemonStartupOps wires daemonStartupOps to the real filesystem and a
+// localhost /health probe, with the production timings from D2 (§3): a 15s
+// readiness budget polled at 200ms, and a 5s SIGTERM→SIGKILL grace.
+func defaultDaemonStartupOps() daemonStartupOps {
+	return daemonStartupOps{
+		loadState: daemon.LoadState,
+		healthOK:  probeHealth,
+		logTail:   daemonLogTail,
+		sleep:     time.Sleep,
+
+		readyTimeout: 15 * time.Second,
+		pollInterval: 200 * time.Millisecond,
+		killGrace:    5 * time.Second,
+	}
+}
+
+// probeHealth issues a single GET /health against the API server at addr
+// (host:port) with a short per-probe timeout, reporting whether it answered 200.
+func probeHealth(addr string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), constants.DaemonHealthProbeTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+addr+"/health", nil)
+	if err != nil {
+		return false
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode == http.StatusOK
+}
+
+// daemonLogTail returns the last n lines of the child's daemon log (.prox/prox.log)
+// for failure diagnostics. Returns "" when the log is missing or empty.
+func daemonLogTail(dir string, n int) string {
+	data, err := os.ReadFile(daemon.LogPath(dir))
+	if err != nil {
+		return ""
+	}
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+	return strings.Join(lines, "\n")
+}
+
+// awaitDaemonStartup owns the parent side of `prox up -d` (D2). It reaps the
+// direct child on a goroutine (preventing a zombie and surfacing early death),
+// then polls up to ops.readyTimeout for the child to become ready:
+//
+//	(a) .prox/prox.state exists AND state.PID == child PID — the PID match is a
+//	    staleness guard so a previous run's leftover state file never fools the
+//	    poll; then
+//	(b) GET /health on the state's address answers.
+//
+// Child startup ordering (verified against runUp in internal/cli/up.go and
+// internal/daemon/state.go): the child writes .prox/prox.state (state.Write, up.go)
+// BEFORE it starts the API server that serves /health (apiServer.Start, launched
+// later in a goroutine). So in practice the state file appears first and /health
+// second. The loop nonetheless re-checks BOTH conditions every interval, so
+// either ordering is tolerated per D2 (a hypothetical future reordering, or a
+// slow state fsync racing an early bind, still converges).
+//
+// Returns nil on success (prints the started line; caller returns 0). On early
+// death or never-ready timeout it prints diagnostics (headline + log tail) and
+// returns an error (caller exits 1). On timeout with the child still alive it
+// SIGTERMs the child and escalates to SIGKILL after killGrace so a child that
+// already registered with the shared daemon gets a chance to deregister.
+func awaitDaemonStartup(child daemonChild, cwd string, ops daemonStartupOps) error {
+	pid := child.Pid()
+
+	// Reap the direct child on a goroutine: this prevents a zombie and signals
+	// early death. Buffered so the goroutine never blocks after we stop reading.
+	childErr := make(chan error, 1)
+	go func() { childErr <- child.Wait() }()
+
+	deadline := time.Now().Add(ops.readyTimeout)
+	for {
+		// Early death: the child exited before it became ready.
+		if err := checkEarlyDeath(childErr, pid, cwd, ops); err != nil {
+			return err
+		}
+
+		if st, err := ops.loadState(cwd); err == nil && st.PID == pid {
+			addr := net.JoinHostPort(st.Host, strconv.Itoa(st.Port))
+			if ops.healthOK(addr) {
+				// Re-check death before declaring success: a child that died
+				// between the probe and here (or whose draining server answered
+				// the probe) must be reported as a failure, not a green start.
+				// This narrows — it cannot close — the inherent window where
+				// the child dies right after the parent exits 0.
+				if err := checkEarlyDeath(childErr, pid, cwd, ops); err != nil {
+					return err
+				}
+				fmt.Printf("prox started (pid %d, api http://%s)\n", pid, addr)
+				return nil
+			}
+		}
+
+		if !time.Now().Before(deadline) {
+			// Deadline reached. Re-check death first: the child may have exited
+			// right at the boundary, in which case report it as early death.
+			if err := checkEarlyDeath(childErr, pid, cwd, ops); err != nil {
+				return err
+			}
+			// Child alive but never ready (API bind failures are fatal in the
+			// child, so this is a genuinely wedged startup: config load hang,
+			// supervisor stall, or similar).
+			printDaemonFailure(cwd, ops, fmt.Sprintf(
+				"prox daemon (pid %d) did not become ready within %s", pid, ops.readyTimeout))
+			terminateChild(child, childErr, ops)
+			return fmt.Errorf("prox daemon failed to become ready within %s", ops.readyTimeout)
+		}
+
+		ops.sleep(ops.pollInterval)
+	}
+}
+
+// checkEarlyDeath does a non-blocking check of childErr. If the child has
+// already exited, it prints early-death diagnostics and returns a non-nil
+// error; awaitDaemonStartup calls this both at the top of each poll iteration
+// and again at the deadline boundary, so a death right at the boundary is
+// still reported as early death rather than a timeout. Returns nil if the
+// child has not exited yet.
+func checkEarlyDeath(childErr <-chan error, pid int, cwd string, ops daemonStartupOps) error {
+	select {
+	case werr := <-childErr:
+		printDaemonFailure(cwd, ops, fmt.Sprintf(
+			"prox daemon (pid %d) exited before startup completed: %s", pid, exitDesc(werr)))
+		return fmt.Errorf("prox daemon failed to start")
+	default:
+		return nil
+	}
+}
+
+// terminateChild SIGTERMs a hung child, waits up to killGrace for it to exit,
+// then escalates to SIGKILL. It consumes the child's Wait() result (from
+// childErr) so the child is reaped either way — but the post-SIGKILL wait is
+// bounded: the parent's exit contract (timeout + grace) must hold even if the
+// child is wedged in an uninterruptible state, so after killWaitBound the
+// parent gives up on the reap (the Wait goroutine drains the channel later if
+// the process ever dies; the parent is exiting anyway) and reports the PID.
+func terminateChild(child daemonChild, childErr <-chan error, ops daemonStartupOps) {
+	_ = child.Signal(syscall.SIGTERM)
+	select {
+	case <-childErr:
+		return // exited within the grace period
+	case <-time.After(ops.killGrace):
+	}
+	_ = child.Signal(syscall.SIGKILL)
+	select {
+	case <-childErr:
+	case <-time.After(killWaitBound):
+		fmt.Fprintf(os.Stderr,
+			"Warning: child (pid %d) did not exit after SIGKILL; giving up on reap\n", child.Pid())
+	}
+}
+
+// printDaemonFailure prints a failure headline plus the last ~20 lines of the
+// child's daemon log to stderr, for `prox up -d` failure diagnostics.
+func printDaemonFailure(dir string, ops daemonStartupOps, headline string) {
+	fmt.Fprintln(os.Stderr, headline)
+	logPath := daemon.LogPath(dir)
+	if tail := ops.logTail(dir, 20); strings.TrimSpace(tail) != "" {
+		fmt.Fprintf(os.Stderr, "\nLast lines of %s:\n%s\n", logPath, tail)
+	} else {
+		fmt.Fprintf(os.Stderr, "\n(no output in %s)\n", logPath)
+	}
+}
+
+// exitDesc renders a child's Wait() result for a diagnostic message.
+func exitDesc(err error) string {
+	if err == nil {
+		return "exited cleanly (exit 0)"
+	}
+	return err.Error()
+}

--- a/internal/cli/daemon_startup_test.go
+++ b/internal/cli/daemon_startup_test.go
@@ -1,0 +1,176 @@
+package cli
+
+import (
+	"errors"
+	"os"
+	"strconv"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/charliek/prox/internal/daemon"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeChild is an in-memory daemonChild so the D2 poll/wait/report logic can be
+// tested without spawning a real process. Wait() blocks until the child is made
+// to exit (either explicitly or by a signal registered in exitOn).
+type fakeChild struct {
+	pid    int
+	done   chan error
+	once   sync.Once
+	exitOn map[syscall.Signal]bool
+	exitBy error
+
+	mu      sync.Mutex
+	signals []os.Signal
+}
+
+func newFakeChild(pid int) *fakeChild {
+	return &fakeChild{pid: pid, done: make(chan error, 1), exitOn: map[syscall.Signal]bool{}}
+}
+
+func (f *fakeChild) Pid() int    { return f.pid }
+func (f *fakeChild) Wait() error { return <-f.done }
+
+func (f *fakeChild) Signal(sig os.Signal) error {
+	f.mu.Lock()
+	f.signals = append(f.signals, sig)
+	f.mu.Unlock()
+	if s, ok := sig.(syscall.Signal); ok && f.exitOn[s] {
+		f.exit(f.exitBy)
+	}
+	return nil
+}
+
+func (f *fakeChild) exit(err error) { f.once.Do(func() { f.done <- err }) }
+
+func (f *fakeChild) sentSignals() []os.Signal {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]os.Signal(nil), f.signals...)
+}
+
+// fastStartupOps returns ops with instant sleeps and tiny deadlines/grace so the
+// timeout path resolves in milliseconds. Defaults model a never-ready child (no
+// state, health down); individual tests override fields.
+func fastStartupOps() daemonStartupOps {
+	return daemonStartupOps{
+		loadState: func(string) (*daemon.State, error) { return nil, errors.New("no state") },
+		healthOK:  func(string) bool { return false },
+		logTail:   func(string, int) string { return "" },
+		sleep:     func(time.Duration) {},
+
+		readyTimeout: 40 * time.Millisecond,
+		pollInterval: time.Millisecond,
+		killGrace:    30 * time.Millisecond,
+	}
+}
+
+// TestAwaitDaemonStartup_Success: state file with the child's PID plus a healthy
+// /health probe → nil (exit 0), and the running child is never signaled.
+func TestAwaitDaemonStartup_Success(t *testing.T) {
+	child := newFakeChild(4242)
+	// Release the (never-exiting) Wait goroutine at test end.
+	t.Cleanup(func() { child.exit(nil) })
+
+	ops := fastStartupOps()
+	ops.loadState = func(string) (*daemon.State, error) {
+		return &daemon.State{PID: 4242, Host: "127.0.0.1", Port: 12345}, nil
+	}
+	healthCalls := 0
+	ops.healthOK = func(addr string) bool {
+		healthCalls++
+		assert.Equal(t, "127.0.0.1:12345", addr)
+		return true
+	}
+
+	err := awaitDaemonStartup(child, t.TempDir(), ops)
+	require.NoError(t, err)
+	assert.Equal(t, 1, healthCalls, "health should be probed once")
+	assert.Empty(t, child.sentSignals(), "a ready child must not be signaled")
+}
+
+// TestAwaitDaemonStartup_EarlyDeath: the child exits (non-zero) before becoming
+// ready → error, no signals (nothing to kill).
+func TestAwaitDaemonStartup_EarlyDeath(t *testing.T) {
+	child := newFakeChild(4243)
+	child.exit(&exitStatusError{code: 1}) // dead before we start polling
+
+	tailUsed := false
+	ops := fastStartupOps()
+	ops.logTail = func(string, int) string { tailUsed = true; return "boom: config invalid" }
+
+	err := awaitDaemonStartup(child, t.TempDir(), ops)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to start")
+	assert.True(t, tailUsed, "log tail should be gathered for diagnostics")
+	assert.Empty(t, child.sentSignals(), "a dead child must not be signaled")
+}
+
+// TestAwaitDaemonStartup_NeverReadyTimeout: child stays alive but never writes
+// state / answers health → SIGTERM then, after the grace, SIGKILL (escalation),
+// and an error is returned.
+func TestAwaitDaemonStartup_NeverReadyTimeout(t *testing.T) {
+	child := newFakeChild(4244)
+	// Only SIGKILL makes it exit → forces the escalation path.
+	child.exitOn[syscall.SIGKILL] = true
+
+	ops := fastStartupOps()
+
+	start := time.Now()
+	err := awaitDaemonStartup(child, t.TempDir(), ops)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to become ready")
+	assert.GreaterOrEqual(t, time.Since(start), ops.readyTimeout, "must poll until the deadline")
+
+	sigs := child.sentSignals()
+	require.Len(t, sigs, 2, "expected SIGTERM then SIGKILL, got %v", sigs)
+	assert.Equal(t, syscall.SIGTERM, sigs[0])
+	assert.Equal(t, syscall.SIGKILL, sigs[1])
+}
+
+// TestAwaitDaemonStartup_TermSuffices: a hung child that exits on SIGTERM is not
+// escalated to SIGKILL.
+func TestAwaitDaemonStartup_TermSuffices(t *testing.T) {
+	child := newFakeChild(4245)
+	child.exitOn[syscall.SIGTERM] = true
+
+	err := awaitDaemonStartup(child, t.TempDir(), fastStartupOps())
+	require.Error(t, err)
+
+	sigs := child.sentSignals()
+	require.Len(t, sigs, 1, "expected only SIGTERM, got %v", sigs)
+	assert.Equal(t, syscall.SIGTERM, sigs[0])
+}
+
+// TestAwaitDaemonStartup_StaleStateIgnored: a pre-existing state file with the
+// WRONG PID (a previous run's leftover) must not satisfy the poll. Health is
+// never probed, and the child is timed out and killed.
+func TestAwaitDaemonStartup_StaleStateIgnored(t *testing.T) {
+	child := newFakeChild(4246)
+	child.exitOn[syscall.SIGKILL] = true
+	child.exitOn[syscall.SIGTERM] = true
+
+	ops := fastStartupOps()
+	ops.loadState = func(string) (*daemon.State, error) {
+		// Stale: belongs to some other/previous process, not our child.
+		return &daemon.State{PID: 9999, Host: "127.0.0.1", Port: 22222}, nil
+	}
+	healthCalls := 0
+	ops.healthOK = func(string) bool { healthCalls++; return true }
+
+	err := awaitDaemonStartup(child, t.TempDir(), ops)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to become ready")
+	assert.Zero(t, healthCalls, "stale state (wrong PID) must not advance to the health probe")
+	assert.NotEmpty(t, child.sentSignals(), "a never-ready child must be signaled")
+}
+
+// exitStatusError is a stand-in for an *exec.ExitError so early-death diagnostics
+// render a non-zero status without spawning a real process.
+type exitStatusError struct{ code int }
+
+func (e *exitStatusError) Error() string { return "exit status " + strconv.Itoa(e.code) }

--- a/internal/cli/proxy_runtime.go
+++ b/internal/cli/proxy_runtime.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"log"
 	"sync"
 	"sync/atomic"
@@ -18,6 +19,15 @@ const (
 	proxyModeShared     = "shared"
 	proxyModeStandalone = "standalone"
 	proxyModeDisabled   = "disabled"
+)
+
+// heal_state values reported in the `prox status` proxy block. C5 reported only
+// healthy/""; C6 (D6b) refines the unreachable case to distinguish an in-progress
+// heal from a busy different-version daemon.
+const (
+	healStateHealthy         = "healthy"
+	healStateHealing         = "healing"
+	healStateVersionMismatch = "version_mismatch"
 )
 
 // proxyRuntime is the single source of truth for this project's proxy path,
@@ -46,8 +56,30 @@ type proxyRuntime struct {
 
 	// shutdownLatch is set (via MarkShuttingDown) before the deregister stage of
 	// performShutdown. C6's heal callback consumes it to no-op once teardown has
-	// begun; C5 only sets it.
+	// begun.
 	shutdownLatch atomic.Bool
+
+	// healMu serializes a heal against shutdown's client read (FIX 3). heal holds
+	// it for its whole body; performShutdown acquires it (clientAfterHealBarrier)
+	// AFTER latching, so a heal that began before the latch finishes its client
+	// swap before shutdown reads the client — the deregister then goes through the
+	// HEALED client. A heal that starts after the latch no-ops (its first action
+	// under healMu re-checks IsShuttingDown). It never nests inside mu.
+	healMu sync.Mutex
+
+	// forwarderCancel cancels the SSE forwarder's context. performShutdown calls
+	// it (via CancelForwarder) BEFORE deregister (D6c) so the forwarder loop stops
+	// and cannot fire a heal that re-registers the project mid-teardown. It lives
+	// on a context derived from runUp's — separate so cancelling the forwarder
+	// never disturbs the supervisor. nil until the shared-mode forwarder launches.
+	forwarderCancel context.CancelFunc
+
+	// healState overrides the derived heal_state while the shared daemon is
+	// unreachable (D6b): "" (down, no heal attempted yet), "healing" (heal
+	// attempts failing), or "version_mismatch" (a busy different-version daemon).
+	// Guarded by mu. When the daemon is reachable, ProxyStatus reports "healthy"
+	// regardless of this field.
+	healState string
 
 	// Forwarder state atomics (D5).
 	consecutiveFailures atomic.Int64
@@ -115,6 +147,17 @@ func (r *proxyRuntime) Client() *proxyd.Client {
 	return r.client
 }
 
+// clientAfterHealBarrier blocks until any in-flight heal completes (its client
+// swap has landed), then returns the current client. performShutdown calls it
+// AFTER MarkShuttingDown()+CancelForwarder() so a heal that began before the latch
+// finishes fully and the deregister goes through the HEALED client; a heal that
+// starts after the latch no-ops under the same mutex (FIX 3).
+func (r *proxyRuntime) clientAfterHealBarrier() *proxyd.Client {
+	r.healMu.Lock()
+	defer r.healMu.Unlock()
+	return r.Client()
+}
+
 // SetRegisterRequest stores the original registration request (C6 re-registers
 // with it after a heal).
 func (r *proxyRuntime) SetRegisterRequest(req proxyd.RegisterRequest) {
@@ -152,6 +195,38 @@ func (r *proxyRuntime) MarkShuttingDown() {
 // IsShuttingDown reports whether teardown has begun.
 func (r *proxyRuntime) IsShuttingDown() bool {
 	return r.shutdownLatch.Load()
+}
+
+// SetForwarderCancel records the SSE forwarder's cancel func so performShutdown
+// can stop the forwarder before deregister (D6c).
+func (r *proxyRuntime) SetForwarderCancel(cancel context.CancelFunc) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.forwarderCancel = cancel
+}
+
+// CancelForwarder cancels the forwarder's context if one was launched (no-op
+// otherwise). Called before deregister so no heal can fire mid-teardown (D6c).
+func (r *proxyRuntime) CancelForwarder() {
+	r.mu.Lock()
+	cancel := r.forwarderCancel
+	r.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+}
+
+// setHealState records the heal state machine's current view (D6b).
+func (r *proxyRuntime) setHealState(state string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.healState = state
+}
+
+func (r *proxyRuntime) getHealState() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.healState
 }
 
 // --- proxyd.ForwarderStatusSink ---
@@ -206,7 +281,11 @@ func (r *proxyRuntime) ProxyStatus() *api.ProxyStatusResponse {
 		resp.DaemonReachable = reachable
 		resp.DaemonVersion = version
 		if reachable {
-			resp.HealState = "healthy"
+			resp.HealState = healStateHealthy
+		} else {
+			// Unreachable: surface the heal state machine's current view — ""
+			// until the first heal attempt, then "healing"/"version_mismatch" (D6b).
+			resp.HealState = r.getHealState()
 		}
 	}
 
@@ -229,6 +308,100 @@ func (r *proxyRuntime) probeDaemon() (bool, string) {
 	r.probeCache = proxyProbeResult{reachable: reachable, version: version}
 	r.probeValidUntil = r.now().Add(r.probeTTL)
 	return reachable, version
+}
+
+// invalidateProbeCache forces the next ProxyStatus to re-probe rather than reuse
+// a cached result. Called after a heal swaps in a fresh client so status reflects
+// the new daemon immediately instead of waiting out the cache TTL.
+func (r *proxyRuntime) invalidateProbeCache() {
+	r.probeMu.Lock()
+	defer r.probeMu.Unlock()
+	r.probeValidUntil = time.Time{}
+}
+
+// --- D6b self-heal ---
+
+// healOps bundles the injectable operations proxyRuntime.heal needs so it can be
+// unit-tested against a fake daemon without real sockets or wall-clock waits
+// (mirrors skewOps / registerRetryOps). defaultHealOps wires the production impls.
+type healOps struct {
+	// ensureRunning starts/connects a daemon of this process's version (the heal
+	// wraps it in ensureRunningWithRetry for the socket-removed-before-PID-lock
+	// window).
+	ensureRunning func() (*proxyd.Client, error)
+	sleep         func(time.Duration)
+	retryDelay    time.Duration
+}
+
+func defaultHealOps() healOps {
+	return healOps{
+		ensureRunning: proxyd.EnsureRunning,
+		sleep:         time.Sleep,
+		retryDelay:    1 * time.Second,
+	}
+}
+
+// heal is the forwarder's self-heal callback (D6b), invoked INLINE from the
+// forwarder reconnect loop after the shared daemon has been unreachable past the
+// heal threshold. It re-ensures a daemon of this version and re-registers this
+// project's stored request against it, swapping in the fresh client on success so
+// performShutdown later deregisters through the healed client (D6c). It returns
+// true only when the project is registered on a healthy daemon — the forwarder
+// then reconnects to it on the same socket.
+//
+// Behavior:
+//   - shutting down (latch set): no-op, return false — never re-register a project
+//     that is tearing down (D6c);
+//   - VersionMismatchError from EnsureRunning: a live daemon of another version is
+//     holding the ports; NEVER restart a busy daemon — set heal_state
+//     "version_mismatch" and keep waiting (heal retried after healMinInterval);
+//   - any other ensure/register error: set heal_state "healing", count the attempt
+//     (the forwarder keeps retrying forever);
+//   - success: swap the client, reset failure state, set heal_state "healthy",
+//     invalidate the probe cache, log one prominent line.
+func (r *proxyRuntime) heal(ops healOps) bool {
+	// Hold healMu for the WHOLE body so shutdown's client read (clientAfterHealBarrier)
+	// blocks until an in-flight heal's client swap has landed (FIX 3).
+	r.healMu.Lock()
+	defer r.healMu.Unlock()
+
+	// First action under the lock: a shutdown that latched before we acquired healMu
+	// owns teardown now — no-op. A shutdown latching AFTER this check is blocked on
+	// healMu until we return, so its client read observes our swap.
+	if r.IsShuttingDown() {
+		return false
+	}
+
+	client, err := ensureRunningWithRetry(ops.ensureRunning, ops.sleep, ops.retryDelay)
+	if err != nil {
+		var vme *proxyd.VersionMismatchError
+		if errors.As(err, &vme) {
+			r.setHealState(healStateVersionMismatch)
+			return false
+		}
+		r.setHealState(healStateHealing)
+		return false
+	}
+
+	resp, err := client.Register(r.RegisterRequest())
+	if err != nil {
+		// A busy different-version daemon holding the ports re-checks versions at
+		// register time and returns VERSION_MISMATCH: surface it as version_mismatch
+		// (like the EnsureRunning VersionMismatchError path), NOT healing (FIX 5).
+		if isVersionMismatchError(err) {
+			r.setHealState(healStateVersionMismatch)
+			return false
+		}
+		r.setHealState(healStateHealing)
+		return false
+	}
+
+	r.SetClient(client)
+	r.consecutiveFailures.Store(0)
+	r.setHealState(healStateHealthy)
+	r.invalidateProbeCache()
+	log.Printf("prox: shared proxy daemon healed — re-registered %d domain(s) with a fresh daemon", len(resp.Registered))
+	return true
 }
 
 // defaultProber issues a live /health probe against the active daemon client

--- a/internal/cli/proxy_runtime.go
+++ b/internal/cli/proxy_runtime.go
@@ -1,0 +1,248 @@
+package cli
+
+import (
+	"context"
+	"log"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/charliek/prox/internal/api"
+	"github.com/charliek/prox/internal/constants"
+	"github.com/charliek/prox/internal/proxy"
+	"github.com/charliek/prox/internal/proxyd"
+)
+
+// Proxy modes reported in the `prox status` proxy block (D5).
+const (
+	proxyModeShared     = "shared"
+	proxyModeStandalone = "standalone"
+	proxyModeDisabled   = "disabled"
+)
+
+// proxyRuntime is the single source of truth for this project's proxy path,
+// shared by the `prox up` runtime, the SSE forwarder, and the API handlers
+// (D5/D6). It owns:
+//
+//   - the mode (shared/standalone/disabled);
+//   - the active daemon client (mutex-guarded; C6 swaps it on heal, and
+//     performShutdown reads the CURRENT client for deregister);
+//   - the original register request (stored for C6's re-register);
+//   - the local forwarding request manager (source of the dropped-events count);
+//   - forwarder connection state as atomics (following the lifecycleEpoch
+//     precedent): consecutive reconnect failures, last successful connect time,
+//     and backfill-failure count;
+//   - a shutdown latch set before deregister so a C6 heal cannot re-register the
+//     project mid-teardown.
+//
+// It implements proxyd.ForwarderStatusSink (the forwarder writes state through
+// it) and api.ProxyStatusProvider (GET /status reads the proxy block from it).
+type proxyRuntime struct {
+	mu       sync.Mutex
+	mode     string
+	client   *proxyd.Client
+	register proxyd.RegisterRequest
+	localRM  *proxy.RequestManager
+
+	// shutdownLatch is set (via MarkShuttingDown) before the deregister stage of
+	// performShutdown. C6's heal callback consumes it to no-op once teardown has
+	// begun; C5 only sets it.
+	shutdownLatch atomic.Bool
+
+	// Forwarder state atomics (D5).
+	consecutiveFailures atomic.Int64
+	lastConnectedAt     atomic.Int64 // unix nanos; 0 == never connected
+	backfillFailures    atomic.Int64
+
+	// Probe cache (D5): the shared-daemon /health probe is cached for probeTTL so
+	// a polled status does not pay the probe timeout on every call, and a downed
+	// daemon is re-probed at most once per TTL. Guarded by probeMu (separate from
+	// mu so a probe never contends with client/state access).
+	probeMu         sync.Mutex
+	probeCache      proxyProbeResult
+	probeValidUntil time.Time
+
+	// Injectable seams for tests (default to production impls).
+	prober   func() (reachable bool, version string)
+	probeTTL time.Duration
+	now      func() time.Time
+}
+
+type proxyProbeResult struct {
+	reachable bool
+	version   string
+}
+
+// newProxyRuntime creates a runtime defaulting to disabled mode with production
+// probe wiring. Mode/client/register/localRM are set as the proxy path resolves.
+func newProxyRuntime() *proxyRuntime {
+	r := &proxyRuntime{
+		mode:     proxyModeDisabled,
+		probeTTL: constants.ProxyStatusProbeCacheTTL,
+		now:      time.Now,
+	}
+	r.prober = r.defaultProber
+	return r
+}
+
+// SetMode records the resolved proxy mode.
+func (r *proxyRuntime) SetMode(mode string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.mode = mode
+}
+
+// Mode returns the current proxy mode.
+func (r *proxyRuntime) Mode() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.mode
+}
+
+// SetClient stores the active daemon client. C6 calls this again on heal.
+func (r *proxyRuntime) SetClient(c *proxyd.Client) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.client = c
+}
+
+// Client returns the active daemon client (nil in standalone/disabled mode).
+// performShutdown reads through this so a C6-healed client is used for
+// deregister rather than the one captured at startup.
+func (r *proxyRuntime) Client() *proxyd.Client {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.client
+}
+
+// SetRegisterRequest stores the original registration request (C6 re-registers
+// with it after a heal).
+func (r *proxyRuntime) SetRegisterRequest(req proxyd.RegisterRequest) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.register = req
+}
+
+// RegisterRequest returns the stored registration request.
+func (r *proxyRuntime) RegisterRequest() proxyd.RegisterRequest {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.register
+}
+
+// SetLocalRequestManager stores the project's local forwarding request manager,
+// the source of the dropped-events count in the status block.
+func (r *proxyRuntime) SetLocalRequestManager(rm *proxy.RequestManager) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.localRM = rm
+}
+
+func (r *proxyRuntime) localRequestManager() *proxy.RequestManager {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.localRM
+}
+
+// MarkShuttingDown latches the shutdown flag before deregister (D6c).
+func (r *proxyRuntime) MarkShuttingDown() {
+	r.shutdownLatch.Store(true)
+}
+
+// IsShuttingDown reports whether teardown has begun.
+func (r *proxyRuntime) IsShuttingDown() bool {
+	return r.shutdownLatch.Load()
+}
+
+// --- proxyd.ForwarderStatusSink ---
+
+// ForwarderConnected resets the failure counter and records the connect time.
+// A down→connected transition (there were prior failures) logs one line.
+func (r *proxyRuntime) ForwarderConnected() {
+	prev := r.consecutiveFailures.Swap(0)
+	r.lastConnectedAt.Store(r.now().UnixNano())
+	if prev > 0 {
+		log.Printf("prox: reconnected to shared proxy daemon after %d failed attempt(s)", prev)
+	}
+}
+
+// ForwarderConnectFailed increments the failure counter. The connected→down
+// transition (first failure of a run) logs one line; subsequent failures are
+// silent so a persistently down daemon does not flood the log.
+func (r *proxyRuntime) ForwarderConnectFailed(err error) {
+	if r.consecutiveFailures.Add(1) == 1 {
+		log.Printf("prox: lost connection to shared proxy daemon: %v (proxied request inspection paused; retrying)", err)
+	}
+}
+
+// ForwarderBackfillFailed increments the backfill-failure counter (the forwarder
+// already logs the single backfill warning).
+func (r *proxyRuntime) ForwarderBackfillFailed() {
+	r.backfillFailures.Add(1)
+}
+
+// --- api.ProxyStatusProvider ---
+
+// ProxyStatus builds the proxy block for GET /status (D5). In shared mode it
+// live-probes the daemon's health (cached); standalone/disabled modes report
+// mode only, with no probe.
+func (r *proxyRuntime) ProxyStatus() *api.ProxyStatusResponse {
+	mode := r.Mode()
+	resp := &api.ProxyStatusResponse{
+		Mode:                mode,
+		ConsecutiveFailures: r.consecutiveFailures.Load(),
+		BackfillFailures:    r.backfillFailures.Load(),
+	}
+	if ns := r.lastConnectedAt.Load(); ns > 0 {
+		t := time.Unix(0, ns)
+		resp.LastConnectedAt = &t
+	}
+	if rm := r.localRequestManager(); rm != nil {
+		resp.DroppedEvents = rm.DroppedEvents()
+	}
+
+	if mode == proxyModeShared {
+		reachable, version := r.probeDaemon()
+		resp.DaemonReachable = reachable
+		resp.DaemonVersion = version
+		if reachable {
+			resp.HealState = "healthy"
+		}
+	}
+
+	return resp
+}
+
+// probeDaemon returns the shared daemon's reachability and version, cached for
+// probeTTL. The cache is keyed on monotonic time (now()) so repeated status
+// polls within the TTL reuse one probe result rather than each paying the probe
+// timeout.
+func (r *proxyRuntime) probeDaemon() (bool, string) {
+	r.probeMu.Lock()
+	defer r.probeMu.Unlock()
+
+	if now := r.now(); now.Before(r.probeValidUntil) {
+		return r.probeCache.reachable, r.probeCache.version
+	}
+
+	reachable, version := r.prober()
+	r.probeCache = proxyProbeResult{reachable: reachable, version: version}
+	r.probeValidUntil = r.now().Add(r.probeTTL)
+	return reachable, version
+}
+
+// defaultProber issues a live /health probe against the active daemon client
+// with a short timeout (D5). reachable is true iff the probe answered.
+func (r *proxyRuntime) defaultProber() (bool, string) {
+	client := r.Client()
+	if client == nil {
+		return false, ""
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), constants.DaemonProxyProbeTimeout)
+	defer cancel()
+	version, err := client.HealthWithContext(ctx)
+	if err != nil {
+		return false, ""
+	}
+	return true, version
+}

--- a/internal/cli/proxy_runtime_heal_test.go
+++ b/internal/cli/proxy_runtime_heal_test.go
@@ -1,0 +1,223 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/charliek/prox/internal/proxyd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHeal_SuccessSwapsClient pins D6b/D6c: a heal that re-ensures a fresh daemon
+// and re-registers succeeds, swaps in the fresh client (so a later deregister
+// uses it), resets the failure counter, and reports heal_state healthy. It stands
+// in for the "kill-fake-daemon -> heal re-registers" path with the ensure step
+// stubbed and the register exercised end-to-end over a real Unix socket.
+func TestHeal_SuccessSwapsClient(t *testing.T) {
+	var registerCalls int32
+	sock := startFakeRegisterDaemon(t, func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&registerCalls, 1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(proxyd.RegisterResponse{Registered: []string{"api.local.dev"}})
+	})
+	fresh := proxyd.NewClient(sock)
+
+	rt := newProxyRuntime()
+	rt.SetMode(proxyModeShared)
+	rt.SetRegisterRequest(proxyd.RegisterRequest{ProjectDir: "/p", PID: os.Getpid(), Version: "test"})
+	// Pre-load some failures so the reset is observable.
+	rt.ForwarderConnectFailed(errors.New("down"))
+	rt.ForwarderConnectFailed(errors.New("down"))
+
+	ops := healOps{
+		ensureRunning: func() (*proxyd.Client, error) { return fresh, nil },
+		sleep:         func(time.Duration) {},
+		retryDelay:    time.Millisecond,
+	}
+
+	ok := rt.heal(ops)
+	require.True(t, ok, "heal must succeed against a daemon that accepts register")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&registerCalls), "heal must re-register exactly once")
+	assert.Same(t, fresh, rt.Client(), "heal must swap in the fresh client for deregister (D6c)")
+	assert.Equal(t, int64(0), rt.consecutiveFailures.Load(), "heal must reset the failure counter")
+	assert.Equal(t, healStateHealthy, rt.getHealState())
+}
+
+// TestHeal_VersionMismatchKeepsWaiting pins D6b: EnsureRunning reporting a busy
+// different-version daemon must NOT restart it; heal returns false and sets
+// heal_state version_mismatch, leaving the client unchanged. The status block
+// surfaces version_mismatch while the daemon is unreachable.
+func TestHeal_VersionMismatchKeepsWaiting(t *testing.T) {
+	rt := newProxyRuntime()
+	rt.SetMode(proxyModeShared)
+	rt.SetRegisterRequest(proxyd.RegisterRequest{ProjectDir: "/p", PID: os.Getpid()})
+
+	ops := healOps{
+		ensureRunning: func() (*proxyd.Client, error) {
+			return nil, &proxyd.VersionMismatchError{DaemonVersion: "0.1.2", ClientVersion: "0.2.0"}
+		},
+		sleep:      func(time.Duration) {},
+		retryDelay: time.Millisecond,
+	}
+
+	ok := rt.heal(ops)
+	assert.False(t, ok, "heal must not claim success against a busy version-skewed daemon")
+	assert.Equal(t, healStateVersionMismatch, rt.getHealState())
+	assert.Nil(t, rt.Client(), "version-mismatch heal must not swap in a client")
+
+	// Status must surface version_mismatch while the daemon is unreachable.
+	rt.prober = func() (bool, string) { return false, "" }
+	assert.Equal(t, healStateVersionMismatch, rt.ProxyStatus().HealState)
+}
+
+// TestHeal_ShutdownBarrierSeesSwappedClient pins FIX 3: a heal that began before
+// the shutdown latch (blocked mid-Register) completes fully, and the shutdown's
+// client read (clientAfterHealBarrier) blocks on the heal mutex until the swap has
+// landed — so the deregister goes through the HEALED client, never the pre-heal one.
+func TestHeal_ShutdownBarrierSeesSwappedClient(t *testing.T) {
+	release := make(chan struct{})
+	var registerCalls int32
+	sock := startFakeRegisterDaemon(t, func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&registerCalls, 1)
+		<-release // block mid-register until the test releases it
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(proxyd.RegisterResponse{Registered: []string{"api.local.dev"}})
+	})
+	fresh := proxyd.NewClient(sock)
+
+	rt := newProxyRuntime()
+	rt.SetMode(proxyModeShared)
+	rt.SetRegisterRequest(proxyd.RegisterRequest{ProjectDir: "/p", PID: os.Getpid(), Version: "test"})
+
+	ops := healOps{
+		ensureRunning: func() (*proxyd.Client, error) { return fresh, nil },
+		sleep:         func(time.Duration) {},
+		retryDelay:    time.Millisecond,
+	}
+
+	healReturned := make(chan bool, 1)
+	go func() { healReturned <- rt.heal(ops) }()
+
+	// Wait until the heal is blocked inside Register (it holds healMu here).
+	require.Eventually(t, func() bool { return atomic.LoadInt32(&registerCalls) == 1 },
+		2*time.Second, time.Millisecond, "heal never reached the blocking Register")
+
+	// Shutdown latches AFTER the heal has begun (heal already passed its
+	// IsShuttingDown check), then reads the client through the barrier.
+	barrierDone := make(chan *proxyd.Client, 1)
+	go func() {
+		rt.MarkShuttingDown()
+		barrierDone <- rt.clientAfterHealBarrier()
+	}()
+
+	// The barrier must not return while the heal is still swapping the client.
+	select {
+	case <-barrierDone:
+		t.Fatal("shutdown barrier returned before the in-flight heal completed its swap")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// Let the register complete: the heal swaps the client and returns.
+	close(release)
+	assert.True(t, <-healReturned, "a heal begun before the latch must complete and swap the client")
+	got := <-barrierDone
+	assert.Same(t, fresh, got, "shutdown must deregister through the HEALED client (FIX 3)")
+}
+
+// TestHeal_RegisterVersionMismatchKeepsWaiting pins FIX 5: when EnsureRunning
+// connects but the daemon's Register returns 409 VERSION_MISMATCH (a busy
+// different-version daemon re-checking versions at register time), heal reports
+// version_mismatch — like the EnsureRunning VersionMismatchError path — not
+// healing, and does not swap in the client.
+func TestHeal_RegisterVersionMismatchKeepsWaiting(t *testing.T) {
+	sock := startFakeRegisterDaemon(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		_ = json.NewEncoder(w).Encode(proxyd.ErrorResponse{
+			Error: "version mismatch: daemon is 0.1.2, client is 0.2.0",
+			Code:  "VERSION_MISMATCH",
+		})
+	})
+	client := proxyd.NewClient(sock)
+
+	rt := newProxyRuntime()
+	rt.SetMode(proxyModeShared)
+	rt.SetRegisterRequest(proxyd.RegisterRequest{ProjectDir: "/p", PID: os.Getpid(), Version: "0.2.0"})
+
+	ops := healOps{
+		ensureRunning: func() (*proxyd.Client, error) { return client, nil },
+		sleep:         func(time.Duration) {},
+		retryDelay:    time.Millisecond,
+	}
+
+	assert.False(t, rt.heal(ops), "a version-mismatch register must not claim success")
+	assert.Equal(t, healStateVersionMismatch, rt.getHealState())
+	assert.Nil(t, rt.Client(), "a version-mismatch register must not swap in the client")
+}
+
+// TestHeal_SuppressedDuringShutdown pins D6c: once the shutdown latch is set the
+// heal callback no-ops without touching the daemon (never re-register a project
+// that is tearing down).
+func TestHeal_SuppressedDuringShutdown(t *testing.T) {
+	rt := newProxyRuntime()
+	rt.MarkShuttingDown()
+
+	called := false
+	ops := healOps{
+		ensureRunning: func() (*proxyd.Client, error) { called = true; return nil, nil },
+		sleep:         func(time.Duration) {},
+	}
+
+	ok := rt.heal(ops)
+	assert.False(t, ok)
+	assert.False(t, called, "heal must not contact the daemon once shutdown is latched")
+}
+
+// TestHeal_EnsureOrRegisterErrorHealing pins that a transient ensure/register
+// failure (not a version mismatch) leaves heal_state "healing" and returns false
+// so the forwarder keeps retrying.
+func TestHeal_EnsureOrRegisterErrorHealing(t *testing.T) {
+	t.Run("ensure_error", func(t *testing.T) {
+		rt := newProxyRuntime()
+		rt.SetRegisterRequest(proxyd.RegisterRequest{ProjectDir: "/p"})
+		ops := healOps{
+			ensureRunning: func() (*proxyd.Client, error) { return nil, errors.New("connect refused") },
+			sleep:         func(time.Duration) {},
+		}
+		assert.False(t, rt.heal(ops))
+		assert.Equal(t, healStateHealing, rt.getHealState())
+	})
+
+	t.Run("register_error", func(t *testing.T) {
+		rt := newProxyRuntime()
+		rt.SetRegisterRequest(proxyd.RegisterRequest{ProjectDir: "/p"})
+		// A client pointed at a dead socket: register fails.
+		dead := proxyd.NewClient(filepath.Join(t.TempDir(), "nope.sock"))
+		ops := healOps{
+			ensureRunning: func() (*proxyd.Client, error) { return dead, nil },
+			sleep:         func(time.Duration) {},
+		}
+		assert.False(t, rt.heal(ops))
+		assert.Equal(t, healStateHealing, rt.getHealState())
+		assert.Nil(t, rt.Client(), "a failed register must not swap in the client")
+	})
+}
+
+// TestCancelForwarder_NilSafe pins that CancelForwarder is a no-op when no
+// forwarder was launched, and cancels the stored context when one was.
+func TestCancelForwarder_NilSafe(t *testing.T) {
+	rt := newProxyRuntime()
+	rt.CancelForwarder() // no forwarder set: must not panic
+
+	cancelled := false
+	rt.SetForwarderCancel(func() { cancelled = true })
+	rt.CancelForwarder()
+	assert.True(t, cancelled, "CancelForwarder must invoke the stored cancel")
+}

--- a/internal/cli/proxy_runtime_test.go
+++ b/internal/cli/proxy_runtime_test.go
@@ -1,0 +1,157 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/charliek/prox/internal/proxy"
+)
+
+// TestProxyRuntime_ProxyStatus_ProbeUpDown pins D5: the proxy block reports
+// mode, reachability, version, and heal_state driven by the injectable prober.
+func TestProxyRuntime_ProxyStatus_ProbeUpDown(t *testing.T) {
+	t.Run("up", func(t *testing.T) {
+		rt := newProxyRuntime()
+		rt.SetMode(proxyModeShared)
+		rt.prober = func() (bool, string) { return true, "9.9.9" }
+
+		s := rt.ProxyStatus()
+		if s.Mode != proxyModeShared {
+			t.Errorf("Mode = %q, want %q", s.Mode, proxyModeShared)
+		}
+		if !s.DaemonReachable {
+			t.Error("DaemonReachable = false, want true")
+		}
+		if s.DaemonVersion != "9.9.9" {
+			t.Errorf("DaemonVersion = %q, want 9.9.9", s.DaemonVersion)
+		}
+		if s.HealState != "healthy" {
+			t.Errorf("HealState = %q, want healthy", s.HealState)
+		}
+	})
+
+	t.Run("down", func(t *testing.T) {
+		rt := newProxyRuntime()
+		rt.SetMode(proxyModeShared)
+		rt.prober = func() (bool, string) { return false, "" }
+
+		s := rt.ProxyStatus()
+		if s.DaemonReachable {
+			t.Error("DaemonReachable = true, want false")
+		}
+		if s.DaemonVersion != "" {
+			t.Errorf("DaemonVersion = %q, want empty", s.DaemonVersion)
+		}
+		if s.HealState != "" {
+			t.Errorf("HealState = %q, want empty when unreachable", s.HealState)
+		}
+	})
+}
+
+// TestProxyRuntime_ProxyStatus_StandaloneNoProbe pins that standalone/disabled
+// modes report mode only and never invoke the probe (no daemon to reach).
+func TestProxyRuntime_ProxyStatus_StandaloneNoProbe(t *testing.T) {
+	for _, mode := range []string{proxyModeStandalone, proxyModeDisabled} {
+		t.Run(mode, func(t *testing.T) {
+			rt := newProxyRuntime()
+			rt.SetMode(mode)
+			probed := false
+			rt.prober = func() (bool, string) { probed = true; return true, "x" }
+
+			s := rt.ProxyStatus()
+			if s.Mode != mode {
+				t.Errorf("Mode = %q, want %q", s.Mode, mode)
+			}
+			if probed {
+				t.Error("prober invoked in non-shared mode; want no probe")
+			}
+			if s.DaemonReachable {
+				t.Error("DaemonReachable = true in non-shared mode")
+			}
+		})
+	}
+}
+
+// TestProxyRuntime_ProbeCacheTTL pins D5: a second status within the TTL reuses
+// the cached probe result rather than re-probing; past the TTL it re-probes.
+func TestProxyRuntime_ProbeCacheTTL(t *testing.T) {
+	rt := newProxyRuntime()
+	rt.SetMode(proxyModeShared)
+
+	calls := 0
+	rt.prober = func() (bool, string) { calls++; return true, "v" }
+
+	base := time.Now()
+	cur := base
+	rt.now = func() time.Time { return cur }
+
+	rt.ProxyStatus() // first call probes
+	rt.ProxyStatus() // within TTL: cached
+	if calls != 1 {
+		t.Fatalf("prober calls = %d after two calls within TTL, want 1 (cache hit)", calls)
+	}
+
+	cur = base.Add(rt.probeTTL + time.Millisecond) // advance past TTL
+	rt.ProxyStatus()
+	if calls != 2 {
+		t.Fatalf("prober calls = %d after advancing past TTL, want 2 (re-probe)", calls)
+	}
+}
+
+// TestProxyRuntime_ForwarderStateTransitions pins D5: as the forwarder status
+// sink, N failures raise consecutive_failures to N with no connect time, and a
+// subsequent connect resets the counter and stamps last_connected_at.
+func TestProxyRuntime_ForwarderStateTransitions(t *testing.T) {
+	rt := newProxyRuntime()
+
+	const n = 3
+	for i := 0; i < n; i++ {
+		rt.ForwarderConnectFailed(errors.New("boom"))
+	}
+	if got := rt.consecutiveFailures.Load(); got != n {
+		t.Errorf("consecutiveFailures = %d, want %d", got, n)
+	}
+	if got := rt.lastConnectedAt.Load(); got != 0 {
+		t.Errorf("lastConnectedAt = %d, want 0 before any connect", got)
+	}
+
+	rt.ForwarderConnected()
+	if got := rt.consecutiveFailures.Load(); got != 0 {
+		t.Errorf("consecutiveFailures = %d after connect, want 0 (reset)", got)
+	}
+	if got := rt.lastConnectedAt.Load(); got == 0 {
+		t.Error("lastConnectedAt = 0 after connect, want set")
+	}
+
+	// Backfill failures accumulate independently.
+	rt.ForwarderBackfillFailed()
+	rt.ForwarderBackfillFailed()
+	if got := rt.backfillFailures.Load(); got != 2 {
+		t.Errorf("backfillFailures = %d, want 2", got)
+	}
+}
+
+// TestProxyRuntime_DroppedEventsFromLocalManager pins that the proxy block's
+// dropped_events reflects the project's local forwarding request manager (D9).
+func TestProxyRuntime_DroppedEventsFromLocalManager(t *testing.T) {
+	rt := newProxyRuntime()
+	rt.SetMode(proxyModeStandalone) // avoid the shared-mode probe
+
+	rm := proxy.NewRequestManager(1000)
+	sub := rm.Subscribe(proxy.RequestFilter{}) // unread channel
+	_ = sub
+	for i := 0; i < 150; i++ {
+		rm.Record(proxy.RequestRecord{ID: fmt.Sprintf("r%03d", i), Method: "GET", URL: "/x"})
+	}
+	rt.SetLocalRequestManager(rm)
+
+	s := rt.ProxyStatus()
+	if s.DroppedEvents <= 0 {
+		t.Errorf("DroppedEvents = %d, want > 0 (mirrors local manager)", s.DroppedEvents)
+	}
+	if s.DroppedEvents != rm.DroppedEvents() {
+		t.Errorf("DroppedEvents = %d, want %d (local manager total)", s.DroppedEvents, rm.DroppedEvents())
+	}
+}

--- a/internal/cli/register_retry.go
+++ b/internal/cli/register_retry.go
@@ -1,0 +1,93 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/charliek/prox/internal/constants"
+	"github.com/charliek/prox/internal/proxyd"
+)
+
+// registerRetryOps bundles the injectable operations the SHUTTING_DOWN
+// register retry (D4) needs, mirroring skewOps (version_skew.go) so
+// retryRegisterAfterShutdown can be unit-tested against a fake daemon without
+// real sockets or wall-clock waits. defaultRegisterRetryOps wires the
+// production implementations.
+type registerRetryOps struct {
+	// healthAnswers reports whether the (old, shutting-down) daemon's socket
+	// still answers /health.
+	healthAnswers func() bool
+	// ensureRunning starts/connects a fresh daemon of this process's version.
+	ensureRunning func() (*proxyd.Client, error)
+
+	sleep func(time.Duration)
+	now   func() time.Time
+
+	drainTimeout time.Duration // max wait for the old socket to stop answering
+	drainPoll    time.Duration // interval between /health drain probes
+	retryDelay   time.Duration // pause before the one EnsureRunning retry
+}
+
+// defaultRegisterRetryOps wires registerRetryOps to the real daemon over its
+// Unix socket, with the production timings from D4 (§3): a 10s bound on the
+// /health drain poll at a 200ms interval, matching the daemon's 5s
+// empty-shutdown grace with headroom.
+func defaultRegisterRetryOps() registerRetryOps {
+	probeClient := proxyd.NewClient(proxyd.SocketPath())
+	return registerRetryOps{
+		healthAnswers: func() bool {
+			ctx, cancel := context.WithTimeout(context.Background(), constants.DaemonHealthProbeTimeout)
+			defer cancel()
+			_, err := probeClient.HealthWithContext(ctx)
+			return err == nil
+		},
+		ensureRunning: proxyd.EnsureRunning,
+		sleep:         time.Sleep,
+		now:           time.Now,
+		drainTimeout:  10 * time.Second,
+		drainPoll:     200 * time.Millisecond,
+		retryDelay:    1 * time.Second,
+	}
+}
+
+// isShuttingDownError reports whether err is the daemon's SHUTTING_DOWN
+// register response (503, ErrorResponse.Code == "SHUTTING_DOWN"): the
+// register queued behind the daemon's graceful-shutdown decision
+// (server.go's isShuttingDown check) rather than a genuine failure.
+func isShuttingDownError(err error) bool {
+	var apiErr *proxyd.DaemonAPIError
+	return errors.As(err, &apiErr) && apiErr.Code == "SHUTTING_DOWN"
+}
+
+// retryRegisterAfterShutdown implements D4: when Register fails with the
+// daemon's SHUTTING_DOWN code, the daemon is mid graceful-shutdown (its 5s
+// empty-shutdown grace — server.go), not genuinely refusing the project. It
+// polls until the old daemon's socket stops answering /health (bounded by
+// ops.drainTimeout), starts a fresh daemon of this version — reusing
+// ensureRunningWithRetry, the same one-retry-on-ErrDaemonNotReady guard the
+// version-skew heal path uses for the identical socket-removed-before-PID-
+// lock-released window — and re-registers once against it.
+//
+// A second SHUTTING_DOWN or any other error from either the restart or the
+// re-register is returned as-is: the caller treats it as fatal exactly as an
+// unrecovered register failure is today (one retry layer only).
+func retryRegisterAfterShutdown(req proxyd.RegisterRequest, ops registerRetryOps) (*proxyd.Client, *proxyd.RegisterResponse, error) {
+	if !waitForDrain(ops.healthAnswers, ops.sleep, ops.now, ops.drainTimeout, ops.drainPoll) {
+		return nil, nil, fmt.Errorf("proxy daemon is shutting down and did not finish within %s", ops.drainTimeout)
+	}
+
+	client, err := ensureRunningWithRetry(ops.ensureRunning, ops.sleep, ops.retryDelay)
+	if err != nil {
+		return nil, nil, fmt.Errorf("starting fresh proxy daemon after shutdown: %w", err)
+	}
+
+	resp, err := client.Register(req)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	fmt.Println("proxy daemon was shutting down; started a fresh one")
+	return client, resp, nil
+}

--- a/internal/cli/register_retry.go
+++ b/internal/cli/register_retry.go
@@ -61,6 +61,17 @@ func isShuttingDownError(err error) bool {
 	return errors.As(err, &apiErr) && apiErr.Code == "SHUTTING_DOWN"
 }
 
+// isVersionMismatchError reports whether err is the daemon's VERSION_MISMATCH
+// register response (409, ErrorResponse.Code == "VERSION_MISMATCH"): a busy
+// different-version daemon holds the ports and re-checked versions at register
+// time. Mirrors isShuttingDownError; the heal path (D6b) uses it to set
+// heal_state version_mismatch rather than healing (FIX 5), matching the
+// EnsureRunning VersionMismatchError treatment.
+func isVersionMismatchError(err error) bool {
+	var apiErr *proxyd.DaemonAPIError
+	return errors.As(err, &apiErr) && apiErr.Code == "VERSION_MISMATCH"
+}
+
 // retryRegisterAfterShutdown implements D4: when Register fails with the
 // daemon's SHUTTING_DOWN code, the daemon is mid graceful-shutdown (its 5s
 // empty-shutdown grace — server.go), not genuinely refusing the project. It

--- a/internal/cli/register_retry_test.go
+++ b/internal/cli/register_retry_test.go
@@ -1,0 +1,231 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/charliek/prox/internal/proxyd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fastRegisterRetryOps returns a registerRetryOps with instant sleeps so tests
+// never pay wall-clock waits, mirroring fastSkewOps (version_skew_test.go).
+// Individual fields are overridden per test.
+func fastRegisterRetryOps() registerRetryOps {
+	return registerRetryOps{
+		sleep:        func(time.Duration) {},
+		now:          time.Now,
+		drainTimeout: 10 * time.Second,
+		drainPoll:    time.Millisecond,
+		retryDelay:   time.Millisecond,
+	}
+}
+
+// startFakeRegisterDaemon starts an HTTP server on a Unix socket serving POST
+// /api/v1/register via registerH, so retryRegisterAfterShutdown's real
+// client.Register call exercises proxyd.Client's actual encode/decode and
+// readError->DaemonAPIError path end-to-end (only the drain probe and the
+// daemon restart are stubbed via registerRetryOps, matching the injectable-ops
+// style in version_skew_test.go).
+func startFakeRegisterDaemon(t *testing.T, registerH http.HandlerFunc) string {
+	t.Helper()
+
+	// Short temp dir: a unix socket path must fit the platform's sun_path
+	// limit (~104 bytes on macOS), which t.TempDir() can overflow.
+	tmpDir, err := os.MkdirTemp("/tmp", "prox-rr-")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(tmpDir) })
+	sockPath := filepath.Join(tmpDir, "d.sock")
+
+	ln, err := net.Listen("unix", sockPath)
+	require.NoError(t, err)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/register", registerH)
+	srv := &http.Server{Handler: mux}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+	return sockPath
+}
+
+// writeDaemonError writes the daemon's ErrorResponse JSON shape (server.go),
+// so the client-side decode exercises the real readError path.
+func writeDaemonError(w http.ResponseWriter, status int, code, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(proxyd.ErrorResponse{Error: message, Code: code})
+}
+
+func shuttingDownHandler(w http.ResponseWriter, _ *http.Request) {
+	writeDaemonError(w, http.StatusServiceUnavailable, "SHUTTING_DOWN", "daemon is shutting down; retry to start a fresh daemon")
+}
+
+func registerConflictHandler(w http.ResponseWriter, _ *http.Request) {
+	writeDaemonError(w, http.StatusConflict, "REGISTRATION_CONFLICT", "project already registered")
+}
+
+func registerSuccessHandler(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(proxyd.RegisterResponse{Registered: []string{"a.local.dev"}})
+}
+
+// TestRetryRegisterAfterShutdown_RecoversAfterDrain pins D4's happy path: the
+// old daemon's socket answers /health once more (still draining), then stops
+// answering; a fresh daemon starts and the re-register succeeds.
+func TestRetryRegisterAfterShutdown_RecoversAfterDrain(t *testing.T) {
+	freshSock := startFakeRegisterDaemon(t, registerSuccessHandler)
+
+	ops := fastRegisterRetryOps()
+	healthCalls := 0
+	ops.healthAnswers = func() bool {
+		healthCalls++
+		return healthCalls == 1 // answers once (still draining), then gone
+	}
+	ensureCalls := 0
+	ops.ensureRunning = func() (*proxyd.Client, error) {
+		ensureCalls++
+		return proxyd.NewClient(freshSock), nil
+	}
+
+	req := proxyd.RegisterRequest{ProjectDir: "/projects/a", PID: os.Getpid(), Version: "test"}
+	client, resp, err := retryRegisterAfterShutdown(req, ops)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	require.NotNil(t, resp)
+	assert.Equal(t, []string{"a.local.dev"}, resp.Registered)
+	assert.Equal(t, 1, ensureCalls, "one EnsureRunning is enough when the first start succeeds")
+	assert.GreaterOrEqual(t, healthCalls, 2, "must poll until the old daemon's /health stops answering")
+}
+
+// TestRetryRegisterAfterShutdown_DoubleShuttingDownFatal pins that a second
+// SHUTTING_DOWN from the fresh daemon's register is returned as-is — the
+// caller (tryDaemonProxy) treats it as fatal, same as any other unrecovered
+// register error, with only one retry layer.
+func TestRetryRegisterAfterShutdown_DoubleShuttingDownFatal(t *testing.T) {
+	freshSock := startFakeRegisterDaemon(t, shuttingDownHandler)
+
+	ops := fastRegisterRetryOps()
+	ops.healthAnswers = func() bool { return false } // old daemon already gone
+	ops.ensureRunning = func() (*proxyd.Client, error) {
+		return proxyd.NewClient(freshSock), nil
+	}
+
+	req := proxyd.RegisterRequest{ProjectDir: "/projects/a", PID: os.Getpid(), Version: "test"}
+	client, resp, err := retryRegisterAfterShutdown(req, ops)
+	require.Error(t, err)
+	assert.Nil(t, client)
+	assert.Nil(t, resp)
+	assert.True(t, isShuttingDownError(err),
+		"a second SHUTTING_DOWN is still identifiable by code, even though the caller no longer retries it")
+}
+
+// TestRetryRegisterAfterShutdown_DrainTimeoutFatal pins that a socket which
+// keeps answering /health past the drain deadline is treated as still busy
+// (never force-restarted) — fatal, mirroring the version-skew slow-drain path.
+func TestRetryRegisterAfterShutdown_DrainTimeoutFatal(t *testing.T) {
+	ops := fastRegisterRetryOps()
+	ops.drainTimeout = 0 // deadline already passed -> single probe, then give up
+	ops.healthAnswers = func() bool { return true }
+	ops.ensureRunning = func() (*proxyd.Client, error) {
+		t.Fatal("must not start over a still-draining daemon")
+		return nil, nil
+	}
+
+	req := proxyd.RegisterRequest{ProjectDir: "/projects/a", PID: os.Getpid(), Version: "test"}
+	client, resp, err := retryRegisterAfterShutdown(req, ops)
+	require.Error(t, err)
+	assert.Nil(t, client)
+	assert.Nil(t, resp)
+}
+
+// TestIsShuttingDownError pins the routing decision in tryDaemonProxy: only a
+// *proxyd.DaemonAPIError with Code "SHUTTING_DOWN" triggers the D4 retry.
+// Every other register error — a different daemon error code, a wrapped plain
+// error, or a connection failure — must fall straight through to the existing
+// fatal path unchanged (no retry, no fresh daemon, no re-register).
+func TestIsShuttingDownError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"shutting down code", &proxyd.DaemonAPIError{Code: "SHUTTING_DOWN", Message: "shutting down"}, true},
+		{"wrapped shutting down code", fmt.Errorf("register: %w", &proxyd.DaemonAPIError{Code: "SHUTTING_DOWN"}), true},
+		{"other daemon code", &proxyd.DaemonAPIError{Code: "REGISTRATION_CONFLICT", Message: "conflict"}, false},
+		{"plain error", errors.New("connection refused"), false},
+		{"nil", nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isShuttingDownError(tt.err))
+		})
+	}
+}
+
+// TestRetryRegisterAfterShutdown_NonShuttingDownRegisterErrorUnchanged pins
+// that when the re-register (against the fresh daemon) fails with a
+// non-SHUTTING_DOWN error, retryRegisterAfterShutdown surfaces it unchanged —
+// the caller's fatal path is identical to today's unrecovered register
+// failure (same error, no special-casing).
+func TestRetryRegisterAfterShutdown_NonShuttingDownRegisterErrorUnchanged(t *testing.T) {
+	freshSock := startFakeRegisterDaemon(t, registerConflictHandler)
+
+	ops := fastRegisterRetryOps()
+	ops.healthAnswers = func() bool { return false }
+	ops.ensureRunning = func() (*proxyd.Client, error) {
+		return proxyd.NewClient(freshSock), nil
+	}
+
+	req := proxyd.RegisterRequest{ProjectDir: "/projects/a", PID: os.Getpid(), Version: "test"}
+	client, resp, err := retryRegisterAfterShutdown(req, ops)
+	require.Error(t, err)
+	assert.Nil(t, client)
+	assert.Nil(t, resp)
+	assert.False(t, isShuttingDownError(err))
+
+	var apiErr *proxyd.DaemonAPIError
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, "REGISTRATION_CONFLICT", apiErr.Code)
+}
+
+// TestRetryRegisterAfterShutdown_TransientHealthMissNotDrain pins the
+// two-consecutive-miss drain confirmation (codex C2 review): a single
+// transient /health miss on a still-draining daemon must not be read as
+// "drained" — the poll keeps waiting through the flap and only confirms
+// after two consecutive misses, so the one re-register attempt is not
+// burned against the still-live old daemon.
+func TestRetryRegisterAfterShutdown_TransientHealthMissNotDrain(t *testing.T) {
+	freshSock := startFakeRegisterDaemon(t, registerSuccessHandler)
+
+	ops := fastRegisterRetryOps()
+	// answers, transient miss, answers again (still draining), then gone.
+	sequence := []bool{true, false, true, false, false}
+	healthCalls := 0
+	ops.healthAnswers = func() bool {
+		if healthCalls < len(sequence) {
+			healthCalls++
+			return sequence[healthCalls-1]
+		}
+		return false
+	}
+	ops.ensureRunning = func() (*proxyd.Client, error) {
+		require.GreaterOrEqual(t, healthCalls, len(sequence),
+			"a fresh daemon must not start until the drain is confirmed by two consecutive misses")
+		return proxyd.NewClient(freshSock), nil
+	}
+
+	req := proxyd.RegisterRequest{ProjectDir: "/projects/a", PID: os.Getpid(), Version: "test"}
+	client, resp, err := retryRegisterAfterShutdown(req, ops)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	require.NotNil(t, resp)
+	assert.Equal(t, len(sequence), healthCalls)
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -33,20 +33,49 @@ processes for local development. It supports:
   - HTTPS reverse proxy with subdomain routing
   - Interactive TUI for monitoring
   - Background daemon mode`,
-	Version:       version.Version,
-	SilenceUsage:  true,
-	SilenceErrors: true,
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		// Check if --addr was explicitly provided
-		if cmd.Flags().Changed("addr") {
-			apiAddrExplicitlySet = true
-		}
+	Version:           version.Version,
+	SilenceUsage:      true,
+	SilenceErrors:     true,
+	PersistentPreRunE: rootPersistentPreRunE,
+}
 
-		// For client commands, try to discover API address if not explicitly set
-		if clientCommands[cmd.Name()] && !apiAddrExplicitlySet {
-			apiAddr = discoverAPIAddress()
+// rootPersistentPreRunE resolves apiAddr before any command runs. It is a
+// standalone function (rather than an inline closure) so tests can drive it
+// directly against a synthetic *cobra.Command without going through the full
+// rootCmd tree.
+//
+// An explicit --addr (cmd.Flags().Changed("addr")) always wins and skips
+// discovery, including the discovery error below. For commands in the
+// clientCommands allowlist, a discovery failure is returned as an error —
+// there is no silent fallback to constants.DefaultAPIAddress (D3). Commands
+// outside the allowlist (version, up, proxy, completion, __complete, help)
+// never call discoverAPIAddress and so are unaffected by missing state.
+func rootPersistentPreRunE(cmd *cobra.Command, args []string) error {
+	// Check if --addr was explicitly provided
+	if cmd.Flags().Changed("addr") {
+		apiAddrExplicitlySet = true
+	}
+
+	// For client commands, try to discover API address if not explicitly set.
+	if needsAPIDiscovery(cmd) && !apiAddrExplicitlySet {
+		addr, err := discoverAPIAddress()
+		if err != nil {
+			return err
 		}
-	},
+		apiAddr = addr
+	}
+	return nil
+}
+
+// needsAPIDiscovery reports whether cmd is a TOP-LEVEL client command that
+// talks to the project daemon API via apiAddr. The allowlist is matched by
+// name AND parent: nested subcommands can share a name with a top-level
+// client command (`prox proxy status`/`prox proxy stop` vs `prox status`/
+// `prox stop`) but talk to the proxy daemon's Unix socket, not apiAddr —
+// matching on bare cmd.Name() would wrongly demand (and now fail) discovery
+// for them outside a project directory.
+func needsAPIDiscovery(cmd *cobra.Command) bool {
+	return clientCommands[cmd.Name()] && cmd.Parent() == cmd.Root()
 }
 
 // clientCommands is the discovery allowlist: the commands that talk to the
@@ -97,7 +126,7 @@ var versionCmd = &cobra.Command{
 func init() {
 	// Persistent flags available to all subcommands
 	rootCmd.PersistentFlags().StringVarP(&configPath, "config", "c", constants.DefaultConfigFile, "Config file")
-	rootCmd.PersistentFlags().StringVar(&apiAddr, "addr", constants.DefaultAPIAddress, "API address for remote commands")
+	rootCmd.PersistentFlags().StringVar(&apiAddr, "addr", constants.DefaultAPIAddress, "API address for remote commands (used only when passed explicitly; otherwise discovered from .prox/prox.state or the config file)")
 	rootCmd.PersistentFlags().BoolVarP(&detach, "detach", "d", false, "Run in background (daemon mode)")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose output")
 
@@ -128,28 +157,38 @@ func loadAPIAddrFromConfig() string {
 	return fmt.Sprintf("http://%s:%d", host, port)
 }
 
+// errNoRunningInstance is returned by discoverAPIAddress when neither the
+// state file nor the config file yields an API address and the caller did
+// not pass --addr explicitly. There is deliberately no silent fallback to
+// constants.DefaultAPIAddress here (see D3 in the hardening plan): dialing
+// the compiled-in :5555 default against a dynamic-port daemon silently talks
+// to nothing, or worse, to an unrelated daemon.
+var errNoRunningInstance = fmt.Errorf(
+	"no running prox instance found in this directory (no .prox/prox.state); run from the project directory, or pass --addr",
+)
+
 // discoverAPIAddress attempts to discover the API address.
 // Priority:
 // 1. State file (.prox/prox.state) - for running instances
-// 2. Config file (prox.yaml) - for configured port
-// 3. Default address
-func discoverAPIAddress() string {
+// 2. Config file (prox.yaml) - for a configured (non-dynamic) port
+// It returns an error if neither source yields an address; callers must not
+// fall back to constants.DefaultAPIAddress implicitly.
+func discoverAPIAddress() (string, error) {
 	// First, try to load from state file
 	cwd, err := os.Getwd()
 	if err == nil {
 		state, err := daemon.LoadState(cwd)
 		if err == nil {
-			return fmt.Sprintf("http://%s:%d", state.Host, state.Port)
+			return fmt.Sprintf("http://%s:%d", state.Host, state.Port), nil
 		}
 	}
 
 	// Fall back to config file
 	if addr := loadAPIAddrFromConfig(); addr != "" {
-		return addr
+		return addr, nil
 	}
 
-	// Fall back to default
-	return constants.DefaultAPIAddress
+	return "", errNoRunningInstance
 }
 
 // getProcessNames returns process names from config for shell completion

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -52,10 +52,11 @@ processes for local development. It supports:
 // outside the allowlist (version, up, proxy, completion, __complete, help)
 // never call discoverAPIAddress and so are unaffected by missing state.
 func rootPersistentPreRunE(cmd *cobra.Command, args []string) error {
-	// Check if --addr was explicitly provided
-	if cmd.Flags().Changed("addr") {
-		apiAddrExplicitlySet = true
-	}
+	// Recompute (assign, don't just latch) on every invocation: the global is
+	// also read by commands.go, and a stale true from a prior in-process
+	// invocation (tests drive the hook repeatedly) would permanently suppress
+	// discovery and its error (CodeRabbit PR #68).
+	apiAddrExplicitlySet = cmd.Flags().Changed("addr")
 
 	// For client commands, try to discover API address if not explicitly set.
 	if needsAPIDiscovery(cmd) && !apiAddrExplicitlySet {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -30,7 +30,8 @@ var rootCmd = &cobra.Command{
 processes for local development. It supports:
   - Process supervision with automatic restarts
   - Real-time log aggregation and filtering
-  - HTTPS reverse proxy with subdomain routing
+  - HTTP/HTTPS reverse proxy with hostname routing, shared across projects
+  - Proxied request inspection (prox requests) with captured bodies
   - Interactive TUI for monitoring
   - Background daemon mode`,
 	Version:           version.Version,

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -3,7 +3,12 @@ package cli
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/charliek/prox/internal/daemon"
+	"github.com/spf13/cobra"
 )
 
 func TestLoadAPIAddrFromConfig(t *testing.T) {
@@ -141,7 +146,17 @@ processes:
 // silently talks to the :5555 default and breaks against dynamic-port daemons.
 // 'start' (#41) and 'requests' (#43) both shipped with exactly that gap; when
 // adding a new client command, add it to clientCommands AND to this list.
+//
+// D3 changed *what* happens for allowlisted commands when discovery fails
+// (they now return an error instead of falling back to :5555 silently), but
+// not *which* commands are allowlisted, so the allowlist itself is unchanged
+// here. The PersistentPreRunE assertion below pins that the error-returning
+// hook is actually wired up, since that's the mechanism the D3 error path
+// depends on.
 func TestClientCommandsDiscoveryAllowlist(t *testing.T) {
+	if rootCmd.PersistentPreRunE == nil {
+		t.Fatal("rootCmd.PersistentPreRunE must be set so discovery errors (D3) can propagate; a plain PersistentPreRun cannot return an error")
+	}
 	// The enumerated apiAddr-consuming commands. downCmd reuses runStop, and
 	// attachCmd honors apiAddr when explicitly set, so both belong here.
 	apiAddrCommands := []string{
@@ -176,5 +191,227 @@ func TestClientCommandsDiscoveryAllowlist(t *testing.T) {
 	if len(clientCommands) != len(apiAddrCommands) {
 		t.Errorf("clientCommands has %d entries but %d apiAddr-consuming commands are enumerated here; keep the allowlist and this test in sync",
 			len(clientCommands), len(apiAddrCommands))
+	}
+}
+
+// withTempCwd chdirs into a fresh temp directory for the duration of the
+// test (so os.Getwd()-based discovery sees no .prox/prox.state) and restores
+// the original working directory on cleanup.
+func withTempCwd(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	oldDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(oldDir); err != nil {
+			t.Fatalf("restoring cwd: %v", err)
+		}
+	})
+	return dir
+}
+
+// TestDiscoverAPIAddress_NoStateNoConfig pins the D3 breaking change: when
+// neither .prox/prox.state nor the config file yields an address, discovery
+// must fail loudly (never fall back to the compiled-in :5555 default), and
+// the error must name both the missing state file and the --addr escape
+// hatch so the operator knows how to recover.
+func TestDiscoverAPIAddress_NoStateNoConfig(t *testing.T) {
+	dir := withTempCwd(t)
+
+	originalConfigPath := configPath
+	defer func() { configPath = originalConfigPath }()
+	configPath = filepath.Join(dir, "prox.yaml") // deliberately does not exist
+
+	addr, err := discoverAPIAddress()
+	if err == nil {
+		t.Fatalf("expected discovery error, got addr %q", addr)
+	}
+	if !strings.Contains(err.Error(), ".prox/prox.state") {
+		t.Errorf("error should name .prox/prox.state, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "--addr") {
+		t.Errorf("error should mention --addr as the fix, got: %v", err)
+	}
+}
+
+// TestDiscoverAPIAddress_StateFilePresent pins that state-file discovery is
+// unchanged by the D3 error-return refactor: a valid .prox/prox.state still
+// resolves to the address it records, with no error.
+func TestDiscoverAPIAddress_StateFilePresent(t *testing.T) {
+	dir := withTempCwd(t)
+
+	state := &daemon.State{
+		PID:        os.Getpid(),
+		Port:       54321,
+		Host:       "127.0.0.1",
+		StartedAt:  time.Now(),
+		ConfigFile: "prox.yaml",
+	}
+	if err := state.Write(dir); err != nil {
+		t.Fatalf("writing state: %v", err)
+	}
+
+	addr, err := discoverAPIAddress()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if want := "http://127.0.0.1:54321"; addr != want {
+		t.Errorf("expected %q, got %q", want, addr)
+	}
+}
+
+// TestDiscoverAPIAddress_ConfigFallbackWhenNoState pins that the config-file
+// fallback (used when no state file exists but prox.yaml pins an explicit
+// port) is unchanged by the D3 refactor.
+func TestDiscoverAPIAddress_ConfigFallbackWhenNoState(t *testing.T) {
+	dir := withTempCwd(t)
+
+	originalConfigPath := configPath
+	defer func() { configPath = originalConfigPath }()
+
+	cfgPath := filepath.Join(dir, "prox.yaml")
+	err := os.WriteFile(cfgPath, []byte(`
+api:
+  port: 6001
+  host: 127.0.0.1
+processes:
+  test: echo hello
+`), 0644)
+	if err != nil {
+		t.Fatalf("writing config: %v", err)
+	}
+	configPath = cfgPath
+
+	addr, err := discoverAPIAddress()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if want := "http://127.0.0.1:6001"; addr != want {
+		t.Errorf("expected %q, got %q", want, addr)
+	}
+}
+
+// resetAPIAddrGlobals saves the apiAddr/apiAddrExplicitlySet/configPath
+// package globals and returns a restore func, so rootPersistentPreRunE tests
+// (which mutate them, mirroring production flag-parsing + hook behavior)
+// don't leak state into other tests in this package.
+func resetAPIAddrGlobals(t *testing.T) {
+	t.Helper()
+	originalAddr := apiAddr
+	originalExplicit := apiAddrExplicitlySet
+	originalConfigPath := configPath
+	apiAddrExplicitlySet = false
+	t.Cleanup(func() {
+		apiAddr = originalAddr
+		apiAddrExplicitlySet = originalExplicit
+		configPath = originalConfigPath
+	})
+}
+
+// TestRootPersistentPreRunE_ClientCommandMissingStateReturnsError pins that
+// the PersistentPreRunE hook (not just discoverAPIAddress in isolation)
+// surfaces the D3 discovery error for allowlisted client commands.
+func TestRootPersistentPreRunE_ClientCommandMissingStateReturnsError(t *testing.T) {
+	withTempCwd(t)
+	resetAPIAddrGlobals(t)
+	configPath = "/nonexistent/prox.yaml"
+
+	root := &cobra.Command{Use: "prox"}
+	cmd := &cobra.Command{Use: "status"}
+	root.AddCommand(cmd)
+	var addr string
+	cmd.Flags().StringVar(&addr, "addr", "", "unused in this test")
+
+	err := rootPersistentPreRunE(cmd, nil)
+	if err == nil {
+		t.Fatal("expected discovery error for a client command with no state, no config, and no --addr")
+	}
+	if !strings.Contains(err.Error(), ".prox/prox.state") || !strings.Contains(err.Error(), "--addr") {
+		t.Errorf("error should name .prox/prox.state and --addr, got: %v", err)
+	}
+}
+
+// TestRootPersistentPreRunE_ExplicitAddrBypassesDiscoveryError pins that an
+// explicitly-passed --addr always wins, even with no state and no config: no
+// discovery is attempted and no error is returned.
+func TestRootPersistentPreRunE_ExplicitAddrBypassesDiscoveryError(t *testing.T) {
+	withTempCwd(t)
+	resetAPIAddrGlobals(t)
+	configPath = "/nonexistent/prox.yaml"
+
+	root := &cobra.Command{Use: "prox"}
+	cmd := &cobra.Command{Use: "status"}
+	root.AddCommand(cmd)
+	// Bind to the real apiAddr global, mirroring how
+	// rootCmd.PersistentFlags().StringVar(&apiAddr, "addr", ...) wires the
+	// production flag: pflag's Set (which cobra's real flag parsing calls)
+	// writes straight through to apiAddr before the hook runs.
+	cmd.Flags().StringVar(&apiAddr, "addr", "", "unused in this test")
+	if err := cmd.Flags().Set("addr", "http://127.0.0.1:9999"); err != nil {
+		t.Fatalf("setting --addr: %v", err)
+	}
+
+	if err := rootPersistentPreRunE(cmd, nil); err != nil {
+		t.Fatalf("explicit --addr must bypass discovery entirely, got error: %v", err)
+	}
+	if !apiAddrExplicitlySet {
+		t.Error("expected apiAddrExplicitlySet to be true after --addr was Changed")
+	}
+	if want := "http://127.0.0.1:9999"; apiAddr != want {
+		t.Errorf("expected apiAddr to remain the explicitly-set value %q, got %q", want, apiAddr)
+	}
+}
+
+// TestRootPersistentPreRunE_NonClientCommandUnaffectedByMissingState pins
+// that commands outside the clientCommands allowlist (version, up, proxy,
+// completion, __complete, help) never attempt discovery and so are
+// unaffected by missing .prox/prox.state.
+func TestRootPersistentPreRunE_NonClientCommandUnaffectedByMissingState(t *testing.T) {
+	withTempCwd(t)
+	resetAPIAddrGlobals(t)
+	configPath = "/nonexistent/prox.yaml"
+
+	cmd := &cobra.Command{Use: "version"}
+	var addr string
+	cmd.Flags().StringVar(&addr, "addr", "", "unused in this test")
+
+	if err := rootPersistentPreRunE(cmd, nil); err != nil {
+		t.Fatalf("non-client command must not be affected by missing state, got error: %v", err)
+	}
+}
+
+// TestNeedsAPIDiscovery_RealCommandTree pins the allowlist match against the
+// REAL rootCmd tree (codex C4 review): top-level client commands need
+// discovery; nested proxy subcommands that share a name with them
+// (`prox proxy status`, `prox proxy stop`) talk to the proxy daemon's Unix
+// socket and must NOT — bare cmd.Name() matching would wrongly demand (and,
+// post-D3, fail) discovery for them outside a project directory.
+func TestNeedsAPIDiscovery_RealCommandTree(t *testing.T) {
+	cases := []struct {
+		path []string
+		want bool
+	}{
+		{[]string{"status"}, true},
+		{[]string{"stop"}, true},
+		{[]string{"requests"}, true},
+		{[]string{"proxy", "status"}, false},
+		{[]string{"proxy", "stop"}, false},
+		{[]string{"proxy", "routes"}, false},
+		{[]string{"version"}, false},
+		{[]string{"up"}, false},
+	}
+	for _, tc := range cases {
+		cmd, _, err := rootCmd.Find(tc.path)
+		if err != nil {
+			t.Fatalf("Find(%v): %v", tc.path, err)
+		}
+		if got := needsAPIDiscovery(cmd); got != tc.want {
+			t.Errorf("needsAPIDiscovery(%v) = %v, want %v", tc.path, got, tc.want)
+		}
 	}
 }

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -818,6 +818,24 @@ func proxyStartError(err error) error {
 	return fmt.Errorf("proxy failed to start: %w\n\nTo start without the proxy:\n  prox up --no-proxy", err)
 }
 
+// captureMaxBodySize resolves the project's configured capture cap to bytes for
+// the register wire (D13, #49). It parses cfg.Proxy.Capture.MaxBodySize (e.g.
+// "1MB", "512KB") with the same parser the standalone capture manager uses. An
+// unset or unparseable value yields 0, which the daemon reads as "use the
+// default cap" — a bad string degrades gracefully rather than failing `prox up`.
+func captureMaxBodySize(cfg *config.Config) int64 {
+	if cfg.Proxy.Capture == nil || cfg.Proxy.Capture.MaxBodySize == "" {
+		return 0
+	}
+	n, err := config.ParseSize(cfg.Proxy.Capture.MaxBodySize)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: invalid proxy.capture.max_body_size %q: %v — using the daemon default capture cap\n",
+			cfg.Proxy.Capture.MaxBodySize, err)
+		return 0
+	}
+	return n
+}
+
 // startProxy attempts to register with the shared proxy daemon. If the daemon
 // cannot be reached (e.g., sandboxed environment), it falls back to starting a
 // standalone proxy. Returns the daemon client (if using daemon) and/or the
@@ -898,6 +916,7 @@ func tryDaemonProxy(cfg *config.Config, cwd string, ctx context.Context, handler
 		HTTPPort:       cfg.Proxy.HTTPPort,
 		HTTPSPort:      cfg.Proxy.HTTPSPort,
 		CaptureEnabled: cfg.Proxy.Capture != nil && cfg.Proxy.Capture.Enabled,
+		MaxBodySize:    captureMaxBodySize(cfg),
 		StartTime:      startToken,
 	}
 

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -346,6 +346,14 @@ func runUp(cmd *cobra.Command, args []string) error {
 	// Create API handlers and server. The handlers get the absolute config path
 	// so GET /status reports the same file the reload path re-reads (#33, D3).
 	handlers := api.NewHandlers(sup, logMgr, absConfigPath, coordinator)
+
+	// The proxy runtime is the single source of truth for the proxy path (D5):
+	// it feeds the `prox status` proxy block via the handlers, receives forwarder
+	// connection state, and (C6) holds the client swapped in on heal. Created
+	// here (mode defaults to disabled) and resolved to shared/standalone below.
+	runtime := newProxyRuntime()
+	handlers.SetProxyStatusProvider(runtime)
+
 	apiServer := api.NewServer(api.ServerConfig{
 		Host:        cfg.API.Host,
 		Port:        cfg.API.Port,
@@ -375,7 +383,7 @@ func runUp(cmd *cobra.Command, args []string) error {
 	var daemonClient *proxyd.Client
 	if !noProxy && cfg.Proxy != nil && cfg.Proxy.Enabled {
 		var proxyErr error
-		daemonClient, proxyService, proxyErr = startProxy(cfg, cwd, ctx, handlers)
+		daemonClient, proxyService, proxyErr = startProxy(cfg, cwd, ctx, handlers, runtime)
 		if proxyErr != nil {
 			return proxyErr
 		}
@@ -485,6 +493,7 @@ func runUp(cmd *cobra.Command, args []string) error {
 	// (before the API stage — see performShutdown).
 	outcome := performShutdown(shutdownDeps{
 		sup:          sup,
+		runtime:      runtime,
 		daemonClient: daemonClient,
 		proxyService: proxyService,
 		apiServer:    apiServer,
@@ -534,7 +543,12 @@ func forwardShutdownSignal(ctx context.Context, sigCh <-chan os.Signal, coordina
 // proxy/API/logMgr deps are nil-able so a helper unit test needs no sockets or
 // daemon.
 type shutdownDeps struct {
-	sup          *supervisor.Supervisor
+	sup *supervisor.Supervisor
+	// runtime is the proxy runtime (D5/D6). When set, performShutdown latches its
+	// shutdown flag before deregister and reads the CURRENT daemon client through
+	// it (a C6-healed client, not the one captured at startup). daemonClient is
+	// the legacy fallback used only when runtime is nil (helper unit tests).
+	runtime      *proxyRuntime
 	daemonClient *proxyd.Client
 	proxyService *proxy.Service
 	apiServer    *api.Server
@@ -601,14 +615,24 @@ func performShutdown(deps shutdownDeps) *domain.ProcessStopError {
 		deps.sup.RefuseLaunches()
 	}
 
+	// Latch the shutdown flag BEFORE deregister (D6c) so a C6 heal cannot
+	// re-register the project mid-teardown, and resolve the daemon client through
+	// the runtime so a healed client (not the startup-captured one) is used for
+	// deregister. daemonClient is the fallback for helper tests with no runtime.
+	daemonClient := deps.daemonClient
+	if deps.runtime != nil {
+		deps.runtime.MarkShuttingDown()
+		daemonClient = deps.runtime.Client()
+	}
+
 	// Stage 1a: deregister from the shared proxy daemon. The proxyd client carries
 	// its own 30s HTTP timeout and takes no ctx, so bound it to the stage here:
 	// run it on a goroutine and proceed once the stage deadline passes, leaving the
 	// call to finish or fail in the background (harmless — the daemon is exiting).
-	if deps.daemonClient != nil {
+	if daemonClient != nil {
 		derr := make(chan error, 1) // buffered so an abandoned goroutine never leaks
 		go func() {
-			derr <- deps.daemonClient.Deregister(proxyd.DeregisterRequest{
+			derr <- daemonClient.Deregister(proxyd.DeregisterRequest{
 				ProjectDir: deps.cwd,
 				PID:        os.Getpid(),
 			})
@@ -794,9 +818,9 @@ func proxyStartError(err error) error {
 // cannot be reached (e.g., sandboxed environment), it falls back to starting a
 // standalone proxy. Returns the daemon client (if using daemon) and/or the
 // standalone proxy service (if using fallback).
-func startProxy(cfg *config.Config, cwd string, ctx context.Context, handlers *api.Handlers) (*proxyd.Client, *proxy.Service, error) {
+func startProxy(cfg *config.Config, cwd string, ctx context.Context, handlers *api.Handlers, rt *proxyRuntime) (*proxyd.Client, *proxy.Service, error) {
 	// Try shared daemon first
-	client, ok, fatalErr := tryDaemonProxy(cfg, cwd, ctx, handlers)
+	client, ok, fatalErr := tryDaemonProxy(cfg, cwd, ctx, handlers, rt)
 	if ok {
 		return client, nil, nil
 	}
@@ -813,6 +837,7 @@ func startProxy(cfg *config.Config, cwd string, ctx context.Context, handlers *a
 	if err != nil {
 		return nil, nil, err
 	}
+	rt.SetMode(proxyModeStandalone)
 	return nil, svc, nil
 }
 
@@ -820,7 +845,7 @@ func startProxy(cfg *config.Config, cwd string, ctx context.Context, handlers *a
 // Returns (client, true, nil) on success, (nil, false, nil) when daemon is
 // unavailable (fall back to standalone), (nil, false, error) when daemon is
 // running but registration failed (don't fall back, fail the command).
-func tryDaemonProxy(cfg *config.Config, cwd string, ctx context.Context, handlers *api.Handlers) (*proxyd.Client, bool, error) {
+func tryDaemonProxy(cfg *config.Config, cwd string, ctx context.Context, handlers *api.Handlers, rt *proxyRuntime) (*proxyd.Client, bool, error) {
 	// Check if we can access the daemon directory
 	if err := proxyd.EnsureDaemonDir(); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: %v — running proxy in standalone mode\n", err)
@@ -905,10 +930,17 @@ func tryDaemonProxy(cfg *config.Config, cwd string, ctx context.Context, handler
 	}
 
 	// Create a local RequestManager and start the SSE forwarder to bridge
-	// daemon proxy requests into this project's TUI and API.
+	// daemon proxy requests into this project's TUI and API. The runtime records
+	// the shared mode, the active client, the original register request (C6
+	// re-registers with it), and the local manager (source of the dropped-events
+	// count), and receives forwarder connection state as the status sink (D5).
 	localRM := proxy.NewRequestManager(constants.DefaultProxyRequestBufferSize)
 	handlers.SetRequestManager(localRM)
-	go proxyd.ForwardRequests(ctx, proxyd.SocketPath(), cwd, localRM)
+	rt.SetMode(proxyModeShared)
+	rt.SetClient(client)
+	rt.SetRegisterRequest(req)
+	rt.SetLocalRequestManager(localRM)
+	go proxyd.ForwardRequests(ctx, proxyd.SocketPath(), cwd, localRM, rt)
 
 	return client, true, nil
 }

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -776,7 +776,7 @@ func proxyStartError(err error) error {
 	if errors.As(err, &portErr) {
 		return fmt.Errorf("%w\n\nAnother process is listening on this port. To identify it:\n  lsof -i :%d\n\nTo start without the proxy:\n  prox up --no-proxy", portErr, portErr.Port)
 	}
-	return fmt.Errorf("proxy failed to start: %w", err)
+	return fmt.Errorf("proxy failed to start: %w\n\nTo start without the proxy:\n  prox up --no-proxy", err)
 }
 
 // startProxy attempts to register with the shared proxy daemon. If the daemon
@@ -794,8 +794,15 @@ func startProxy(cfg *config.Config, cwd string, ctx context.Context, handlers *a
 		return nil, nil, fatalErr
 	}
 
-	// Fallback to standalone proxy (daemon unavailable or sandboxed)
-	return nil, startStandaloneProxy(cfg, cwd, ctx, handlers), nil
+	// Fallback to standalone proxy (daemon unavailable or sandboxed). A proxy is
+	// configured, so a create/start failure here is fatal (D1): `prox up` must
+	// never start a project with the proxy silently disabled. --no-proxy is the
+	// escape hatch (named in the returned error).
+	svc, err := startStandaloneProxy(cfg, cwd, ctx, handlers)
+	if err != nil {
+		return nil, nil, err
+	}
+	return nil, svc, nil
 }
 
 // tryDaemonProxy attempts to register with the shared proxy daemon.
@@ -812,8 +819,21 @@ func tryDaemonProxy(cfg *config.Config, cwd string, ctx context.Context, handler
 	// Ensure daemon is running
 	client, err := proxyd.EnsureRunning()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: proxy daemon unavailable: %v — running proxy in standalone mode\n", err)
-		return nil, false, nil
+		var vme *proxyd.VersionMismatchError
+		if !errors.As(err, &vme) {
+			// Connection-refused / no socket (e.g. a sandboxed environment that
+			// legitimately cannot reach the daemon): fall back to standalone.
+			fmt.Fprintf(os.Stderr, "Warning: proxy daemon unavailable: %v — running proxy in standalone mode\n", err)
+			return nil, false, nil
+		}
+		// Version skew: the shared daemon runs a different version. Never fall
+		// back to standalone (its ports are daemon-held, and a silent
+		// proxy-less start is exactly what D1 closes). Recover or fail fatally.
+		healed, ferr := recoverFromVersionSkew(vme, defaultSkewOps())
+		if ferr != nil {
+			return nil, false, ferr
+		}
+		client = healed
 	}
 
 	// Build registration request
@@ -870,8 +890,12 @@ func tryDaemonProxy(cfg *config.Config, cwd string, ctx context.Context, handler
 	return client, true, nil
 }
 
-// startStandaloneProxy creates and starts a standalone proxy (current behavior).
-func startStandaloneProxy(cfg *config.Config, cwd string, ctx context.Context, handlers *api.Handlers) *proxy.Service {
+// startStandaloneProxy creates and starts a standalone proxy. When a proxy is
+// configured, create/start failures are fatal (D1): they return an error so
+// `prox up` exits non-zero rather than continuing with the proxy silently
+// disabled. The returned error carries the proxyStartError hint (port-conflict
+// detail plus the --no-proxy escape hatch).
+func startStandaloneProxy(cfg *config.Config, cwd string, ctx context.Context, handlers *api.Handlers) (*proxy.Service, error) {
 	level := slog.LevelInfo
 	if verbose {
 		level = slog.LevelDebug
@@ -880,12 +904,10 @@ func startStandaloneProxy(cfg *config.Config, cwd string, ctx context.Context, h
 
 	proxyService, err := proxy.NewService(cfg.Proxy, cfg.Services, cfg.Certs, logger, cwd)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: failed to create proxy: %v\n", err)
-		return nil
+		return nil, proxyStartError(err)
 	}
 	if err := proxyService.Start(ctx); err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: %v\n", proxyStartError(err))
-		return nil
+		return nil, proxyStartError(err)
 	}
 
 	var proxyAddrs []string
@@ -901,7 +923,7 @@ func startStandaloneProxy(cfg *config.Config, cwd string, ctx context.Context, h
 	handlers.SetRequestManager(proxyService.RequestManager())
 	handlers.SetCaptureManager(proxyService.CaptureManager())
 
-	return proxyService
+	return proxyService, nil
 }
 
 // localRequestManager returns the RequestManager for use by the TUI.

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -863,7 +863,19 @@ func tryDaemonProxy(cfg *config.Config, cwd string, ctx context.Context, handler
 
 	resp, err := client.Register(req)
 	if err != nil {
-		return nil, false, fmt.Errorf("failed to register with proxy daemon: %w", err)
+		if !isShuttingDownError(err) {
+			return nil, false, fmt.Errorf("failed to register with proxy daemon: %w", err)
+		}
+		// D4: the daemon was mid graceful-shutdown when the register queued
+		// behind it. Wait for it to drain, start a fresh daemon, and
+		// re-register once — a second SHUTTING_DOWN or any other error is
+		// fatal exactly as an unrecovered register failure is today.
+		healedClient, healedResp, rerr := retryRegisterAfterShutdown(req, defaultRegisterRetryOps())
+		if rerr != nil {
+			return nil, false, fmt.Errorf("failed to register with proxy daemon: %w", rerr)
+		}
+		client = healedClient
+		resp = healedResp
 	}
 
 	// Print registered routes

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -88,7 +88,7 @@ func completeProcessNames(cmd *cobra.Command, args []string, toComplete string) 
 	return names, cobra.ShellCompDirectiveNoFileComp
 }
 
-func runUp(cmd *cobra.Command, args []string) error {
+func runUp(cmd *cobra.Command, args []string) (err error) {
 	processes := args
 
 	// Validate mutually exclusive flags
@@ -128,6 +128,16 @@ func runUp(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("failed to setup logging: %w", err)
 		}
 		defer logFile.Close()
+		// Flush a fatal startup error INTO the log before the Close above
+		// runs (defers are LIFO): Execute() prints the returned error to
+		// os.Stderr only after runUp's defers have closed the redirected
+		// log file, so without this the child dies with its reason lost —
+		// the parent's log tail (D2) would show only stale content.
+		defer func() {
+			if err != nil {
+				fmt.Fprintf(logFile, "Error: %v\n", err)
+			}
+		}()
 	}
 
 	// Load config

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -371,6 +371,15 @@ func runUp(cmd *cobra.Command, args []string) (err error) {
 		Token:       token,
 	}, handlers)
 
+	// Bind the API listener BEFORE the supervisor starts any processes: a
+	// bind failure (port taken) must fail the daemon while nothing is running
+	// yet — binding later would leak an already-started supervisor on the
+	// early error return (CodeRabbit PR #68). Serve starts further down.
+	apiListener, err := apiServer.Listen()
+	if err != nil {
+		return err
+	}
+
 	// Set up signal handling
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
@@ -453,14 +462,7 @@ func runUp(cmd *cobra.Command, args []string) (err error) {
 		}
 	}
 
-	// Bind the API listener synchronously: a bind failure (port taken) must
-	// fail the daemon rather than leave it running with no control surface —
-	// and, in detach mode, must surface through the parent's early-death path
-	// instead of letting a stranger on the port answer the readiness probe.
-	apiListener, err := apiServer.Listen()
-	if err != nil {
-		return err
-	}
+	// Serve on the listener bound before supervisor startup (see above).
 	go func() {
 		if err := apiServer.Serve(apiListener); err != nil {
 			// Server closed is expected on shutdown

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -615,14 +615,18 @@ func performShutdown(deps shutdownDeps) *domain.ProcessStopError {
 		deps.sup.RefuseLaunches()
 	}
 
-	// Latch the shutdown flag BEFORE deregister (D6c) so a C6 heal cannot
-	// re-register the project mid-teardown, and resolve the daemon client through
-	// the runtime so a healed client (not the startup-captured one) is used for
-	// deregister. daemonClient is the fallback for helper tests with no runtime.
+	// D6c shutdown ordering. Latch the shutdown flag FIRST so an in-flight or next
+	// heal no-ops, then cancel the forwarder BEFORE deregister so its reconnect
+	// loop cannot fire a heal that re-registers the project mid-teardown. Resolve
+	// the daemon client through clientAfterHealBarrier AFTER both: it blocks on the
+	// heal mutex until any heal that began before the latch has finished swapping
+	// the client, so we deregister through the HEALED client, never the one captured
+	// at startup (FIX 3). daemonClient is the fallback for helper tests with no runtime.
 	daemonClient := deps.daemonClient
 	if deps.runtime != nil {
 		deps.runtime.MarkShuttingDown()
-		daemonClient = deps.runtime.Client()
+		deps.runtime.CancelForwarder()
+		daemonClient = deps.runtime.clientAfterHealBarrier()
 	}
 
 	// Stage 1a: deregister from the shared proxy daemon. The proxyd client carries
@@ -940,7 +944,17 @@ func tryDaemonProxy(cfg *config.Config, cwd string, ctx context.Context, handler
 	rt.SetClient(client)
 	rt.SetRegisterRequest(req)
 	rt.SetLocalRequestManager(localRM)
-	go proxyd.ForwardRequests(ctx, proxyd.SocketPath(), cwd, localRM, rt)
+
+	// Run the forwarder on a context derived from ctx but cancellable on its own,
+	// so performShutdown can stop it BEFORE deregister (D6c) without disturbing the
+	// supervisor (which shares ctx). Its heal callback (D6b) re-ensures and
+	// re-registers against a fresh daemon after a prolonged outage; it no-ops once
+	// shutdown is latched. Deriving from ctx guarantees the forwarder still stops
+	// on any runUp return even if performShutdown never runs.
+	fwdCtx, fwdCancel := context.WithCancel(ctx)
+	rt.SetForwarderCancel(fwdCancel)
+	heal := func() bool { return rt.heal(defaultHealOps()) }
+	go proxyd.ForwardRequests(fwdCtx, proxyd.SocketPath(), cwd, localRM, rt, heal)
 
 	return client, true, nil
 }

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -108,11 +108,15 @@ func runUp(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		// Daemonize - this will re-exec and exit the parent
-		if err := daemon.Daemonize(); err != nil {
+		// Re-exec ourselves detached; the parent no longer blindly exits 0.
+		child, err := daemon.Daemonize()
+		if err != nil {
 			return fmt.Errorf("failed to daemonize: %w", err)
 		}
-		// Parent exits in Daemonize(), this is unreachable for parent
+		// The parent owns wait-and-report (D2): it never runs the supervisor
+		// itself. It returns here — nil (exit 0) once the child is confirmed
+		// ready, or an error (exit 1) on early death / never-ready timeout.
+		return awaitDaemonStartup(&execChild{cmd: child}, cwd, defaultDaemonStartupOps())
 	}
 
 	// If we're the daemon child, set up logging
@@ -431,9 +435,16 @@ func runUp(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Start API server in background
+	// Bind the API listener synchronously: a bind failure (port taken) must
+	// fail the daemon rather than leave it running with no control surface —
+	// and, in detach mode, must surface through the parent's early-death path
+	// instead of letting a stranger on the port answer the readiness probe.
+	apiListener, err := apiServer.Listen()
+	if err != nil {
+		return err
+	}
 	go func() {
-		if err := apiServer.Start(); err != nil {
+		if err := apiServer.Serve(apiListener); err != nil {
 			// Server closed is expected on shutdown
 			if !errors.Is(err, http.ErrServerClosed) {
 				fmt.Fprintf(os.Stderr, "API server error: %v\n", err)

--- a/internal/cli/version_skew.go
+++ b/internal/cli/version_skew.go
@@ -91,22 +91,14 @@ func recoverFromVersionSkew(vme *proxyd.VersionMismatchError, ops skewOps) (*pro
 	// Poll until the old daemon's socket stops answering /health (bounded). Never
 	// force-kill a still-draining daemon: if it still answers at the deadline,
 	// treat it as busy and fail.
-	deadline := ops.now().Add(ops.drainTimeout)
-	for ops.healthAnswers() {
-		if !ops.now().Before(deadline) {
-			return nil, versionSkewFatalError(vme, status.Routes)
-		}
-		ops.sleep(ops.drainPoll)
+	if !waitForDrain(ops.healthAnswers, ops.sleep, ops.now, ops.drainTimeout, ops.drainPoll) {
+		return nil, versionSkewFatalError(vme, status.Routes)
 	}
 
 	// Start a fresh daemon of this version. The old daemon removes its socket
 	// before its deferred PID-lock release, so the first start can lose the race
 	// and report not-ready; retry once after a short delay (ErrDaemonNotReady).
-	client, err := ops.ensureRunning()
-	if err != nil && errors.Is(err, proxyd.ErrDaemonNotReady) {
-		ops.sleep(ops.retryDelay)
-		client, err = ops.ensureRunning()
-	}
+	client, err := ensureRunningWithRetry(ops.ensureRunning, ops.sleep, ops.retryDelay)
 	if err != nil {
 		return nil, versionSkewFatalError(vme, status.Routes)
 	}
@@ -114,6 +106,55 @@ func recoverFromVersionSkew(vme *proxyd.VersionMismatchError, ops skewOps) (*pro
 	fmt.Printf("Replaced idle proxy daemon (version %s) with a fresh daemon (version %s).\n",
 		vme.DaemonVersion, vme.ClientVersion)
 	return client, nil
+}
+
+// ensureRunningWithRetry starts/connects a fresh daemon via ensureRunning,
+// retrying once after retryDelay if the first attempt reports
+// proxyd.ErrDaemonNotReady. This covers the socket-removed-before-PID-lock-
+// released window (an old daemon removes its socket in server.Shutdown before
+// its deferred PID-lock release in RunDaemon, so a replacement start can
+// briefly lose the lock and report not-ready). Shared by the version-skew
+// heal path (D1) and the SHUTTING_DOWN register retry (D4) — both restart a
+// daemon that just vacated the same socket/PID-lock pair, so both need the
+// identical one-retry guard.
+func ensureRunningWithRetry(ensureRunning func() (*proxyd.Client, error), sleep func(time.Duration), retryDelay time.Duration) (*proxyd.Client, error) {
+	client, err := ensureRunning()
+	if err != nil && errors.Is(err, proxyd.ErrDaemonNotReady) {
+		sleep(retryDelay)
+		client, err = ensureRunning()
+	}
+	return client, err
+}
+
+// waitForDrain polls healthAnswers until the old daemon's socket stops
+// answering /health, bounded by drainTimeout (checked via now, slept between
+// probes via drainPoll). Drained requires TWO consecutive misses: a single
+// failed probe can be a transient blip on a daemon that is still draining,
+// and declaring victory on it would hand the caller a fresh-daemon path that
+// immediately collides with the still-live old daemon (burning the one
+// re-register attempt). Returns false if the deadline elapsed without a
+// confirmed drain — callers must never force-restart over a still-draining
+// daemon, so a false means "treat as busy and fail". Shared by the
+// version-skew heal path (D1) and the SHUTTING_DOWN register retry (D4),
+// which poll the identical old-daemon socket the identical way; only the
+// fatal error each builds on a false differs.
+func waitForDrain(healthAnswers func() bool, sleep func(time.Duration), now func() time.Time, drainTimeout, drainPoll time.Duration) bool {
+	deadline := now().Add(drainTimeout)
+	misses := 0
+	for {
+		if !healthAnswers() {
+			misses++
+			if misses >= 2 {
+				return true
+			}
+		} else {
+			misses = 0
+		}
+		if !now().Before(deadline) {
+			return false
+		}
+		sleep(drainPoll)
+	}
 }
 
 // dedupeProjectDirs returns the unique, order-preserving project dirs across the

--- a/internal/cli/version_skew.go
+++ b/internal/cli/version_skew.go
@@ -1,0 +1,163 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charliek/prox/internal/constants"
+	"github.com/charliek/prox/internal/proxyd"
+)
+
+// skewOps bundles the injectable operations the version-skew recovery path
+// needs so recoverFromVersionSkew can be unit-tested against a fake daemon
+// without real sockets or wall-clock waits. defaultSkewOps wires the production
+// implementations.
+type skewOps struct {
+	// statusProbe queries the (old) daemon's /status with a short timeout.
+	statusProbe func() (*proxyd.DaemonStatusResponse, error)
+	// shutdown asks the old daemon to shut down gracefully (force=false).
+	shutdown func() error
+	// healthAnswers reports whether the old daemon's socket still answers /health.
+	healthAnswers func() bool
+	// ensureRunning starts/connects a fresh daemon of this process's version.
+	ensureRunning func() (*proxyd.Client, error)
+
+	sleep func(time.Duration)
+	now   func() time.Time
+
+	drainTimeout time.Duration // max wait for the old socket to stop answering
+	drainPoll    time.Duration // interval between /health drain probes
+	retryDelay   time.Duration // pause before the one EnsureRunning retry
+}
+
+// defaultSkewOps wires skewOps to the real daemon over its Unix socket, with the
+// production timeouts.
+func defaultSkewOps() skewOps {
+	probeClient := proxyd.NewClient(proxyd.SocketPath())
+	return skewOps{
+		statusProbe: func() (*proxyd.DaemonStatusResponse, error) {
+			ctx, cancel := context.WithTimeout(context.Background(), constants.DaemonStatusProbeTimeout)
+			defer cancel()
+			return probeClient.StatusWithContext(ctx)
+		},
+		shutdown: func() error { return probeClient.Shutdown(false) },
+		healthAnswers: func() bool {
+			ctx, cancel := context.WithTimeout(context.Background(), constants.DaemonHealthProbeTimeout)
+			defer cancel()
+			_, err := probeClient.HealthWithContext(ctx)
+			return err == nil
+		},
+		ensureRunning: proxyd.EnsureRunning,
+		sleep:         time.Sleep,
+		now:           time.Now,
+		drainTimeout:  5 * time.Second,
+		drainPoll:     200 * time.Millisecond,
+		retryDelay:    1 * time.Second,
+	}
+}
+
+// recoverFromVersionSkew handles a VersionMismatchError from EnsureRunning per
+// D1. It probes the old daemon's /status (short timeout); if the daemon holds no
+// projects it auto-heals — asks the old daemon to shut down, waits for its
+// socket to drain, then starts a fresh daemon of this version. If the daemon
+// holds projects, the probe fails, the shutdown is refused, or the drain/start
+// fails, it returns a fatal error with remediation (no standalone fallback).
+// Returns the healed client on success.
+func recoverFromVersionSkew(vme *proxyd.VersionMismatchError, ops skewOps) (*proxyd.Client, error) {
+	status, err := ops.statusProbe()
+	if err != nil {
+		// Can't tell whether the daemon is busy — never auto-heal blind.
+		return nil, versionSkewFatalError(vme, nil)
+	}
+	if status.ProjectCount > 0 {
+		return nil, versionSkewFatalError(vme, status.Routes)
+	}
+
+	// Idle daemon: attempt auto-heal. A shutdown refusal (ACTIVE_ROUTES: a
+	// project registered in the probe→shutdown TOCTOU window) or any error means
+	// it is no longer safe to replace — fall through to the busy-fatal path,
+	// re-probing best-effort so the message can name the racing project.
+	if serr := ops.shutdown(); serr != nil {
+		routes := status.Routes
+		if fresh, ferr := ops.statusProbe(); ferr == nil {
+			routes = fresh.Routes
+		}
+		return nil, versionSkewFatalError(vme, routes)
+	}
+
+	// Poll until the old daemon's socket stops answering /health (bounded). Never
+	// force-kill a still-draining daemon: if it still answers at the deadline,
+	// treat it as busy and fail.
+	deadline := ops.now().Add(ops.drainTimeout)
+	for ops.healthAnswers() {
+		if !ops.now().Before(deadline) {
+			return nil, versionSkewFatalError(vme, status.Routes)
+		}
+		ops.sleep(ops.drainPoll)
+	}
+
+	// Start a fresh daemon of this version. The old daemon removes its socket
+	// before its deferred PID-lock release, so the first start can lose the race
+	// and report not-ready; retry once after a short delay (ErrDaemonNotReady).
+	client, err := ops.ensureRunning()
+	if err != nil && errors.Is(err, proxyd.ErrDaemonNotReady) {
+		ops.sleep(ops.retryDelay)
+		client, err = ops.ensureRunning()
+	}
+	if err != nil {
+		return nil, versionSkewFatalError(vme, status.Routes)
+	}
+
+	fmt.Printf("Replaced idle proxy daemon (version %s) with a fresh daemon (version %s).\n",
+		vme.DaemonVersion, vme.ClientVersion)
+	return client, nil
+}
+
+// dedupeProjectDirs returns the unique, order-preserving project dirs across the
+// given routes. Empty dirs (a very old daemon that omits project_dir) are
+// skipped so the caller degrades gracefully to a generic message.
+func dedupeProjectDirs(routes []proxyd.RouteInfo) []string {
+	seen := make(map[string]struct{}, len(routes))
+	var dirs []string
+	for _, r := range routes {
+		if r.ProjectDir == "" {
+			continue
+		}
+		if _, ok := seen[r.ProjectDir]; ok {
+			continue
+		}
+		seen[r.ProjectDir] = struct{}{}
+		dirs = append(dirs, r.ProjectDir)
+	}
+	return dirs
+}
+
+// versionSkewFatalError builds the fatal message for an unrecoverable version
+// skew (D1): both versions, the registered project dirs when known, and exact
+// remediation. routes may be nil (probe failed or unavailable) — the list is
+// omitted gracefully and generic remediation is given.
+func versionSkewFatalError(vme *proxyd.VersionMismatchError, routes []proxyd.RouteInfo) error {
+	dirs := dedupeProjectDirs(routes)
+	var b strings.Builder
+	fmt.Fprintf(&b, "shared proxy daemon is running version %s, but this prox is version %s",
+		vme.DaemonVersion, vme.ClientVersion)
+	if len(dirs) > 0 {
+		fmt.Fprintf(&b, "\n\nThe shared daemon still has %d registered project(s):", len(dirs))
+		for _, d := range dirs {
+			fmt.Fprintf(&b, "\n  - %s", d)
+		}
+	}
+	b.WriteString("\n\nTo resolve, stop the shared proxy, then restart each project on this version:")
+	b.WriteString("\n  prox proxy stop --force")
+	if len(dirs) > 0 {
+		for _, d := range dirs {
+			fmt.Fprintf(&b, "\n  (cd %s && prox up)   # or: prox restart", d)
+		}
+	} else {
+		b.WriteString("\n  then run 'prox up' (or 'prox restart') in each affected project")
+	}
+	return errors.New(b.String())
+}

--- a/internal/cli/version_skew_test.go
+++ b/internal/cli/version_skew_test.go
@@ -1,0 +1,210 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charliek/prox/internal/config"
+	"github.com/charliek/prox/internal/proxy"
+	"github.com/charliek/prox/internal/proxyd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fastSkewOps returns a skewOps with instant sleeps and real-but-unused clock so
+// tests never pay wall-clock waits. Individual fields are overridden per test.
+func fastSkewOps() skewOps {
+	return skewOps{
+		sleep:        func(time.Duration) {},
+		now:          time.Now,
+		drainTimeout: 5 * time.Second,
+		drainPoll:    time.Millisecond,
+		retryDelay:   time.Millisecond,
+	}
+}
+
+func route(dir string) proxyd.RouteInfo { return proxyd.RouteInfo{ProjectDir: dir} }
+
+// TestRecoverFromVersionSkew_BusyLists pins the busy-daemon fatal path: a daemon
+// holding projects yields a fatal error (no client) naming both versions, the
+// deduped project dirs, and the remediation commands.
+func TestRecoverFromVersionSkew_BusyLists(t *testing.T) {
+	ops := fastSkewOps()
+	ops.statusProbe = func() (*proxyd.DaemonStatusResponse, error) {
+		return &proxyd.DaemonStatusResponse{
+			ProjectCount: 2,
+			// Two routes for /a (deduped to one) plus /b.
+			Routes: []proxyd.RouteInfo{route("/projects/a"), route("/projects/a"), route("/projects/b")},
+		}, nil
+	}
+	ops.shutdown = func() error { t.Fatal("must not shut down a busy daemon"); return nil }
+
+	vme := &proxyd.VersionMismatchError{DaemonVersion: "0.1.2", ClientVersion: "0.2.0"}
+	client, err := recoverFromVersionSkew(vme, ops)
+	require.Error(t, err)
+	assert.Nil(t, client)
+
+	msg := err.Error()
+	assert.Contains(t, msg, "0.1.2")
+	assert.Contains(t, msg, "0.2.0")
+	assert.Contains(t, msg, "/projects/a")
+	assert.Contains(t, msg, "/projects/b")
+	assert.Equal(t, 1, strings.Count(msg, "/projects/a\n"), "duplicate route dir must be listed once")
+	assert.Contains(t, msg, "prox proxy stop --force")
+	assert.Contains(t, msg, "prox up")
+}
+
+// TestRecoverFromVersionSkew_IdleHealSuccess pins the happy heal path: an idle
+// daemon is shut down, drains, and a fresh daemon starts — recover returns that
+// client with no error.
+func TestRecoverFromVersionSkew_IdleHealSuccess(t *testing.T) {
+	ops := fastSkewOps()
+	ops.statusProbe = func() (*proxyd.DaemonStatusResponse, error) {
+		return &proxyd.DaemonStatusResponse{ProjectCount: 0}, nil
+	}
+	shutdownCalled := false
+	ops.shutdown = func() error { shutdownCalled = true; return nil }
+	// Socket stops answering immediately after shutdown.
+	ops.healthAnswers = func() bool { return false }
+	fresh := proxyd.NewClient("/tmp/does-not-matter.sock")
+	ensureCalls := 0
+	ops.ensureRunning = func() (*proxyd.Client, error) { ensureCalls++; return fresh, nil }
+
+	vme := &proxyd.VersionMismatchError{DaemonVersion: "0.1.2", ClientVersion: "0.2.0"}
+	client, err := recoverFromVersionSkew(vme, ops)
+	require.NoError(t, err)
+	assert.Same(t, fresh, client, "recover must return the freshly started client")
+	assert.True(t, shutdownCalled, "idle heal must shut the old daemon down")
+	assert.Equal(t, 1, ensureCalls, "one EnsureRunning is enough when the first start succeeds")
+}
+
+// TestRecoverFromVersionSkew_RetriesOnNotReady pins the PID-lock-release window:
+// the first EnsureRunning reports ErrDaemonNotReady, the heal retries once after
+// a delay and succeeds.
+func TestRecoverFromVersionSkew_RetriesOnNotReady(t *testing.T) {
+	ops := fastSkewOps()
+	ops.statusProbe = func() (*proxyd.DaemonStatusResponse, error) {
+		return &proxyd.DaemonStatusResponse{ProjectCount: 0}, nil
+	}
+	ops.shutdown = func() error { return nil }
+	ops.healthAnswers = func() bool { return false }
+	fresh := proxyd.NewClient("/tmp/x.sock")
+	calls := 0
+	// The first start loses the PID-lock race (wrapped ErrDaemonNotReady); the
+	// heal retries once and succeeds.
+	ops.ensureRunning = func() (*proxyd.Client, error) {
+		calls++
+		if calls == 1 {
+			return nil, fmt.Errorf("start failed: %w", proxyd.ErrDaemonNotReady)
+		}
+		return fresh, nil
+	}
+
+	vme := &proxyd.VersionMismatchError{DaemonVersion: "0.1.2", ClientVersion: "0.2.0"}
+	client, err := recoverFromVersionSkew(vme, ops)
+	require.NoError(t, err)
+	assert.Same(t, fresh, client)
+	assert.Equal(t, 2, calls, "heal must retry EnsureRunning once on ErrDaemonNotReady")
+}
+
+// TestRecoverFromVersionSkew_ShutdownRefusedFatal pins the concurrent-register
+// case: a project registers in the probe→shutdown window, the daemon refuses the
+// graceful shutdown, and recover fails fatally — naming the racing project from a
+// best-effort re-probe.
+func TestRecoverFromVersionSkew_ShutdownRefusedFatal(t *testing.T) {
+	ops := fastSkewOps()
+	probeCalls := 0
+	ops.statusProbe = func() (*proxyd.DaemonStatusResponse, error) {
+		probeCalls++
+		if probeCalls == 1 {
+			return &proxyd.DaemonStatusResponse{ProjectCount: 0}, nil
+		}
+		// Re-probe after the refusal sees the racing project.
+		return &proxyd.DaemonStatusResponse{ProjectCount: 1, Routes: []proxyd.RouteInfo{route("/projects/racer")}}, nil
+	}
+	ops.shutdown = func() error { return errors.New("cannot shutdown: active routes (ACTIVE_ROUTES)") }
+	ops.ensureRunning = func() (*proxyd.Client, error) {
+		t.Fatal("must not start a fresh daemon after refusal")
+		return nil, nil
+	}
+
+	vme := &proxyd.VersionMismatchError{DaemonVersion: "0.1.2", ClientVersion: "0.2.0"}
+	client, err := recoverFromVersionSkew(vme, ops)
+	require.Error(t, err)
+	assert.Nil(t, client)
+	assert.Contains(t, err.Error(), "/projects/racer", "refused-heal message should name the racing project")
+	assert.Equal(t, 2, probeCalls, "refusal re-probes status best-effort")
+}
+
+// TestRecoverFromVersionSkew_ProbeTimeoutFatal pins that a status probe
+// timeout/failure is fatal with generic remediation (no project list, no
+// shutdown attempt).
+func TestRecoverFromVersionSkew_ProbeTimeoutFatal(t *testing.T) {
+	ops := fastSkewOps()
+	ops.statusProbe = func() (*proxyd.DaemonStatusResponse, error) {
+		return nil, context.DeadlineExceeded
+	}
+	ops.shutdown = func() error { t.Fatal("must not shut down when status is unknown"); return nil }
+
+	vme := &proxyd.VersionMismatchError{DaemonVersion: "0.1.2", ClientVersion: "0.2.0"}
+	client, err := recoverFromVersionSkew(vme, ops)
+	require.Error(t, err)
+	assert.Nil(t, client)
+	assert.Contains(t, err.Error(), "0.1.2")
+	assert.Contains(t, err.Error(), "prox proxy stop --force")
+	assert.NotContains(t, err.Error(), "registered project", "no project list when status is unknown")
+}
+
+// TestRecoverFromVersionSkew_SlowDrainFatal pins that a daemon whose socket
+// keeps answering past the drain deadline is treated as busy (never force
+// killed) → fatal.
+func TestRecoverFromVersionSkew_SlowDrainFatal(t *testing.T) {
+	ops := fastSkewOps()
+	ops.drainTimeout = 0 // deadline already passed → single probe, then give up
+	ops.statusProbe = func() (*proxyd.DaemonStatusResponse, error) {
+		return &proxyd.DaemonStatusResponse{ProjectCount: 0}, nil
+	}
+	ops.shutdown = func() error { return nil }
+	ops.healthAnswers = func() bool { return true } // never drains
+	ops.ensureRunning = func() (*proxyd.Client, error) { t.Fatal("must not start over a draining daemon"); return nil, nil }
+
+	vme := &proxyd.VersionMismatchError{DaemonVersion: "0.1.2", ClientVersion: "0.2.0"}
+	client, err := recoverFromVersionSkew(vme, ops)
+	require.Error(t, err)
+	assert.Nil(t, client)
+}
+
+// TestStartStandaloneProxy_BindFailureFatal pins D1's last silent path: with a
+// proxy configured, a standalone bind failure returns an error (fatal) instead
+// of warning and continuing. The error names the port conflict and --no-proxy.
+func TestStartStandaloneProxy_BindFailureFatal(t *testing.T) {
+	// Occupy a port on all interfaces so the proxy's ":port" bind collides.
+	ln, err := net.Listen("tcp", ":0")
+	require.NoError(t, err)
+	defer ln.Close()
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	cfg := &config.Config{
+		Proxy: &config.ProxyConfig{
+			Enabled:  true,
+			Domain:   "local.dev",
+			HTTPPort: port,
+		},
+		Services: map[string]config.ServiceConfig{
+			"api": {Host: "127.0.0.1", Port: 3000},
+		},
+	}
+
+	// handlers is only touched on the success path; the bind fails before that,
+	// so nil is safe here (and asserts the failure returns early).
+	svc, err := startStandaloneProxy(cfg, t.TempDir(), context.Background(), nil)
+	require.Error(t, err)
+	assert.Nil(t, svc)
+	assert.ErrorIs(t, err, proxy.ErrPortInUse, "bind failure must surface a port conflict")
+	assert.Contains(t, err.Error(), "--no-proxy", "escape hatch must be named")
+}

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -62,6 +62,15 @@ const (
 	// route timeout, the CLI lifecycle http.Client timeout, and the TUI restart
 	// timeout (#35, D2).
 	LifecycleTimeoutCeiling = MaxStopTimeout + time.Minute
+
+	// DaemonStatusProbeTimeout bounds the /status probe against a possibly
+	// draining old daemon during version-skew recovery (D1). The proxyd client's
+	// 30s default is far too long for an interactive `prox up`.
+	DaemonStatusProbeTimeout = 2 * time.Second
+
+	// DaemonHealthProbeTimeout bounds a single /health probe used while polling
+	// for an old daemon's socket to stop answering during a version-skew heal.
+	DaemonHealthProbeTimeout = 1 * time.Second
 )
 
 // Log configuration

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -71,6 +71,16 @@ const (
 	// DaemonHealthProbeTimeout bounds a single /health probe used while polling
 	// for an old daemon's socket to stop answering during a version-skew heal.
 	DaemonHealthProbeTimeout = 1 * time.Second
+
+	// DaemonProxyProbeTimeout bounds the live /health probe `prox status` issues
+	// against the shared daemon to report proxy health (D5). Short so a downed
+	// daemon never makes `prox status` sit out a long timeout.
+	DaemonProxyProbeTimeout = 500 * time.Millisecond
+
+	// ProxyStatusProbeCacheTTL caches the shared-proxy health probe result so a
+	// polled `prox status` (TUIs/agents) does not pay the probe timeout on every
+	// call; a downed daemon is re-probed at most once per TTL (D5).
+	ProxyStatusProbeCacheTTL = 2 * time.Second
 )
 
 // Log configuration

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -81,6 +81,16 @@ const (
 	// polled `prox status` (TUIs/agents) does not pay the probe timeout on every
 	// call; a downed daemon is re-probed at most once per TTL (D5).
 	ProxyStatusProbeCacheTTL = 2 * time.Second
+
+	// ForwarderHealAfterDown is how long the SSE forwarder's reconnect must have
+	// failed continuously before it fires a self-heal (re-ensure a daemon of this
+	// version + re-register this project) from inside its reconnect loop (D6b).
+	// Injectable in tests so the heal path never waits out real wall-clock.
+	ForwarderHealAfterDown = 15 * time.Second
+
+	// ForwarderHealMinInterval is the minimum spacing between forwarder heal
+	// attempts, damping churn against a flapping daemon (D6b). Injectable in tests.
+	ForwarderHealMinInterval = 30 * time.Second
 )
 
 // Log configuration

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -91,6 +91,18 @@ const (
 	// ForwarderHealMinInterval is the minimum spacing between forwarder heal
 	// attempts, damping churn against a flapping daemon (D6b). Injectable in tests.
 	ForwarderHealMinInterval = 30 * time.Second
+
+	// InFlightStaleAfter is how long a request record may sit in-flight before
+	// it is reported as stale (D8, #53). Stale does NOT mean broken: SSE
+	// streams, WebSocket upgrades, and large transfers can legitimately stay
+	// in-flight this long while completely healthy. It means "completion
+	// unknown" — the record's completion event (published when the response
+	// body finishes) may have been lost (subscriber channel overrun, process
+	// crash mid-request, etc.), so the true outcome can no longer be inferred
+	// from this record alone. 5 minutes comfortably outlasts ordinary
+	// request/response cycles while still surfacing genuinely stuck rows in a
+	// timely way.
+	InFlightStaleAfter = 5 * time.Minute
 )
 
 // Log configuration

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -18,35 +18,27 @@ func IsDaemonChild() bool {
 	return os.Getenv(DaemonEnvVar) == "1"
 }
 
-// Daemonize re-executes the current process as a daemon.
+// buildDaemonCommand constructs (but does not start) the detached daemon-child
+// command. It is split out from Daemonize so a test can pin the child protocol
+// (executable, argv, _PROX_DAEMON=1 env marker, Setsid, nil stdio) without
+// actually spawning a process.
 //
-// IMPORTANT: In the parent process, this function calls os.Exit(0) and never returns.
-// Only the child process continues execution (where IsDaemonChild() returns true).
-//
-// The function:
-//  1. Re-executes the current binary with the same arguments
-//  2. Sets _PROX_DAEMON=1 environment variable to mark the child
-//  3. Detaches the child from the terminal (new session)
-//  4. Prints the child PID and exits the parent with status 0
-//
-// Note: There is a small race window where the parent exits before confirming
-// the child successfully initialized. This is acceptable because:
-//   - Client commands use discoverDaemon() which reads state and retries
-//   - The window is very small (child starts immediately)
-//   - A pipe-based confirmation would add significant complexity
-func Daemonize() error {
+// The child protocol here is byte-for-byte identical to prox's pre-D2 behavior:
+// same executable, same os.Args[1:], _PROX_DAEMON=1 appended to the inherited
+// environment, Setsid to detach from the controlling terminal, and nil stdio
+// (the child redirects its own output to the daemon log via SetupLogging).
+func buildDaemonCommand() (*exec.Cmd, error) {
 	// Get the current executable path
 	executable, err := os.Executable()
 	if err != nil {
-		return fmt.Errorf("getting executable path: %w", err)
+		return nil, fmt.Errorf("getting executable path: %w", err)
 	}
-
-	// Prepare environment with daemon marker
-	env := append(os.Environ(), DaemonEnvVar+"=1")
 
 	// Create command with same args
 	cmd := exec.Command(executable, os.Args[1:]...)
-	cmd.Env = env
+
+	// Prepare environment with daemon marker
+	cmd.Env = append(os.Environ(), DaemonEnvVar+"=1")
 
 	// Detach from terminal - create new session
 	cmd.SysProcAttr = &syscall.SysProcAttr{
@@ -58,18 +50,31 @@ func Daemonize() error {
 	cmd.Stdout = nil
 	cmd.Stderr = nil
 
-	// Start the daemon process
-	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("starting daemon process: %w", err)
+	return cmd, nil
+}
+
+// Daemonize re-executes the current process as a detached daemon child and
+// returns the started child command. Unlike its pre-D2 form, it no longer
+// prints a success line or calls os.Exit(0): the caller (runUp's daemonize
+// branch) owns wait-and-report so `prox up -d` only reports success once the
+// child is actually ready (D2). The returned *exec.Cmd is the direct child, so
+// the caller must Wait() on it (both to detect early death and to reap the
+// zombie).
+//
+// The child continues execution where IsDaemonChild() returns true. The child
+// protocol is unchanged — see buildDaemonCommand.
+func Daemonize() (*exec.Cmd, error) {
+	cmd, err := buildDaemonCommand()
+	if err != nil {
+		return nil, err
 	}
 
-	// Return the child's PID
-	fmt.Printf("prox started (pid %d)\n", cmd.Process.Pid)
+	// Start the daemon process
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("starting daemon process: %w", err)
+	}
 
-	// Parent exits successfully
-	os.Exit(0)
-
-	return nil // Unreachable, but needed for compiler
+	return cmd, nil
 }
 
 // SetupLogging redirects stdout and stderr to the daemon log file.

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -5,6 +5,61 @@ import (
 	"testing"
 )
 
+// TestBuildDaemonCommand pins the daemon child protocol (D2): the constructed
+// command must re-exec this binary with the same os.Args[1:], append exactly
+// one _PROX_DAEMON=1 env marker, request Setsid, and use nil stdio. This is the
+// byte-for-byte contract the parent's wait-and-report path depends on and must
+// not drift.
+func TestBuildDaemonCommand(t *testing.T) {
+	cmd, err := buildDaemonCommand()
+	if err != nil {
+		t.Fatalf("buildDaemonCommand failed: %v", err)
+	}
+
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable failed: %v", err)
+	}
+
+	// argv: [executable, os.Args[1:]...]
+	if cmd.Path != exe {
+		t.Errorf("expected Path %q, got %q", exe, cmd.Path)
+	}
+	wantArgs := append([]string{exe}, os.Args[1:]...)
+	if len(cmd.Args) != len(wantArgs) {
+		t.Fatalf("expected %d args %v, got %d args %v", len(wantArgs), wantArgs, len(cmd.Args), cmd.Args)
+	}
+	for i := range wantArgs {
+		if cmd.Args[i] != wantArgs[i] {
+			t.Errorf("arg[%d]: expected %q, got %q", i, wantArgs[i], cmd.Args[i])
+		}
+	}
+
+	// env: inherited environment plus exactly one _PROX_DAEMON=1 marker.
+	markerCount := 0
+	for _, e := range cmd.Env {
+		if e == DaemonEnvVar+"=1" {
+			markerCount++
+		}
+	}
+	if markerCount != 1 {
+		t.Errorf("expected exactly one %s=1 env entry, got %d (env=%v)", DaemonEnvVar, markerCount, cmd.Env)
+	}
+	if len(cmd.Env) != len(os.Environ())+1 {
+		t.Errorf("expected env len %d (environ+marker), got %d", len(os.Environ())+1, len(cmd.Env))
+	}
+
+	// SysProcAttr: detached session.
+	if cmd.SysProcAttr == nil || !cmd.SysProcAttr.Setsid {
+		t.Errorf("expected SysProcAttr.Setsid=true, got %+v", cmd.SysProcAttr)
+	}
+
+	// nil stdio — the child manages its own logging.
+	if cmd.Stdin != nil || cmd.Stdout != nil || cmd.Stderr != nil {
+		t.Errorf("expected nil stdio, got stdin=%v stdout=%v stderr=%v", cmd.Stdin, cmd.Stdout, cmd.Stderr)
+	}
+}
+
 func TestIsDaemonChild(t *testing.T) {
 	t.Run("returns false when env var not set", func(t *testing.T) {
 		// Save current value

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -97,6 +97,13 @@ const (
 	ErrCodeStreamingNotSupported = "STREAMING_NOT_SUPPORTED"
 	ErrCodeRequestNotFound       = "REQUEST_NOT_FOUND"
 	ErrCodeMissingRequestID      = "MISSING_REQUEST_ID"
+	// ErrCodeCursorGone marks a before_id cursor whose anchor record is
+	// unknown, evicted, or out of the request's filter scope (e.g. a
+	// different project). 410, not 404: the cursor once referred to a real
+	// position that has since aged out of the ring, so pollers should
+	// restart pagination without a cursor rather than retry the same one
+	// (D12, #50).
+	ErrCodeCursorGone = "CURSOR_GONE"
 )
 
 // ErrorCode returns the API error code for a domain error

--- a/internal/proxy/body.go
+++ b/internal/proxy/body.go
@@ -2,12 +2,18 @@ package proxy
 
 import (
 	"bytes"
+	"compress/flate"
 	"compress/gzip"
+	"compress/zlib"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/andybalholm/brotli"
+	"github.com/klauspost/compress/zstd"
 
 	"github.com/charliek/prox/internal/constants"
 )
@@ -131,12 +137,13 @@ func CaptureAllowedDirs(primaryDir string) []string {
 // DecodeCapturedBody content-decodes raw (per body.ContentEncoding) and returns
 // serve-ready bytes with post-decode binary semantics.
 //
-// Supported encodings are gzip and x-gzip (case-insensitive, surrounding
-// whitespace tolerated); identity/empty means no decode. Any other token
-// (deflate, br, zstd, chained values like "gzip, br"), a truncated body, a
-// decode failure, or a decoded size exceeding the cap all fall back to serving
-// the raw bytes with IsBinary=true so a JSON string conversion cannot mangle
-// them.
+// Supported encodings are gzip/x-gzip, deflate (zlib-wrapped per RFC 9110,
+// with a fallback to raw deflate for servers that send it unwrapped), zstd,
+// and br (case-insensitive, surrounding whitespace tolerated); identity/empty
+// means no decode. Any other token (chained values like "gzip, br"), a
+// truncated body, a decode failure, or a decoded size exceeding the cap all
+// fall back to serving the raw bytes with IsBinary=true so a JSON string
+// conversion cannot mangle them.
 func DecodeCapturedBody(body *CapturedBody, raw []byte) DecodedBody {
 	token := strings.ToLower(strings.TrimSpace(body.ContentEncoding))
 
@@ -148,23 +155,39 @@ func DecodeCapturedBody(body *CapturedBody, raw []byte) DecodedBody {
 			Available: true,
 		}
 	case "gzip", "x-gzip":
-		// A truncated stream is broken; do not attempt to decode it.
-		if body.Truncated {
-			return rawEncoded(raw, token)
-		}
-		decoded, ok := gunzipLimited(raw, constants.MaxDecodedBodySize)
-		if !ok {
-			return rawEncoded(raw, token)
-		}
-		return DecodedBody{
-			Data:            decoded,
-			IsBinary:        isBinaryContent(decoded, body.ContentType),
-			ContentEncoding: token,
-			Available:       true,
-		}
+		return decodeWithFallback(body, raw, token, gunzipLimited)
+	case "deflate":
+		return decodeWithFallback(body, raw, token, inflateLimited)
+	case "zstd":
+		return decodeWithFallback(body, raw, token, zstdLimited)
+	case "br":
+		return decodeWithFallback(body, raw, token, brotliLimited)
 	default:
 		// Unsupported encoding: serve raw, flagged binary.
 		return rawEncoded(raw, token)
+	}
+}
+
+// decodeWithFallback runs decodeFn (one of the bounded per-codec decoders
+// below) against raw and returns serve-ready decoded bytes, or the raw
+// fallback when the body was truncated, the decode failed, or the decoded
+// size exceeded the cap. Shared by every content-encoding case so the
+// truncated-short-circuit and cap-exceeded-fallback behavior stay identical
+// across codecs.
+func decodeWithFallback(body *CapturedBody, raw []byte, token string, decodeFn func([]byte, int64) ([]byte, bool)) DecodedBody {
+	// A truncated stream is broken; do not attempt to decode it.
+	if body.Truncated {
+		return rawEncoded(raw, token)
+	}
+	decoded, ok := decodeFn(raw, constants.MaxDecodedBodySize)
+	if !ok {
+		return rawEncoded(raw, token)
+	}
+	return DecodedBody{
+		Data:            decoded,
+		IsBinary:        isBinaryContent(decoded, body.ContentType),
+		ContentEncoding: token,
+		Available:       true,
 	}
 }
 
@@ -179,18 +202,15 @@ func rawEncoded(raw []byte, token string) DecodedBody {
 	}
 }
 
-// gunzipLimited gzip-decodes raw, capping output at limit bytes. It returns
-// (nil, false) on a header/stream error or when the decoded size would exceed
-// the cap (zip-bomb guard); memory is bounded to limit+1 bytes.
-func gunzipLimited(raw []byte, limit int64) ([]byte, bool) {
-	gr, err := gzip.NewReader(bytes.NewReader(raw))
-	if err != nil {
-		return nil, false
-	}
-	defer gr.Close()
-
+// decodeLimited drains r, capping output at limit bytes. It returns (nil,
+// false) on a read/stream error or when the decoded size would exceed the
+// cap (zip-bomb guard); memory is bounded to limit+1 bytes regardless of
+// codec. Every bounded decoder below (gzip, deflate, zstd, br) funnels
+// through this so the cap-exceeded and stream-error semantics stay identical
+// across encodings.
+func decodeLimited(r io.Reader, limit int64) ([]byte, bool) {
 	// Read one byte past the cap so an over-cap payload is detectable.
-	decoded, err := io.ReadAll(io.LimitReader(gr, limit+1))
+	decoded, err := io.ReadAll(io.LimitReader(r, limit+1))
 	if err != nil {
 		return nil, false
 	}
@@ -198,6 +218,71 @@ func gunzipLimited(raw []byte, limit int64) ([]byte, bool) {
 		return nil, false
 	}
 	return decoded, true
+}
+
+// gunzipLimited gzip-decodes raw, capping output at limit bytes. It returns
+// (nil, false) on a header/stream error or when the decoded size would exceed
+// the cap.
+func gunzipLimited(raw []byte, limit int64) ([]byte, bool) {
+	gr, err := gzip.NewReader(bytes.NewReader(raw))
+	if err != nil {
+		return nil, false
+	}
+	defer gr.Close()
+	return decodeLimited(gr, limit)
+}
+
+// inflateLimited deflate-decodes raw, capping output at limit bytes.
+//
+// RFC 9110 defines the "deflate" content-coding as a zlib-wrapped deflate
+// stream (RFC 1950 header around an RFC 1951 payload), so zlib is tried
+// first. Some servers instead send raw deflate with no zlib header; that
+// case is detected specifically as zlib.ErrHeader from zlib.NewReader (the
+// two-byte CMF/FLG header doesn't look like zlib) and retried against
+// compress/flate. A zlib stream that opens fine but fails later — a
+// mid-stream corruption error — is a genuinely broken stream and must NOT be
+// silently retried as raw deflate; it falls straight through to the raw
+// fallback like any other decode failure.
+func inflateLimited(raw []byte, limit int64) ([]byte, bool) {
+	zr, err := zlib.NewReader(bytes.NewReader(raw))
+	if err != nil {
+		if !errors.Is(err, zlib.ErrHeader) {
+			return nil, false
+		}
+		fr := flate.NewReader(bytes.NewReader(raw))
+		defer fr.Close()
+		return decodeLimited(fr, limit)
+	}
+	defer zr.Close()
+	return decodeLimited(zr, limit)
+}
+
+// zstdLimited zstd-decodes raw, capping output at limit bytes. It returns
+// (nil, false) on a header/stream error or when the decoded size would
+// exceed the cap. WithDecoderMaxMemory bounds the decoder's own window/
+// in-memory allocation to limit bytes as a defense-in-depth measure on top of
+// decodeLimited's output cap, so a hostile stream can't force a large
+// allocation before the output-size check ever runs.
+func zstdLimited(raw []byte, limit int64) ([]byte, bool) {
+	// WithDecoderConcurrency(1) keeps the decode synchronous: the default
+	// spawns per-decoder goroutines, which an adversarial stream could
+	// multiply for CPU burn before the output cap bites. One captured body
+	// decodes at a time here; concurrency buys nothing.
+	zr, err := zstd.NewReader(bytes.NewReader(raw),
+		zstd.WithDecoderMaxMemory(uint64(limit)), zstd.WithDecoderConcurrency(1))
+	if err != nil {
+		return nil, false
+	}
+	defer zr.Close()
+	return decodeLimited(zr, limit)
+}
+
+// brotliLimited brotli-decodes raw, capping output at limit bytes. It
+// returns (nil, false) on a stream error or when the decoded size would
+// exceed the cap.
+func brotliLimited(raw []byte, limit int64) ([]byte, bool) {
+	br := brotli.NewReader(bytes.NewReader(raw))
+	return decodeLimited(br, limit)
 }
 
 // LoadDecodedBody composes LoadCapturedBody + DecodeCapturedBody.

--- a/internal/proxy/body_test.go
+++ b/internal/proxy/body_test.go
@@ -2,11 +2,15 @@ package proxy
 
 import (
 	"bytes"
+	"compress/flate"
 	"compress/gzip"
+	"compress/zlib"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/andybalholm/brotli"
+	"github.com/klauspost/compress/zstd"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -19,6 +23,54 @@ func gzipBytes(t *testing.T, data []byte) []byte {
 	_, err := gw.Write(data)
 	require.NoError(t, err)
 	require.NoError(t, gw.Close())
+	return buf.Bytes()
+}
+
+// zlibBytes returns the zlib-wrapped deflate form of data (RFC 1950 header
+// around an RFC 1951 payload) — the "deflate" content-coding per RFC 9110.
+func zlibBytes(t *testing.T, data []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zlib.NewWriter(&buf)
+	_, err := zw.Write(data)
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+	return buf.Bytes()
+}
+
+// rawDeflateBytes returns a bare RFC 1951 deflate stream with no zlib
+// header — what some servers send despite advertising "deflate".
+func rawDeflateBytes(t *testing.T, data []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	fw, err := flate.NewWriter(&buf, flate.DefaultCompression)
+	require.NoError(t, err)
+	_, err = fw.Write(data)
+	require.NoError(t, err)
+	require.NoError(t, fw.Close())
+	return buf.Bytes()
+}
+
+// zstdBytes returns the zstd-compressed form of data.
+func zstdBytes(t *testing.T, data []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw, err := zstd.NewWriter(&buf)
+	require.NoError(t, err)
+	_, err = zw.Write(data)
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+	return buf.Bytes()
+}
+
+// brotliBytes returns the brotli-compressed form of data.
+func brotliBytes(t *testing.T, data []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	bw := brotli.NewWriter(&buf)
+	_, err := bw.Write(data)
+	require.NoError(t, err)
+	require.NoError(t, bw.Close())
 	return buf.Bytes()
 }
 
@@ -178,7 +230,10 @@ func TestDecodeCapturedBody(t *testing.T) {
 	})
 
 	t.Run("unsupported encodings fall back to raw binary", func(t *testing.T) {
-		for _, enc := range []string{"br", "deflate", "zstd", "gzip, br"} {
+		// "compress" (legacy LZW) is a real-but-unimplemented token; "gzip, br"
+		// is a chained encoding, which stays unsupported regardless of whether
+		// the individual codecs it names are each supported.
+		for _, enc := range []string{"compress", "gzip, br"} {
 			body := &CapturedBody{ContentEncoding: enc, ContentType: "application/json"}
 			got := DecodeCapturedBody(body, jsonPayload)
 			assert.True(t, got.Available, enc)
@@ -197,6 +252,111 @@ func TestDecodeCapturedBody(t *testing.T) {
 		got := DecodeCapturedBody(body, raw)
 		assert.True(t, got.IsBinary)
 		assert.Equal(t, raw, got.Data) // served raw, not the expanded bomb
+	})
+}
+
+// TestDecodeCapturedBody_D10Codecs table-drives the same behaviors already
+// proven for gzip above (roundtrip, corrupt-stream fallback, truncated
+// short-circuit, cap-exceeded fallback) across the D10 codecs: deflate
+// (both zlib-wrapped and raw), zstd, and br.
+func TestDecodeCapturedBody_D10Codecs(t *testing.T) {
+	jsonPayload := []byte(`{"hello":"world","n":42}`)
+
+	type codecCase struct {
+		name   string
+		token  string
+		encode func(t *testing.T, data []byte) []byte
+		// corruptIndex picks which byte of the encoded stream to flip to
+		// produce a genuinely corrupt (decode-failing) stream. Defaults to
+		// len(raw)-3 (same recipe as the pre-existing gzip test) when nil;
+		// brotli has no trailing checksum, so flipping near the end can land
+		// on padding bits the decoder tolerates — corrupting byte 0 (the
+		// stream header) reliably fails instead.
+		corruptIndex func(raw []byte) int
+	}
+
+	nearEnd := func(raw []byte) int { return len(raw) - 3 }
+
+	cases := []codecCase{
+		{"deflate (zlib-wrapped, RFC 9110)", "deflate", zlibBytes, nearEnd},
+		{"deflate (raw, no zlib header)", "deflate", rawDeflateBytes, nearEnd},
+		{"zstd", "zstd", zstdBytes, nearEnd},
+		{"br", "br", brotliBytes, func(raw []byte) int { return 0 }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name+"/roundtrip decodes", func(t *testing.T) {
+			raw := tc.encode(t, jsonPayload)
+			body := &CapturedBody{ContentEncoding: tc.token, ContentType: "application/json", IsBinary: true}
+			got := DecodeCapturedBody(body, raw)
+			assert.True(t, got.Available)
+			assert.False(t, got.IsBinary) // decoded JSON is text
+			assert.Equal(t, jsonPayload, got.Data)
+			assert.Equal(t, tc.token, got.ContentEncoding)
+		})
+
+		t.Run(tc.name+"/corrupt stream falls back to raw binary", func(t *testing.T) {
+			raw := tc.encode(t, jsonPayload)
+			raw[tc.corruptIndex(raw)] ^= 0xff
+			body := &CapturedBody{ContentEncoding: tc.token, ContentType: "application/json"}
+			got := DecodeCapturedBody(body, raw)
+			assert.True(t, got.Available)
+			assert.True(t, got.IsBinary)
+			assert.Equal(t, raw, got.Data)
+			assert.Equal(t, tc.token, got.ContentEncoding)
+		})
+
+		t.Run(tc.name+"/truncated body short-circuits to raw", func(t *testing.T) {
+			raw := tc.encode(t, jsonPayload)
+			body := &CapturedBody{ContentEncoding: tc.token, ContentType: "application/json", Truncated: true}
+			got := DecodeCapturedBody(body, raw)
+			assert.True(t, got.Available)
+			assert.True(t, got.IsBinary)
+			assert.Equal(t, raw, got.Data)
+			assert.Equal(t, tc.token, got.ContentEncoding)
+		})
+
+		t.Run(tc.name+"/decode cap exceeded falls back to raw binary", func(t *testing.T) {
+			// Highly compressible payload larger than the 10MB decode cap.
+			bomb := bytes.Repeat([]byte{'a'}, 11*1024*1024)
+			raw := tc.encode(t, bomb)
+			require.Less(t, len(raw), len(bomb)) // compressed is much smaller
+			body := &CapturedBody{ContentEncoding: tc.token, ContentType: "text/plain"}
+			got := DecodeCapturedBody(body, raw)
+			assert.True(t, got.Available)
+			assert.True(t, got.IsBinary)
+			assert.Equal(t, raw, got.Data) // served raw, not the expanded bomb
+		})
+	}
+}
+
+// TestInflateLimited unit-tests the deflate zlib-vs-raw dispatch directly
+// (same package, so the unexported helper is reachable), pinning the D10
+// requirement that a mid-stream zlib corruption must NOT be silently
+// retried as raw deflate — only a zlib *header* error triggers the retry.
+func TestInflateLimited(t *testing.T) {
+	jsonPayload := []byte(`{"hello":"world"}`)
+	const limit = 10 * 1024 * 1024
+
+	t.Run("zlib-wrapped stream decodes directly", func(t *testing.T) {
+		raw := zlibBytes(t, jsonPayload)
+		decoded, ok := inflateLimited(raw, limit)
+		require.True(t, ok)
+		assert.Equal(t, jsonPayload, decoded)
+	})
+
+	t.Run("raw deflate falls back from zlib header error and decodes", func(t *testing.T) {
+		raw := rawDeflateBytes(t, jsonPayload)
+		decoded, ok := inflateLimited(raw, limit)
+		require.True(t, ok)
+		assert.Equal(t, jsonPayload, decoded)
+	})
+
+	t.Run("mid-stream zlib corruption is not retried as raw deflate", func(t *testing.T) {
+		raw := zlibBytes(t, jsonPayload)
+		raw[len(raw)-3] ^= 0xff // corrupt payload bytes; the 2-byte zlib header is untouched
+		_, ok := inflateLimited(raw, limit)
+		assert.False(t, ok)
 	})
 }
 

--- a/internal/proxy/capture.go
+++ b/internal/proxy/capture.go
@@ -115,10 +115,33 @@ func (cm *CaptureManager) Enabled() bool {
 	return cm.enabled
 }
 
-// CaptureRequest captures the request body using a TeeReader.
+// effectiveLimit resolves a per-call capture cap: a positive limit is used
+// verbatim, and 0 (or negative) falls back to the manager's configured
+// maxBodySize (which itself defaults to DefaultCaptureMaxBodySize). The daemon
+// passes each route's own cap here (D13, #49); the standalone in-process proxy
+// passes 0, keeping the project's configured cap. maxBodySize is set once at
+// construction and never mutated, so no lock is needed.
+func (cm *CaptureManager) effectiveLimit(limit int64) int64 {
+	if limit > 0 {
+		return limit
+	}
+	return cm.maxBodySize
+}
+
+// CaptureRequest captures the request body using the manager's configured cap.
+// It is CaptureRequestWithLimit with a 0 (manager-default) limit — the signature
+// the standalone in-process proxy uses.
+func (cm *CaptureManager) CaptureRequest(requestID string, r *http.Request) (*CapturedBody, io.ReadCloser, http.Header) {
+	return cm.CaptureRequestWithLimit(requestID, r, 0)
+}
+
+// CaptureRequestWithLimit captures the request body using a TeeReader bounded by
+// a per-call cap (D13, #49): the daemon passes the matched route's MaxBodySize so
+// each project honors its own quota through the one shared capture dir. A limit
+// of 0 falls back to the manager's configured cap (see effectiveLimit).
 // Returns the captured body info and a new ReadCloser to use in place of the original body.
 // The original body is wrapped so that reading from the returned ReadCloser also captures the data.
-func (cm *CaptureManager) CaptureRequest(requestID string, r *http.Request) (*CapturedBody, io.ReadCloser, http.Header) {
+func (cm *CaptureManager) CaptureRequestWithLimit(requestID string, r *http.Request, limit int64) (*CapturedBody, io.ReadCloser, http.Header) {
 	if !cm.enabled || r.Body == nil {
 		return nil, r.Body, cloneHeaders(r.Header)
 	}
@@ -128,7 +151,7 @@ func (cm *CaptureManager) CaptureRequest(requestID string, r *http.Request) (*Ca
 
 	// Create a buffer to capture the body
 	captured := &captureBuffer{
-		maxSize:   cm.maxBodySize,
+		maxSize:   cm.effectiveLimit(limit),
 		requestID: requestID,
 		suffix:    "_req",
 		cm:        cm,
@@ -152,11 +175,20 @@ func (cm *CaptureManager) CaptureRequest(requestID string, r *http.Request) (*Ca
 	return body, wrappedBody, headers
 }
 
-// WrapResponseWriter wraps w in a CaptureResponseWriter that records up to the
-// manager's configured max body size while forwarding all writes downstream.
-// The returned writer preserves http.Flusher/Hijacker/Pusher/Unwrap behavior.
+// WrapResponseWriter wraps w in a CaptureResponseWriter bounded by the manager's
+// configured max body size. It is WrapResponseWriterWithLimit with a 0
+// (manager-default) limit — the signature the standalone in-process proxy uses.
 func (cm *CaptureManager) WrapResponseWriter(w http.ResponseWriter) *CaptureResponseWriter {
-	return newCaptureResponseWriter(w, cm.maxBodySize)
+	return cm.WrapResponseWriterWithLimit(w, 0)
+}
+
+// WrapResponseWriterWithLimit wraps w in a CaptureResponseWriter that records up
+// to a per-call cap (D13, #49) while forwarding all writes downstream: the daemon
+// passes the matched route's MaxBodySize so each project honors its own quota. A
+// limit of 0 falls back to the manager's configured cap (see effectiveLimit).
+// The returned writer preserves http.Flusher/Hijacker/Pusher/Unwrap behavior.
+func (cm *CaptureManager) WrapResponseWriterWithLimit(w http.ResponseWriter, limit int64) *CaptureResponseWriter {
+	return newCaptureResponseWriter(w, cm.effectiveLimit(limit))
 }
 
 // FinalizeResponse captures the response body from a CaptureResponseWriter.

--- a/internal/proxy/capture_test.go
+++ b/internal/proxy/capture_test.go
@@ -1109,3 +1109,67 @@ func TestCaptureResponseWriter_FirstResponseHook(t *testing.T) {
 		assert.Equal(t, []int{http.StatusSwitchingProtocols}, calls, "hook must not re-fire after hijack")
 	})
 }
+
+// TestPerCallCaptureLimits pins the D13 per-call caps: CaptureRequestWithLimit
+// and WrapResponseWriterWithLimit honor a positive per-call byte limit, while a
+// 0 limit falls back to the manager's configured cap (which itself defaults to
+// DefaultCaptureMaxBodySize). This is what lets the daemon apply each project's
+// own MaxBodySize through the one shared capture manager, and what keeps the
+// standalone in-process proxy on its project's configured cap.
+func TestPerCallCaptureLimits(t *testing.T) {
+	// A manager whose configured cap is 50 bytes; positive per-call limits must
+	// override it in both directions.
+	cfg := &config.CaptureConfig{Enabled: true, MaxBodySize: "50"}
+	cm, err := NewCaptureManager(cfg, t.TempDir())
+	require.NoError(t, err)
+
+	payload := strings.Repeat("a", 200)
+
+	t.Run("request tighter per-call limit wins", func(t *testing.T) {
+		req := httptest.NewRequest("POST", "/test", strings.NewReader(payload))
+		captured, wrapped, _ := cm.CaptureRequestWithLimit("req-tight", req, 10)
+		_, _ = io.ReadAll(wrapped)
+		require.NoError(t, wrapped.Close())
+		assert.Equal(t, int64(200), captured.Size, "total observed unchanged")
+		assert.Equal(t, int64(10), captured.CapturedSize, "per-call limit 10 caps retained bytes")
+		assert.True(t, captured.Truncated)
+	})
+
+	t.Run("request looser per-call limit wins", func(t *testing.T) {
+		req := httptest.NewRequest("POST", "/test", strings.NewReader(payload))
+		captured, wrapped, _ := cm.CaptureRequestWithLimit("req-loose", req, 150)
+		_, _ = io.ReadAll(wrapped)
+		require.NoError(t, wrapped.Close())
+		assert.Equal(t, int64(150), captured.CapturedSize, "per-call limit 150 overrides the 50-byte manager cap")
+		assert.True(t, captured.Truncated)
+	})
+
+	t.Run("request zero per-call limit falls back to manager cap", func(t *testing.T) {
+		req := httptest.NewRequest("POST", "/test", strings.NewReader(payload))
+		captured, wrapped, _ := cm.CaptureRequestWithLimit("req-zero", req, 0)
+		_, _ = io.ReadAll(wrapped)
+		require.NoError(t, wrapped.Close())
+		assert.Equal(t, int64(50), captured.CapturedSize, "0 limit uses the manager's configured 50-byte cap")
+		assert.True(t, captured.Truncated)
+	})
+
+	t.Run("response per-call limit and zero fallback", func(t *testing.T) {
+		body := []byte(payload)
+
+		tight := cm.WrapResponseWriterWithLimit(httptest.NewRecorder(), 10)
+		tight.WriteHeader(http.StatusOK)
+		_, _ = tight.Write(body)
+		assert.Len(t, tight.CapturedBody(), 10, "per-call limit 10 caps response capture")
+
+		fallback := cm.WrapResponseWriterWithLimit(httptest.NewRecorder(), 0)
+		fallback.WriteHeader(http.StatusOK)
+		_, _ = fallback.Write(body)
+		assert.Len(t, fallback.CapturedBody(), 50, "0 limit uses the manager's configured 50-byte cap")
+
+		// The no-limit convenience wrapper is exactly the 0-limit path.
+		def := cm.WrapResponseWriter(httptest.NewRecorder())
+		def.WriteHeader(http.StatusOK)
+		_, _ = def.Write(body)
+		assert.Len(t, def.CapturedBody(), 50, "WrapResponseWriter delegates to the manager cap")
+	})
+}

--- a/internal/proxy/requests.go
+++ b/internal/proxy/requests.go
@@ -208,6 +208,15 @@ func (m *RequestManager) Record(record RequestRecord) bool {
 	var onEvict EvictionCallback
 
 	m.mu.Lock()
+	// Re-check the latch under mu: Close does not hold the ring lock, so a
+	// writer that passed the pre-lock check can otherwise commit after the
+	// destroy path's final purge (CodeRabbit PR #68). Under mu the store is
+	// either visible here (rejected) or this write commits before the purge's
+	// own mu acquisition (covered by the purge).
+	if m.writesClosed.Load() {
+		m.mu.Unlock()
+		return false
+	}
 	// Check if we're about to overwrite an existing record
 	if m.count == m.capacity {
 		evicted := m.buffer[m.head]
@@ -269,6 +278,11 @@ func (m *RequestManager) Upsert(record RequestRecord) bool {
 	var onEvict EvictionCallback
 
 	m.mu.Lock()
+	// Re-check the latch under mu (same reasoning as Record).
+	if m.writesClosed.Load() {
+		m.mu.Unlock()
+		return false
+	}
 	// Scan newest→oldest: in-flight records live in the newest slots.
 	idx := -1
 	for i := 0; i < m.count; i++ {

--- a/internal/proxy/requests.go
+++ b/internal/proxy/requests.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/charliek/prox/internal/constants"
 )
 
 // RequestRecord represents a single proxied request.
@@ -38,6 +40,17 @@ type RequestRecord struct {
 
 	// Details contains captured headers and bodies (nil when capture is disabled)
 	Details *RequestDetails `json:"details,omitempty"`
+}
+
+// StaleAt reports whether this record is stale as of now (D8, #53): still
+// marked in-flight, but running longer than constants.InFlightStaleAfter.
+// "Stale" means completion-unknown, not broken — see the constant's doc
+// comment. Final (non-in-flight) records are never stale: their completion,
+// whatever it was, is already known. This is the single staleness check;
+// every consumer (API response conversion, CLI rendering, TUI rendering)
+// calls it rather than re-deriving the condition.
+func (r RequestRecord) StaleAt(now time.Time) bool {
+	return r.InFlight && now.Sub(r.Timestamp) > constants.InFlightStaleAfter
 }
 
 // RequestDetails contains captured request/response headers and bodies.

--- a/internal/proxy/requests.go
+++ b/internal/proxy/requests.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"log"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -99,10 +100,16 @@ type RequestFilter struct {
 }
 
 // RequestSubscription represents a subscription to request updates.
+//
+// dropped counts events this subscription lost because its channel was full
+// when notifySubscribers tried to deliver (D9). It is an atomic so
+// notifySubscribers can bump it under the manager's read lock; the first drop
+// (0→1 transition) logs once so a slow subscriber is visible without spamming.
 type RequestSubscription struct {
-	ID     string
-	Filter RequestFilter
-	Ch     chan RequestRecord
+	ID      string
+	Filter  RequestFilter
+	Ch      chan RequestRecord
+	dropped atomic.Int64
 }
 
 // EvictionCallback is called when a request is evicted from the ring buffer.
@@ -123,6 +130,12 @@ type RequestManager struct {
 	// closed latches after Close: new Subscribe calls get an already-closed
 	// channel so post-shutdown streams end immediately.
 	closed bool
+
+	// droppedTotal is the manager-wide count of notifications dropped because a
+	// subscriber's channel was full (D9). Exposed via DroppedEvents(); surfaced
+	// daemon-side in DaemonStatusResponse and project-side (via the forwarder's
+	// local manager) in the `prox status` proxy block.
+	droppedTotal atomic.Int64
 
 	// onEvict is called when a request is evicted from the buffer
 	onEvict EvictionCallback
@@ -361,10 +374,28 @@ func (m *RequestManager) notifySubscribers(record RequestRecord) {
 			select {
 			case sub.Ch <- record:
 			default:
-				// Channel full, drop the message
+				// Channel full: drop the message and count it (D9). The
+				// manager-wide total feeds DroppedEvents(); the per-subscription
+				// count logs once on the first drop so a persistently slow
+				// subscriber is visible without a per-drop log flood. The log
+				// itself runs on a goroutine: notifySubscribers is called with
+				// the ring mutex held on the Upsert path (ordering guarantee),
+				// and logger I/O must not stall the SSE hot path under that
+				// lock.
+				m.droppedTotal.Add(1)
+				if sub.dropped.Add(1) == 1 {
+					go log.Printf("prox: request subscription %s is dropping events (subscriber not keeping up)", sub.ID)
+				}
 			}
 		}
 	}
+}
+
+// DroppedEvents returns the manager-wide number of subscriber notifications
+// dropped because a subscription's channel was full (D9). It is monotonic for
+// the life of the manager.
+func (m *RequestManager) DroppedEvents() int64 {
+	return m.droppedTotal.Load()
 }
 
 func (m *RequestManager) matchesFilter(record RequestRecord, filter RequestFilter) bool {

--- a/internal/proxy/requests.go
+++ b/internal/proxy/requests.go
@@ -110,6 +110,18 @@ type RequestFilter struct {
 	MaxStatus   int
 	Since       time.Time
 	Limit       int
+
+	// BeforeID anchors RecentPage (and, transitively, Recent) at the ring
+	// position of the record with this ID: only records strictly OLDER than
+	// the anchor, BY RING POSITION, are considered (D12, #50). This is
+	// arrival order, not time order. Backfill interleavings and
+	// completion-after-eviction re-appends (see Upsert: an in-flight record
+	// whose original slot was evicted re-enters the ring at the newest
+	// position when its completion arrives) mean a record's ring position
+	// can diverge from its Timestamp — a page can legitimately contain a
+	// record with a newer Timestamp than the anchor. Empty = no anchor
+	// (start at the newest record, i.e. today's Recent behavior).
+	BeforeID string
 }
 
 // RequestSubscription represents a subscription to request updates.
@@ -279,8 +291,35 @@ func (m *RequestManager) Upsert(record RequestRecord) {
 	}
 }
 
-// Recent returns the most recent requests matching the filter.
+// Recent returns the most recent requests matching the filter. It is
+// RecentPage without the cursor metadata, kept as the simple signature for
+// the many callers (CLI, daemon-internal endpoints, tests) that don't page.
 func (m *RequestManager) Recent(filter RequestFilter) []RequestRecord {
+	records, _, _ := m.RecentPage(filter)
+	return records
+}
+
+// RecentPage returns up to filter.Limit matching records, newest first,
+// optionally anchored at filter.BeforeID (ring-position cursor pagination,
+// D12/#50). It is the shared scan behind Recent.
+//
+// nextBeforeID is the ID of the OLDEST SCANNED record in this call's scan
+// window — not the oldest RETURNED record. The scan continues past
+// non-matching records (up to the ring's oldest record) until it collects
+// filter.Limit matches, so a page whose filter excludes everything
+// remaining still advances all the way through the ring and reports where
+// it stopped, rather than stalling a poller that keeps re-requesting the
+// same cursor. nextBeforeID is empty when the scan reached the ring's
+// oldest record (no older records remain: this is the last page).
+//
+// anchorFound is true when filter.BeforeID is empty (no anchor requested)
+// or names a record that both exists in the ring and matches the rest of
+// filter. An anchor that is unknown, evicted, or excluded by scope (e.g. a
+// different filter.ProjectDir than the anchor's) reports anchorFound=false
+// with no records — callers must treat both cases identically (410 Gone)
+// so an out-of-scope anchor can't be distinguished from a nonexistent one
+// and leak the other scope's record existence.
+func (m *RequestManager) RecentPage(filter RequestFilter) (records []RequestRecord, nextBeforeID string, anchorFound bool) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
@@ -289,19 +328,53 @@ func (m *RequestManager) Recent(filter RequestFilter) []RequestRecord {
 		limit = m.count
 	}
 
-	result := make([]RequestRecord, 0, limit)
+	// startOffset is how many newest-to-oldest steps to skip before scanning
+	// begins: 0 with no anchor (start at the newest record), or the
+	// anchor's position + 1 (strictly older) when filter.BeforeID is set.
+	startOffset := 0
+	if filter.BeforeID != "" {
+		anchorPos := -1
+		for i := 0; i < m.count; i++ {
+			idx := (m.head - 1 - i + m.capacity) % m.capacity
+			if m.buffer[idx].ID == filter.BeforeID {
+				anchorPos = i
+				break
+			}
+		}
+		if anchorPos == -1 {
+			return nil, "", false
+		}
+		anchorIdx := (m.head - 1 - anchorPos + m.capacity) % m.capacity
+		if !m.matchesFilter(m.buffer[anchorIdx], filter) {
+			// Anchor exists but is out of the requested scope (e.g. another
+			// project). Same signal as "not found" — see doc comment.
+			return nil, "", false
+		}
+		startOffset = anchorPos + 1
+	}
 
-	// Iterate from newest to oldest
-	for i := 0; i < m.count && len(result) < limit; i++ {
+	result := make([]RequestRecord, 0, limit)
+	lastScanned := startOffset - 1
+
+	for i := startOffset; i < m.count; i++ {
 		idx := (m.head - 1 - i + m.capacity) % m.capacity
 		record := m.buffer[idx]
+		lastScanned = i
 
 		if m.matchesFilter(record, filter) {
 			result = append(result, record)
 		}
+		if len(result) >= limit {
+			break
+		}
 	}
 
-	return result
+	if lastScanned >= startOffset && lastScanned != m.count-1 {
+		lastIdx := (m.head - 1 - lastScanned + m.capacity) % m.capacity
+		nextBeforeID = m.buffer[lastIdx].ID
+	}
+
+	return result, nextBeforeID, true
 }
 
 // GetByID returns a request record by its ID.

--- a/internal/proxy/requests.go
+++ b/internal/proxy/requests.go
@@ -156,6 +156,13 @@ type RequestManager struct {
 	// channel so post-shutdown streams end immediately.
 	closed bool
 
+	// writesClosed latches ring WRITES after Close (D13): a manager destroyed
+	// on deregister must reject a straggler Record/Upsert racing the teardown
+	// — an accepted write would land in a detached ring after the final purge
+	// already ran, leaking that request's capture files. Rejected writers get
+	// false back and clean up their own capture state.
+	writesClosed atomic.Bool
+
 	// droppedTotal is the manager-wide count of notifications dropped because a
 	// subscriber's channel was full (D9). Exposed via DroppedEvents(); surfaced
 	// daemon-side in DaemonStatusResponse and project-side (via the forwarder's
@@ -186,8 +193,13 @@ func (m *RequestManager) SetEvictionCallback(fn EvictionCallback) {
 }
 
 // Record adds a new request record to the buffer and notifies subscribers.
-// If the record doesn't have an ID, one is generated.
-func (m *RequestManager) Record(record RequestRecord) {
+// If the record doesn't have an ID, one is generated. It reports whether the
+// record was accepted: false means the manager was already Closed (see
+// writesClosed) and the caller owns any capture-file cleanup for the record.
+func (m *RequestManager) Record(record RequestRecord) bool {
+	if m.writesClosed.Load() {
+		return false
+	}
 	if record.ID == "" {
 		record.ID = GenerateRequestID(record.Timestamp, record.Method, record.URL)
 	}
@@ -219,6 +231,7 @@ func (m *RequestManager) Record(record RequestRecord) {
 
 	// Notify subscribers
 	m.notifySubscribers(record)
+	return true
 }
 
 // Upsert applies a record as a monotonic two-state transition keyed by ID:
@@ -239,7 +252,12 @@ func (m *RequestManager) Record(record RequestRecord) {
 // notifySubscribers only performs non-blocking channel sends under subMu,
 // and no path acquires mu while holding subMu, so this cannot block or
 // deadlock. The eviction callback (disk IO) still runs after unlock.
-func (m *RequestManager) Upsert(record RequestRecord) {
+// Upsert reports whether the record was accepted; false means the manager was
+// already Closed (writesClosed) and the caller owns capture-file cleanup.
+func (m *RequestManager) Upsert(record RequestRecord) bool {
+	if m.writesClosed.Load() {
+		return false
+	}
 	if record.ID == "" {
 		// Defensive: callers always supply IDs. Generate one and fall through
 		// to the normal append path (NOT Record, whose after-unlock notify
@@ -265,7 +283,7 @@ func (m *RequestManager) Upsert(record RequestRecord) {
 	case idx >= 0 && (!m.buffer[idx].InFlight || record.InFlight):
 		// Terminal existing record, or duplicate in-flight delivery.
 		m.mu.Unlock()
-		return
+		return true
 	case idx >= 0:
 		// In-flight → final: replace in place, ring position preserved.
 		m.buffer[idx] = record
@@ -289,6 +307,7 @@ func (m *RequestManager) Upsert(record RequestRecord) {
 	if evictedID != "" && onEvict != nil {
 		onEvict(evictedID)
 	}
+	return true
 }
 
 // Recent returns the most recent requests matching the filter. It is
@@ -441,6 +460,11 @@ func (m *RequestManager) Count() int {
 // request racing a shutdown-time Close cannot re-subscribe and pin the API
 // server open. Idempotent.
 func (m *RequestManager) Close() {
+	// Latch writes BEFORE subscriptions: a destroy-path Close must guarantee
+	// that any Record/Upsert observing the latch is rejected, so every record
+	// that DID land in the ring is covered by the destroy's final purge.
+	m.writesClosed.Store(true)
+
 	m.subMu.Lock()
 	defer m.subMu.Unlock()
 

--- a/internal/proxy/requests_drop_test.go
+++ b/internal/proxy/requests_drop_test.go
@@ -1,0 +1,73 @@
+package proxy
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// syncBuffer is a mutex-guarded log sink: the first-drop log line is emitted
+// on a goroutine (so logger I/O never runs under the ring mutex on the SSE
+// hot path), which means the test's capture buffer is written concurrently
+// with the test's own reads and must be synchronized.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// TestRequestManager_DroppedEventsUnderBurst pins D9: a burst larger than a
+// subscriber's channel buffer against a subscriber that never reads yields a
+// non-zero DroppedEvents total, and the per-subscription first drop logs exactly
+// once (not per-drop).
+func TestRequestManager_DroppedEventsUnderBurst(t *testing.T) {
+	logBuf := &syncBuffer{}
+	log.SetOutput(logBuf)
+	t.Cleanup(func() { log.SetOutput(nil) })
+
+	m := NewRequestManager(1000)
+	// Subscribe with the default 100-slot channel and never read it, so a burst
+	// past 100 forces the non-blocking send in notifySubscribers to drop.
+	sub := m.Subscribe(RequestFilter{})
+	if sub == nil {
+		t.Fatal("Subscribe returned nil")
+	}
+
+	const burst = 150
+	for i := 0; i < burst; i++ {
+		m.Record(RequestRecord{ID: fmt.Sprintf("r%03d", i), Method: "GET", URL: "/x"})
+	}
+
+	if got := m.DroppedEvents(); got <= 0 {
+		t.Fatalf("DroppedEvents() = %d, want > 0 after a %d-event burst against an unread subscriber", got, burst)
+	}
+	// Expect roughly burst-100 drops (the first 100 fill the buffer).
+	if got := m.DroppedEvents(); got < int64(burst-100) {
+		t.Errorf("DroppedEvents() = %d, want >= %d", got, burst-100)
+	}
+
+	// The first-drop log is asynchronous (goroutine); wait for it to land,
+	// then confirm no further lines arrive (exactly-once).
+	deadline := time.Now().Add(2 * time.Second)
+	for strings.Count(logBuf.String(), "is dropping events") == 0 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if n := strings.Count(logBuf.String(), "is dropping events"); n != 1 {
+		t.Errorf("first-drop log lines = %d, want exactly 1 (first drop per subscription logs once); log:\n%s", n, logBuf.String())
+	}
+}

--- a/internal/proxy/requests_drop_test.go
+++ b/internal/proxy/requests_drop_test.go
@@ -37,8 +37,9 @@ func (b *syncBuffer) String() string {
 // once (not per-drop).
 func TestRequestManager_DroppedEventsUnderBurst(t *testing.T) {
 	logBuf := &syncBuffer{}
+	prev := log.Writer()
 	log.SetOutput(logBuf)
-	t.Cleanup(func() { log.SetOutput(nil) })
+	t.Cleanup(func() { log.SetOutput(prev) })
 
 	m := NewRequestManager(1000)
 	// Subscribe with the default 100-slot channel and never read it, so a burst

--- a/internal/proxy/requests_test.go
+++ b/internal/proxy/requests_test.go
@@ -660,3 +660,167 @@ func TestRequestRecord_InFlightOmittedWhenFinal(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(data), `"in_flight":true`)
 }
+
+// --- D12 (#50): RecentPage ring-position cursor pagination ---
+
+func TestRequestManager_RecentPage_AnchorMidRing(t *testing.T) {
+	m := NewRequestManager(10)
+	for _, id := range []string{"r1", "r2", "r3", "r4", "r5"} {
+		m.Record(RequestRecord{ID: id, Method: "GET", URL: "/x"})
+	}
+	// Ring newest->oldest: r5, r4, r3, r2, r1.
+
+	page, next, found := m.RecentPage(RequestFilter{BeforeID: "r3", Limit: 10})
+	require.True(t, found)
+	require.Len(t, page, 2)
+	assert.Equal(t, "r2", page[0].ID)
+	assert.Equal(t, "r1", page[1].ID)
+	assert.Empty(t, next, "scan reached the ring's oldest record")
+}
+
+func TestRequestManager_RecentPage_AnchorEvicted(t *testing.T) {
+	m := NewRequestManager(3)
+	for _, id := range []string{"r1", "r2", "r3", "r4"} {
+		m.Record(RequestRecord{ID: id})
+	}
+	// Capacity 3: r1 has been evicted; ring holds r2, r3, r4.
+	_, ok := m.GetByID("r1")
+	require.False(t, ok, "precondition: r1 must be evicted")
+
+	page, next, found := m.RecentPage(RequestFilter{BeforeID: "r1"})
+	assert.False(t, found)
+	assert.Empty(t, page)
+	assert.Empty(t, next)
+
+	// A never-existed ID reports the same anchorFound=false shape.
+	page2, next2, found2 := m.RecentPage(RequestFilter{BeforeID: "does-not-exist"})
+	assert.False(t, found2)
+	assert.Empty(t, page2)
+	assert.Empty(t, next2)
+}
+
+func TestRequestManager_RecentPage_FilterWithCursor(t *testing.T) {
+	m := NewRequestManager(10)
+	m.Record(RequestRecord{ID: "a1", Method: "GET"})
+	m.Record(RequestRecord{ID: "b1", Method: "POST"})
+	m.Record(RequestRecord{ID: "a2", Method: "GET"})
+	m.Record(RequestRecord{ID: "b2", Method: "POST"})
+	m.Record(RequestRecord{ID: "a3", Method: "GET"})
+	// Ring newest->oldest: a3, b2, a2, b1, a1.
+
+	page, next, found := m.RecentPage(RequestFilter{Method: "GET", BeforeID: "a3", Limit: 10})
+	require.True(t, found)
+	require.Len(t, page, 2)
+	assert.Equal(t, "a2", page[0].ID)
+	assert.Equal(t, "a1", page[1].ID)
+	assert.Empty(t, next, "scan reached the ring's oldest record")
+}
+
+func TestRequestManager_RecentPage_FullyFilteredPageAdvancesCursor(t *testing.T) {
+	m := NewRequestManager(10)
+	for i := 0; i < 5; i++ {
+		m.Record(RequestRecord{ID: fmt.Sprintf("old%d", i), Method: "POST"})
+	}
+	m.Record(RequestRecord{ID: "anchor", Method: "GET"})
+	// Ring newest->oldest: anchor, old4, old3, old2, old1, old0.
+
+	page, next, found := m.RecentPage(RequestFilter{Method: "GET", BeforeID: "anchor", Limit: 10})
+	require.True(t, found)
+	// None of the POST records match the GET filter: a page that returned
+	// nothing must still report that the scan reached the ring's oldest
+	// record (next empty) instead of stalling on an unadvanced cursor.
+	assert.Empty(t, page)
+	assert.Empty(t, next)
+}
+
+func TestRequestManager_RecentPage_CrossProjectScope(t *testing.T) {
+	m := NewRequestManager(10)
+	m.Record(RequestRecord{ID: "p1", ProjectDir: "/projects/a"})
+	m.Record(RequestRecord{ID: "p2", ProjectDir: "/projects/b"})
+
+	// p1 exists in the ring but belongs to a different project than the
+	// filter's scope. It must report the same anchorFound=false shape as an
+	// unknown ID so an out-of-scope anchor can't leak its existence (D12).
+	page, next, found := m.RecentPage(RequestFilter{ProjectDir: "/projects/b", BeforeID: "p1"})
+	assert.False(t, found)
+	assert.Empty(t, page)
+	assert.Empty(t, next)
+}
+
+// TestRequestManager_RecentPage_ReappendOrdering pins the central D12
+// invariant: RecentPage orders and pages by RING POSITION (arrival order),
+// not by Timestamp. An in-flight record whose original slot is evicted
+// while its response is still in flight re-enters the ring at the newest
+// position once its completion arrives (Upsert's absent-ID append path) —
+// even though it carries the oldest Timestamp of any surviving record.
+func TestRequestManager_RecentPage_ReappendOrdering(t *testing.T) {
+	m := NewRequestManager(3)
+	base := time.Now()
+
+	// s1 starts in-flight: earliest arrival, earliest timestamp.
+	m.Upsert(RequestRecord{ID: "s1", Method: "GET", URL: "/stream", InFlight: true, Timestamp: base})
+	m.Upsert(RequestRecord{ID: "b", Method: "GET", URL: "/b", Timestamp: base.Add(1 * time.Second)})
+	m.Upsert(RequestRecord{ID: "c", Method: "GET", URL: "/c", Timestamp: base.Add(2 * time.Second)})
+	// "d" wraps the capacity-3 ring, evicting s1's original slot.
+	m.Upsert(RequestRecord{ID: "d", Method: "GET", URL: "/d", Timestamp: base.Add(3 * time.Second)})
+
+	_, ok := m.GetByID("s1")
+	require.False(t, ok, "precondition: s1's original slot must be evicted")
+
+	// s1's completion arrives after eviction. Its ID is no longer in the
+	// ring, so Upsert treats it as a brand-new arrival at the newest
+	// position (evicting "b"), despite carrying the oldest Timestamp here.
+	m.Upsert(RequestRecord{ID: "s1", Method: "GET", URL: "/stream", Timestamp: base, Duration: time.Second})
+
+	page, next, found := m.RecentPage(RequestFilter{Limit: 10})
+	require.True(t, found)
+	require.Len(t, page, 3)
+	got := []string{page[0].ID, page[1].ID, page[2].ID}
+	assert.Equal(t, []string{"s1", "d", "c"}, got, "ring (arrival) order, not time order")
+	assert.Empty(t, next)
+
+	// s1's Timestamp is the OLDEST of the three surviving records even
+	// though it paginates as the newest — the divergence this test pins.
+	assert.True(t, page[0].Timestamp.Before(page[1].Timestamp))
+	assert.True(t, page[0].Timestamp.Before(page[2].Timestamp))
+
+	// Paginating with before_id=s1 must return strictly-older-by-POSITION
+	// records (d, c) — not records reordered by Timestamp.
+	older, next2, found2 := m.RecentPage(RequestFilter{BeforeID: "s1", Limit: 10})
+	require.True(t, found2)
+	require.Len(t, older, 2)
+	assert.Equal(t, "d", older[0].ID)
+	assert.Equal(t, "c", older[1].ID)
+	assert.Empty(t, next2)
+}
+
+func TestRequestManager_RecentPage_PaginationCarriesAndOmitsCursor(t *testing.T) {
+	m := NewRequestManager(10)
+	for _, id := range []string{"r1", "r2", "r3", "r4", "r5"} {
+		m.Record(RequestRecord{ID: id})
+	}
+	// Ring newest->oldest: r5, r4, r3, r2, r1.
+
+	// Plain first page (no before_id): next_before_id must still be
+	// populated when older records remain, so a poller can start cursoring
+	// from an unqualified first call.
+	page1, next1, found1 := m.RecentPage(RequestFilter{Limit: 2})
+	require.True(t, found1)
+	require.Len(t, page1, 2)
+	assert.Equal(t, []string{"r5", "r4"}, []string{page1[0].ID, page1[1].ID})
+	require.Equal(t, "r4", next1, "next_before_id is the oldest SCANNED record")
+
+	page2, next2, found2 := m.RecentPage(RequestFilter{Limit: 2, BeforeID: next1})
+	require.True(t, found2)
+	require.Len(t, page2, 2)
+	assert.Equal(t, []string{"r3", "r2"}, []string{page2[0].ID, page2[1].ID})
+	require.Equal(t, "r2", next2)
+
+	page3, next3, found3 := m.RecentPage(RequestFilter{Limit: 2, BeforeID: next2})
+	require.True(t, found3)
+	require.Len(t, page3, 1)
+	assert.Equal(t, "r1", page3[0].ID)
+	// Last page: the scan reached the ring's oldest record, so the cursor is
+	// omitted (no more pages) instead of pointing back at r1.
+	assert.Empty(t, next3)
+}

--- a/internal/proxy/requests_test.go
+++ b/internal/proxy/requests_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/charliek/prox/internal/constants"
 )
 
 func TestRequestManager_Record(t *testing.T) {
@@ -594,6 +596,58 @@ func TestRequestManager_Upsert_ConcurrentTransitions(t *testing.T) {
 		got, ok := m.GetByID(id)
 		require.True(t, ok, id)
 		assert.False(t, got.InFlight, id)
+	}
+}
+
+// TestRequestRecord_StaleAt is the truth table for D8 (#53) staleness: stale
+// iff InFlight && now.Sub(Timestamp) > constants.InFlightStaleAfter. Covers a
+// fresh in-flight row, the exact boundary (exclusive: equal to the threshold
+// is NOT stale), just past the boundary, well past it, and final records
+// (never stale regardless of age).
+func TestRequestRecord_StaleAt(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name   string
+		record RequestRecord
+		want   bool
+	}{
+		{
+			name:   "in-flight, fresh",
+			record: RequestRecord{InFlight: true, Timestamp: now.Add(-1 * time.Minute)},
+			want:   false,
+		},
+		{
+			name:   "in-flight, exactly at the threshold is not yet stale",
+			record: RequestRecord{InFlight: true, Timestamp: now.Add(-constants.InFlightStaleAfter)},
+			want:   false,
+		},
+		{
+			name:   "in-flight, one nanosecond past the threshold is stale",
+			record: RequestRecord{InFlight: true, Timestamp: now.Add(-constants.InFlightStaleAfter - time.Nanosecond)},
+			want:   true,
+		},
+		{
+			name:   "in-flight, well past the threshold",
+			record: RequestRecord{InFlight: true, Timestamp: now.Add(-1 * time.Hour)},
+			want:   true,
+		},
+		{
+			name:   "final record with an old timestamp is never stale",
+			record: RequestRecord{InFlight: false, Timestamp: now.Add(-1 * time.Hour)},
+			want:   false,
+		},
+		{
+			name:   "final record with a fresh timestamp is never stale",
+			record: RequestRecord{InFlight: false, Timestamp: now},
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.record.StaleAt(now))
+		})
 	}
 }
 

--- a/internal/proxy/requests_test.go
+++ b/internal/proxy/requests_test.go
@@ -824,3 +824,31 @@ func TestRequestManager_RecentPage_PaginationCarriesAndOmitsCursor(t *testing.T)
 	// omitted (no more pages) instead of pointing back at r1.
 	assert.Empty(t, next3)
 }
+
+// TestRequestManager_WritesRejectedAfterClose pins the D13 destroy-race latch
+// (codex C12 review): once Close runs, Record and Upsert are rejected (false)
+// so a completion racing a deregister-destroy cleans its own capture files
+// instead of landing in a detached ring after the final purge already ran.
+// Writes accepted BEFORE the latch stay covered by the destroy's final purge.
+func TestRequestManager_WritesRejectedAfterClose(t *testing.T) {
+	m := NewRequestManager(10)
+
+	if ok := m.Record(RequestRecord{ID: "before-close", Method: "GET", URL: "/a"}); !ok {
+		t.Fatal("Record before Close must be accepted")
+	}
+	if ok := m.Upsert(RequestRecord{ID: "before-close", Method: "GET", URL: "/a"}); !ok {
+		t.Fatal("Upsert before Close must be accepted (terminal no-op still reports accepted)")
+	}
+
+	m.Close()
+
+	if ok := m.Record(RequestRecord{ID: "after-close-r", Method: "GET", URL: "/b"}); ok {
+		t.Error("Record after Close must be rejected")
+	}
+	if ok := m.Upsert(RequestRecord{ID: "after-close-u", Method: "GET", URL: "/c"}); ok {
+		t.Error("Upsert after Close must be rejected")
+	}
+	if m.Count() != 1 {
+		t.Errorf("ring count = %d, want 1 (no post-Close writes landed)", m.Count())
+	}
+}

--- a/internal/proxyd/cert_registration_test.go
+++ b/internal/proxyd/cert_registration_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/charliek/prox/internal/proxy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -152,11 +151,11 @@ func newProxyServerWithCertMgr(t *testing.T, cm certManager) *Server {
 	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
 	s := NewServer(ServerConfig{SocketPath: "", Logger: logger, Version: "test"})
 	reg := NewRegistry()
-	rm := proxy.NewRequestManager(100)
-	dp := NewDynamicProxy(reg, cm, rm, nil, logger)
+	ms := NewManagers(100, nil)
+	dp := NewDynamicProxy(reg, cm, ms, nil, logger)
 	s.SetRegistry(reg)
 	s.SetProxy(dp)
-	s.SetRequestManager(rm)
+	s.SetManagers(ms)
 	t.Cleanup(func() { _ = dp.Shutdown(context.Background()) })
 	return s
 }

--- a/internal/proxyd/client.go
+++ b/internal/proxyd/client.go
@@ -39,7 +39,14 @@ func NewClient(socketPath string) *Client {
 
 // Health checks if the daemon is alive and returns its version.
 func (c *Client) Health() (string, error) {
-	resp, err := c.get("/health")
+	return c.HealthWithContext(context.Background())
+}
+
+// HealthWithContext is Health bounded by ctx, so a caller can probe a possibly
+// unresponsive daemon with a short timeout instead of waiting out the client's
+// 30s default (used by the version-skew drain poll in D1).
+func (c *Client) HealthWithContext(ctx context.Context) (string, error) {
+	resp, err := c.getWithContext(ctx, "/health")
 	if err != nil {
 		return "", err
 	}
@@ -91,7 +98,14 @@ func (c *Client) Deregister(req DeregisterRequest) error {
 
 // Status returns the daemon's current status.
 func (c *Client) Status() (*DaemonStatusResponse, error) {
-	resp, err := c.get("/api/v1/status")
+	return c.StatusWithContext(context.Background())
+}
+
+// StatusWithContext is Status bounded by ctx. The version-skew recovery path
+// probes a possibly-draining old daemon with a short timeout (D1) rather than
+// the client's 30s default.
+func (c *Client) StatusWithContext(ctx context.Context) (*DaemonStatusResponse, error) {
+	resp, err := c.getWithContext(ctx, "/api/v1/status")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/proxyd/client.go
+++ b/internal/proxyd/client.go
@@ -21,6 +21,27 @@ type Client struct {
 	httpClient *http.Client
 }
 
+// DaemonAPIError is returned by Client methods when the daemon responds with a
+// non-2xx status and a decodable ErrorResponse body. It carries the daemon's
+// Code (e.g. "SHUTTING_DOWN", "VERSION_MISMATCH") so callers can drive
+// recovery via errors.As instead of matching on message text — following the
+// ProjectConflictError precedent (registry.go). Error() reproduces the plain
+// message text callers previously saw from readError, so existing
+// message-only handling keeps working unchanged.
+type DaemonAPIError struct {
+	// Code is the daemon's machine-readable error code (ErrorResponse.Code).
+	// Empty when the daemon's body didn't include one.
+	Code string
+	// Message is the daemon's human-readable error text (ErrorResponse.Error).
+	Message string
+	// Status is the HTTP status code the daemon responded with.
+	Status int
+}
+
+func (e *DaemonAPIError) Error() string {
+	return e.Message
+}
+
 // NewClient creates a new daemon client that connects via Unix socket.
 func NewClient(socketPath string) *Client {
 	dialer := &net.Dialer{}
@@ -63,7 +84,10 @@ func (c *Client) HealthWithContext(ctx context.Context) (string, error) {
 	return result["version"], nil
 }
 
-// Register registers a project's routes with the daemon.
+// Register registers a project's routes with the daemon. On a non-2xx
+// response it returns a *DaemonAPIError (errors.As) carrying the daemon's
+// error Code — e.g. "SHUTTING_DOWN" during the daemon's graceful-shutdown
+// grace (D4 retries this in tryDaemonProxy) or "VERSION_MISMATCH".
 func (c *Client) Register(req RegisterRequest) (*RegisterResponse, error) {
 	resp, err := c.post("/api/v1/register", req)
 	if err != nil {
@@ -246,13 +270,17 @@ func (c *Client) post(path string, body any) (*http.Response, error) {
 	return c.httpClient.Post("http://proxyd"+path, "application/json", bodyReader)
 }
 
-// readError reads an error response from the daemon.
+// readError reads an error response from the daemon. When the body decodes to
+// an ErrorResponse with a non-empty Error field, it returns a *DaemonAPIError
+// (matched with errors.As by callers, e.g. the D4 SHUTTING_DOWN retry) rather
+// than a plain error, so the daemon's Code survives past this call. Its
+// Error() text is identical to what callers previously received.
 func (c *Client) readError(resp *http.Response) error {
 	body, _ := io.ReadAll(resp.Body)
 
 	var errResp ErrorResponse
 	if json.Unmarshal(body, &errResp) == nil && errResp.Error != "" {
-		return fmt.Errorf("%s", errResp.Error)
+		return &DaemonAPIError{Code: errResp.Code, Message: errResp.Error, Status: resp.StatusCode}
 	}
 	return fmt.Errorf("daemon returned %d: %s", resp.StatusCode, string(body))
 }

--- a/internal/proxyd/client_server_test.go
+++ b/internal/proxyd/client_server_test.go
@@ -38,6 +38,9 @@ func startTestServer(t *testing.T) (*Server, *Client, string) {
 
 	registry := NewRegistry()
 	server.SetRegistry(registry)
+	// Wire the per-project ring set so the request endpoints resolve rings;
+	// tests that need records ensure their project's ring via server.managers.
+	server.SetManagers(NewManagers(constants.DefaultProxyRequestBufferSize, nil))
 
 	errCh := make(chan error, 1)
 	go func() {
@@ -230,20 +233,19 @@ func TestShutdownProtected(t *testing.T) {
 func TestClientRequests(t *testing.T) {
 	server, client, _ := startTestServer(t)
 
-	daemonRM := proxy.NewRequestManager(100)
-	server.SetRequestManager(daemonRM)
-
 	// A project dir with a space and a '#': if the client did not URL-escape it,
 	// the '#' would be treated as a fragment and the server's project filter
 	// would never match, returning zero records.
 	const dir = "/weird dir #1"
+	dirRing := server.managers.ensure(dir)
 	for i := 0; i < 5; i++ {
-		daemonRM.Record(proxy.RequestRecord{
+		dirRing.Record(proxy.RequestRecord{
 			ID: fmt.Sprintf("r%d", i), ProjectDir: dir, Method: "GET", URL: "/x", Timestamp: time.Now(),
 		})
 	}
-	// A record for a different project must never leak into the filtered result.
-	daemonRM.Record(proxy.RequestRecord{ID: "other", ProjectDir: "/other", Method: "GET", URL: "/y", Timestamp: time.Now()})
+	// A record for a different project (its own ring) must never leak into the
+	// filtered result.
+	server.managers.ensure("/other").Record(proxy.RequestRecord{ID: "other", ProjectDir: "/other", Method: "GET", URL: "/y", Timestamp: time.Now()})
 
 	t.Run("escapes dir, honors limit, decodes wrapper", func(t *testing.T) {
 		recs, err := client.Requests(t.Context(), dir, 3)

--- a/internal/proxyd/daemon.go
+++ b/internal/proxyd/daemon.go
@@ -171,7 +171,6 @@ func RunDaemon(ctx context.Context) error {
 	// Create core components
 	registry := NewRegistry()
 	certMgr := NewMultiDomainCertManager(constants.DefaultCertsDir)
-	requestMgr := proxy.NewRequestManager(constants.DefaultProxyRequestBufferSize)
 
 	// Create the daemon's capture manager, rooted at ~/.prox/capture. Resolve
 	// the home directory explicitly; on failure log and run without capture
@@ -190,14 +189,22 @@ func RunDaemon(ctx context.Context) error {
 	// first. Registered immediately after construction so an early startup
 	// error still removes the capture dir. Cleanup is RemoveAll, so it is
 	// idempotent and safe to leave deferred here.
+	var evict proxy.EvictionCallback
 	if captureMgr != nil {
 		defer func() { _ = captureMgr.Cleanup() }()
-		// Evicting a record from the ring buffer must delete its on-disk body
+		// Evicting a record from a project ring must delete its on-disk body
 		// files; the capture manager's per-request cleanup does exactly that.
-		requestMgr.SetEvictionCallback(captureMgr.CleanupRequest)
+		// The set wires this onto every per-project ring at creation.
+		evict = captureMgr.CleanupRequest
 	}
 
-	dynamicProxy := NewDynamicProxy(registry, certMgr, requestMgr, captureMgr, logger)
+	// Per-project request rings (D13, #49): one full-capacity ring per registered
+	// project, created at register time, so one project's flood cannot evict
+	// another's records. Shared by the dynamic proxy (hot path) and the socket
+	// server (control-plane endpoints).
+	managers := NewManagers(constants.DefaultProxyRequestBufferSize, evict)
+
+	dynamicProxy := NewDynamicProxy(registry, certMgr, managers, captureMgr, logger)
 
 	// Create and configure the socket server
 	server := NewServer(ServerConfig{
@@ -207,7 +214,7 @@ func RunDaemon(ctx context.Context) error {
 	})
 	server.SetRegistry(registry)
 	server.SetProxy(dynamicProxy)
-	server.SetRequestManager(requestMgr)
+	server.SetManagers(managers)
 
 	// Handle OS signals
 	ctx, cancel := context.WithCancel(ctx)
@@ -293,10 +300,10 @@ func RunDaemon(ctx context.Context) error {
 	if err := dynamicProxy.Shutdown(shutdownCtx); err != nil {
 		logger.Error("error shutting down proxy", "error", err)
 	}
-	// Close the request manager before the socket server so active SSE
+	// Close every project ring before the socket server so active SSE
 	// subscribers observe end-of-stream and release the server, rather than
 	// pinning it open through the shutdown grace period.
-	requestMgr.Close()
+	managers.closeAll()
 	if err := server.Shutdown(shutdownCtx); err != nil {
 		logger.Error("error shutting down server", "error", err)
 	}

--- a/internal/proxyd/daemon.go
+++ b/internal/proxyd/daemon.go
@@ -38,6 +38,32 @@ func IsDaemonProcess() bool {
 	return os.Getenv(ProxyDaemonEnvVar) == "1"
 }
 
+// VersionMismatchError is returned by EnsureRunning when a running daemon — or a
+// freshly started one — reports a version different from this process. It is
+// matched with errors.As so the caller (tryDaemonProxy) can drive version-skew
+// recovery (D1) rather than silently falling back to a standalone proxy, which
+// used to leave a project running with the proxy disabled.
+type VersionMismatchError struct {
+	DaemonVersion string
+	ClientVersion string
+}
+
+func (e *VersionMismatchError) Error() string {
+	return fmt.Sprintf(
+		"proxy daemon is running version %s, but this process is version %s",
+		e.DaemonVersion, e.ClientVersion,
+	)
+}
+
+// ErrDaemonNotReady is returned by EnsureRunning when a freshly started daemon
+// did not answer /health within the startup window. During a version-skew heal
+// this also covers the socket-removed-before-PID-lock-released race: the old
+// daemon removes its socket (server.Shutdown) before its deferred PID-lock
+// release (RunDaemon), so a replacement start can briefly lose the lock and
+// report not-ready. The skew recovery retries once after a short delay on this.
+// Matched with errors.Is.
+var ErrDaemonNotReady = errors.New("proxy daemon did not become ready")
+
 // EnsureRunning ensures the proxy daemon is running and returns a connected client.
 // If the daemon is not running, it starts one. Verifies version compatibility.
 func EnsureRunning() (*Client, error) {
@@ -49,11 +75,7 @@ func EnsureRunning() (*Client, error) {
 	if err == nil {
 		// Daemon is running — check version
 		if daemonVersion != version.Version {
-			return nil, fmt.Errorf(
-				"proxy daemon is running version %s, but this process is version %s; "+
-					"stop all projects and restart, or run 'prox proxy stop --force' to reset",
-				daemonVersion, version.Version,
-			)
+			return nil, &VersionMismatchError{DaemonVersion: daemonVersion, ClientVersion: version.Version}
 		}
 		return client, nil
 	}
@@ -69,14 +91,14 @@ func EnsureRunning() (*Client, error) {
 		daemonVersion, err = client.Health()
 		if err == nil {
 			if daemonVersion != version.Version {
-				return nil, fmt.Errorf("started daemon has version %s, expected %s", daemonVersion, version.Version)
+				return nil, &VersionMismatchError{DaemonVersion: daemonVersion, ClientVersion: version.Version}
 			}
 			return client, nil
 		}
 		time.Sleep(startupRetryInterval)
 	}
 
-	return nil, fmt.Errorf("proxy daemon did not become ready within %s", startupTimeout)
+	return nil, fmt.Errorf("%w within %s", ErrDaemonNotReady, startupTimeout)
 }
 
 // startDaemon forks the proxy daemon as a background process.

--- a/internal/proxyd/dynamic_proxy.go
+++ b/internal/proxyd/dynamic_proxy.go
@@ -37,12 +37,17 @@ type managedListener struct {
 // DynamicProxy manages multiple HTTP/HTTPS listeners that can be added and
 // removed at runtime as projects register and deregister routes.
 type DynamicProxy struct {
-	mu             sync.RWMutex
-	listeners      map[int]*managedListener
-	registry       *Registry
-	transport      *http.Transport
-	certMgr        certManager
-	requestManager *proxy.RequestManager
+	mu        sync.RWMutex
+	listeners map[int]*managedListener
+	registry  *Registry
+	transport *http.Transport
+	certMgr   certManager
+	// managers holds the per-project request rings (D13, #49). The hot path
+	// resolves the matched route's ring via managers.get(route.ProjectDir): a nil
+	// result (a request completing after its project deregistered) drops the
+	// record safely. The set is shared with the Server so the data plane and the
+	// control-plane endpoints see the identical rings.
+	managers       *Managers
 	captureManager *proxy.CaptureManager
 	logger         *slog.Logger
 }
@@ -55,12 +60,12 @@ type DynamicProxy struct {
 // literal: the HTTPS bind path and the register flow gate on certMgr != nil, so
 // a typed nil such as (*MultiDomainCertManager)(nil) would slip past that guard
 // (a non-nil interface wrapping a nil pointer) and panic on the first HTTPS bind.
-func NewDynamicProxy(registry *Registry, certMgr certManager, requestManager *proxy.RequestManager, captureManager *proxy.CaptureManager, logger *slog.Logger) *DynamicProxy {
+func NewDynamicProxy(registry *Registry, certMgr certManager, managers *Managers, captureManager *proxy.CaptureManager, logger *slog.Logger) *DynamicProxy {
 	return &DynamicProxy{
 		listeners:      make(map[int]*managedListener),
 		registry:       registry,
 		certMgr:        certMgr,
-		requestManager: requestManager,
+		managers:       managers,
 		captureManager: captureManager,
 		logger:         logger,
 		transport: &http.Transport{
@@ -224,7 +229,9 @@ func (dp *DynamicProxy) handler(port int) http.Handler {
 		var reqBody *proxy.CapturedBody
 		var reqHeaders http.Header
 		if captureEnabled {
-			reqBody, r.Body, reqHeaders = dp.captureManager.CaptureRequest(requestID, r)
+			// Per-project capture cap (D13, #49): the matched route carries the
+			// owning project's configured MaxBodySize; 0 means the daemon default.
+			reqBody, r.Body, reqHeaders = dp.captureManager.CaptureRequestWithLimit(requestID, r, route.MaxBodySize)
 		}
 
 		originalDirector := rp.Director
@@ -241,7 +248,7 @@ func (dp *DynamicProxy) handler(port int) http.Handler {
 		var crw *proxy.CaptureResponseWriter
 		var srw *statusResponseWriter
 		if captureEnabled {
-			crw = dp.captureManager.WrapResponseWriter(w)
+			crw = dp.captureManager.WrapResponseWriterWithLimit(w, route.MaxBodySize)
 			rw = crw
 		} else {
 			srw = &statusResponseWriter{ResponseWriter: w, statusCode: http.StatusOK}
@@ -289,10 +296,14 @@ func (dp *DynamicProxy) handler(port int) http.Handler {
 		// Phase 1 (in-flight): register a first-response hook that publishes a
 		// header-time record via Record (plain append — the fresh ID cannot
 		// already exist). buildRecord pins field parity with the completion
-		// record below.
-		if dp.requestManager != nil {
+		// record below. The hook re-resolves the project's ring at fire time
+		// (managers.get): if the project deregistered before the first response,
+		// the ring is gone and the in-flight record is dropped safely.
+		if dp.managers != nil {
 			onFirst := func(statusCode int) {
-				dp.requestManager.Record(buildRecord(statusCode, nil, true))
+				if mgr := dp.managers.get(route.ProjectDir); mgr != nil {
+					mgr.Record(buildRecord(statusCode, nil, true))
+				}
 			}
 			if crw != nil {
 				crw.SetFirstResponseCallback(onFirst)
@@ -308,7 +319,7 @@ func (dp *DynamicProxy) handler(port int) http.Handler {
 		// propagating; net/http suppresses ErrAbortHandler. Completion goes
 		// through Upsert (same ID as the in-flight record; final beats it).
 		defer func() {
-			if dp.requestManager == nil {
+			if dp.managers == nil {
 				return
 			}
 
@@ -353,7 +364,23 @@ func (dp *DynamicProxy) handler(port int) http.Handler {
 				statusCode = srw.statusCode
 			}
 
-			dp.requestManager.Upsert(buildRecord(statusCode, details, false))
+			// Re-resolve the project's ring at completion time. A nil result
+			// means the project deregistered while this request was in flight
+			// (its route was resolved before the deregister, its completion
+			// arrives after): drop the completion safely — no record, no panic —
+			// and clean any capture files this request spilled to disk, since no
+			// PurgeByProject on the removed ring will ever reach them (D13).
+			// A nil manager (project deregistered mid-request) and a rejected
+			// Upsert (manager Closed between the get and the write) both mean
+			// this completion has no ring: clean the request's spilled capture
+			// files, since no purge on the destroyed ring will reach them (D13).
+			mgr := dp.managers.get(route.ProjectDir)
+			if mgr == nil || !mgr.Upsert(buildRecord(statusCode, details, false)) {
+				if captureEnabled {
+					dp.captureManager.CleanupRequest(requestID)
+				}
+				return
+			}
 		}()
 
 		rp.ServeHTTP(rw, r)

--- a/internal/proxyd/dynamic_proxy_test.go
+++ b/internal/proxyd/dynamic_proxy_test.go
@@ -69,11 +69,13 @@ func newCaptureProxy(t *testing.T, captureEnabled bool, backendHost string, back
 	if err != nil {
 		t.Fatalf("NewCaptureManagerAt: %v", err)
 	}
-	rm := proxy.NewRequestManager(bufferCap)
-	rm.SetEvictionCallback(cm.CleanupRequest)
+	ms := NewManagers(bufferCap, cm.CleanupRequest)
+	// Pre-create the project ring the hot path will record into, and return it as
+	// the manager under test (the hot path resolves managers.get("/projects/a")).
+	rm := ms.ensure("/projects/a")
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	dp := NewDynamicProxy(reg, nil, rm, cm, logger)
+	dp := NewDynamicProxy(reg, nil, ms, cm, logger)
 	return dp, rm, cm
 }
 
@@ -306,9 +308,9 @@ func TestDynamicProxy_ErrorHandler_CaptureRecordsBadGateway(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewCaptureManagerAt: %v", err)
 	}
-	rm := proxy.NewRequestManager(10)
-	rm.SetEvictionCallback(cm.CleanupRequest)
-	dp := NewDynamicProxy(reg, nil, rm, cm, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	ms := NewManagers(10, cm.CleanupRequest)
+	rm := ms.ensure("/projects/a")
+	dp := NewDynamicProxy(reg, nil, ms, cm, slog.New(slog.NewTextHandler(io.Discard, nil)))
 
 	rec := serve(dp, "GET", "http://api.local.dev/down", "", nil)
 	if rec.Code != http.StatusBadGateway {

--- a/internal/proxyd/forwarder.go
+++ b/internal/proxyd/forwarder.go
@@ -47,6 +47,10 @@ type ForwarderStatusSink interface {
 // the same socket. It no-ops (returns false) once shutdown has been latched.
 type HealFunc func() bool
 
+// streamFlapThreshold is the minimum time a connected SSE stream must survive
+// to count as a real recovery in the reconnect loop (see the flap guard).
+const streamFlapThreshold = time.Second
+
 // ForwardRequests subscribes to the daemon's SSE request stream and forwards
 // this project's records into the local RequestManager. This bridges the
 // daemon's proxy request data into the project's TUI and API.
@@ -79,6 +83,7 @@ func ForwardRequests(ctx context.Context, socketPath string, projectDir string, 
 		after:           time.After,
 		healAfterDown:   constants.ForwarderHealAfterDown,
 		healMinInterval: constants.ForwarderHealMinInterval,
+		flapThreshold:   streamFlapThreshold,
 	})
 }
 
@@ -96,6 +101,10 @@ type forwarderConfig struct {
 	after           func(time.Duration) <-chan time.Time // backoff timer
 	healAfterDown   time.Duration
 	healMinInterval time.Duration
+	// flapThreshold is the minimum lifetime for a connected stream to count
+	// as a recovery (streamFlapThreshold in production; tests with instant
+	// scripted streams set 0 to opt out, and the flap test pins the guard).
+	flapThreshold time.Duration
 	// stream is the single connect-and-forward attempt (nil → the production
 	// streamRequests). Injectable so heal-timing tests can script a deterministic
 	// connect/drop/outage sequence without real sockets (FIX 4).
@@ -140,9 +149,27 @@ func forwardRequests(ctx context.Context, cfg forwarderConfig) {
 	var lastHeal time.Time  // zero until the first heal attempt of an outage
 
 	for {
+		// attemptStart feeds the flap guard below; only sample the clock when
+		// the guard is enabled (scripted-clock tests with flapThreshold 0
+		// must not consume extra instants).
+		var attemptStart time.Time
+		if cfg.flapThreshold > 0 {
+			attemptStart = cfg.now()
+		}
 		connected, err := stream(ctx, cfg.socketPath, snapClient, cfg.projectDir, cfg.localRM, cfg.sink)
 		if ctx.Err() != nil {
 			return // context cancelled, clean shutdown
+		}
+		// A 200 that dies immediately is a FLAP, not a recovery: a
+		// crash-looping daemon that accepts and instantly EOFs would
+		// otherwise clear the outage clock on every cycle and permanently
+		// suppress healing (CodeRabbit PR #68). Only a stream that lived
+		// past the flap threshold counts as connected for reset purposes.
+		if connected && cfg.flapThreshold > 0 && cfg.now().Sub(attemptStart) < cfg.flapThreshold {
+			connected = false
+			if err == nil {
+				err = fmt.Errorf("stream ended within %s of connecting (flapping daemon)", cfg.flapThreshold)
+			}
 		}
 		if connected {
 			// The previous attempt reached a live stream: the daemon is (or was

--- a/internal/proxyd/forwarder.go
+++ b/internal/proxyd/forwarder.go
@@ -17,6 +17,26 @@ import (
 	"github.com/charliek/prox/internal/proxy"
 )
 
+// ForwarderStatusSink receives connection-state and backfill signals from the
+// SSE forwarder so the CLI can surface shared-proxy health in `prox status`
+// (D5/D9). It is defined here — not in internal/cli — so proxyd stays free of a
+// cli import; the cli's proxyRuntime implements it. All methods must be safe to
+// call from the forwarder goroutine and are no-ops when the sink is nil.
+type ForwarderStatusSink interface {
+	// ForwarderConnected is called each time the bridge establishes an SSE
+	// connection (HTTP 200). Implementations reset the consecutive-failure
+	// counter and record the connect time.
+	ForwarderConnected()
+	// ForwarderConnectFailed is called each time a connection attempt fails
+	// before reaching a live stream. Implementations increment the
+	// consecutive-failure counter.
+	ForwarderConnectFailed(err error)
+	// ForwarderBackfillFailed is called when a post-connect ring snapshot fetch
+	// fails (the stream continues degraded). Implementations increment the
+	// backfill-failure counter.
+	ForwarderBackfillFailed()
+}
+
 // ForwardRequests subscribes to the daemon's SSE request stream and forwards
 // this project's records into the local RequestManager. This bridges the
 // daemon's proxy request data into the project's TUI and API.
@@ -30,8 +50,12 @@ import (
 // lossy (bounded, non-blocking channels), so the guarantee is bounded gap
 // closure, not losslessness.
 //
+// sink (may be nil) receives connect/disconnect/backfill signals so the CLI can
+// report shared-proxy health; it replaces the old silent `_ = err` reconnect
+// loop with state that surfaces in `prox status`.
+//
 // It runs until ctx is cancelled. On disconnect, it reconnects with backoff.
-func ForwardRequests(ctx context.Context, socketPath string, projectDir string, localRM *proxy.RequestManager) {
+func ForwardRequests(ctx context.Context, socketPath string, projectDir string, localRM *proxy.RequestManager, sink ForwarderStatusSink) {
 	// One snapshot client for the whole forwarder lifetime: its transport pools
 	// the idle unix connection across reconnect attempts, rather than leaking a
 	// fresh idle conn per attempt (the daemon only reaps idle conns after 60s, so
@@ -41,11 +65,24 @@ func ForwardRequests(ctx context.Context, socketPath string, projectDir string, 
 	backoff := 500 * time.Millisecond
 
 	for {
-		err := streamRequests(ctx, socketPath, snapClient, projectDir, localRM)
+		connected, err := streamRequests(ctx, socketPath, snapClient, projectDir, localRM, sink)
 		if ctx.Err() != nil {
 			return // context cancelled, clean shutdown
 		}
-		_ = err // reconnect silently
+		// A connect that never reached a live stream is a reconnect failure: the
+		// sink counts it (and logs the connected→down transition once). A stream
+		// that connected and then dropped is not itself a failure — the NEXT
+		// failed reconnect, if any, records the outage. streamRequests already
+		// signalled ForwarderConnected on a successful connect.
+		if !connected && sink != nil {
+			sink.ForwarderConnectFailed(err)
+		}
+		if connected {
+			// The previous attempt reached a live stream: the daemon is (or
+			// was just) healthy, so reconnect eagerly instead of carrying a
+			// stale outage-sized backoff into the recovery.
+			backoff = 500 * time.Millisecond
+		}
 
 		// Backoff before reconnecting
 		select {
@@ -60,8 +97,14 @@ func ForwardRequests(ctx context.Context, socketPath string, projectDir string, 
 }
 
 // streamRequests opens an SSE connection to the daemon and processes events.
-// snapClient is the shared daemon client used for the backfill snapshot.
-func streamRequests(ctx context.Context, socketPath string, snapClient *Client, projectDir string, localRM *proxy.RequestManager) error {
+// snapClient is the shared daemon client used for the backfill snapshot; sink
+// (may be nil) receives connect/backfill signals.
+//
+// It returns connected=true once the SSE connection reached a live stream (HTTP
+// 200), regardless of how the stream later ended, so the caller can distinguish
+// a failed reconnect (connected=false, count it) from a dropped live stream
+// (connected=true, do not count it).
+func streamRequests(ctx context.Context, socketPath string, snapClient *Client, projectDir string, localRM *proxy.RequestManager, sink ForwarderStatusSink) (connected bool, err error) {
 	// Create HTTP client that dials the Unix socket
 	dialer := &net.Dialer{}
 	client := &http.Client{
@@ -75,17 +118,25 @@ func streamRequests(ctx context.Context, socketPath string, snapClient *Client, 
 	streamURL := fmt.Sprintf("http://proxyd/api/v1/requests/stream?project=%s", url.QueryEscape(projectDir))
 	req, err := http.NewRequestWithContext(ctx, "GET", streamURL, nil)
 	if err != nil {
-		return fmt.Errorf("creating SSE request: %w", err)
+		return false, fmt.Errorf("creating SSE request: %w", err)
 	}
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("connecting to daemon SSE: %w", err)
+		return false, fmt.Errorf("connecting to daemon SSE: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("daemon SSE returned %d", resp.StatusCode)
+		return false, fmt.Errorf("daemon SSE returned %d", resp.StatusCode)
+	}
+
+	// The subscription is live once the daemon returned 200. Signal the sink so
+	// it resets the failure counter and records the connect time (D5); a
+	// down→connected transition logs one line there.
+	connected = true
+	if sink != nil {
+		sink.ForwarderConnected()
 	}
 
 	// The daemon Subscribes before it writes response headers, so once Do
@@ -105,7 +156,7 @@ func streamRequests(ctx context.Context, socketPath string, snapClient *Client, 
 	// so it never leaks; it writes only to localRM, which outlives the stream.
 	attemptCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	go backfillSnapshot(attemptCtx, snapClient, projectDir, localRM)
+	go backfillSnapshot(attemptCtx, snapClient, projectDir, localRM, sink)
 
 	// Read SSE events line by line. bufio.Scanner is NOT used: its token size is
 	// capped (and even a raised cap would kill the subscription on the first
@@ -147,9 +198,9 @@ func streamRequests(ctx context.Context, socketPath string, snapClient *Client, 
 
 		if readErr != nil {
 			if readErr == io.EOF {
-				return nil
+				return connected, nil
 			}
-			return readErr
+			return connected, readErr
 		}
 	}
 }
@@ -173,9 +224,12 @@ func streamRequests(ctx context.Context, socketPath string, snapClient *Client, 
 //
 // ctx is the per-attempt context, so a stream error/return cancels an in-flight
 // fetch; client is the forwarder's shared snapshot client (pooled unix conn).
-func backfillSnapshot(ctx context.Context, client *Client, projectDir string, localRM *proxy.RequestManager) {
+func backfillSnapshot(ctx context.Context, client *Client, projectDir string, localRM *proxy.RequestManager, sink ForwarderStatusSink) {
 	records, err := client.Requests(ctx, projectDir, constants.MaxProxyRequests)
 	if err != nil {
+		if sink != nil {
+			sink.ForwarderBackfillFailed()
+		}
 		log.Printf("prox: request snapshot backfill failed: %v", err)
 		return
 	}

--- a/internal/proxyd/forwarder.go
+++ b/internal/proxyd/forwarder.go
@@ -37,6 +37,16 @@ type ForwarderStatusSink interface {
 	ForwarderBackfillFailed()
 }
 
+// HealFunc is the forwarder's self-heal callback (D6b). It is a plain func passed
+// in from internal/cli (keeping proxyd free of a cli import): when the shared
+// daemon has been unreachable past the heal threshold, the forwarder invokes it
+// INLINE in the reconnect loop (never concurrent with a connect attempt). The
+// implementation re-ensures a daemon of this version and re-registers the
+// project against it, returning true only when the project is registered on a
+// healthy daemon — the forwarder then reconnects eagerly to the fresh daemon on
+// the same socket. It no-ops (returns false) once shutdown has been latched.
+type HealFunc func() bool
+
 // ForwardRequests subscribes to the daemon's SSE request stream and forwards
 // this project's records into the local RequestManager. This bridges the
 // daemon's proxy request data into the project's TUI and API.
@@ -54,41 +64,128 @@ type ForwarderStatusSink interface {
 // report shared-proxy health; it replaces the old silent `_ = err` reconnect
 // loop with state that surfaces in `prox status`.
 //
+// heal (may be nil) is invoked inline after a prolonged outage to re-ensure and
+// re-register against a fresh daemon (D6b).
+//
 // It runs until ctx is cancelled. On disconnect, it reconnects with backoff.
-func ForwardRequests(ctx context.Context, socketPath string, projectDir string, localRM *proxy.RequestManager, sink ForwarderStatusSink) {
+func ForwardRequests(ctx context.Context, socketPath string, projectDir string, localRM *proxy.RequestManager, sink ForwarderStatusSink, heal HealFunc) {
+	forwardRequests(ctx, forwarderConfig{
+		socketPath:      socketPath,
+		projectDir:      projectDir,
+		localRM:         localRM,
+		sink:            sink,
+		heal:            heal,
+		now:             time.Now,
+		after:           time.After,
+		healAfterDown:   constants.ForwarderHealAfterDown,
+		healMinInterval: constants.ForwarderHealMinInterval,
+	})
+}
+
+// forwarderConfig bundles the forwarder loop's inputs plus the injectable clock,
+// timer, and heal thresholds so C6's heal timing can be unit-tested with no
+// wall-clock waits (mirrors the injectable-ops pattern used by the cli's
+// skewOps/registerRetryOps). ForwardRequests wires the production values.
+type forwarderConfig struct {
+	socketPath      string
+	projectDir      string
+	localRM         *proxy.RequestManager
+	sink            ForwarderStatusSink
+	heal            HealFunc                             // may be nil
+	now             func() time.Time                     // heal-timing clock
+	after           func(time.Duration) <-chan time.Time // backoff timer
+	healAfterDown   time.Duration
+	healMinInterval time.Duration
+	// stream is the single connect-and-forward attempt (nil → the production
+	// streamRequests). Injectable so heal-timing tests can script a deterministic
+	// connect/drop/outage sequence without real sockets (FIX 4).
+	stream func(ctx context.Context, socketPath string, snapClient *Client, projectDir string, localRM *proxy.RequestManager, sink ForwarderStatusSink) (connected bool, err error)
+}
+
+// shouldHeal reports whether a heal should fire now, given when the current
+// outage started (downSince, zero when connected), when the last heal was
+// attempted (lastHeal, zero when none yet), and the D6b thresholds: the outage
+// must have lasted at least healAfterDown AND at least healMinInterval must have
+// elapsed since the last heal attempt (damping a flapping daemon). The first
+// heal of an outage is gated only by healAfterDown.
+func shouldHeal(now, downSince, lastHeal time.Time, healAfterDown, healMinInterval time.Duration) bool {
+	if downSince.IsZero() {
+		return false
+	}
+	if now.Sub(downSince) < healAfterDown {
+		return false
+	}
+	if !lastHeal.IsZero() && now.Sub(lastHeal) < healMinInterval {
+		return false
+	}
+	return true
+}
+
+func forwardRequests(ctx context.Context, cfg forwarderConfig) {
 	// One snapshot client for the whole forwarder lifetime: its transport pools
 	// the idle unix connection across reconnect attempts, rather than leaking a
 	// fresh idle conn per attempt (the daemon only reaps idle conns after 60s, so
 	// a reconnect storm would otherwise accumulate them).
-	snapClient := NewClient(socketPath)
+	snapClient := NewClient(cfg.socketPath)
+
+	stream := cfg.stream
+	if stream == nil {
+		stream = streamRequests
+	}
 
 	backoff := 500 * time.Millisecond
+	// Heal-timing state, tracked locally so it is single-threaded with the connect
+	// attempts (the heal runs inline in this loop, never concurrently).
+	var downSince time.Time // zero while connected; set on the first failed reconnect of an outage
+	var lastHeal time.Time  // zero until the first heal attempt of an outage
 
 	for {
-		connected, err := streamRequests(ctx, socketPath, snapClient, projectDir, localRM, sink)
+		connected, err := stream(ctx, cfg.socketPath, snapClient, cfg.projectDir, cfg.localRM, cfg.sink)
 		if ctx.Err() != nil {
 			return // context cancelled, clean shutdown
 		}
-		// A connect that never reached a live stream is a reconnect failure: the
-		// sink counts it (and logs the connected→down transition once). A stream
-		// that connected and then dropped is not itself a failure — the NEXT
-		// failed reconnect, if any, records the outage. streamRequests already
-		// signalled ForwarderConnected on a successful connect.
-		if !connected && sink != nil {
-			sink.ForwarderConnectFailed(err)
-		}
 		if connected {
-			// The previous attempt reached a live stream: the daemon is (or
-			// was just) healthy, so reconnect eagerly instead of carrying a
-			// stale outage-sized backoff into the recovery.
+			// The previous attempt reached a live stream: the daemon is (or was
+			// just) healthy. Clear the outage clock and reconnect eagerly instead
+			// of carrying a stale outage-sized backoff into the recovery.
+			//
+			// lastHeal is deliberately NOT reset here (FIX 4): the ≥healMinInterval
+			// heal spacing must hold ACROSS a brief reconnect, so a daemon that
+			// flaps (heal, reconnect, drop, new outage) cannot fire a second heal
+			// sooner than healMinInterval after the first. Resetting it would let a
+			// new outage's healAfterDown alone re-trigger a heal within seconds.
+			downSince = time.Time{}
 			backoff = 500 * time.Millisecond
+		} else {
+			// A connect that never reached a live stream is a reconnect failure:
+			// the sink counts it (and logs the connected→down transition once). A
+			// stream that connected and then dropped is not itself a failure — the
+			// NEXT failed reconnect, if any, records the outage.
+			if cfg.sink != nil {
+				cfg.sink.ForwarderConnectFailed(err)
+			}
+			now := cfg.now()
+			if downSince.IsZero() {
+				downSince = now
+			}
+			// Self-heal (D6b), inline so it cannot race the next connect attempt.
+			if cfg.heal != nil && shouldHeal(now, downSince, lastHeal, cfg.healAfterDown, cfg.healMinInterval) {
+				lastHeal = now
+				if cfg.heal() {
+					// Fresh daemon on the same socket: restart the outage clock and
+					// reconnect eagerly so a momentary miss doesn't immediately
+					// re-heal, and so the next attempt binds the healthy daemon.
+					downSince = time.Time{}
+					backoff = 500 * time.Millisecond
+				}
+			}
 		}
 
-		// Backoff before reconnecting
+		// Backoff before reconnecting.
 		select {
 		case <-ctx.Done():
 			return
-		case <-time.After(backoff):
+		case <-cfg.after(backoff):
 		}
 		if backoff < 5*time.Second {
 			backoff *= 2

--- a/internal/proxyd/forwarder_heal_test.go
+++ b/internal/proxyd/forwarder_heal_test.go
@@ -1,0 +1,209 @@
+package proxyd
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/charliek/prox/internal/proxy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// instantAfter is a forwarderConfig.after that fires immediately, so the loop's
+// backoff never costs wall-clock time in tests.
+func instantAfter(time.Duration) <-chan time.Time {
+	ch := make(chan time.Time, 1)
+	ch <- time.Time{}
+	return ch
+}
+
+// TestShouldHeal pins the D6b timing gates: no heal while connected or before the
+// down threshold; the first heal fires once the outage exceeds healAfterDown; a
+// second heal is damped until healMinInterval has elapsed since the last attempt.
+func TestShouldHeal(t *testing.T) {
+	const (
+		afterDown   = 15 * time.Second
+		minInterval = 30 * time.Second
+	)
+	base := time.Unix(1_000_000, 0)
+
+	// Connected: never heal.
+	assert.False(t, shouldHeal(base, time.Time{}, time.Time{}, afterDown, minInterval))
+
+	// Down but under the threshold: no heal.
+	assert.False(t, shouldHeal(base.Add(10*time.Second), base, time.Time{}, afterDown, minInterval))
+
+	// Down past the threshold, no prior heal: first heal fires.
+	assert.True(t, shouldHeal(base.Add(15*time.Second), base, time.Time{}, afterDown, minInterval))
+
+	// A heal just happened: damped until healMinInterval elapses.
+	last := base.Add(15 * time.Second)
+	assert.False(t, shouldHeal(base.Add(40*time.Second), base, last, afterDown, minInterval),
+		"second heal must not fire before healMinInterval since the last attempt")
+	assert.True(t, shouldHeal(base.Add(45*time.Second), base, last, afterDown, minInterval),
+		"second heal fires once healMinInterval has elapsed")
+}
+
+// TestForwardRequests_InvokesHealAfterThreshold pins that the forwarder loop
+// invokes the heal callback inline once the outage exceeds healAfterDown, using
+// an injected clock (no wall-clock 15s wait) and an instant backoff timer. The
+// socket points at nothing, so every connect fails and the outage clock advances
+// via the injected now().
+func TestForwardRequests_InvokesHealAfterThreshold(t *testing.T) {
+	deadSocket := filepath.Join(t.TempDir(), "dead.sock") // nothing listens
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// now() advances 20s per call, so the second failed reconnect is >15s after
+	// downSince (set on the first) and the heal fires.
+	var mu sync.Mutex
+	cur := time.Unix(1_000_000, 0)
+	now := func() time.Time {
+		mu.Lock()
+		defer mu.Unlock()
+		t := cur
+		cur = cur.Add(20 * time.Second)
+		return t
+	}
+
+	healed := make(chan struct{}, 1)
+	cfg := forwarderConfig{
+		socketPath: deadSocket,
+		projectDir: "/p",
+		localRM:    proxy.NewRequestManager(100),
+		heal: func() bool {
+			select {
+			case healed <- struct{}{}:
+			default:
+			}
+			cancel() // stop the loop once the heal fired
+			return false
+		},
+		now:             now,
+		after:           instantAfter,
+		healAfterDown:   15 * time.Second,
+		healMinInterval: 30 * time.Second,
+	}
+
+	go forwardRequests(ctx, cfg)
+
+	select {
+	case <-healed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("forwarder never invoked the heal callback after the down threshold")
+	}
+}
+
+// TestForwardRequests_HealDampingAcrossOutages pins FIX 4: lastHeal is NOT reset
+// when the forwarder reconnects, so the ≥healMinInterval heal spacing holds across
+// a brief reconnect. Scenario: heal at t, a successful connect, a drop into a new
+// outage that itself exceeds healAfterDown — the next heal must still wait until
+// t+healMinInterval (t+30s), NOT re-fire at new-outage-start + healAfterDown.
+//
+// The stream attempt and clock are injected so the connect/drop/outage sequence
+// and the heal timestamps are fully deterministic (no wall-clock, no sockets).
+func TestForwardRequests_HealDampingAcrossOutages(t *testing.T) {
+	const (
+		afterDown   = 15 * time.Second
+		minInterval = 30 * time.Second
+	)
+	t0 := time.Unix(2_000_000, 0)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// now() is called exactly once per FAILED connect (never on a connected one).
+	// The five failed iterations below observe these instants in order.
+	nowVals := []time.Time{
+		t0,                       // fail #1: outage starts, under threshold
+		t0.Add(20 * time.Second), // fail #2: >15s down, no prior heal -> HEAL #1 at t0+20
+		t0.Add(25 * time.Second), // fail #3: drop into a new outage
+		t0.Add(40 * time.Second), // fail #4: new outage >15s, but <30s since heal #1 -> damped
+		t0.Add(51 * time.Second), // fail #5: >=30s since heal #1 -> HEAL #2
+	}
+	var mu sync.Mutex
+	var nowIdx int
+	var lastNow time.Time
+	now := func() time.Time {
+		mu.Lock()
+		defer mu.Unlock()
+		// Clamp past the script: heal #2 cancels ctx, and the loop's post-stream
+		// ctx.Err() check returns before another scripted instant is needed — but the
+		// instant-backoff select can race ctx.Done() for one extra iteration.
+		if nowIdx >= len(nowVals) {
+			return lastNow
+		}
+		v := nowVals[nowIdx]
+		nowIdx++
+		lastNow = v
+		return v
+	}
+
+	// Scripted connect outcomes: fail, fail(heal), connect, fail, fail, fail.
+	streamResults := []bool{false, false, true, false, false, false}
+	var streamIdx int
+	stream := func(context.Context, string, *Client, string, *proxy.RequestManager, ForwarderStatusSink) (bool, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		// Clamp: after heal #2 cancels ctx, an extra iteration may fire before the
+		// loop observes cancellation. Return a plain failure (the caller returns on
+		// its next ctx.Err() check) rather than indexing past the script.
+		if streamIdx >= len(streamResults) {
+			return false, errors.New("down")
+		}
+		r := streamResults[streamIdx]
+		streamIdx++
+		if r {
+			return true, nil
+		}
+		return false, errors.New("down")
+	}
+
+	var healTimes []time.Time
+	heal := func() bool {
+		mu.Lock()
+		healTimes = append(healTimes, lastNow)
+		n := len(healTimes)
+		mu.Unlock()
+		if n == 1 {
+			return true // first heal "succeeds" -> the next iteration connects
+		}
+		cancel() // second heal recorded: stop the loop
+		return false
+	}
+
+	cfg := forwarderConfig{
+		socketPath:      filepath.Join(t.TempDir(), "unused.sock"),
+		projectDir:      "/p",
+		localRM:         proxy.NewRequestManager(100),
+		heal:            heal,
+		stream:          stream,
+		now:             now,
+		after:           instantAfter,
+		healAfterDown:   afterDown,
+		healMinInterval: minInterval,
+	}
+
+	done := make(chan struct{})
+	go func() { forwardRequests(ctx, cfg); close(done) }()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("forwarder loop did not complete the scripted sequence")
+	}
+
+	require.Len(t, healTimes, 2, "exactly two heals must fire across the scenario")
+	assert.Equal(t, t0.Add(20*time.Second), healTimes[0], "first heal fires once the outage exceeds healAfterDown")
+	// The core of FIX 4: the second heal is damped to >= t+healMinInterval despite
+	// the new outage independently exceeding healAfterDown at t0+40s.
+	assert.True(t, !healTimes[1].Before(healTimes[0].Add(minInterval)),
+		"second heal must not fire before healMinInterval after the first (got %v, first %v)", healTimes[1], healTimes[0])
+	assert.Equal(t, t0.Add(51*time.Second), healTimes[1],
+		"second heal fires only once >=healMinInterval has elapsed since the first, not at the new outage's healAfterDown")
+}

--- a/internal/proxyd/forwarder_heal_test.go
+++ b/internal/proxyd/forwarder_heal_test.go
@@ -3,6 +3,7 @@ package proxyd
 import (
 	"context"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -206,4 +207,76 @@ func TestForwardRequests_HealDampingAcrossOutages(t *testing.T) {
 		"second heal must not fire before healMinInterval after the first (got %v, first %v)", healTimes[1], healTimes[0])
 	assert.Equal(t, t0.Add(51*time.Second), healTimes[1],
 		"second heal fires only once >=healMinInterval has elapsed since the first, not at the new outage's healAfterDown")
+}
+
+// TestForwardRequests_ImmediateEOFIsNotRecovery pins the flap guard
+// (CodeRabbit PR #68): a stream that connects (HTTP 200) but dies within
+// flapThreshold must NOT clear the outage clock — a crash-looping daemon
+// that accepts and instantly EOFs would otherwise suppress healing forever.
+// Scripted: failures past healAfterDown, then an instant 200-EOF flap, then
+// another failure — the heal must still fire (the flap did not reset
+// downSince).
+func TestForwardRequests_ImmediateEOFIsNotRecovery(t *testing.T) {
+	errNoDaemon := fmt.Errorf("connect: no such file or directory")
+	base := time.Unix(1000, 0)
+	clock := base
+	healCalls := 0
+
+	// Script: attempt 0 fails at t=0; attempt 1 fails at t=16s (past the 15s
+	// threshold BUT we want the flap first, so): attempt 1 = instant
+	// connected flap at t=8s; attempt 2 fails at t=16s → downSince must
+	// still be t=0 → heal fires. If the flap had reset the clock, the next
+	// outage would start at 16s and no heal could fire until 31s.
+	step := 0
+	cfg := forwarderConfig{
+		socketPath: "/nonexistent",
+		projectDir: "/p",
+		localRM:    proxy.NewRequestManager(10),
+		now:        func() time.Time { return clock },
+		// Each backoff advances the scripted clock 8s; the streams themselves
+		// never advance it, so a "connected" return has zero duration — the
+		// flap the guard exists to catch.
+		after: func(time.Duration) <-chan time.Time {
+			clock = clock.Add(8 * time.Second)
+			ch := make(chan time.Time, 1)
+			ch <- clock
+			return ch
+		},
+		healAfterDown:   15 * time.Second,
+		healMinInterval: 30 * time.Second,
+		flapThreshold:   time.Second,
+		heal: func() bool {
+			healCalls++
+			return false
+		},
+		stream: func(ctx context.Context, _ string, _ *Client, _ string, _ *proxy.RequestManager, _ ForwarderStatusSink) (bool, error) {
+			switch step {
+			case 0:
+				step++ // fail at t=0 → downSince=t0
+				return false, errNoDaemon
+			case 1:
+				step++ // instant 200-EOF at t=8s: zero duration → flap
+				return true, nil
+			case 2:
+				step++ // fail at t=16s → heal must fire (downSince still t0)
+				return false, errNoDaemon
+			default:
+				<-ctx.Done()
+				return false, ctx.Err()
+			}
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	go func() {
+		// Give the loop a few scripted iterations then stop it.
+		time.Sleep(200 * time.Millisecond)
+		cancel()
+	}()
+	forwardRequests(ctx, cfg)
+
+	if healCalls == 0 {
+		t.Fatal("heal must fire at t=16s: the instant 200-EOF flap at t=8s must not reset the outage clock")
+	}
 }

--- a/internal/proxyd/forwarder_test.go
+++ b/internal/proxyd/forwarder_test.go
@@ -166,8 +166,11 @@ func TestStreamRequests_OversizeEventSkippedStreamContinues(t *testing.T) {
 func TestForwardRequests_FiltersByProject(t *testing.T) {
 	server, _, socketPath := startTestServer(t)
 
-	daemonRM := proxy.NewRequestManager(100)
-	server.SetRequestManager(daemonRM)
+	// Create both projects' rings before the forwarder subscribes, so its first
+	// subscription to /projects/a's ring succeeds rather than hitting the
+	// no-ring clean-end path.
+	aRing := server.managers.ensure("/projects/a")
+	bRing := server.managers.ensure("/projects/b")
 
 	localRM := proxy.NewRequestManager(100)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -191,8 +194,8 @@ loop:
 		case <-tick.C:
 			i++
 			ts := time.Now()
-			daemonRM.Record(proxy.RequestRecord{Timestamp: ts, Method: "GET", URL: "/a", Hostname: "api.local.dev", ProjectDir: "/projects/a"})
-			daemonRM.Record(proxy.RequestRecord{Timestamp: ts.Add(time.Duration(i)), Method: "GET", URL: "/b", Hostname: "api.local.dev", ProjectDir: "/projects/b"})
+			aRing.Record(proxy.RequestRecord{Timestamp: ts, Method: "GET", URL: "/a", Hostname: "api.local.dev", ProjectDir: "/projects/a"})
+			bRing.Record(proxy.RequestRecord{Timestamp: ts.Add(time.Duration(i)), Method: "GET", URL: "/b", Hostname: "api.local.dev", ProjectDir: "/projects/b"})
 			if localRM.Count() > 0 {
 				break loop
 			}

--- a/internal/proxyd/forwarder_test.go
+++ b/internal/proxyd/forwarder_test.go
@@ -173,7 +173,7 @@ func TestForwardRequests_FiltersByProject(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	go ForwardRequests(ctx, socketPath, "/projects/a", localRM, nil)
+	go ForwardRequests(ctx, socketPath, "/projects/a", localRM, nil, nil)
 
 	// The bridge backfills a snapshot on connect and then applies live events;
 	// this test exercises the live path, recording both projects on a tick until
@@ -245,7 +245,7 @@ func TestBackfill_AllRecordsDeliveredPinsLimit(t *testing.T) {
 	localRM := proxy.NewRequestManager(constants.MaxProxyRequests)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go ForwardRequests(ctx, socketPath, "/p", localRM, nil)
+	go ForwardRequests(ctx, socketPath, "/p", localRM, nil, nil)
 
 	require.Eventually(t, func() bool { return localRM.Count() == n }, 3*time.Second, 10*time.Millisecond,
 		"all %d snapshot records must be delivered locally", n)
@@ -292,7 +292,7 @@ func TestBackfill_RecordsAddedDuringDisconnectAppearAfterReconnect(t *testing.T)
 	localRM := proxy.NewRequestManager(100)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go ForwardRequests(ctx, socketPath, "/p", localRM, nil)
+	go ForwardRequests(ctx, socketPath, "/p", localRM, nil, nil)
 
 	require.Eventually(t, func() bool {
 		return atomic.LoadInt32(&connects) >= 2 && localRM.Count() == 2
@@ -367,7 +367,7 @@ func TestBackfill_OverlapDedupe(t *testing.T) {
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-			go ForwardRequests(ctx, socketPath, "/p", localRM, nil)
+			go ForwardRequests(ctx, socketPath, "/p", localRM, nil, nil)
 
 			// Collect notifications for a fixed window; both the snapshot copy and
 			// the stream copy apply, but only the first notifies.
@@ -420,7 +420,7 @@ func TestBackfill_ConcurrentDrainDelayedSnapshot(t *testing.T) {
 	localRM := proxy.NewRequestManager(100)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go ForwardRequests(ctx, socketPath, "/p", localRM, nil)
+	go ForwardRequests(ctx, socketPath, "/p", localRM, nil, nil)
 
 	// The snapshot is still blocked (release not yet closed); the live event must
 	// nevertheless be delivered — proof the read loop drains concurrently.
@@ -466,7 +466,7 @@ func TestBackfill_SnapshotFailureStreamStillDelivers(t *testing.T) {
 			localRM := proxy.NewRequestManager(100)
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-			go ForwardRequests(ctx, socketPath, "/p", localRM, nil)
+			go ForwardRequests(ctx, socketPath, "/p", localRM, nil, nil)
 
 			require.Eventually(t, func() bool { return localRM.Count() == 1 }, 2*time.Second, 10*time.Millisecond)
 			// Let any erroneous snapshot apply race in, then confirm still just the

--- a/internal/proxyd/forwarder_test.go
+++ b/internal/proxyd/forwarder_test.go
@@ -114,7 +114,8 @@ func TestStreamRequests_LargeInlineBodies(t *testing.T) {
 
 	localRM := proxy.NewRequestManager(100)
 	// streamRequests returns nil once the server closes the stream (io.EOF).
-	require.NoError(t, streamRequests(context.Background(), socketPath, NewClient(socketPath), "/p", localRM))
+	_, err = streamRequests(context.Background(), socketPath, NewClient(socketPath), "/p", localRM, nil)
+	require.NoError(t, err)
 
 	require.Equal(t, 1, localRM.Count())
 	got := localRM.Recent(proxy.RequestFilter{})[0]
@@ -151,7 +152,8 @@ func TestStreamRequests_OversizeEventSkippedStreamContinues(t *testing.T) {
 	})
 
 	localRM := proxy.NewRequestManager(100)
-	require.NoError(t, streamRequests(context.Background(), socketPath, NewClient(socketPath), "/p", localRM))
+	_, err = streamRequests(context.Background(), socketPath, NewClient(socketPath), "/p", localRM, nil)
+	require.NoError(t, err)
 
 	require.Equal(t, 1, localRM.Count(), "oversize event skipped, following event delivered")
 	got := localRM.Recent(proxy.RequestFilter{})[0]
@@ -171,7 +173,7 @@ func TestForwardRequests_FiltersByProject(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	go ForwardRequests(ctx, socketPath, "/projects/a", localRM)
+	go ForwardRequests(ctx, socketPath, "/projects/a", localRM, nil)
 
 	// The bridge backfills a snapshot on connect and then applies live events;
 	// this test exercises the live path, recording both projects on a tick until
@@ -243,7 +245,7 @@ func TestBackfill_AllRecordsDeliveredPinsLimit(t *testing.T) {
 	localRM := proxy.NewRequestManager(constants.MaxProxyRequests)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go ForwardRequests(ctx, socketPath, "/p", localRM)
+	go ForwardRequests(ctx, socketPath, "/p", localRM, nil)
 
 	require.Eventually(t, func() bool { return localRM.Count() == n }, 3*time.Second, 10*time.Millisecond,
 		"all %d snapshot records must be delivered locally", n)
@@ -290,7 +292,7 @@ func TestBackfill_RecordsAddedDuringDisconnectAppearAfterReconnect(t *testing.T)
 	localRM := proxy.NewRequestManager(100)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go ForwardRequests(ctx, socketPath, "/p", localRM)
+	go ForwardRequests(ctx, socketPath, "/p", localRM, nil)
 
 	require.Eventually(t, func() bool {
 		return atomic.LoadInt32(&connects) >= 2 && localRM.Count() == 2
@@ -365,7 +367,7 @@ func TestBackfill_OverlapDedupe(t *testing.T) {
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-			go ForwardRequests(ctx, socketPath, "/p", localRM)
+			go ForwardRequests(ctx, socketPath, "/p", localRM, nil)
 
 			// Collect notifications for a fixed window; both the snapshot copy and
 			// the stream copy apply, but only the first notifies.
@@ -418,7 +420,7 @@ func TestBackfill_ConcurrentDrainDelayedSnapshot(t *testing.T) {
 	localRM := proxy.NewRequestManager(100)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go ForwardRequests(ctx, socketPath, "/p", localRM)
+	go ForwardRequests(ctx, socketPath, "/p", localRM, nil)
 
 	// The snapshot is still blocked (release not yet closed); the live event must
 	// nevertheless be delivered — proof the read loop drains concurrently.
@@ -464,7 +466,7 @@ func TestBackfill_SnapshotFailureStreamStillDelivers(t *testing.T) {
 			localRM := proxy.NewRequestManager(100)
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-			go ForwardRequests(ctx, socketPath, "/p", localRM)
+			go ForwardRequests(ctx, socketPath, "/p", localRM, nil)
 
 			require.Eventually(t, func() bool { return localRM.Count() == 1 }, 2*time.Second, 10*time.Millisecond)
 			// Let any erroneous snapshot apply race in, then confirm still just the
@@ -499,7 +501,7 @@ func TestBackfillSnapshot_CtxCancelExitsCleanly(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	go func() {
-		backfillSnapshot(ctx, NewClient(socketPath), "/p", localRM)
+		backfillSnapshot(ctx, NewClient(socketPath), "/p", localRM, nil)
 		close(done)
 	}()
 

--- a/internal/proxyd/idempotent_register_test.go
+++ b/internal/proxyd/idempotent_register_test.go
@@ -1,0 +1,219 @@
+package proxyd
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/charliek/prox/internal/proxy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// liveIdentity returns this process's PID and its real start token, skipping the
+// test when the token is unreadable or zero (an idempotent re-register requires a
+// provable non-zero token; without one the register is treated as a genuine
+// conflict, so the idempotent path can't be exercised). It builds on the
+// package's mustSelfToken skip helper, adding the non-zero requirement.
+func liveIdentity(t *testing.T) (int, int64) {
+	t.Helper()
+	token := mustSelfToken(t)
+	if token == 0 {
+		t.Skip("process start token is zero on this platform; idempotent re-register needs a non-zero token")
+	}
+	return os.Getpid(), token
+}
+
+// TestIdempotentReRegister_SameLiveIdentitySucceeds pins D6a: a same-dir register
+// whose live holder is the SAME process generation (same PID + matching non-zero
+// start token) is an idempotent re-register — it returns 200 with the registered
+// hostnames and leaves the routes in place, rather than the hard 409 a genuine
+// second `prox up` gets. It also pins listener refcount correctness: re-register
+// twice, deregister once, and the port must close.
+func TestIdempotentReRegister_SameLiveIdentitySucceeds(t *testing.T) {
+	backendHost, backendPort := newTestBackend(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "ok")
+	})
+	s := newProxyServer(t)
+	port := freePort(t)
+	pid, token := liveIdentity(t)
+
+	req := RegisterRequest{
+		ProjectDir: "/projects/live", PID: pid, StartTime: token, Version: "test", Domain: "local.dev",
+		Services: map[string]ServiceTarget{"api": {Host: backendHost, Port: backendPort}},
+		HTTPPort: port,
+	}
+
+	// Initial registration binds the port (refcount 1).
+	registerOK(t, s, req)
+	require.Equal(t, 1, s.registry.ProjectCount())
+
+	// Re-register twice: each is idempotent, replacing the registration wholesale
+	// while keeping the net listener refcount at exactly one.
+	registerOK(t, s, req)
+	registerOK(t, s, req)
+
+	require.Equal(t, 1, s.registry.ProjectCount(), "idempotent re-register must not duplicate the project")
+	route, ok := s.registry.Lookup("api.local.dev", port)
+	require.True(t, ok, "route must survive idempotent re-register")
+	assert.Equal(t, "/projects/live", route.ProjectDir)
+
+	// The rebound listener must accept connections after the re-registers.
+	conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	require.NoError(t, err, "idempotent re-register must leave a routable listener")
+	_ = conn.Close()
+
+	// A SINGLE deregister must close the port — proof the two re-registers did not
+	// leak the listener refcount to two.
+	s.removeProject("/projects/live")
+	require.Equal(t, 0, s.registry.ProjectCount())
+	_, ok = s.registry.Lookup("api.local.dev", port)
+	assert.False(t, ok, "route must be gone after one deregister")
+	assert.NotContains(t, s.registry.ListenerPorts(), port, "one deregister must close the port after two re-registers")
+	_, err = net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	assert.Error(t, err, "port must be closed after a single deregister")
+}
+
+// TestIdempotentReRegister_NoOpRefreshPreservesRecords pins the FIX 1 no-op
+// refresh path (D6a): a same-identity re-register whose config is UNCHANGED must
+// NOT purge the project's daemon-side records (the destructive remove+add would),
+// and the route must keep resolving. This is the real heal case — the SSE stream
+// broke but the daemon and registration are intact.
+func TestIdempotentReRegister_NoOpRefreshPreservesRecords(t *testing.T) {
+	backendHost, backendPort := newTestBackend(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "ok")
+	})
+	s := newProxyServer(t)
+	port := freePort(t)
+	pid, token := liveIdentity(t)
+
+	req := RegisterRequest{
+		ProjectDir: "/projects/rec", PID: pid, StartTime: token, Version: "test", Domain: "local.dev",
+		Services: map[string]ServiceTarget{"api": {Host: backendHost, Port: backendPort}},
+		HTTPPort: port,
+	}
+	registerOK(t, s, req)
+
+	// Record a daemon-side request for the project (as the proxy hot path would).
+	s.requestManager.Record(proxy.RequestRecord{
+		ID:         "rec000000001",
+		Timestamp:  time.Now(),
+		Method:     "GET",
+		URL:        "http://api.local.dev/health",
+		Hostname:   "api.local.dev",
+		StatusCode: 200,
+		ProjectDir: "/projects/rec",
+	})
+	before := s.requestManager.Recent(proxy.RequestFilter{ProjectDir: "/projects/rec"})
+	require.Len(t, before, 1, "precondition: one record captured for the project")
+
+	// Re-register the SAME identity with the SAME config: a true no-op refresh.
+	status, body := s.register(req)
+	require.Equal(t, http.StatusOK, status, "no-op refresh must succeed: %v", body)
+
+	// The record must survive (the destructive path would have purged it), and the
+	// route must be unchanged.
+	after := s.requestManager.Recent(proxy.RequestFilter{ProjectDir: "/projects/rec"})
+	require.Len(t, after, 1, "no-op refresh must NOT purge the project's daemon-side records")
+	assert.Equal(t, "rec000000001", after[0].ID, "the exact record must survive the no-op refresh")
+
+	route, ok := s.registry.Lookup("api.local.dev", port)
+	require.True(t, ok, "route must be unchanged after a no-op refresh")
+	assert.Equal(t, "/projects/rec", route.ProjectDir)
+}
+
+// TestIdempotentReRegister_SharedPortOtherProjectUnaffected pins that a
+// same-identity re-register of one project does not disturb ANOTHER project's
+// route sharing the same listener port (D6a). Two projects share one HTTP port on
+// different domains; re-registering one must leave the other's route resolvable
+// and the shared listener open.
+func TestIdempotentReRegister_SharedPortOtherProjectUnaffected(t *testing.T) {
+	backendHost, backendPort := newTestBackend(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "ok")
+	})
+	s := newProxyServer(t)
+	port := freePort(t)
+	pid, token := liveIdentity(t)
+
+	reqA := RegisterRequest{
+		ProjectDir: "/projects/a", PID: pid, StartTime: token, Version: "test", Domain: "a.dev",
+		Services: map[string]ServiceTarget{"api": {Host: backendHost, Port: backendPort}},
+		HTTPPort: port,
+	}
+	reqB := RegisterRequest{
+		ProjectDir: "/projects/b", PID: pid, StartTime: token, Version: "test", Domain: "b.dev",
+		Services: map[string]ServiceTarget{"api": {Host: backendHost, Port: backendPort}},
+		HTTPPort: port,
+	}
+	registerOK(t, s, reqA)
+	registerOK(t, s, reqB) // shares the same HTTP port (refcount 2)
+
+	// Re-register A (same identity, unchanged config -> no-op refresh).
+	status, body := s.register(reqA)
+	require.Equal(t, http.StatusOK, status, "same-identity re-register must succeed: %v", body)
+
+	// B's route must still resolve and the shared port must still be open.
+	route, ok := s.registry.Lookup("api.b.dev", port)
+	require.True(t, ok, "the other project's shared-port route must survive a same-identity re-register")
+	assert.Equal(t, "/projects/b", route.ProjectDir)
+	assert.Contains(t, s.registry.ListenerPorts(), port, "the shared listener port must stay open")
+
+	conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	require.NoError(t, err, "the shared listener must still accept connections")
+	_ = conn.Close()
+}
+
+// TestIdempotentReRegister_DifferentLivePIDStays409 pins that a same-dir register
+// from a DIFFERENT live generation (different PID) is a genuine conflict — 409,
+// never an idempotent replace.
+func TestIdempotentReRegister_DifferentLivePIDStays409(t *testing.T) {
+	backendHost, backendPort := newTestBackend(t, func(http.ResponseWriter, *http.Request) {})
+	s := newProxyServer(t)
+	port := freePort(t)
+	pid, token := liveIdentity(t)
+
+	holder := RegisterRequest{
+		ProjectDir: "/projects/x", PID: pid, StartTime: token, Version: "test", Domain: "local.dev",
+		Services: map[string]ServiceTarget{"api": {Host: backendHost, Port: backendPort}},
+		HTTPPort: port,
+	}
+	registerOK(t, s, holder)
+
+	// A different live PID (this process is alive, so the holder passes the
+	// liveness check) with a different identity must be refused.
+	other := holder
+	other.PID = pid + 1
+	other.StartTime = token + 1
+	status, body := s.register(other)
+	assert.Equal(t, http.StatusConflict, status, "different-identity live holder must stay 409: %v", body)
+}
+
+// TestIdempotentReRegister_ZeroTokenSamePIDStays409 pins that a same-PID register
+// with a zero start token on either side is NOT idempotent (the generation can't
+// be proven identical vs a reused PID) — it stays 409 against a live holder.
+func TestIdempotentReRegister_ZeroTokenSamePIDStays409(t *testing.T) {
+	backendHost, backendPort := newTestBackend(t, func(http.ResponseWriter, *http.Request) {})
+	s := newProxyServer(t)
+	port := freePort(t)
+	pid, token := liveIdentity(t)
+
+	// Holder registered with a real (non-zero) token so its liveness check reads
+	// as alive.
+	holder := RegisterRequest{
+		ProjectDir: "/projects/z", PID: pid, StartTime: token, Version: "test", Domain: "local.dev",
+		Services: map[string]ServiceTarget{"api": {Host: backendHost, Port: backendPort}},
+		HTTPPort: port,
+	}
+	registerOK(t, s, holder)
+
+	// Same PID but a zero requester token: a zero token on either side must not
+	// match, so this is a genuine conflict.
+	reReq := holder
+	reReq.StartTime = 0
+	status, body := s.register(reReq)
+	assert.Equal(t, http.StatusConflict, status, "zero-token same-PID must stay 409: %v", body)
+}

--- a/internal/proxyd/idempotent_register_test.go
+++ b/internal/proxyd/idempotent_register_test.go
@@ -99,7 +99,10 @@ func TestIdempotentReRegister_NoOpRefreshPreservesRecords(t *testing.T) {
 	registerOK(t, s, req)
 
 	// Record a daemon-side request for the project (as the proxy hot path would).
-	s.requestManager.Record(proxy.RequestRecord{
+	// registerOK created the project's ring; record straight into it.
+	ring := s.managers.get("/projects/rec")
+	require.NotNil(t, ring, "register must have created the project's ring")
+	ring.Record(proxy.RequestRecord{
 		ID:         "rec000000001",
 		Timestamp:  time.Now(),
 		Method:     "GET",
@@ -108,16 +111,17 @@ func TestIdempotentReRegister_NoOpRefreshPreservesRecords(t *testing.T) {
 		StatusCode: 200,
 		ProjectDir: "/projects/rec",
 	})
-	before := s.requestManager.Recent(proxy.RequestFilter{ProjectDir: "/projects/rec"})
+	before := projectRecent(s, "/projects/rec")
 	require.Len(t, before, 1, "precondition: one record captured for the project")
 
 	// Re-register the SAME identity with the SAME config: a true no-op refresh.
 	status, body := s.register(req)
 	require.Equal(t, http.StatusOK, status, "no-op refresh must succeed: %v", body)
 
-	// The record must survive (the destructive path would have purged it), and the
-	// route must be unchanged.
-	after := s.requestManager.Recent(proxy.RequestFilter{ProjectDir: "/projects/rec"})
+	// The record must survive (the destructive path would have purged it) in the
+	// SAME preserved ring, and the route must be unchanged.
+	require.Same(t, ring, s.managers.get("/projects/rec"), "no-op refresh must keep the same ring instance")
+	after := projectRecent(s, "/projects/rec")
 	require.Len(t, after, 1, "no-op refresh must NOT purge the project's daemon-side records")
 	assert.Equal(t, "rec000000001", after[0].ID, "the exact record must survive the no-op refresh")
 

--- a/internal/proxyd/managers.go
+++ b/internal/proxyd/managers.go
@@ -1,0 +1,143 @@
+package proxyd
+
+import (
+	"sync"
+
+	"github.com/charliek/prox/internal/proxy"
+)
+
+// Managers holds the daemon's per-project request rings (D13, #49): one
+// full-capacity *proxy.RequestManager per registered project dir, so one
+// project's flood cannot evict another project's records. It replaces the single
+// global RequestManager the daemon used to share across every project.
+//
+// Its own RWMutex guards the map ONLY. The data plane (the proxy hot path's
+// get lookup, and status reads) takes this mutex — never lifecycleMu — honoring
+// the server's data-plane rule (server.go): the hot path must not contend on the
+// control-plane lifecycle lock. All map mutations (ensure/remove) are still made
+// under the caller's lifecycleMu so a lifecycle transaction and a shutdown sweep
+// can't race a manager into or out of existence mid-flow, but the map's own lock
+// is what the lock-free-of-lifecycleMu hot path synchronizes against.
+type Managers struct {
+	mu       sync.RWMutex
+	managers map[string]*proxy.RequestManager
+	capacity int
+	// onEvict is wired onto every manager at creation (mirroring what the daemon
+	// wired onto the single global manager): evicting a record with captured
+	// Details deletes its on-disk body files. nil when capture is disabled.
+	onEvict proxy.EvictionCallback
+}
+
+// NewManagers creates an empty set whose managers are each created with the
+// given ring capacity and eviction callback.
+func NewManagers(capacity int, onEvict proxy.EvictionCallback) *Managers {
+	if capacity <= 0 {
+		capacity = 1
+	}
+	return &Managers{
+		managers: make(map[string]*proxy.RequestManager),
+		capacity: capacity,
+		onEvict:  onEvict,
+	}
+}
+
+// ensure returns the manager for projectDir, creating it (with the eviction
+// callback wired) if absent. It is IDEMPOTENT: an existing manager is returned
+// as-is, preserving its record history and SSE subscriptions across
+// re-registers — the property that lets an idempotent or config-changed
+// re-register keep the same project's ring rather than churning it. Called only
+// under the server's lifecycleMu.
+func (ms *Managers) ensure(projectDir string) *proxy.RequestManager {
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+	if m, ok := ms.managers[projectDir]; ok {
+		return m
+	}
+	m := proxy.NewRequestManager(ms.capacity)
+	if ms.onEvict != nil {
+		m.SetEvictionCallback(ms.onEvict)
+	}
+	ms.managers[projectDir] = m
+	return m
+}
+
+// get returns the manager for projectDir, or nil when the project has no ring
+// (never registered, or already removed). This is the hot-path RLock lookup: a
+// nil result means a completion arriving after its project deregistered, which
+// the caller drops safely.
+func (ms *Managers) get(projectDir string) *proxy.RequestManager {
+	ms.mu.RLock()
+	defer ms.mu.RUnlock()
+	return ms.managers[projectDir]
+}
+
+// remove Closes the project's manager FIRST — releasing any daemon-side SSE
+// handler blocked on its subscription (Close latches, so a handler racing the
+// removal also ends cleanly) — then deletes it from the map so subsequent hot
+// path lookups return nil. It returns the removed manager (nil when absent) so
+// the caller can purge its capture files. Called only under lifecycleMu.
+func (ms *Managers) remove(projectDir string) *proxy.RequestManager {
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+	m, ok := ms.managers[projectDir]
+	if !ok {
+		return nil
+	}
+	m.Close()
+	delete(ms.managers, projectDir)
+	return m
+}
+
+// purge drops a project's records and their on-disk body files from its ring,
+// without removing the manager itself — the records-only cleanup shared by
+// finishRemoval and rollbackRegistration. No-op when the set is nil (capture
+// disabled) or the project has no ring, so callers needn't guard either, and it
+// takes only the map RLock (never lifecycleMu). Teardown that also detaches the
+// manager uses remove/destroyProjectManager instead.
+func (ms *Managers) purge(projectDir string) {
+	if ms == nil {
+		return
+	}
+	if m := ms.get(projectDir); m != nil {
+		m.PurgeByProject(projectDir)
+	}
+}
+
+// closeAll Closes every manager (daemon teardown), releasing all SSE handlers so
+// they don't pin the socket server open through the shutdown grace. The map is
+// left intact — the daemon is exiting.
+func (ms *Managers) closeAll() {
+	ms.mu.RLock()
+	defer ms.mu.RUnlock()
+	for _, m := range ms.managers {
+		m.Close()
+	}
+}
+
+// droppedTotal sums DroppedEvents across every live project ring (D9/D13). The
+// daemon status reports this as the single daemon-wide dropped-events total.
+func (ms *Managers) droppedTotal() int64 {
+	ms.mu.RLock()
+	defer ms.mu.RUnlock()
+	var total int64
+	for _, m := range ms.managers {
+		total += m.DroppedEvents()
+	}
+	return total
+}
+
+// recordCounts returns the per-project in-memory record count keyed by project
+// dir, for daemon status memory diagnosability (D13). Returns nil when no
+// project is registered.
+func (ms *Managers) recordCounts() map[string]int {
+	ms.mu.RLock()
+	defer ms.mu.RUnlock()
+	if len(ms.managers) == 0 {
+		return nil
+	}
+	counts := make(map[string]int, len(ms.managers))
+	for dir, m := range ms.managers {
+		counts[dir] = m.Count()
+	}
+	return counts
+}

--- a/internal/proxyd/managers_helpers_test.go
+++ b/internal/proxyd/managers_helpers_test.go
@@ -1,0 +1,49 @@
+package proxyd
+
+import "github.com/charliek/prox/internal/proxy"
+
+// Test helpers for the per-project ring set (D13). The daemon now keeps one
+// *proxy.RequestManager per project instead of a single global one, so tests
+// that used to reach through s.requestManager go through these instead.
+
+// recordInto records r into its project's ring, creating the ring on demand
+// (mirroring what a successful register does in production). Tests that seed
+// records for a project registered directly through s.registry.Register — which
+// does not create a ring — use this to make the ring exist.
+func recordInto(s *Server, r proxy.RequestRecord) {
+	s.managers.ensure(r.ProjectDir).Record(r)
+}
+
+// projectRing returns the project's ring, or nil when it has none (never
+// created, or destroyed by a genuine removal).
+func projectRing(s *Server, projectDir string) *proxy.RequestManager {
+	return s.managers.get(projectDir)
+}
+
+// projectCount returns the number of records in the project's ring, or 0 when
+// the project has no ring.
+func projectCount(s *Server, projectDir string) int {
+	if m := s.managers.get(projectDir); m != nil {
+		return m.Count()
+	}
+	return 0
+}
+
+// projectRecent returns the project's records (newest first), or nil when the
+// project has no ring.
+func projectRecent(s *Server, projectDir string) []proxy.RequestRecord {
+	if m := s.managers.get(projectDir); m != nil {
+		return m.Recent(proxy.RequestFilter{ProjectDir: projectDir})
+	}
+	return nil
+}
+
+// projectHas reports whether the project's ring holds a record with the given
+// ID. False when the project has no ring.
+func projectHas(s *Server, projectDir, id string) bool {
+	if m := s.managers.get(projectDir); m != nil {
+		_, ok := m.GetByID(id)
+		return ok
+	}
+	return false
+}

--- a/internal/proxyd/managers_test.go
+++ b/internal/proxyd/managers_test.go
@@ -1,0 +1,325 @@
+package proxyd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charliek/prox/internal/constants"
+	"github.com/charliek/prox/internal/proxy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// serveHost drives one request through the proxy handler for a port with an
+// explicit Host header (so multi-project shared-port setups can be exercised).
+func serveHost(dp *DynamicProxy, port int, method, target, host, body string) *httptest.ResponseRecorder {
+	handler := dp.handler(port)
+	req := httptest.NewRequest(method, target, bytes.NewReader([]byte(body)))
+	req.Host = host
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	return rec
+}
+
+// TestPerProjectRing_FloodIsolation pins AC10's first clause: one project
+// flooding its ring past capacity cannot evict another project's records,
+// because each project owns a full-capacity ring of its own. Two projects share
+// one HTTP listener; A is flooded past a small ring capacity while B holds a
+// single record, and B's record must survive intact.
+func TestPerProjectRing_FloodIsolation(t *testing.T) {
+	const ringCap = 5
+	backendHost, backendPort := newTestBackend(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		_, _ = io.WriteString(w, "ok")
+	})
+
+	reg := NewRegistry()
+	base := RegisterRequest{PID: 1, Version: "dev", HTTPPort: 80,
+		Services: map[string]ServiceTarget{"api": {Host: backendHost, Port: backendPort}}}
+	reqA := base
+	reqA.ProjectDir, reqA.Domain = "/projects/a", "a.dev"
+	reqB := base
+	reqB.ProjectDir, reqB.Domain = "/projects/b", "b.dev"
+	_, _, err := reg.Register(reqA)
+	require.NoError(t, err)
+	_, _, err = reg.Register(reqB)
+	require.NoError(t, err)
+
+	ms := NewManagers(ringCap, nil)
+	ms.ensure("/projects/a")
+	ms.ensure("/projects/b")
+	dp := NewDynamicProxy(reg, nil, ms, nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	// B records exactly one request first.
+	recB := serveHost(dp, 80, "GET", "http://api.b.dev/only", "api.b.dev", "")
+	require.Equal(t, http.StatusOK, recB.Code)
+	bRecords := ms.get("/projects/b").Recent(proxy.RequestFilter{ProjectDir: "/projects/b"})
+	require.Len(t, bRecords, 1)
+	bID := bRecords[0].ID
+
+	// A floods far past its ring capacity.
+	for i := 0; i < ringCap*4; i++ {
+		rec := serveHost(dp, 80, "GET", fmt.Sprintf("http://api.a.dev/flood/%d", i), "api.a.dev", "")
+		require.Equal(t, http.StatusOK, rec.Code)
+	}
+
+	// A's ring is capped; B's ring still holds its one record — no cross-eviction.
+	assert.Equal(t, ringCap, ms.get("/projects/a").Count(), "A's ring is bounded by its own capacity")
+	assert.Equal(t, 1, ms.get("/projects/b").Count(), "A's flood must not evict B's record")
+	_, ok := ms.get("/projects/b").GetByID(bID)
+	assert.True(t, ok, "B's exact record must survive A's flood")
+}
+
+// TestPerProjectMaxBodySize_EndToEnd pins AC10's max_body_size clause: a project
+// registered with a tiny MaxBodySize yields captured_size <= that cap in the
+// daemon capture path, while a project registered with 0 (default) captures the
+// full body — both through the one shared capture manager, keyed on the route's
+// stamped MaxBodySize.
+func TestPerProjectMaxBodySize_EndToEnd(t *testing.T) {
+	const respLen = 5000
+	backendHost, backendPort := newTestBackend(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		_, _ = io.WriteString(w, strings.Repeat("x", respLen))
+	})
+
+	reg := NewRegistry()
+	base := RegisterRequest{PID: 1, Version: "dev", HTTPPort: 80, CaptureEnabled: true,
+		Services: map[string]ServiceTarget{"api": {Host: backendHost, Port: backendPort}}}
+	tiny := base
+	tiny.ProjectDir, tiny.Domain, tiny.MaxBodySize = "/projects/tiny", "tiny.dev", 100
+	big := base
+	big.ProjectDir, big.Domain, big.MaxBodySize = "/projects/big", "big.dev", 0 // 0 -> daemon default
+	_, _, err := reg.Register(tiny)
+	require.NoError(t, err)
+	_, _, err = reg.Register(big)
+	require.NoError(t, err)
+
+	// Stamped onto the routes.
+	tinyRoute, ok := reg.Lookup("api.tiny.dev", 80)
+	require.True(t, ok)
+	assert.Equal(t, int64(100), tinyRoute.MaxBodySize, "route must carry the project's MaxBodySize")
+
+	cm, err := proxy.NewCaptureManagerAt(t.TempDir(), constants.DefaultCaptureMaxBodySize)
+	require.NoError(t, err)
+	ms := NewManagers(100, cm.CleanupRequest)
+	ms.ensure("/projects/tiny")
+	ms.ensure("/projects/big")
+	dp := NewDynamicProxy(reg, nil, ms, cm, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	recTiny := serveHost(dp, 80, "GET", "http://api.tiny.dev/x", "api.tiny.dev", "")
+	require.Equal(t, http.StatusOK, recTiny.Code)
+	recBig := serveHost(dp, 80, "GET", "http://api.big.dev/x", "api.big.dev", "")
+	require.Equal(t, http.StatusOK, recBig.Code)
+
+	tinyRecords := ms.get("/projects/tiny").Recent(proxy.RequestFilter{ProjectDir: "/projects/tiny"})
+	require.Len(t, tinyRecords, 1)
+	require.NotNil(t, tinyRecords[0].Details)
+	require.NotNil(t, tinyRecords[0].Details.ResponseBody)
+	assert.LessOrEqual(t, tinyRecords[0].Details.ResponseBody.CapturedSize, int64(100),
+		"tiny project's captured_size must honor its 100-byte cap")
+	assert.True(t, tinyRecords[0].Details.ResponseBody.Truncated, "tiny capture must be truncated")
+
+	bigRecords := ms.get("/projects/big").Recent(proxy.RequestFilter{ProjectDir: "/projects/big"})
+	require.Len(t, bigRecords, 1)
+	require.NotNil(t, bigRecords[0].Details)
+	require.NotNil(t, bigRecords[0].Details.ResponseBody)
+	assert.Equal(t, int64(respLen), bigRecords[0].Details.ResponseBody.CapturedSize,
+		"default-cap project captures the full body")
+	assert.False(t, bigRecords[0].Details.ResponseBody.Truncated)
+}
+
+// TestDeregister_ClosesDaemonSideSSESubscribers pins AC10's SSE clause: a
+// daemon-side stream handler blocked on a project's ring subscription returns
+// when that project deregisters (the ring is Closed first, releasing the
+// subscription channel).
+func TestDeregister_ClosesDaemonSideSSESubscribers(t *testing.T) {
+	s := newLifecycleServer()
+	s.managers.ensure("/projects/a")
+
+	rec := httptest.NewRecorder()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/requests/stream?project=/projects/a", nil).WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		s.handleStreamRequests(rec, req)
+		close(done)
+	}()
+
+	// Give the handler time to subscribe and reach its blocking select.
+	time.Sleep(50 * time.Millisecond)
+
+	// Deregister the project: this Closes the ring FIRST, so the blocked handler
+	// observes end-of-stream and returns — it must not hang.
+	s.removeProject("/projects/a")
+
+	select {
+	case <-done:
+		// correct — the handler returned when the ring closed
+	case <-time.After(2 * time.Second):
+		t.Fatal("deregister must release the blocked daemon-side SSE handler")
+	}
+}
+
+// TestInFlightCompletionAfterDeregister_DropsSafely pins AC10's race clause: a
+// request whose route resolved before its project deregistered, and whose
+// completion arrives after the ring was destroyed, drops safely — no panic, no
+// record, and its capture files are cleaned. Run under -race, the concurrent
+// hot-path ring lookup and the control-plane ring removal must not race.
+func TestInFlightCompletionAfterDeregister_DropsSafely(t *testing.T) {
+	release := make(chan struct{})
+	hit := make(chan struct{}, 1)
+	backendHost, backendPort := newTestBackend(t, func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case hit <- struct{}{}:
+		default:
+		}
+		<-release // hold the response open until the test deregisters
+		_, _ = io.WriteString(w, "late")
+	})
+
+	s := newProxyServer(t)
+	req := RegisterRequest{
+		ProjectDir: "/projects/inflight", PID: 1, Version: "test", Domain: "local.dev",
+		Services: map[string]ServiceTarget{"api": {Host: backendHost, Port: backendPort}},
+		HTTPPort: freePort(t), CaptureEnabled: true,
+	}
+	registerOK(t, s, req)
+
+	served := make(chan struct{})
+	go func() {
+		defer close(served)
+		serveHost(s.proxy, req.HTTPPort, "GET", "http://api.local.dev/slow", "api.local.dev", "body")
+	}()
+
+	// Wait until the request is in flight at the backend.
+	select {
+	case <-hit:
+	case <-time.After(2 * time.Second):
+		t.Fatal("request never reached the backend")
+	}
+
+	// Deregister mid-request: destroys the ring while the completion is pending.
+	s.removeProject("/projects/inflight")
+
+	// Let the response complete: the completion defer resolves a nil ring and
+	// drops the record safely.
+	close(release)
+
+	select {
+	case <-served:
+		// correct — no panic on the completion path
+	case <-time.After(2 * time.Second):
+		t.Fatal("in-flight request never completed")
+	}
+
+	assert.Nil(t, s.managers.get("/projects/inflight"),
+		"the deregistered project's ring must be gone; the late completion left no ring")
+}
+
+// TestMissingProjectSnapshot_ReturnsEmpty200 pins the D13 endpoint contract: a
+// requests snapshot for a project with no ring returns 200 with an empty list
+// (a stable forwarder backfill contract during heal/deregister windows).
+func TestMissingProjectSnapshot_ReturnsEmpty200(t *testing.T) {
+	_, client, _ := startTestServer(t)
+
+	resp, err := client.httpClient.Get("http://proxyd/api/v1/requests?project=/projects/missing")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body struct {
+		Requests []proxy.RequestRecord `json:"requests"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.NotNil(t, body.Requests, "missing project must return a non-nil empty list")
+	assert.Empty(t, body.Requests)
+}
+
+// TestMissingProjectStream_EndsCleanly pins the D13 endpoint contract: a stream
+// for a project with no ring returns 200 and ends cleanly right after the
+// headers (the forwarder treats a clean end as a reconnect signal).
+func TestMissingProjectStream_EndsCleanly(t *testing.T) {
+	_, client, _ := startTestServer(t)
+
+	resp, err := client.httpClient.Get("http://proxyd/api/v1/requests/stream?project=/projects/missing")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// The body ends cleanly (EOF) after the connected comment rather than
+	// blocking forever.
+	done := make(chan []byte, 1)
+	go func() {
+		data, _ := io.ReadAll(resp.Body)
+		done <- data
+	}()
+	select {
+	case data := <-done:
+		assert.Contains(t, string(data), ": connected", "stream must emit the connected comment then end")
+	case <-time.After(2 * time.Second):
+		t.Fatal("missing-project stream must end cleanly, not block")
+	}
+}
+
+// TestDaemonStatus_PerProjectCountsAndSummedDrops pins the D13 status surface:
+// per-project record counts and a daemon-wide dropped-events total summed across
+// every project's ring.
+func TestDaemonStatus_PerProjectCountsAndSummedDrops(t *testing.T) {
+	s := newLifecycleServer()
+	aRing := s.managers.ensure("/projects/a")
+	bRing := s.managers.ensure("/projects/b")
+
+	for i := 0; i < 3; i++ {
+		aRing.Record(proxy.RequestRecord{ID: fmt.Sprintf("a%d", i), ProjectDir: "/projects/a", Method: "GET", URL: "/a"})
+	}
+	bRing.Record(proxy.RequestRecord{ID: "b0", ProjectDir: "/projects/b", Method: "GET", URL: "/b"})
+
+	assert.Equal(t, map[string]int{"/projects/a": 3, "/projects/b": 1}, s.managers.recordCounts())
+
+	// Force drops on A's ring: a subscriber that never reads, flooded past its
+	// 100-slot channel. The daemon-wide total sums across rings.
+	sub := aRing.Subscribe(proxy.RequestFilter{ProjectDir: "/projects/a"})
+	defer aRing.Unsubscribe(sub.ID)
+	for i := 0; i < 250; i++ {
+		aRing.Record(proxy.RequestRecord{ID: fmt.Sprintf("flood%d", i), ProjectDir: "/projects/a", Method: "GET", URL: "/f"})
+	}
+	assert.Positive(t, s.managers.droppedTotal(), "a slow subscriber must register dropped events in the daemon-wide total")
+
+	// The status handler surfaces both.
+	rec := httptest.NewRecorder()
+	s.handleStatus(rec, httptest.NewRequest(http.MethodGet, "/api/v1/status", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var status DaemonStatusResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &status))
+	assert.Positive(t, status.DroppedEvents, "status must report the summed dropped events")
+	assert.Equal(t, s.managers.recordCounts()["/projects/b"], status.RecordCounts["/projects/b"])
+}
+
+// TestRegisterCreatesRing_DeregisterDestroys pins the per-project ring lifecycle
+// at the register/deregister boundary: a fresh register creates the ring, and a
+// genuine deregister destroys it.
+func TestRegisterCreatesRing_DeregisterDestroys(t *testing.T) {
+	s := newLifecycleServer()
+	req := newTestRequest("/projects/a", "local.dev",
+		map[string]ServiceTarget{"api": {Host: "localhost", Port: 3000}}, 0, 443)
+	req.PID = 1
+	req.StartTime = 12345
+
+	status, body := s.register(req)
+	require.Equal(t, http.StatusOK, status, "register failed: %v", body)
+	require.NotNil(t, projectRing(s, "/projects/a"), "register must create the project's ring")
+
+	s.removeProject("/projects/a")
+	assert.Nil(t, projectRing(s, "/projects/a"), "deregister must destroy the project's ring")
+}

--- a/internal/proxyd/registry.go
+++ b/internal/proxyd/registry.go
@@ -28,6 +28,10 @@ type Route struct {
 	// dynamic proxy can gate body capture per project (a capture-disabled
 	// project's traffic is recorded as metadata only).
 	CaptureEnabled bool
+	// MaxBodySize is the project's per-request/response capture cap in bytes
+	// (D13, #49), stamped from the registration like CaptureEnabled. The dynamic
+	// proxy passes it as the per-call capture limit; 0 means the daemon default.
+	MaxBodySize int64
 }
 
 // ProjectRegistration tracks all routes belonging to a project.
@@ -42,6 +46,9 @@ type ProjectRegistration struct {
 	StartTime      int64
 	RegisteredAt   time.Time
 	CaptureEnabled bool
+	// MaxBodySize is the project's per-request/response capture cap in bytes
+	// (D13, #49); 0 means the daemon default. Stamped onto each Route.
+	MaxBodySize int64
 }
 
 // ListenerInfo tracks the protocol and route count for a port.
@@ -188,6 +195,7 @@ func (r *Registry) Register(req RegisterRequest) (hostnames []string, newPorts [
 			PID:            req.PID,
 			RegisteredAt:   now,
 			CaptureEnabled: req.CaptureEnabled,
+			MaxBodySize:    req.MaxBodySize,
 		}
 		routeKeys = append(routeKeys, key)
 		hostnames = append(hostnames, p.hostname)
@@ -213,6 +221,7 @@ func (r *Registry) Register(req RegisterRequest) (hostnames []string, newPorts [
 		StartTime:      req.StartTime,
 		RegisteredAt:   now,
 		CaptureEnabled: req.CaptureEnabled,
+		MaxBodySize:    req.MaxBodySize,
 	}
 
 	for port, proto := range portsNeeded {
@@ -278,6 +287,11 @@ func (r *Registry) registrationMatches(req RegisterRequest) bool {
 		return false
 	}
 	if proj.CaptureEnabled != req.CaptureEnabled {
+		return false
+	}
+	// A changed capture cap must NOT take the no-op refresh path — the new cap
+	// has to reach the routes so subsequent captures honor it (D13).
+	if proj.MaxBodySize != req.MaxBodySize {
 		return false
 	}
 

--- a/internal/proxyd/registry.go
+++ b/internal/proxyd/registry.go
@@ -255,6 +255,153 @@ func (r *Registry) DeregisterIfIdentity(projectDir string, pid int, startTime in
 	return true, removedHostnames, emptyPorts
 }
 
+// routeDescriptor builds a canonical key for a single route's full identity
+// (hostname, port, protocol, and backend target) so two route sets can be
+// compared as sets regardless of iteration order. Used by registrationMatches.
+func routeDescriptor(hostname string, port int, protocol string, target ServiceTarget) string {
+	return fmt.Sprintf("%s:%d|%s|%s:%d", hostname, port, protocol, target.Host, target.Port)
+}
+
+// registrationMatches reports whether projectDir's CURRENT registration would be
+// reproduced byte-for-byte by req: the same route set (hostname + port + protocol
+// + backend target for every route) AND the same capture flag. It is the D6a
+// no-op-refresh discriminator — server.register's same-identity arm uses it to
+// take a true no-op path (no remove+add, no listener churn, no record purge) when
+// the re-registering process's config is unchanged, which is the common heal case.
+// r.mu is taken for read.
+func (r *Registry) registrationMatches(req RegisterRequest) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	proj, ok := r.projects[req.ProjectDir]
+	if !ok {
+		return false
+	}
+	if proj.CaptureEnabled != req.CaptureEnabled {
+		return false
+	}
+
+	// Build the descriptor set the request would register (mirrors Register's
+	// pending-route construction).
+	desired := make(map[string]struct{})
+	for svcName, target := range req.Services {
+		hostname := fmt.Sprintf("%s.%s", svcName, req.Domain)
+		if req.HTTPSPort > 0 {
+			desired[routeDescriptor(hostname, req.HTTPSPort, "https", target)] = struct{}{}
+		}
+		if req.HTTPPort > 0 {
+			desired[routeDescriptor(hostname, req.HTTPPort, "http", target)] = struct{}{}
+		}
+	}
+
+	// The existing route set must be exactly the desired set: same cardinality
+	// AND every current route present in desired.
+	if len(desired) != len(proj.RouteKeys) {
+		return false
+	}
+	for _, key := range proj.RouteKeys {
+		route, ok := r.routes[key]
+		if !ok {
+			return false
+		}
+		if _, want := desired[routeDescriptor(route.Hostname, route.Port, route.Protocol, route.Target)]; !want {
+			return false
+		}
+	}
+	return true
+}
+
+// ProjectHostnames returns the hostnames currently registered for projectDir in
+// route-key order, or nil when it isn't registered. server.register's no-op
+// idempotent-refresh arm (D6a) echoes this unchanged set instead of running a
+// remove+add.
+func (r *Registry) ProjectHostnames(projectDir string) []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	proj, ok := r.projects[projectDir]
+	if !ok {
+		return nil
+	}
+	hostnames := make([]string, 0, len(proj.RouteKeys))
+	for _, key := range proj.RouteKeys {
+		if route, ok := r.routes[key]; ok {
+			hostnames = append(hostnames, route.Hostname)
+		}
+	}
+	return hostnames
+}
+
+// projectSnapshot captures a project's full registry footprint (its
+// ProjectRegistration plus a deep copy of every Route it owns) so
+// server.register's same-identity DIFFERENT arm can restore it verbatim when a
+// config-changed remove+add fails — a failed re-register must NEVER leave the
+// project unregistered (D6a failure-atomicity).
+type projectSnapshot struct {
+	proj   *ProjectRegistration
+	routes []*Route
+}
+
+// snapshotProject deep-copies projectDir's registration and routes under RLock.
+// ok is false when the project isn't registered.
+func (r *Registry) snapshotProject(projectDir string) (projectSnapshot, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	proj, ok := r.projects[projectDir]
+	if !ok {
+		return projectSnapshot{}, false
+	}
+	projCopy := *proj
+	projCopy.RouteKeys = append([]string(nil), proj.RouteKeys...)
+	routes := make([]*Route, 0, len(proj.RouteKeys))
+	for _, key := range proj.RouteKeys {
+		if route, ok := r.routes[key]; ok {
+			rc := *route
+			routes = append(routes, &rc)
+		}
+	}
+	return projectSnapshot{proj: &projCopy, routes: routes}, true
+}
+
+// restoreProject re-inserts a snapshot taken by snapshotProject, rebuilding the
+// project's route entries and listener refcounts. It returns the ports whose
+// listener entry did NOT exist before restore (their physical listener was closed
+// by the removal and must be re-opened by the caller). Used only by
+// server.register's failure-atomic DIFFERENT arm.
+func (r *Registry) restoreProject(snap projectSnapshot) (reopenPorts []PortSpec) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for _, route := range snap.routes {
+		rc := *route
+		r.routes[routeKey(rc.Hostname, rc.Port)] = &rc
+		if li, ok := r.listeners[rc.Port]; ok {
+			li.RouteCount++
+		} else {
+			r.listeners[rc.Port] = &ListenerInfo{Port: rc.Port, Protocol: rc.Protocol, RouteCount: 1}
+			reopenPorts = append(reopenPorts, PortSpec{Port: rc.Port, Protocol: rc.Protocol})
+		}
+	}
+	projCopy := *snap.proj
+	projCopy.RouteKeys = append([]string(nil), snap.proj.RouteKeys...)
+	r.projects[projCopy.Dir] = &projCopy
+	return reopenPorts
+}
+
+// sameRegistrationIdentity reports whether a same-dir conflict holder is the
+// SAME process generation as the requester, making the register an idempotent
+// re-register (D6a) rather than a genuine second `prox up`. It requires an exact
+// PID match AND matching NON-ZERO start tokens: a zero token on either side means
+// the generation cannot be distinguished from a reused PID, so it is treated as a
+// genuine conflict (a hard 409) — deliberately stricter than DeregisterIfIdentity,
+// which lets a zero token match for the crash-recovery teardown guard, because
+// here we would otherwise silently REPLACE a possibly-different live holder.
+func sameRegistrationIdentity(holderPID int, holderToken int64, reqPID int, reqToken int64) bool {
+	if holderToken == 0 || reqToken == 0 {
+		return false
+	}
+	return holderPID == reqPID && holderToken == reqToken
+}
+
 // deregisterLocked is the shared removal body; r.mu must be held.
 func (r *Registry) deregisterLocked(projectDir string) (removedHostnames []string, emptyPorts []int) {
 	proj, ok := r.projects[projectDir]

--- a/internal/proxyd/registry_starttime_test.go
+++ b/internal/proxyd/registry_starttime_test.go
@@ -63,10 +63,14 @@ func TestStalePIDs_TokenMismatchIsStale(t *testing.T) {
 	assert.Equal(t, os.Getpid(), stale[0].PID)
 }
 
-// TestSelfHeal_TokenMatchStillConflicts pins that a same-dir conflict whose
-// stored holder is (PID=self, StartTime=realToken) — a genuinely live, matching
-// generation — still 409s rather than being silently replaced.
-func TestSelfHeal_TokenMatchStillConflicts(t *testing.T) {
+// TestReRegister_SameIdentityIsIdempotent pins D6a (supersedes the pre-C6 hard
+// 409): a same-dir register whose live holder is the SAME generation (PID=self,
+// StartTime=realToken) is an idempotent re-register — it returns 200 with the
+// registered hostnames instead of conflicting, so a heal against a live daemon
+// whose SSE stream broke can re-register instead of looping on
+// REGISTRATION_CONFLICT forever. Only the same process (a heal or a retry) can
+// present the same PID+token; two distinct `prox up` invocations always differ.
+func TestReRegister_SameIdentityIsIdempotent(t *testing.T) {
 	realToken := mustSelfToken(t)
 
 	s := newLifecycleServer()
@@ -75,10 +79,11 @@ func TestSelfHeal_TokenMatchStillConflicts(t *testing.T) {
 	require.NoError(t, err)
 
 	status, body := s.register(req)
-	require.Equal(t, http.StatusConflict, status, "live, token-matching holder must still conflict: %v", body)
-	errResp, ok := body.(ErrorResponse)
-	require.True(t, ok, "conflict body should be an ErrorResponse")
-	assert.Equal(t, "REGISTRATION_CONFLICT", errResp.Code)
+	require.Equal(t, http.StatusOK, status, "live, same-identity holder must re-register idempotently: %v", body)
+	resp, ok := body.(RegisterResponse)
+	require.True(t, ok, "idempotent re-register body should be a RegisterResponse")
+	assert.Contains(t, resp.Registered, "api.local.dev")
+	assert.Equal(t, 1, s.registry.ProjectCount(), "idempotent re-register must not duplicate the project")
 }
 
 // TestSelfHeal_TokenMismatchIsReplaced pins the #61 self-heal path: a same-dir

--- a/internal/proxyd/selfheal_test.go
+++ b/internal/proxyd/selfheal_test.go
@@ -27,11 +27,11 @@ func newProxyServer(t *testing.T) *Server {
 	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
 	s := NewServer(ServerConfig{SocketPath: "", Logger: logger, Version: "test"})
 	reg := NewRegistry()
-	rm := proxy.NewRequestManager(100)
-	dp := NewDynamicProxy(reg, nil, rm, nil, logger)
+	ms := NewManagers(100, nil)
+	dp := NewDynamicProxy(reg, nil, ms, nil, logger)
 	s.SetRegistry(reg)
 	s.SetProxy(dp)
-	s.SetRequestManager(rm)
+	s.SetManagers(ms)
 	t.Cleanup(func() { _ = dp.Shutdown(context.Background()) })
 	return s
 }
@@ -182,13 +182,12 @@ func TestSelfHeal_Concurrency_RegisterVsSweep(t *testing.T) {
 			// A late sweep tick for the dead PID must not touch the live
 			// generation's route or records.
 			recID := fmt.Sprintf("newgen-%d", i)
-			s.requestManager.Record(proxy.RequestRecord{ID: recID, ProjectDir: "/projects/dead", Method: "GET", URL: "/n", Details: &proxy.RequestDetails{}})
+			recordInto(s, proxy.RequestRecord{ID: recID, ProjectDir: "/projects/dead", Method: "GET", URL: "/n", Details: &proxy.RequestDetails{}})
 			removed, _, _ := s.removeStaleProject("/projects/dead", dead, 0)
 			assert.False(t, removed, "iteration %d: late sweep must skip the live generation", i)
 			_, ok = s.registry.Lookup("api.local.dev", port)
 			assert.True(t, ok, "iteration %d: live route must survive a late sweep", i)
-			_, ok = s.requestManager.GetByID(recID)
-			assert.True(t, ok, "iteration %d: new generation's record must survive a late sweep", i)
+			assert.True(t, projectHas(s, "/projects/dead", recID), "iteration %d: new generation's record must survive a late sweep", i)
 		}
 	}
 	// The race must not be able to starve the restart entirely — the whole
@@ -221,7 +220,7 @@ func TestSelfHeal_RollbackBindFailSchedulesShutdown(t *testing.T) {
 	// A record captured for the project while its routes were briefly visible
 	// (shared-port listener window) must not survive the rollback as an
 	// orphan — pre-seed one to pin the purge.
-	s.requestManager.Record(proxy.RequestRecord{
+	recordInto(s, proxy.RequestRecord{
 		ID: "rollback-orphan", ProjectDir: "/projects/dead", Method: "GET", URL: "/w",
 	})
 
@@ -233,8 +232,7 @@ func TestSelfHeal_RollbackBindFailSchedulesShutdown(t *testing.T) {
 	status, body := s.register(reReq)
 	require.Equal(t, http.StatusInternalServerError, status, "bind failure expected: %v", body)
 	require.True(t, s.registry.IsEmpty(), "rollback must empty the registry")
-	_, found := s.requestManager.GetByID("rollback-orphan")
-	require.False(t, found, "rollback must purge the project's captured records")
+	require.False(t, projectHas(s, "/projects/dead", "rollback-orphan"), "rollback must purge the project's captured records")
 
 	select {
 	case <-s.ShutdownCh():

--- a/internal/proxyd/server.go
+++ b/internal/proxyd/server.go
@@ -53,9 +53,14 @@ type Server struct {
 	lifecycleEpoch atomic.Uint64
 
 	// Core components
-	registry       *Registry
-	proxy          *DynamicProxy
-	requestManager *proxy.RequestManager
+	registry *Registry
+	proxy    *DynamicProxy
+	// managers holds the per-project request rings (D13, #49): one full-capacity
+	// ring per registered project, so one project's flood cannot evict another's
+	// records. It replaces the single shared RequestManager. Guarded by its own
+	// lock (see Managers); the hot path reaches it via DynamicProxy, never
+	// touching lifecycleMu.
+	managers *Managers
 }
 
 // ServerConfig holds configuration for creating a daemon server.
@@ -93,9 +98,11 @@ func (s *Server) SetProxy(p *DynamicProxy) {
 	s.proxy = p
 }
 
-// SetRequestManager sets the request manager (called during daemon setup).
-func (s *Server) SetRequestManager(rm *proxy.RequestManager) {
-	s.requestManager = rm
+// SetManagers sets the per-project request-ring set (called during daemon
+// setup). The same set is shared with the DynamicProxy so the hot path and the
+// control-plane endpoints resolve the identical per-project rings.
+func (s *Server) SetManagers(ms *Managers) {
+	s.managers = ms
 }
 
 // ShutdownCh returns a channel that is closed when the daemon should exit.
@@ -307,6 +314,18 @@ func (s *Server) register(req RegisterRequest) (int, any) {
 		}
 	}
 
+	// The registry now holds this project's routes, so the hot path can resolve
+	// them. Ensure its per-project ring exists BEFORE the cert/listener phases so
+	// records captured while the routes are briefly visible on already-bound
+	// shared-port listeners land in the ring (and are purged on rollback), and so
+	// the no-op idempotent refresh — which returned earlier without reaching this
+	// point — keeps the project's existing ring untouched. ensure is idempotent:
+	// the config-changed and crash-replace arms above kept the manager, and this
+	// returns it unchanged.
+	if s.managers != nil {
+		s.managers.ensure(req.ProjectDir)
+	}
+
 	// Ensure a cert exists for the registration's domain whenever it registers any
 	// HTTPS route. Gating on req.HTTPSPort > 0 (not on a NEW listener port) is the
 	// #58 fix: a domain joining an already-bound shared HTTPS port has no new port
@@ -314,10 +333,7 @@ func (s *Server) register(req RegisterRequest) (int, any) {
 	// EnsureDomain is idempotent (one cert per base domain), so re-calls are cheap.
 	if s.proxy != nil && s.proxy.certMgr != nil && req.HTTPSPort > 0 {
 		if err := s.proxy.certMgr.EnsureDomain(req.Domain); err != nil {
-			s.rollbackRegistration(req.ProjectDir)
-			if restoreSnap != nil {
-				s.restoreSnapshotLocked(*restoreSnap)
-			}
+			s.unwindRegistration(req.ProjectDir, restoreSnap)
 			return http.StatusInternalServerError, ErrorResponse{
 				Error: fmt.Sprintf("failed to generate certs for %s: %v", req.Domain, err),
 				Code:  "CERT_GENERATION_FAILED",
@@ -340,10 +356,7 @@ func (s *Server) register(req RegisterRequest) (int, any) {
 				for _, p := range startedPorts {
 					_ = s.proxy.RemoveListener(p)
 				}
-				s.rollbackRegistration(req.ProjectDir)
-				if restoreSnap != nil {
-					s.restoreSnapshotLocked(*restoreSnap)
-				}
+				s.unwindRegistration(req.ProjectDir, restoreSnap)
 				return http.StatusInternalServerError, ErrorResponse{
 					Error: fmt.Sprintf("failed to bind port %d: %v", ps.Port, err),
 					Code:  "PORT_BIND_FAILED",
@@ -442,11 +455,19 @@ func (s *Server) removeProject(projectDir string) (removedHostnames []string, em
 	if s.isShuttingDown() {
 		return nil, nil
 	}
-	return s.removeProjectLocked(projectDir)
+	removedHostnames, emptyPorts = s.removeProjectLocked(projectDir)
+	// Genuine deregister: tear down the project's per-project ring after the
+	// shared removeProjectLocked purged its records. The register-inline arms
+	// (config-changed / crash-replace re-register) call removeProjectLocked
+	// directly and KEEP the ring — only this top-level entry destroys it.
+	s.destroyProjectManager(projectDir)
+	return removedHostnames, emptyPorts
 }
 
 // removeProjectLocked is removeProject's body; lifecycleMu must be held. It lets
 // register run a stale-registration replace while already holding the mutex.
+// It purges the project's records but KEEPS its ring manager (the re-register
+// arms reuse it); only the top-level removeProject destroys the manager.
 func (s *Server) removeProjectLocked(projectDir string) (removedHostnames []string, emptyPorts []int) {
 	if s.registry == nil {
 		return nil, nil
@@ -471,7 +492,14 @@ func (s *Server) removeStaleProject(projectDir string, pid int, startTime int64)
 	if s.isShuttingDown() {
 		return false, nil, nil
 	}
-	return s.removeStaleProjectLocked(projectDir, pid, startTime)
+	removed, removedHostnames, emptyPorts = s.removeStaleProjectLocked(projectDir, pid, startTime)
+	// Only destroy the ring when a removal actually happened: a guarded no-op
+	// (the project re-registered under a live PID between detection and removal)
+	// must leave the live generation's ring — and its records — untouched.
+	if removed {
+		s.destroyProjectManager(projectDir)
+	}
+	return removed, removedHostnames, emptyPorts
 }
 
 // removeStaleProjectLocked is removeStaleProject's body; lifecycleMu must be
@@ -490,8 +518,10 @@ func (s *Server) removeStaleProjectLocked(projectDir string, pid int, startTime 
 }
 
 // finishRemoval closes listeners for now-empty ports and purges the project's
-// captured requests (firing eviction callbacks so on-disk body files are
-// cleaned up).
+// captured requests from its per-project ring (firing eviction callbacks so
+// on-disk body files are cleaned up). It KEEPS the ring manager itself — the
+// register-inline re-register arms reuse it. Genuine removal additionally
+// destroys the manager via destroyProjectManager.
 func (s *Server) finishRemoval(projectDir string, emptyPorts []int) {
 	if s.proxy != nil {
 		for _, port := range emptyPorts {
@@ -501,8 +531,24 @@ func (s *Server) finishRemoval(projectDir string, emptyPorts []int) {
 		}
 	}
 
-	if s.requestManager != nil {
-		s.requestManager.PurgeByProject(projectDir)
+	s.managers.purge(projectDir)
+}
+
+// destroyProjectManager tears down a project's request ring on genuine removal
+// (explicit deregister, stale-PID sweep, or a fresh registration's rollback):
+// it Closes the manager FIRST — releasing any daemon-side SSE handler blocked on
+// its subscription — then removes it from the set so later hot-path lookups
+// return nil. finishRemoval (or rollbackRegistration) already purged the
+// records+bodies for the common path; the final PurgeByProject on the detached
+// manager is a safety sweep so a record that landed in the narrow window between
+// that purge and the Close doesn't orphan its on-disk body file. lifecycleMu
+// must be held. No-op when the project has no ring.
+func (s *Server) destroyProjectManager(projectDir string) {
+	if s.managers == nil {
+		return
+	}
+	if mgr := s.managers.remove(projectDir); mgr != nil {
+		mgr.PurgeByProject(projectDir)
 	}
 }
 
@@ -514,11 +560,23 @@ func (s *Server) finishRemoval(projectDir string, emptyPorts []int) {
 // strand an idle daemon. lifecycleMu must be held.
 func (s *Server) rollbackRegistration(projectDir string) {
 	s.registry.Deregister(projectDir)
-	if s.requestManager != nil {
-		s.requestManager.PurgeByProject(projectDir)
-	}
+	s.managers.purge(projectDir)
 	s.lifecycleEpoch.Add(1)
 	s.scheduleShutdownWhenEmpty()
+}
+
+// unwindRegistration reverses a registration attempt that failed AFTER its ring
+// was ensured (cert or listener phase): it rolls back the registry entry and
+// purges the ring, then either restores the project's prior registration (the
+// same-identity config-change replace arm) or destroys the freshly-ensured ring
+// (a brand-new project's rollback). lifecycleMu must be held.
+func (s *Server) unwindRegistration(projectDir string, restoreSnap *projectSnapshot) {
+	s.rollbackRegistration(projectDir)
+	if restoreSnap != nil {
+		s.restoreSnapshotLocked(*restoreSnap)
+	} else {
+		s.destroyProjectManager(projectDir)
+	}
 }
 
 // restoreSnapshotLocked re-injects a project snapshot into the registry and
@@ -586,8 +644,11 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 	if resp.ListenerPorts == nil {
 		resp.ListenerPorts = []int{}
 	}
-	if s.requestManager != nil {
-		resp.DroppedEvents = s.requestManager.DroppedEvents()
+	if s.managers != nil {
+		// Dropped events are summed across every project's ring; per-project
+		// record counts make the N×ring memory trade-off diagnosable (D13).
+		resp.DroppedEvents = s.managers.droppedTotal()
+		resp.RecordCounts = s.managers.recordCounts()
 	}
 
 	writeJSON(w, http.StatusOK, resp)
@@ -642,7 +703,7 @@ func (s *Server) handleShutdown(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleStreamRequests(w http.ResponseWriter, r *http.Request) {
-	if s.requestManager == nil {
+	if s.managers == nil {
 		writeJSON(w, http.StatusServiceUnavailable, ErrorResponse{
 			Error: "request manager not available",
 			Code:  "NOT_READY",
@@ -662,8 +723,8 @@ func (s *Server) handleStreamRequests(w http.ResponseWriter, r *http.Request) {
 	// Filter the stream by owning project (exact match). Scoping by project
 	// dir rather than hostname prevents cross-project record delivery when two
 	// projects own the same hostname on different ports. The param is
-	// mandatory: an empty ProjectDir filter would match ALL projects' records,
-	// so a caller that forgot the param would silently receive everything.
+	// mandatory: an empty ProjectDir filter would resolve no ring, so a caller
+	// that forgot the param would silently receive nothing.
 	projectDir := r.URL.Query().Get("project")
 	if projectDir == "" {
 		writeJSON(w, http.StatusBadRequest, ErrorResponse{
@@ -672,15 +733,29 @@ func (s *Server) handleStreamRequests(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
-	filter := proxy.RequestFilter{ProjectDir: projectDir}
-	sub := s.requestManager.Subscribe(filter)
-	defer s.requestManager.Unsubscribe(sub.ID)
 
-	// Set SSE headers
+	// Set SSE headers before resolving the ring so a missing-project stream
+	// still returns 200 (the forwarder treats a clean stream end as a reconnect
+	// signal, which is exactly right during a heal/deregister window).
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
 	w.Header().Set("X-Accel-Buffering", "no")
+
+	// A project with no ring (never registered, or already deregistered)
+	// subscribes to nothing and ends cleanly right after the headers rather than
+	// blocking forever on a subscription no writer will ever feed (D13).
+	mgr := s.managers.get(projectDir)
+	if mgr == nil {
+		s.logger.Info("requests stream for a project with no ring; ending cleanly", "project", projectDir)
+		fmt.Fprintf(w, ": connected\n\n")
+		flusher.Flush()
+		return
+	}
+
+	filter := proxy.RequestFilter{ProjectDir: projectDir}
+	sub := mgr.Subscribe(filter)
+	defer mgr.Unsubscribe(sub.ID)
 
 	fmt.Fprintf(w, ": connected\n\n")
 	flusher.Flush()
@@ -706,7 +781,7 @@ func (s *Server) handleStreamRequests(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleGetRequests(w http.ResponseWriter, r *http.Request) {
-	if s.requestManager == nil {
+	if s.managers == nil {
 		writeJSON(w, http.StatusServiceUnavailable, ErrorResponse{
 			Error: "request manager not available",
 			Code:  "NOT_READY",
@@ -715,13 +790,23 @@ func (s *Server) handleGetRequests(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Mandatory for the same reason as the stream endpoint: an empty
-	// ProjectDir filter matches every project's records.
+	// ProjectDir resolves no ring.
 	projectDir := r.URL.Query().Get("project")
 	if projectDir == "" {
 		writeJSON(w, http.StatusBadRequest, ErrorResponse{
 			Error: "project query parameter is required",
 			Code:  "BAD_REQUEST",
 		})
+		return
+	}
+
+	// A project with no ring (never registered, or already deregistered)
+	// returns 200 with an empty list — a stable contract for the forwarder's
+	// backfill during a heal/deregister window (D13). One log line records it.
+	mgr := s.managers.get(projectDir)
+	if mgr == nil {
+		s.logger.Info("requests snapshot for a project with no ring; returning empty list", "project", projectDir)
+		writeJSON(w, http.StatusOK, map[string]any{"requests": []proxy.RequestRecord{}})
 		return
 	}
 
@@ -741,7 +826,10 @@ func (s *Server) handleGetRequests(w http.ResponseWriter, r *http.Request) {
 		Limit:      limit,
 	}
 
-	records := s.requestManager.Recent(filter)
+	records := mgr.Recent(filter)
+	if records == nil {
+		records = []proxy.RequestRecord{}
+	}
 	writeJSON(w, http.StatusOK, map[string]any{"requests": records})
 }
 

--- a/internal/proxyd/server.go
+++ b/internal/proxyd/server.go
@@ -237,6 +237,12 @@ func (s *Server) register(req RegisterRequest) (int, any) {
 		}
 	}
 
+	// restoreSnap, when non-nil, is the pre-removal snapshot of a same-identity
+	// holder whose config CHANGED (the D6a DIFFERENT arm): every failure point
+	// after its removal must restore it rather than leave the project
+	// unregistered. It stays nil for the crash-replace and fresh-register paths.
+	var restoreSnap *projectSnapshot
+
 	hostnames, newPorts, err := s.registry.Register(req)
 	if err != nil {
 		var conflict *ProjectConflictError
@@ -245,17 +251,58 @@ func (s *Server) register(req RegisterRequest) (int, any) {
 			return http.StatusConflict, ErrorResponse{Error: err.Error(), Code: "REGISTRATION_CONFLICT"}
 		}
 		if daemon.IsProcessAlive(conflict.PID, conflict.StartTime) {
-			// A second live prox up in the same dir is a genuine conflict.
-			return http.StatusConflict, ErrorResponse{Error: err.Error(), Code: "REGISTRATION_CONFLICT"}
+			// The same-dir holder is still live. Sub-cases:
+			//   - SAME generation as the requester (same PID AND matching non-zero
+			//     start token): an idempotent re-register (D6a) — the heal path
+			//     (D6b) re-registering against a live daemon whose SSE stream broke,
+			//     or a client retrying a register it already won.
+			//   - A DIFFERENT generation (different PID, or an unreadable token on
+			//     either side that can't be proven identical): a genuine second
+			//     `prox up` in the same dir — stays a hard 409.
+			if !sameRegistrationIdentity(conflict.PID, conflict.StartTime, req.PID, req.StartTime) {
+				return http.StatusConflict, ErrorResponse{Error: err.Error(), Code: "REGISTRATION_CONFLICT"}
+			}
+			// FIX 1: when the re-registering process's config is UNCHANGED (the
+			// common heal case), take a true no-op refresh — echo the current
+			// hostnames without any remove+add, so no listeners churn and, crucially,
+			// no daemon-side records are purged. This is what a heal against a live
+			// daemon whose SSE stream merely broke actually needs.
+			if s.registry.registrationMatches(req) {
+				s.logger.Info("idempotent re-register: config unchanged, no-op refresh",
+					"project", conflict.Dir, "pid", conflict.PID, "start_time", conflict.StartTime)
+				return http.StatusOK, RegisterResponse{Registered: s.registry.ProjectHostnames(conflict.Dir)}
+			}
+			// FIX 2: the same process re-registers with a CHANGED config (rare).
+			// Keep the remove+add, but make it failure-atomic: snapshot the current
+			// registration first so any failure in the retry Register / cert /
+			// listener phases below can restore it — a failed re-register must never
+			// leave the project unregistered.
+			if snap, ok := s.registry.snapshotProject(conflict.Dir); ok {
+				restoreSnap = &snap
+			}
+			s.logger.Info("idempotent re-register: config changed, replacing registration",
+				"project", conflict.Dir, "pid", conflict.PID, "start_time", conflict.StartTime)
+			// removeProjectLocked drops the holder's routes and refcounts (closing
+			// now-empty listeners) and purges its records; the shared re-register
+			// below rebinds the ports and refcounts them back to one, so N
+			// re-registers followed by ONE deregister still close the port.
+			s.removeProjectLocked(conflict.Dir)
+		} else {
+			// The holder crashed without deregistering. Replace its stale
+			// registration inline (PID-guarded; purges its records + body files and
+			// closes its listeners) and retry once. Under lifecycleMu the retry
+			// cannot lose a race, so a single retry is a correctness guarantee.
+			s.logger.Warn("replacing stale registration", "project", conflict.Dir, "pid", conflict.PID, "start_time", conflict.StartTime)
+			s.removeStaleProjectLocked(conflict.Dir, conflict.PID, conflict.StartTime)
 		}
-		// The holder crashed without deregistering. Replace its stale
-		// registration inline (PID-guarded; purges its records + body files and
-		// closes its listeners) and retry once. Under lifecycleMu the retry
-		// cannot lose a race, so a single retry is a correctness guarantee.
-		s.logger.Warn("replacing stale registration", "project", conflict.Dir, "pid", conflict.PID, "start_time", conflict.StartTime)
-		s.removeStaleProjectLocked(conflict.Dir, conflict.PID, conflict.StartTime)
+		// Shared retry tail: whichever removal ran above freed the same-dir holder,
+		// so rebind under the still-held lifecycleMu. A single retry cannot lose a
+		// race, so this is a correctness guarantee, not a hopeful retry.
 		hostnames, newPorts, err = s.registry.Register(req)
 		if err != nil {
+			if restoreSnap != nil {
+				s.restoreSnapshotLocked(*restoreSnap)
+			}
 			return http.StatusConflict, ErrorResponse{Error: err.Error(), Code: "REGISTRATION_CONFLICT"}
 		}
 	}
@@ -268,6 +315,9 @@ func (s *Server) register(req RegisterRequest) (int, any) {
 	if s.proxy != nil && s.proxy.certMgr != nil && req.HTTPSPort > 0 {
 		if err := s.proxy.certMgr.EnsureDomain(req.Domain); err != nil {
 			s.rollbackRegistration(req.ProjectDir)
+			if restoreSnap != nil {
+				s.restoreSnapshotLocked(*restoreSnap)
+			}
 			return http.StatusInternalServerError, ErrorResponse{
 				Error: fmt.Sprintf("failed to generate certs for %s: %v", req.Domain, err),
 				Code:  "CERT_GENERATION_FAILED",
@@ -291,6 +341,9 @@ func (s *Server) register(req RegisterRequest) (int, any) {
 					_ = s.proxy.RemoveListener(p)
 				}
 				s.rollbackRegistration(req.ProjectDir)
+				if restoreSnap != nil {
+					s.restoreSnapshotLocked(*restoreSnap)
+				}
 				return http.StatusInternalServerError, ErrorResponse{
 					Error: fmt.Sprintf("failed to bind port %d: %v", ps.Port, err),
 					Code:  "PORT_BIND_FAILED",
@@ -466,6 +519,28 @@ func (s *Server) rollbackRegistration(projectDir string) {
 	}
 	s.lifecycleEpoch.Add(1)
 	s.scheduleShutdownWhenEmpty()
+}
+
+// restoreSnapshotLocked re-injects a project snapshot into the registry and
+// re-opens any physical listener the removal closed, then bumps the lifecycle
+// epoch. lifecycleMu must be held. It is register's failure-atomic recovery for
+// the same-identity DIFFERENT arm (D6a): when a config-changed remove+add fails
+// partway, the original registration is restored so the project is never left
+// unregistered. A listener that cannot be re-opened is logged (best-effort): the
+// alternative — returning without restoring — would strand the project entirely.
+func (s *Server) restoreSnapshotLocked(snap projectSnapshot) {
+	reopen := s.registry.restoreProject(snap)
+	if s.proxy != nil {
+		for _, ps := range reopen {
+			if err := s.addListenerWithBriefRetry(ps.Port, ps.Protocol); err != nil {
+				s.logger.Error("failed to re-open listener while restoring a registration after a failed re-register",
+					"project", snap.proj.Dir, "port", ps.Port, "protocol", ps.Protocol, "error", err)
+			}
+		}
+	}
+	s.lifecycleEpoch.Add(1)
+	s.logger.Info("restored prior registration after a failed re-register",
+		"project", snap.proj.Dir, "pid", snap.proj.PID)
 }
 
 // addListenerWithBriefRetry binds a listener, retrying briefly on a transient

--- a/internal/proxyd/server.go
+++ b/internal/proxyd/server.go
@@ -511,6 +511,9 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 	if resp.ListenerPorts == nil {
 		resp.ListenerPorts = []int{}
 	}
+	if s.requestManager != nil {
+		resp.DroppedEvents = s.requestManager.DroppedEvents()
+	}
 
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/internal/proxyd/server.go
+++ b/internal/proxyd/server.go
@@ -529,12 +529,24 @@ func (s *Server) handleRoutes(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleShutdown(w http.ResponseWriter, r *http.Request) {
 	force := r.URL.Query().Get("force") == "true"
 
+	// The emptiness check and the shutdown decision must be one atomic step
+	// with respect to lifecycle transactions: an unserialized IsEmpty() could
+	// read "empty" while a register handler (holding lifecycleMu, having
+	// passed its isShuttingDown gate) is about to commit — the register would
+	// return 200 and the daemon would exit anyway, stranding that project.
+	// Under lifecycleMu, a register either committed first (refused here with
+	// ACTIVE_ROUTES) or arrives after the flag is set (503 SHUTTING_DOWN).
+	// Lock ordering (lifecycleMu → shutdownMu via RequestShutdown) matches
+	// the scheduleShutdownWhenEmpty timer path.
+	s.lifecycleMu.Lock()
 	if s.registry != nil && !s.registry.IsEmpty() && !force {
-		routes := s.registry.AllRoutes()
+		routeCount := len(s.registry.AllRoutes())
+		projectCount := s.registry.ProjectCount()
+		s.lifecycleMu.Unlock()
 		writeJSON(w, http.StatusConflict, ErrorResponse{
 			Error: fmt.Sprintf(
 				"proxy has %d active route(s) from %d project(s). Use --force to stop anyway.",
-				len(routes), s.registry.ProjectCount(),
+				routeCount, projectCount,
 			),
 			Code: "ACTIVE_ROUTES",
 		})
@@ -547,6 +559,7 @@ func (s *Server) handleShutdown(w http.ResponseWriter, r *http.Request) {
 	// and gets 503. server.Shutdown is graceful (it waits for this active handler),
 	// so the response still flushes.
 	s.RequestShutdown()
+	s.lifecycleMu.Unlock()
 	writeJSON(w, http.StatusOK, map[string]string{"status": "shutting down"})
 }
 

--- a/internal/proxyd/server_lifecycle_test.go
+++ b/internal/proxyd/server_lifecycle_test.go
@@ -25,7 +25,7 @@ func newLifecycleServer() *Server {
 	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
 	s := NewServer(ServerConfig{SocketPath: "", Logger: logger, Version: "test"})
 	s.SetRegistry(NewRegistry())
-	s.SetRequestManager(proxy.NewRequestManager(100))
+	s.SetManagers(NewManagers(100, nil))
 	return s
 }
 
@@ -43,9 +43,9 @@ func TestServer_RemoveProject_ScopedByProject(t *testing.T) {
 		map[string]ServiceTarget{"api": {Host: "localhost", Port: 4000}}, 0, 8443))
 	require.NoError(t, err)
 
-	// Records for each project, same hostname.
-	s.requestManager.Record(proxy.RequestRecord{ID: "a1", Method: "GET", URL: "/a", Hostname: "api.local.dev", ProjectDir: "/projects/a"})
-	s.requestManager.Record(proxy.RequestRecord{ID: "b1", Method: "GET", URL: "/b", Hostname: "api.local.dev", ProjectDir: "/projects/b"})
+	// Records for each project, same hostname, in their own per-project rings.
+	recordInto(s, proxy.RequestRecord{ID: "a1", Method: "GET", URL: "/a", Hostname: "api.local.dev", ProjectDir: "/projects/a"})
+	recordInto(s, proxy.RequestRecord{ID: "b1", Method: "GET", URL: "/b", Hostname: "api.local.dev", ProjectDir: "/projects/b"})
 
 	removed, _ := s.removeProject("/projects/a")
 	assert.Equal(t, []string{"api.local.dev"}, removed)
@@ -56,8 +56,9 @@ func TestServer_RemoveProject_ScopedByProject(t *testing.T) {
 	_, okB := s.registry.Lookup("api.local.dev", 8443)
 	assert.True(t, okB, "B's route should survive")
 
-	// A's records purged, B's survive.
-	remaining := s.requestManager.Recent(proxy.RequestFilter{})
+	// A's ring destroyed, B's ring survives with its record.
+	assert.Nil(t, projectRing(s, "/projects/a"), "A's ring must be destroyed on deregister")
+	remaining := projectRecent(s, "/projects/b")
 	require.Len(t, remaining, 1)
 	assert.Equal(t, "b1", remaining[0].ID)
 }
@@ -78,8 +79,8 @@ func TestServer_StalePIDSweep_PurgesRecords(t *testing.T) {
 	_, _, err := s.registry.Register(req)
 	require.NoError(t, err)
 
-	s.requestManager.Record(proxy.RequestRecord{ID: "d1", Method: "GET", URL: "/d", Hostname: "api.local.dev", ProjectDir: "/projects/dead"})
-	require.Equal(t, 1, s.requestManager.Count())
+	recordInto(s, proxy.RequestRecord{ID: "d1", Method: "GET", URL: "/d", Hostname: "api.local.dev", ProjectDir: "/projects/dead"})
+	require.Equal(t, 1, projectCount(s, "/projects/dead"))
 
 	// The daemon sweep: detect stale PIDs, then remove via the PID-guarded path.
 	stale := s.registry.StalePIDs()
@@ -90,7 +91,7 @@ func TestServer_StalePIDSweep_PurgesRecords(t *testing.T) {
 	}
 
 	assert.True(t, s.registry.IsEmpty(), "registry should be empty after stale sweep")
-	assert.Equal(t, 0, s.requestManager.Count(), "stale project's records must be purged")
+	assert.Nil(t, projectRing(s, "/projects/dead"), "stale project's ring must be destroyed")
 }
 
 // TestServer_RemoveStaleProject_SkipsReRegistered pins the detection→removal
@@ -117,13 +118,13 @@ func TestServer_RemoveStaleProject_SkipsReRegistered(t *testing.T) {
 	reReq.PID = 1 // always-alive PID (launchd/init)
 	_, _, err = s.registry.Register(reReq)
 	require.NoError(t, err)
-	s.requestManager.Record(proxy.RequestRecord{ID: "x1", Method: "GET", URL: "/x", ProjectDir: "/projects/x"})
+	recordInto(s, proxy.RequestRecord{ID: "x1", Method: "GET", URL: "/x", ProjectDir: "/projects/x"})
 
 	removed, _, _ := s.removeStaleProject(stale[0].Dir, stale[0].PID, stale[0].StartTime)
 	assert.False(t, removed, "guarded removal must skip the re-registered project")
 	_, ok := s.registry.Lookup("api.local.dev", 443)
 	assert.True(t, ok, "live registration's route must survive")
-	assert.Equal(t, 1, s.requestManager.Count(), "live registration's records must survive")
+	assert.Equal(t, 1, projectCount(s, "/projects/x"), "live registration's records must survive")
 }
 
 // TestServer_RemoveStaleProject_SkipsReusedPID pins the reused-PID teardown fix
@@ -164,7 +165,7 @@ func TestServer_RemoveStaleProject_SkipsReusedPID(t *testing.T) {
 	reReq.StartTime = t2
 	_, _, err = s.registry.Register(reReq)
 	require.NoError(t, err)
-	s.requestManager.Record(proxy.RequestRecord{ID: "x1", Method: "GET", URL: "/x", ProjectDir: "/projects/x"})
+	recordInto(s, proxy.RequestRecord{ID: "x1", Method: "GET", URL: "/x", ProjectDir: "/projects/x"})
 
 	// Guard half: the delayed sweep removal targets the dead generation's
 	// identity (deadP, T1), but the current registration carries T2 — the
@@ -173,7 +174,7 @@ func TestServer_RemoveStaleProject_SkipsReusedPID(t *testing.T) {
 	assert.False(t, removed, "reused-PID restart under a new token must survive the sweep")
 	_, ok := s.registry.Lookup("api.local.dev", 443)
 	assert.True(t, ok, "live restart's route must survive")
-	assert.Equal(t, 1, s.requestManager.Count(), "live restart's records must survive")
+	assert.Equal(t, 1, projectCount(s, "/projects/x"), "live restart's records must survive")
 }
 
 // TestHandleRegister_RejectsEmptyProjectDir pins the identity requirement:
@@ -195,7 +196,7 @@ func TestHandleRegister_RejectsEmptyProjectDir(t *testing.T) {
 // records.
 func TestRequestEndpoints_RequireProjectParam(t *testing.T) {
 	server, client, _ := startTestServer(t)
-	server.SetRequestManager(proxy.NewRequestManager(10))
+	_ = server // ring set already wired by startTestServer
 
 	resp, err := client.httpClient.Get("http://proxyd/api/v1/requests")
 	require.NoError(t, err)
@@ -215,8 +216,7 @@ func TestRequestEndpoints_RequireProjectParam(t *testing.T) {
 // default of 100.
 func TestHandleGetRequests_LimitClamp(t *testing.T) {
 	server, client, _ := startTestServer(t)
-	rm := proxy.NewRequestManager(1500)
-	server.SetRequestManager(rm)
+	rm := server.managers.ensure("/projects/a")
 
 	for i := 0; i < 150; i++ {
 		rm.Record(proxy.RequestRecord{
@@ -281,7 +281,10 @@ func TestServer_SelfHeal_DeadPIDReRegister(t *testing.T) {
 	// purged — the eviction callback fires only for records carrying Details.
 	bodyFile := filepath.Join(t.TempDir(), "body.bin")
 	require.NoError(t, os.WriteFile(bodyFile, []byte("stale body"), 0o600))
-	s.requestManager.SetEvictionCallback(func(id string) {
+	// Wire the eviction callback onto the dead project's own ring: purging its
+	// records must delete the on-disk body file.
+	deadRing := s.managers.ensure("/projects/dead")
+	deadRing.SetEvictionCallback(func(id string) {
 		if id == "dead-rec" {
 			_ = os.Remove(bodyFile)
 		}
@@ -293,7 +296,7 @@ func TestServer_SelfHeal_DeadPIDReRegister(t *testing.T) {
 	otherReq.PID = os.Getpid()
 	_, _, err := s.registry.Register(otherReq)
 	require.NoError(t, err)
-	s.requestManager.Record(proxy.RequestRecord{ID: "other-rec", ProjectDir: "/projects/other", Method: "GET", URL: "/o", Details: &proxy.RequestDetails{}})
+	recordInto(s, proxy.RequestRecord{ID: "other-rec", ProjectDir: "/projects/other", Method: "GET", URL: "/o", Details: &proxy.RequestDetails{}})
 
 	// Dead generation: register under a PID that is guaranteed dead.
 	deadReq := newTestRequest("/projects/dead", "local.dev",
@@ -301,7 +304,7 @@ func TestServer_SelfHeal_DeadPIDReRegister(t *testing.T) {
 	deadReq.PID = deadPID(t)
 	_, _, err = s.registry.Register(deadReq)
 	require.NoError(t, err)
-	s.requestManager.Record(proxy.RequestRecord{ID: "dead-rec", ProjectDir: "/projects/dead", Method: "GET", URL: "/d", Details: &proxy.RequestDetails{}})
+	deadRing.Record(proxy.RequestRecord{ID: "dead-rec", ProjectDir: "/projects/dead", Method: "GET", URL: "/d", Details: &proxy.RequestDetails{}})
 
 	// Restart: same dir, a live PID. Self-heal replaces the dead registration.
 	reReq := deadReq
@@ -315,16 +318,15 @@ func TestServer_SelfHeal_DeadPIDReRegister(t *testing.T) {
 	require.True(t, ok, "new generation's route must be registered")
 	assert.Equal(t, os.Getpid(), route.PID, "route must carry the live generation's PID")
 
-	// Dead generation's record purged, including its on-disk body file.
-	_, ok = s.requestManager.GetByID("dead-rec")
-	assert.False(t, ok, "dead generation's record must be purged")
+	// Dead generation's record purged (the crash-replace keeps the ring but
+	// purges its records), including its on-disk body file.
+	assert.False(t, projectHas(s, "/projects/dead", "dead-rec"), "dead generation's record must be purged")
 	assert.NoFileExists(t, bodyFile, "dead generation's body file must be deleted")
 
 	// Unrelated project untouched.
 	_, ok = s.registry.Lookup("api.other.dev", 8443)
 	assert.True(t, ok, "unrelated project's route must survive")
-	_, ok = s.requestManager.GetByID("other-rec")
-	assert.True(t, ok, "unrelated project's records must survive")
+	assert.True(t, projectHas(s, "/projects/other", "other-rec"), "unrelated project's records must survive")
 }
 
 // TestServer_SelfHeal_LivePIDStillConflicts pins that a second prox up in the
@@ -557,7 +559,7 @@ func TestRemoveProject_NoOpsWhileShuttingDown(t *testing.T) {
 		req.PID = os.Getpid()
 		_, _, err := s.registry.Register(req)
 		require.NoError(t, err)
-		s.requestManager.Record(proxy.RequestRecord{ID: "a1", Method: "GET", URL: "/a", ProjectDir: "/projects/a"})
+		recordInto(s, proxy.RequestRecord{ID: "a1", Method: "GET", URL: "/a", ProjectDir: "/projects/a"})
 
 		s.RequestShutdown()
 
@@ -567,7 +569,7 @@ func TestRemoveProject_NoOpsWhileShuttingDown(t *testing.T) {
 
 		_, ok := s.registry.Lookup("api.local.dev", 443)
 		assert.True(t, ok, "route must survive for the exiting daemon to reap")
-		assert.Equal(t, 1, s.requestManager.Count(), "records must not be purged mid-teardown")
+		assert.Equal(t, 1, projectCount(s, "/projects/a"), "records must not be purged mid-teardown")
 	})
 
 	t.Run("removeStaleProject", func(t *testing.T) {
@@ -577,7 +579,7 @@ func TestRemoveProject_NoOpsWhileShuttingDown(t *testing.T) {
 		req.PID = os.Getpid()
 		_, _, err := s.registry.Register(req)
 		require.NoError(t, err)
-		s.requestManager.Record(proxy.RequestRecord{ID: "a1", Method: "GET", URL: "/a", ProjectDir: "/projects/a"})
+		recordInto(s, proxy.RequestRecord{ID: "a1", Method: "GET", URL: "/a", ProjectDir: "/projects/a"})
 
 		s.RequestShutdown()
 
@@ -588,7 +590,7 @@ func TestRemoveProject_NoOpsWhileShuttingDown(t *testing.T) {
 
 		_, ok := s.registry.Lookup("api.local.dev", 443)
 		assert.True(t, ok, "route must survive for the exiting daemon to reap")
-		assert.Equal(t, 1, s.requestManager.Count(), "records must not be purged mid-teardown")
+		assert.Equal(t, 1, projectCount(s, "/projects/a"), "records must not be purged mid-teardown")
 	})
 }
 
@@ -608,10 +610,10 @@ func TestHandleShutdown_SetsFlagBeforeResponse(t *testing.T) {
 }
 
 // TestServer_RemoveProject_NilRequestManager guards the daemon-startup window
-// where the request manager may not be set yet.
+// where the ring set may not be set yet.
 func TestServer_RemoveProject_NilRequestManager(t *testing.T) {
 	s := newLifecycleServer()
-	s.requestManager = nil // model the startup window before the manager is wired
+	s.managers = nil // model the startup window before the ring set is wired
 
 	_, _, err := s.registry.Register(newTestRequest("/projects/a", "local.dev",
 		map[string]ServiceTarget{"api": {Host: "localhost", Port: 3000}}, 0, 443))

--- a/internal/proxyd/server_lifecycle_test.go
+++ b/internal/proxyd/server_lifecycle_test.go
@@ -620,3 +620,55 @@ func TestServer_RemoveProject_NilRequestManager(t *testing.T) {
 	require.NotPanics(t, func() { s.removeProject("/projects/a") })
 	assert.True(t, s.registry.IsEmpty())
 }
+
+// TestHandleShutdown_SerializesWithRegister pins that the non-force shutdown
+// decision is atomic with lifecycle transactions: while a register transaction
+// holds lifecycleMu, handleShutdown must block rather than read a stale
+// IsEmpty(); once the register has committed, the queued shutdown must refuse
+// with ACTIVE_ROUTES instead of stranding the just-registered project. Without
+// the lifecycleMu serialization in handleShutdown, this test fails fast: the
+// handler responds 200 while the "in-flight" register still holds the lock.
+func TestHandleShutdown_SerializesWithRegister(t *testing.T) {
+	s := newLifecycleServer()
+
+	// Simulate an in-flight register transaction: hold lifecycleMu, exactly as
+	// server.register does around its registry commit.
+	s.lifecycleMu.Lock()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/shutdown", nil)
+	done := make(chan struct{})
+	go func() {
+		s.handleShutdown(rec, req)
+		close(done)
+	}()
+
+	// The shutdown decision must not be made while the transaction is open.
+	select {
+	case <-done:
+		t.Fatalf("handleShutdown decided while a lifecycle transaction was in flight (status %d)", rec.Code)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// The in-flight transaction commits a registration (registry has its own
+	// lock — this is the exact interleaving the serialization exists for).
+	regReq := newTestRequest("/projects/race", "local.dev",
+		map[string]ServiceTarget{"api": {Host: "localhost", Port: 3000}}, 0, 443)
+	regReq.PID = os.Getpid()
+	_, _, err := s.registry.Register(regReq)
+	require.NoError(t, err)
+	s.lifecycleMu.Unlock()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handleShutdown never completed after the transaction released")
+	}
+
+	// The queued shutdown observed the committed registration and refused.
+	require.Equal(t, http.StatusConflict, rec.Code)
+	var er ErrorResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &er))
+	assert.Equal(t, "ACTIVE_ROUTES", er.Code)
+	assert.False(t, s.isShuttingDown(), "a refused shutdown must not set the flag")
+}

--- a/internal/proxyd/server_lifecycle_test.go
+++ b/internal/proxyd/server_lifecycle_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/charliek/prox/internal/constants"
 	"github.com/charliek/prox/internal/proxy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -25,7 +26,7 @@ func newLifecycleServer() *Server {
 	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
 	s := NewServer(ServerConfig{SocketPath: "", Logger: logger, Version: "test"})
 	s.SetRegistry(NewRegistry())
-	s.SetManagers(NewManagers(100, nil))
+	s.SetManagers(NewManagers(constants.DefaultProxyRequestBufferSize, nil))
 	return s
 }
 

--- a/internal/proxyd/types.go
+++ b/internal/proxyd/types.go
@@ -61,6 +61,10 @@ type DaemonStatusResponse struct {
 	ListenerPorts []int       `json:"listener_ports"`
 	ProjectCount  int         `json:"project_count"`
 	RouteCount    int         `json:"route_count"`
+	// DroppedEvents is the daemon-wide count of SSE-subscriber notifications
+	// dropped because a subscriber's channel was full (D9). It surfaces the
+	// request-stream degradation the forwarder would otherwise absorb silently.
+	DroppedEvents int64 `json:"dropped_events"`
 }
 
 // ErrorResponse is the standard error format for daemon API responses.

--- a/internal/proxyd/types.go
+++ b/internal/proxyd/types.go
@@ -23,6 +23,13 @@ type RegisterRequest struct {
 	HTTPPort       int                      `json:"http_port,omitempty"`
 	HTTPSPort      int                      `json:"https_port,omitempty"`
 	CaptureEnabled bool                     `json:"capture_enabled,omitempty"`
+	// MaxBodySize is the project's configured per-request/response capture cap in
+	// BYTES, populated from cfg.Proxy.Capture.MaxBodySize (D13, #49). The daemon
+	// stamps it onto the project's routes and passes it as the per-call capture
+	// limit on the hot path; 0 means "use the daemon default"
+	// (DefaultCaptureMaxBodySize). Wire-compatible in both directions: an older
+	// daemon ignores the unknown field, and an omitted field decodes to 0.
+	MaxBodySize int64 `json:"max_body_size,omitempty"`
 	// StartTime is an opaque process start token (see daemon.ProcessStartTime):
 	// a generation discriminator, not a timestamp. 0 means the client could not
 	// read it, so the daemon falls back to bare-PID liveness for this holder.
@@ -62,9 +69,14 @@ type DaemonStatusResponse struct {
 	ProjectCount  int         `json:"project_count"`
 	RouteCount    int         `json:"route_count"`
 	// DroppedEvents is the daemon-wide count of SSE-subscriber notifications
-	// dropped because a subscriber's channel was full (D9). It surfaces the
+	// dropped because a subscriber's channel was full (D9). It is summed across
+	// every project's ring (D13 per-project managers). It surfaces the
 	// request-stream degradation the forwarder would otherwise absorb silently.
 	DroppedEvents int64 `json:"dropped_events"`
+	// RecordCounts is the per-project count of records currently held in memory,
+	// keyed by project dir (D13). It makes the N×ring memory trade-off of the
+	// per-project rings diagnosable. Empty when no project is registered.
+	RecordCounts map[string]int `json:"record_counts,omitempty"`
 }
 
 // ErrorResponse is the standard error format for daemon API responses.

--- a/internal/proxyd/version_skew_test.go
+++ b/internal/proxyd/version_skew_test.go
@@ -1,0 +1,35 @@
+package proxyd
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestVersionMismatchError_AsAndFields pins that EnsureRunning's version-skew
+// error is matchable with errors.As (so tryDaemonProxy can distinguish it from a
+// connection-refused failure) and carries both versions for the remediation
+// message.
+func TestVersionMismatchError_AsAndFields(t *testing.T) {
+	err := error(&VersionMismatchError{DaemonVersion: "0.1.2", ClientVersion: "0.2.0"})
+	// Wrapped, as EnsureRunning's callers may re-wrap.
+	wrapped := fmt.Errorf("ensure running: %w", err)
+
+	var vme *VersionMismatchError
+	if !errors.As(wrapped, &vme) {
+		t.Fatalf("errors.As did not match VersionMismatchError in %v", wrapped)
+	}
+	assert.Equal(t, "0.1.2", vme.DaemonVersion)
+	assert.Equal(t, "0.2.0", vme.ClientVersion)
+	assert.Contains(t, vme.Error(), "0.1.2")
+	assert.Contains(t, vme.Error(), "0.2.0")
+}
+
+// TestErrDaemonNotReady_Is pins that the startup-timeout error wraps the
+// ErrDaemonNotReady sentinel, which the version-skew heal keys its one retry on.
+func TestErrDaemonNotReady_Is(t *testing.T) {
+	err := fmt.Errorf("%w within 5s", ErrDaemonNotReady)
+	assert.True(t, errors.Is(err, ErrDaemonNotReady), "startup-timeout error must wrap ErrDaemonNotReady")
+}

--- a/internal/supervisor/orphans.go
+++ b/internal/supervisor/orphans.go
@@ -8,6 +8,8 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"syscall"
 	"time"
 
@@ -41,6 +43,55 @@ const (
 	reapPollInterval = 50 * time.Millisecond
 )
 
+// linuxBootIDPath is the kernel-provided per-boot UUID. It changes on every
+// reboot, so it is the boot marker used to detect a cross-boot orphan ledger
+// (plan 010 D7, #67).
+const linuxBootIDPath = "/proc/sys/kernel/random/boot_id"
+
+// bootMarkerFor reads this host's boot marker with the platform and file reader
+// injected, matching the sameGenerationWith seam so tests can drive both
+// platforms without touching the real /proc.
+//
+//   - Linux: the trimmed contents of /proc/sys/kernel/random/boot_id, which
+//     changes on every reboot. A read failure (minimal containers lacking that
+//     file) returns ("", err) so the caller can log once and degrade to today's
+//     markerless behavior.
+//   - Darwin (and anything else): "". ProcessStartTime tokens there are
+//     wall-clock microseconds and so are already cross-boot-unique; no marker is
+//     needed and none is a positive signal.
+func bootMarkerFor(goos string, readFile func(string) ([]byte, error)) (string, error) {
+	if goos != "linux" {
+		return "", nil
+	}
+	data, err := readFile(linuxBootIDPath)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+// currentBootMarker returns this host's boot marker for the running platform,
+// logging one line via logger (may be nil) if the Linux boot_id is unreadable.
+// It is used by ReapOrphans to compare against the recorded marker.
+func currentBootMarker(logger *slog.Logger) string {
+	marker, err := bootMarkerFor(runtime.GOOS, os.ReadFile)
+	if err != nil && logger != nil {
+		logger.Warn("could not read boot marker; orphan ledger uses markerless behavior",
+			"path", linuxBootIDPath, "err", err)
+	}
+	return marker
+}
+
+// childrenLedger is the on-disk envelope for the ownership ledger (plan 010 D7,
+// #67). The boot marker lets the next generation detect a cross-boot ledger whose
+// boot-relative start tokens (Linux) can no longer be trusted and discard it
+// without signaling. An empty marker means "unknown": a legacy bare-array ledger,
+// a marker that could not be read, or Darwin (where it is deliberately unused).
+type childrenLedger struct {
+	BootMarker string        `json:"boot_marker"`
+	Children   []ChildRecord `json:"children"`
+}
+
 // ChildRecord is one entry in the ownership ledger: a process GROUP the running
 // generation supervises.
 type ChildRecord struct {
@@ -50,16 +101,17 @@ type ChildRecord struct {
 	StartToken int64  `json:"start_token"` // daemon.ProcessStartTime(PID)
 }
 
-// WriteChildren marshals recs to JSON and writes them to
-// <stateDir>/prox.children via a temp file + atomic rename (0600). The rename
-// is atomic so a torn ledger read at the next startup can never mis-drive the
-// reap.
-func WriteChildren(stateDir string, recs []ChildRecord) error {
+// WriteChildren marshals recs into the {boot_marker,children} envelope and writes
+// it to <stateDir>/prox.children via a temp file + atomic rename (0600). The
+// rename is atomic so a torn ledger read at the next startup can never mis-drive
+// the reap. bootMarker is threaded in from the supervisor (read once at init) so
+// the next generation can detect and safely discard a cross-boot ledger (D7, #67).
+func WriteChildren(stateDir, bootMarker string, recs []ChildRecord) error {
 	if err := os.MkdirAll(stateDir, 0700); err != nil {
 		return fmt.Errorf("creating state directory: %w", err)
 	}
 
-	data, err := json.MarshalIndent(recs, "", "  ")
+	data, err := json.MarshalIndent(childrenLedger{BootMarker: bootMarker, Children: recs}, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshaling children ledger: %w", err)
 	}
@@ -95,22 +147,54 @@ func WriteChildren(stateDir string, recs []ChildRecord) error {
 	return nil
 }
 
-// LoadChildren reads the ownership ledger from <stateDir>/prox.children. A
-// missing ledger is not an error: it returns (nil, nil).
-func LoadChildren(stateDir string) ([]ChildRecord, error) {
-	data, err := os.ReadFile(filepath.Join(stateDir, daemon.ChildrenFileName))
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil, nil
+// loadLedger reads the ownership ledger from <stateDir>/prox.children, accepting
+// BOTH the current envelope ({"boot_marker":...,"children":[...]}) and the legacy
+// bare JSON array written by pre-D7 generations. For a legacy array (or any
+// envelope with no marker) the boot marker is unknown and returned as "". A
+// missing ledger is not an error: it returns ("", nil, nil).
+//
+// Downgrade safety (D7): the inverse holds for a pre-D7 binary. Its LoadChildren
+// unmarshaled straight into []ChildRecord; handed a D7 envelope (a JSON OBJECT)
+// that fails ("cannot unmarshal object into Go value of type []ChildRecord"), so
+// its ReapOrphans returns the error and SKIPS the reap entirely -- never a
+// mis-signal. The envelope is therefore forward-incompatible with downgrades but
+// never unsafe.
+//
+// A syntactically-valid object missing both fields parses as an empty markerless
+// ledger. That cannot mis-signal, and losing records that way would require a
+// hand-edited file: prox itself only ever writes complete envelopes atomically
+// (temp + rename), so no partial write can surface here.
+func loadLedger(stateDir string) (bootMarker string, recs []ChildRecord, err error) {
+	data, rerr := os.ReadFile(filepath.Join(stateDir, daemon.ChildrenFileName))
+	if rerr != nil {
+		if errors.Is(rerr, os.ErrNotExist) {
+			return "", nil, nil
 		}
-		return nil, fmt.Errorf("reading children ledger: %w", err)
+		return "", nil, fmt.Errorf("reading children ledger: %w", rerr)
 	}
 
-	var recs []ChildRecord
-	if err := json.Unmarshal(data, &recs); err != nil {
-		return nil, fmt.Errorf("unmarshaling children ledger: %w", err)
+	// Try the envelope first (a JSON object); an array fails to unmarshal into a
+	// struct, so fall back to the legacy bare array. Only if BOTH fail is the
+	// ledger genuinely corrupt.
+	var env childrenLedger
+	if err := json.Unmarshal(data, &env); err == nil {
+		return env.BootMarker, env.Children, nil
 	}
-	return recs, nil
+	var arr []ChildRecord
+	if err := json.Unmarshal(data, &arr); err != nil {
+		return "", nil, fmt.Errorf("unmarshaling children ledger: %w", err)
+	}
+	return "", arr, nil
+}
+
+// LoadChildren reads the ownership ledger and returns its records, accepting both
+// the current envelope and the legacy bare array (see loadLedger). A missing
+// ledger is not an error: it returns (nil, nil). It exists for callers that only
+// need the records; ReapOrphans uses loadLedger to also obtain the boot marker
+// for the cross-boot guard.
+func LoadChildren(stateDir string) ([]ChildRecord, error) {
+	_, recs, err := loadLedger(stateDir)
+	return recs, err
 }
 
 // RemoveChildren deletes the ownership ledger. A missing ledger is tolerated.
@@ -128,14 +212,15 @@ func RemoveChildren(stateDir string) error {
 // return false. This is the single gate that decides whether the reaper is
 // allowed to signal a group at all.
 //
-// Accepted residual (plan §9), Linux-only: daemon.ProcessStartTime is boot-scoped
-// on Linux (clock ticks since boot), while the ledger can survive a reboot. After
-// a reboot the recorded orphans are already dead (nothing survives a reboot), so
-// the reap has no upside; but an unrelated process that reused both the PID AND
-// the same boot-relative start tick would collide here and be signaled. Darwin
-// tokens are wall-clock microseconds (P_starttime) and so are cross-boot-unique --
-// no collision. Persisting a boot marker to discard a cross-boot ledger is a
-// recommended follow-up.
+// Cross-boot collision (#67), Linux-only: daemon.ProcessStartTime is boot-scoped
+// on Linux (clock ticks since boot), while the ledger can survive a reboot, so an
+// unrelated process that reused both the PID AND the same boot-relative start tick
+// could collide here and be signaled. This gate does NOT defend against that on
+// its own; the boot-marker envelope (plan 010 D7, ledgerDisposition) does, by
+// discarding a cross-boot or legacy-markerless Linux ledger BEFORE any record
+// reaches sameGeneration. Darwin tokens are wall-clock microseconds (P_starttime)
+// and so are cross-boot-unique -- no collision, so Darwin keeps reaping markerless
+// ledgers.
 func sameGeneration(pid int, token int64) bool {
 	return sameGenerationWith(daemon.ProcessStartTime, pid, token)
 }
@@ -305,29 +390,93 @@ func (r *reaper) waitGroupGone(pgid int) bool {
 	}
 }
 
+// ledgerAction is the disposition ReapOrphans applies to a loaded ledger.
+type ledgerAction int
+
+const (
+	// ledgerReap runs the identity-checked reap over the records (same boot on
+	// Linux; any boot on Darwin, where tokens are cross-boot-unique).
+	ledgerReap ledgerAction = iota
+	// ledgerDiscard signals NOTHING and just removes the ledger file: the recorded
+	// boot-relative tokens can no longer be trusted, so the safety bias forbids
+	// signaling any of them.
+	ledgerDiscard
+)
+
+// ledgerDisposition decides how ReapOrphans treats a loaded ledger from the
+// recorded boot marker, the current boot marker, and the platform (plan 010 D7,
+// #67). It is the whole cross-boot decision matrix in one pure function:
+//
+//   - recorded marker non-empty and != current   -> discard (cross-boot ledger).
+//   - recorded marker empty/legacy AND on Linux   -> discard (a pre-D7 or
+//     markerless ledger's boot-relative tokens are unsafe through the upgrade;
+//     the panel accepted one missed reap of pre-upgrade orphans, recovered by the
+//     port-conflict UX, over leaving #67's collision alive).
+//   - recorded marker empty/legacy on Darwin      -> reap (no collision exists;
+//     P_starttime tokens are cross-boot-unique).
+//   - markers match                               -> reap (same boot, unchanged).
+//
+// Note recorded!="" && current=="" (e.g. an unreadable current marker on Linux)
+// falls to the cross-boot discard branch: unable to confirm same-boot, the safety
+// bias discards rather than signals.
+func ledgerDisposition(recorded, current string, isLinux bool) (action ledgerAction, reason string) {
+	if recorded == "" {
+		if isLinux {
+			return ledgerDiscard, "legacy/markerless ledger on Linux; boot-relative start tokens are unsafe across the upgrade (#67)"
+		}
+		return ledgerReap, ""
+	}
+	if recorded == current {
+		return ledgerReap, ""
+	}
+	return ledgerDiscard, "boot marker changed since the ledger was written (cross-boot)"
+}
+
 // ReapOrphans loads the ownership ledger written by the previous prox generation
 // and reaps any process group still positively identifiable as belonging to it
 // (see the package doc above). It returns the reaped and skipped records. The
 // ledger is removed after the pass regardless of outcome: it has served its
 // purpose, and the new generation rewrites it from its first successful launch.
 //
+// Before any reaping, the D7 boot-marker guard (ledgerDisposition) may discard a
+// cross-boot or legacy-markerless-on-Linux ledger unsignaled (#67): its recorded
+// records are surfaced as skipped so up.go still reports them, but NO signal is
+// ever sent.
+//
 // This must be called AFTER the per-project PID-file lock is held and BEFORE the
 // supervisor starts, so concurrent `prox up` invocations are serialized by that
 // lock.
 func ReapOrphans(stateDir string, logger *slog.Logger) (reaped, skipped []ChildRecord, err error) {
-	recs, err := LoadChildren(stateDir)
+	return reapOrphansWith(stateDir, newReaper(logger), currentBootMarker(logger), runtime.GOOS == "linux")
+}
+
+// reapOrphansWith is ReapOrphans with the reaper, current boot marker, and
+// platform flag injected so tests can drive the D7 decision matrix without a real
+// reboot and WITHOUT ever signaling the test runner's own process group.
+func reapOrphansWith(stateDir string, r *reaper, currentMarker string, isLinux bool) (reaped, skipped []ChildRecord, err error) {
+	recorded, recs, err := loadLedger(stateDir)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	r := newReaper(logger)
-	reaped, skipped = r.reap(recs)
+	switch action, reason := ledgerDisposition(recorded, currentMarker, isLinux); action {
+	case ledgerDiscard:
+		// Signal NOTHING. Surface the discarded records as skipped so up.go's count
+		// still reflects that a port-holding orphan may remain, but the reaper is
+		// never even constructed against them.
+		r.logger.Info("discarding children ledger without signaling",
+			"reason", reason, "recorded_marker", recorded, "current_marker", currentMarker,
+			"records", len(recs))
+		skipped = recs
+	default: // ledgerReap
+		reaped, skipped = r.reap(recs)
+	}
 
 	// Remove the old ledger after the pass (tolerates a missing file). A removal
 	// failure is RETURNED to the caller (up.go logs it non-fatally) rather than
 	// swallowed: a readable-but-unremovable ledger would otherwise drive a spurious
-	// reap pass on every subsequent startup with no signal (codex review). The
-	// reaped/skipped classification is still valid, so it is returned alongside.
+	// reap pass on every subsequent startup with no signal. The reaped/skipped
+	// classification is still valid, so it is returned alongside.
 	if rmErr := RemoveChildren(stateDir); rmErr != nil {
 		r.logger.Warn("failed to remove children ledger after reap", "err", rmErr)
 		return reaped, skipped, rmErr

--- a/internal/supervisor/orphans_test.go
+++ b/internal/supervisor/orphans_test.go
@@ -99,7 +99,7 @@ func TestWriteLoadChildren_RoundTrip(t *testing.T) {
 		{Name: "web", PID: 4321, PGID: 4321, StartToken: 111},
 		{Name: "worker", PID: 8765, PGID: 8765, StartToken: 222},
 	}
-	require.NoError(t, WriteChildren(dir, recs))
+	require.NoError(t, WriteChildren(dir, "", recs))
 
 	// The ledger is written 0600.
 	info, err := os.Stat(filepath.Join(dir, daemon.ChildrenFileName))
@@ -270,7 +270,10 @@ func TestReapOrphans_StaleLedger_SkipsAndRemoves(t *testing.T) {
 	// never be positively identified and ReapOrphans (real syscalls) never signals
 	// anything -- a clean no-op with NO SIGKILL.
 	dp := deadPID(t)
-	require.NoError(t, WriteChildren(dir, []ChildRecord{
+	// Stamp the CURRENT boot marker so this stays a genuine same-boot reap on both
+	// platforms (Linux: recorded==current -> reap; Darwin: markerless -> reap),
+	// exercising the sameGeneration real-syscall path rather than the D7 discard.
+	require.NoError(t, WriteChildren(dir, currentBootMarker(discardLogger()), []ChildRecord{
 		{Name: "gone", PID: dp, PGID: dp, StartToken: 123456789},
 	}))
 
@@ -282,6 +285,156 @@ func TestReapOrphans_StaleLedger_SkipsAndRemoves(t *testing.T) {
 	// The old ledger is removed after the pass.
 	_, statErr := os.Stat(filepath.Join(dir, daemon.ChildrenFileName))
 	assert.True(t, os.IsNotExist(statErr), "the ledger must be removed after the reap pass")
+}
+
+// --- D7 boot-marker envelope + cross-boot guard (#67) ------------------------
+
+func TestLoadLedger_EnvelopeRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	recs := []ChildRecord{
+		{Name: "web", PID: 4321, PGID: 4321, StartToken: 111},
+		{Name: "worker", PID: 8765, PGID: 8765, StartToken: 222},
+	}
+	require.NoError(t, WriteChildren(dir, "boot-abc", recs))
+
+	marker, loaded, err := loadLedger(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "boot-abc", marker, "the envelope must round-trip the boot marker")
+	assert.Equal(t, recs, loaded, "the envelope must round-trip every record")
+
+	// The compatibility wrapper still returns just the records.
+	viaLoad, err := LoadChildren(dir)
+	require.NoError(t, err)
+	assert.Equal(t, recs, viaLoad)
+}
+
+func TestLoadLedger_LegacyBareArray(t *testing.T) {
+	dir := t.TempDir()
+	// A pre-D7 ledger: a bare JSON array with no envelope, hence no marker.
+	legacy := `[{"name":"web","pid":4321,"pgid":4321,"start_token":111}]`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, daemon.ChildrenFileName), []byte(legacy), 0600))
+
+	marker, loaded, err := loadLedger(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "", marker, "a legacy bare-array ledger has an unknown (empty) marker")
+	assert.Equal(t, []ChildRecord{{Name: "web", PID: 4321, PGID: 4321, StartToken: 111}}, loaded,
+		"the legacy bare array must still load its records")
+}
+
+func TestBootMarkerFor(t *testing.T) {
+	t.Run("linux trims boot_id", func(t *testing.T) {
+		read := func(string) ([]byte, error) { return []byte("  abc-123-uuid\n"), nil }
+		marker, err := bootMarkerFor("linux", read)
+		require.NoError(t, err)
+		assert.Equal(t, "abc-123-uuid", marker)
+	})
+	t.Run("linux read failure returns error", func(t *testing.T) {
+		read := func(string) ([]byte, error) { return nil, os.ErrNotExist }
+		marker, err := bootMarkerFor("linux", read)
+		require.Error(t, err, "an unreadable boot_id must surface so the caller can log + degrade")
+		assert.Equal(t, "", marker)
+	})
+	t.Run("darwin never reads and returns empty", func(t *testing.T) {
+		read := func(string) ([]byte, error) {
+			t.Fatal("darwin must not read the boot_id file")
+			return nil, nil
+		}
+		marker, err := bootMarkerFor("darwin", read)
+		require.NoError(t, err)
+		assert.Equal(t, "", marker)
+	})
+}
+
+func TestLedgerDisposition(t *testing.T) {
+	cases := []struct {
+		name          string
+		recorded, cur string
+		isLinux       bool
+		wantAction    ledgerAction
+	}{
+		{"same boot linux -> reap", "boot-A", "boot-A", true, ledgerReap},
+		{"same boot darwin (both empty) -> reap", "", "", false, ledgerReap},
+		{"cross boot linux -> discard", "boot-A", "boot-B", true, ledgerDiscard},
+		{"cross boot: recorded set, current unreadable -> discard", "boot-A", "", true, ledgerDiscard},
+		{"legacy markerless linux -> discard", "", "boot-B", true, ledgerDiscard},
+		{"legacy markerless darwin -> reap", "", "", false, ledgerReap},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			action, reason := ledgerDisposition(tc.recorded, tc.cur, tc.isLinux)
+			assert.Equal(t, tc.wantAction, action)
+			if action == ledgerDiscard {
+				assert.NotEmpty(t, reason, "a discard must carry a log-friendly reason")
+			}
+		})
+	}
+}
+
+// TestReapOrphans_CrossBootDiscard_NoSignal writes an envelope whose record WOULD
+// be positively identified and reaped, then reaps under a DIFFERENT current
+// marker. The cross-boot guard must discard it: NO signal, ledger removed, record
+// surfaced as skipped.
+func TestReapOrphans_CrossBootDiscard_NoSignal(t *testing.T) {
+	dir := t.TempDir()
+	rec := ChildRecord{Name: "web", PID: 4321, PGID: 4321, StartToken: 111}
+	require.NoError(t, WriteChildren(dir, "boot-OLD", []ChildRecord{rec}))
+
+	rk := &killpgRecorder{}
+	// startTime WOULD positively identify rec, and groupAlive=false WOULD confirm a
+	// reap -- proving the discard, not an identity miss, is what suppresses signals.
+	r := newTestReaper(rk.killpg, func(int) bool { return false }, alwaysStartTime(rec.PID, rec.StartToken))
+
+	reaped, skipped, err := reapOrphansWith(dir, r, "boot-NEW", true /*isLinux*/)
+	require.NoError(t, err)
+	assert.Empty(t, reaped, "a cross-boot ledger must reap nothing")
+	assert.Equal(t, []ChildRecord{rec}, skipped, "discarded records are surfaced as skipped")
+	assert.Empty(t, rk.signals(), "a cross-boot ledger must NEVER be signaled")
+
+	_, statErr := os.Stat(filepath.Join(dir, daemon.ChildrenFileName))
+	assert.True(t, os.IsNotExist(statErr), "the discarded ledger must be removed")
+}
+
+// TestReapOrphans_LinuxMarkerlessDiscard_NoSignal: a legacy bare-array (markerless)
+// ledger on Linux is discarded without signaling (#67 panel decision).
+func TestReapOrphans_LinuxMarkerlessDiscard_NoSignal(t *testing.T) {
+	dir := t.TempDir()
+	legacy := `[{"name":"web","pid":4321,"pgid":4321,"start_token":111}]`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, daemon.ChildrenFileName), []byte(legacy), 0600))
+
+	rk := &killpgRecorder{}
+	r := newTestReaper(rk.killpg, func(int) bool { return false }, alwaysStartTime(4321, 111))
+
+	reaped, skipped, err := reapOrphansWith(dir, r, "boot-NEW", true /*isLinux*/)
+	require.NoError(t, err)
+	assert.Empty(t, reaped)
+	assert.Len(t, skipped, 1, "the legacy record is surfaced as skipped")
+	assert.Empty(t, rk.signals(), "a legacy markerless ledger on Linux must NEVER be signaled")
+
+	_, statErr := os.Stat(filepath.Join(dir, daemon.ChildrenFileName))
+	assert.True(t, os.IsNotExist(statErr), "the discarded ledger must be removed")
+}
+
+// TestReapOrphans_DarwinMarkerlessKeepsReaping: on Darwin, a markerless ledger has
+// no cross-boot collision (P_starttime tokens are cross-boot-unique), so the full
+// sameGeneration reap still runs and signals a positively-identified group.
+func TestReapOrphans_DarwinMarkerlessKeepsReaping(t *testing.T) {
+	dir := t.TempDir()
+	rec := ChildRecord{Name: "web", PID: 4321, PGID: 4321, StartToken: 111}
+	require.NoError(t, WriteChildren(dir, "", []ChildRecord{rec}))
+
+	rk := &killpgRecorder{}
+	// Positively identified, and gone after SIGTERM -> a clean reap.
+	r := newTestReaper(rk.killpg, func(int) bool { return false }, alwaysStartTime(rec.PID, rec.StartToken))
+
+	reaped, skipped, err := reapOrphansWith(dir, r, "" /*currentMarker*/, false /*isLinux*/)
+	require.NoError(t, err)
+	assert.Equal(t, []ChildRecord{rec}, reaped, "Darwin markerless ledgers are still reaped")
+	assert.Empty(t, skipped)
+	assert.Equal(t, []syscall.Signal{syscall.SIGTERM}, rk.signals(),
+		"a positively-identified group is signaled on Darwin")
+
+	_, statErr := os.Stat(filepath.Join(dir, daemon.ChildrenFileName))
+	assert.True(t, os.IsNotExist(statErr), "the ledger is removed after the reap pass")
 }
 
 // --- persistence concurrency -------------------------------------------------
@@ -362,7 +515,7 @@ func TestPersistChildren_SkippedAfterRefuseLaunches(t *testing.T) {
 	// Positive control: with launches OPEN, persistChildren rewrites the ledger
 	// (no child is running yet, so it writes an empty set). This proves the no-op
 	// below is due to the gate, not some other reason.
-	require.NoError(t, WriteChildren(stateDir, retained))
+	require.NoError(t, WriteChildren(stateDir, "", retained))
 	sup.launchable.Store(true)
 	sup.persistChildren()
 	open, err := LoadChildren(stateDir)
@@ -371,7 +524,7 @@ func TestPersistChildren_SkippedAfterRefuseLaunches(t *testing.T) {
 
 	// Shutdown has begun: launches refused, Stop owns the ledger. A late callback
 	// must NOT touch the retained ledger.
-	require.NoError(t, WriteChildren(stateDir, retained))
+	require.NoError(t, WriteChildren(stateDir, "", retained))
 	sup.RefuseLaunches()
 	sup.persistChildren()
 	got, err := LoadChildren(stateDir)

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"runtime"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -104,6 +106,12 @@ type Supervisor struct {
 	// final write reflects reality even when starts race. Lock order is
 	// childrenMu -> s.mu (persistChildren); no path takes them the other way.
 	childrenMu sync.Mutex
+
+	// bootMarker is this host's boot identity (plan 010 D7, #67), read ONCE at
+	// construction and stamped into every ledger write so the next generation can
+	// detect and safely discard a cross-boot ledger. Empty on Darwin/others (not
+	// needed) and on a Linux boot_id read failure (degrades to markerless).
+	bootMarker string
 }
 
 // SupervisorEvent represents a supervisor event
@@ -139,8 +147,37 @@ func New(cfg *config.Config, logManager *logs.Manager, runner ProcessRunner, sup
 		logManager: logManager,
 		state:      "stopped",
 	}
+	s.bootMarker = s.readBootMarker()
 
 	return s
+}
+
+// readBootMarker reads this host's boot marker once at construction (plan 010 D7,
+// #67). A Linux boot_id read failure is logged once and degrades to markerless
+// behavior (an empty marker); Darwin/others never read and return "".
+func (s *Supervisor) readBootMarker() string {
+	marker, err := bootMarkerFor(runtime.GOOS, os.ReadFile)
+	if err != nil {
+		s.systemErrorf("WARNING: could not read boot marker (%v); orphan-reap ledger falls back to markerless behavior", err)
+	}
+	return marker
+}
+
+// ledgerBootMarker returns the marker persistChildren stamps on the ledger.
+// If the construction-time read failed (empty marker on Linux), it retries
+// the read here: a markerless ledger on Linux is DISCARDED unsignaled by the
+// next generation (ledgerDisposition), so letting one transient init-time
+// /proc read failure poison every ledger this generation writes would
+// silently disable same-boot orphan reaping for the whole run. Called under
+// childrenMu, so the lazy backfill of s.bootMarker does not race.
+func (s *Supervisor) ledgerBootMarker() string {
+	if s.bootMarker == "" && runtime.GOOS == "linux" {
+		if marker, err := bootMarkerFor(runtime.GOOS, os.ReadFile); err == nil && marker != "" {
+			s.bootMarker = marker
+			s.systemErrorf("boot marker became readable; orphan-reap ledger is marker-guarded again")
+		}
+	}
+	return s.bootMarker
 }
 
 // Start starts the supervisor and all configured processes
@@ -444,7 +481,7 @@ func (s *Supervisor) persistChildren() {
 		return
 	}
 
-	if err := WriteChildren(s.supConfig.StateDir, recs); err != nil {
+	if err := WriteChildren(s.supConfig.StateDir, s.ledgerBootMarker(), recs); err != nil {
 		s.systemErrorf("ERROR: failed to persist child ownership ledger: %v", err)
 	}
 }

--- a/internal/tui/base.go
+++ b/internal/tui/base.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 	"unicode/utf8"
 
 	"github.com/charmbracelet/bubbles/textinput"
@@ -1064,9 +1065,12 @@ func (b *BaseModel) formatRequestDetail() []string {
 	lines = append(lines, fmt.Sprintf("  Method:   %s", d.Method))
 	lines = append(lines, fmt.Sprintf("  URL:      %s", d.URL))
 	lines = append(lines, fmt.Sprintf("  Status:   %d", d.StatusCode))
-	if d.InFlight {
+	switch {
+	case d.InFlight && d.Stale:
+		lines = append(lines, "  Duration: (in flight, stale?)")
+	case d.InFlight:
 		lines = append(lines, "  Duration: (in flight)")
-	} else {
+	default:
 		lines = append(lines, fmt.Sprintf("  Duration: %dms", d.DurationMs))
 	}
 	lines = append(lines, fmt.Sprintf("  Remote:   %s", d.RemoteAddr))
@@ -1078,12 +1082,18 @@ func (b *BaseModel) formatRequestDetail() []string {
 	// rendering nothing.
 	if d.InFlight {
 		lines = append(lines, "")
-		if b.detailRefreshFailed {
+		switch {
+		case b.detailRefreshFailed:
 			// A live-refresh attempt (attach mode — D16) failed while this
 			// in-flight snapshot was on screen: say so instead of silently
 			// re-promising details that may never arrive automatically.
 			lines = append(lines, dimStyle.Render("(live refresh failed — press esc and re-enter to reload)"))
-		} else {
+		case d.Stale:
+			// D8, #53: the completion event may have been lost — the true
+			// outcome is unknown, not necessarily broken (long-lived
+			// streams/transfers can legitimately still be live here).
+			lines = append(lines, dimStyle.Render("(request in flight, stale? — the completion event may have been lost; true outcome unknown)"))
+		default:
 			lines = append(lines, dimStyle.Render("(request in flight — details arrive on completion)"))
 		}
 	}
@@ -1304,21 +1314,26 @@ func (b *BaseModel) formatProxyRequest(req proxy.RequestRecord) string {
 	}
 	status := statusStyle.Render(fmt.Sprintf("%3d", req.StatusCode))
 
-	// Format duration with overflow handling. In-flight rows have no
-	// duration yet (the response is still streaming) — render dots in place
-	// of digits, padded to the same 5-char width so columns stay aligned.
+	// Format the duration column, including its "ms" unit, in one piece: the
+	// normal/in-flight/overflow cases share a digits-or-filler value plus
+	// "ms". A stale in-flight row (D8, #53: the completion event may have
+	// been lost, true outcome unknown — not necessarily broken, long-lived
+	// streams/transfers can legitimately still be live here) renders
+	// "stale?" instead, which isn't a duration so it carries no "ms" suffix.
 	durationMs := req.Duration.Milliseconds()
 	var duration string
 	switch {
+	case req.StaleAt(time.Now()):
+		duration = "stale?"
 	case req.InFlight:
-		duration = "  ..."
+		duration = "  ...ms"
 	case durationMs > 9999:
-		duration = "9999+"
+		duration = "9999+ms"
 	default:
-		duration = fmt.Sprintf("%5d", durationMs)
+		duration = fmt.Sprintf("%5dms", durationMs)
 	}
 
-	return fmt.Sprintf("%s  %s  %s %s %sms  %s",
+	return fmt.Sprintf("%s  %s  %s %s %s  %s",
 		dimStyle.Render(ts),
 		dimStyle.Render(subdomain),
 		method,
@@ -1702,6 +1717,7 @@ func convertRequestRecordToDetailWithDirs(req proxy.RequestRecord, allowedDirs [
 		DurationMs: req.Duration.Milliseconds(),
 		RemoteAddr: req.RemoteAddr,
 		InFlight:   req.InFlight,
+		Stale:      req.StaleAt(time.Now()),
 	}
 
 	if req.Details != nil {

--- a/internal/tui/base.go
+++ b/internal/tui/base.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -1166,21 +1167,22 @@ func bodySectionTitle(title string, b *BodyData) string {
 }
 
 // renderBodyLines renders the content lines for a captured body: an
-// unavailable (evicted) notice, a binary-data marker, or the body text split
-// into lines. Non-binary JSON bodies (Content-Type contains "json", or the
-// raw text is itself valid JSON) are pretty-printed 2-space indented; any
-// json.Indent failure falls back to the raw text. Text otherwise renders
-// unchanged except that ASCII control characters (< 0x20, other than tab and
-// the newlines used for line splitting) and DEL (0x7F) are replaced with the
-// Unicode replacement character, so ESC/BEL/OSC sequences from a captured body
-// cannot manipulate the terminal. (Classification usually marks such bodies
-// binary, but a socket-supplied record could lie; this is a cheap defense.)
+// unavailable (evicted) notice, a bounded hexdump preview for binary data, or
+// the body text split into lines. Non-binary JSON bodies (Content-Type
+// contains "json", or the raw text is itself valid JSON) are pretty-printed
+// 2-space indented; any json.Indent failure falls back to the raw text. Text
+// otherwise renders unchanged except that ASCII control characters (< 0x20,
+// other than tab and the newlines used for line splitting) and DEL (0x7F) are
+// replaced with the Unicode replacement character, so ESC/BEL/OSC sequences
+// from a captured body cannot manipulate the terminal. (Classification
+// usually marks such bodies binary, but a socket-supplied record could lie;
+// this is a cheap defense.)
 func renderBodyLines(body *BodyData) []string {
 	if body.Unavailable {
 		return []string{dimStyle.Render("(body no longer available)")}
 	}
 	if body.IsBinary {
-		return []string{dimStyle.Render("[binary data]")}
+		return renderBinaryPreview(body.Data, body.DataBase64)
 	}
 	if body.Data == "" {
 		return nil
@@ -1215,6 +1217,116 @@ func sanitizeControlChars(s string) string {
 		}
 		return r
 	}, s)
+}
+
+// hexPreviewMaxBytes caps how many leading bytes of a binary body are
+// hex-dumped in the detail view (D11, #50.2): enough to identify the format
+// (magic bytes, headers) without flooding the terminal with a large payload.
+const hexPreviewMaxBytes = 256
+
+// hexPreviewBytesPerLine is the hexdump -C convention of 16 bytes per line,
+// split into two 8-byte groups.
+const hexPreviewBytesPerLine = 16
+
+// renderBinaryPreview turns a binary body's Data into hexdump-style preview
+// lines, dimming the trailing "more bytes" line. Data reaches the TUI two
+// ways: the API always base64-encodes binary bytes for the wire
+// (attach mode, client.go fetchRequestDetail -> clientBodyToBodyData), while
+// local mode (convertCapturedBodyToBodyData) stores the raw decoded bytes
+// directly in the string. A base64 decode is tried first; a decode failure
+// (the common case for raw local-mode bytes, which are essentially never
+// valid base64) falls back to treating Data as the raw bytes themselves, so
+// both paths are previewed correctly. Empty raw bytes (nothing to preview,
+// e.g. a body flagged binary but not actually loaded) fall back to the
+// original placeholder rather than an empty hexdump.
+func renderBinaryPreview(data string, dataBase64 bool) []string {
+	raw := []byte(data)
+	if dataBase64 {
+		decoded, err := base64.StdEncoding.DecodeString(data)
+		if err == nil {
+			raw = decoded
+		}
+	}
+	if len(raw) == 0 {
+		return []string{dimStyle.Render("[binary data]")}
+	}
+
+	lines := hexPreviewLines(raw, hexPreviewMaxBytes)
+	if len(raw) > hexPreviewMaxBytes && len(lines) > 0 {
+		lines[len(lines)-1] = dimStyle.Render(lines[len(lines)-1])
+	}
+	return lines
+}
+
+// hexPreviewLines renders up to maxBytes of data as an `hexdump -C`-style
+// preview: an 8-digit offset, two 8-byte hex groups (an extra space between
+// the groups), and an ASCII gutter between pipes where only printable ASCII
+// (0x20-0x7E) renders as itself and everything else renders as '.' — the
+// gutter never emits a raw control byte, the same terminal-safety discipline
+// as sanitizeControlChars. When data is longer than maxBytes, only the first
+// maxBytes are dumped and a final "(… N more bytes)" line reports the
+// remainder (styling that line, if desired, is the caller's job — this
+// function returns plain text so it stays a pure, golden-testable mapping
+// from bytes to lines).
+func hexPreviewLines(data []byte, maxBytes int) []string {
+	preview := data
+	remaining := 0
+	if len(data) > maxBytes {
+		preview = data[:maxBytes]
+		remaining = len(data) - maxBytes
+	}
+
+	var lines []string
+	for offset := 0; offset < len(preview); offset += hexPreviewBytesPerLine {
+		end := offset + hexPreviewBytesPerLine
+		if end > len(preview) {
+			end = len(preview)
+		}
+		lines = append(lines, formatHexLine(offset, preview[offset:end]))
+	}
+	if remaining > 0 {
+		lines = append(lines, fmt.Sprintf("(… %d more bytes)", remaining))
+	}
+	return lines
+}
+
+// formatHexLine renders one hexdump -C line for a chunk of 1-16 bytes at the
+// given offset: "OFFSET  HEXGROUP1 HEXGROUP2 |ASCII|". Short chunks (the
+// final line of a body whose length isn't a multiple of 16) pad the hex
+// groups with blanks to keep the ASCII gutter aligned, but the ASCII gutter
+// itself only shows the bytes actually present (matching hexdump -C).
+func formatHexLine(offset int, chunk []byte) string {
+	first := chunk
+	var second []byte
+	if len(chunk) > hexPreviewBytesPerLine/2 {
+		first = chunk[:hexPreviewBytesPerLine/2]
+		second = chunk[hexPreviewBytesPerLine/2:]
+	}
+
+	var ascii strings.Builder
+	for _, b := range chunk {
+		if b >= 0x20 && b <= 0x7e {
+			ascii.WriteByte(b)
+		} else {
+			ascii.WriteByte('.')
+		}
+	}
+
+	return fmt.Sprintf("%08x  %s %s |%s|", offset, hexGroup(first), hexGroup(second), ascii.String())
+}
+
+// hexGroup renders up to 8 bytes as "%02x " each, padding absent slots with
+// "   " so hex columns stay aligned regardless of how many bytes are present.
+func hexGroup(b []byte) string {
+	var sb strings.Builder
+	for i := 0; i < hexPreviewBytesPerLine/2; i++ {
+		if i < len(b) {
+			fmt.Fprintf(&sb, "%02x ", b[i])
+		} else {
+			sb.WriteString("   ")
+		}
+	}
+	return sb.String()
 }
 
 // shouldPrettyPrintJSON reports whether a non-binary body should be run
@@ -1759,14 +1871,17 @@ func convertCapturedBodyToBodyData(body *proxy.CapturedBody, allowedDirs []strin
 	}
 
 	bd.IsBinary = decoded.IsBinary
-	// Defense in depth (mirrors the API serve path): never string-convert bytes
-	// that are not valid UTF-8, even if the loaded record claims they are text —
-	// a socket-supplied flag or a mutated disk file must not reach the terminal
-	// as raw control bytes.
+	// Defense in depth (mirrors the API serve path): never treat bytes that are
+	// not valid UTF-8 as text, even if the loaded record claims they are — a
+	// socket-supplied flag or a mutated disk file must not reach the terminal
+	// as raw control bytes. Either way the raw bytes are kept in bd.Data
+	// (unlike the attach path, local mode never base64-encodes them) so a
+	// binary body still has bytes for the hexdump preview (D11, #50.2).
 	if !decoded.IsBinary && utf8.Valid(decoded.Data) {
 		bd.Data = string(decoded.Data)
 	} else {
 		bd.IsBinary = true
+		bd.Data = string(decoded.Data)
 	}
 	return bd
 }

--- a/internal/tui/base_convert_test.go
+++ b/internal/tui/base_convert_test.go
@@ -82,22 +82,27 @@ func TestConvertRequestRecordToDetail_Stale(t *testing.T) {
 }
 
 // TestConvertCapturedBodyToBodyData_InvalidUTF8NotStringified pins the TUI's
-// defense-in-depth: bytes that are not valid UTF-8 are never string-converted
+// defense-in-depth: bytes that are not valid UTF-8 are never treated as text
 // for rendering, even when the stored record claims IsBinary=false (e.g. a
-// socket-supplied flag or a disk file mutated after classification).
+// socket-supplied flag or a disk file mutated after classification) — they
+// are reclassified binary instead. The raw bytes are still carried in
+// bd.Data byte-for-byte (a Go string is just bytes) so the hexdump preview
+// (D11, #50.2) has something to dump; what must never happen is those bytes
+// reaching the plain-text render path.
 func TestConvertCapturedBodyToBodyData_InvalidUTF8NotStringified(t *testing.T) {
+	raw := []byte{'h', 'i', 0xFF, 0xFE}
 	body := &proxy.CapturedBody{
 		Size:         4,
 		CapturedSize: 4,
 		ContentType:  "text/plain",
 		IsBinary:     false, // lies: data is not valid UTF-8
-		Data:         []byte{'h', 'i', 0xFF, 0xFE},
+		Data:         raw,
 	}
 
 	bd := convertCapturedBodyToBodyData(body, nil)
 	require.NotNil(t, bd)
 	assert.True(t, bd.IsBinary, "invalid UTF-8 must be reclassified binary")
-	assert.Empty(t, bd.Data, "invalid UTF-8 must not be string-converted")
+	assert.Equal(t, string(raw), bd.Data, "raw bytes are preserved for the hexdump preview")
 }
 
 func TestConvertRequestRecordToDetail_GzipFilePath(t *testing.T) {

--- a/internal/tui/base_convert_test.go
+++ b/internal/tui/base_convert_test.go
@@ -55,6 +55,32 @@ func TestConvertRequestRecordToDetail_FilePathBacked(t *testing.T) {
 	assert.Equal(t, string(payload), detail.ResponseBody.Data)
 }
 
+// TestConvertRequestRecordToDetail_Stale verifies local-mode conversion
+// (Model, which holds real proxy.RequestRecord values) computes Stale itself
+// via RequestRecord.StaleAt rather than needing it threaded in separately
+// (D8, #53), and that a fresh in-flight record is not marked stale.
+func TestConvertRequestRecordToDetail_Stale(t *testing.T) {
+	staleRec := proxy.RequestRecord{
+		ID:        "stale1",
+		Timestamp: time.Now().Add(-10 * time.Minute),
+		Method:    "GET",
+		URL:       "/stream",
+		InFlight:  true,
+	}
+	detail := convertRequestRecordToDetail(staleRec)
+	assert.True(t, detail.Stale)
+
+	freshRec := proxy.RequestRecord{
+		ID:        "fresh1",
+		Timestamp: time.Now(),
+		Method:    "GET",
+		URL:       "/stream",
+		InFlight:  true,
+	}
+	detail = convertRequestRecordToDetail(freshRec)
+	assert.False(t, detail.Stale)
+}
+
 // TestConvertCapturedBodyToBodyData_InvalidUTF8NotStringified pins the TUI's
 // defense-in-depth: bytes that are not valid UTF-8 are never string-converted
 // for rendering, even when the stored record claims IsBinary=false (e.g. a

--- a/internal/tui/base_render_test.go
+++ b/internal/tui/base_render_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"encoding/base64"
 	"strings"
 	"testing"
 
@@ -55,18 +56,84 @@ func TestRenderBodySection_InvalidJSONWithJSONContentType(t *testing.T) {
 }
 
 // TestRenderBodySection_BinaryWithJSONContentType pins that a binary body
-// short-circuits to the "[binary data]" marker without any pretty-print
-// attempt, even when Content-Type claims JSON.
+// short-circuits to the hexdump preview without any pretty-print attempt,
+// even when Content-Type claims JSON: the raw bytes are dumped, not the
+// pretty-printed JSON they happen to spell out.
 func TestRenderBodySection_BinaryWithJSONContentType(t *testing.T) {
 	b := &BodyData{
-		Size:        4,
+		Size:        15,
 		ContentType: "application/json",
 		IsBinary:    true,
-		Data:        `{"key":"value"}`, // must be ignored entirely
+		Data:        `{"key":"value"}`, // dumped as raw bytes, not pretty-printed
 	}
 	out := joinBody(t, "Request Body", b)
-	assert.Contains(t, out, "[binary data]")
 	assert.NotContains(t, out, `"key": "value"`)
+	assert.NotContains(t, out, "[binary data]")
+	// First byte '{' = 0x7b, present in both the hex and ASCII gutter.
+	assert.Contains(t, out, "7b")
+	assert.Contains(t, out, "|{\"key\":\"value\"}|")
+}
+
+// TestRenderBodyLines_BinaryEmptyDataFallsBackToPlaceholder pins that a body
+// flagged binary but carrying no bytes at all (nothing was actually loaded)
+// still falls back to the original "[binary data]" placeholder rather than
+// an empty hexdump.
+func TestRenderBodyLines_BinaryEmptyDataFallsBackToPlaceholder(t *testing.T) {
+	b := &BodyData{
+		Size:     4,
+		IsBinary: true,
+		Data:     "",
+	}
+	out := strings.Join(renderBodyLines(b), "\n")
+	assert.Contains(t, out, "[binary data]")
+}
+
+// TestRenderBodyLines_BinaryBase64Data pins the attach-mode path: the API
+// base64-encodes binary bytes on the wire (client.go clientBodyToBodyData
+// sets DataBase64), and the flag — not a decode-guess — drives the base64
+// decode, so the hexdump previews the underlying bytes rather than the
+// base64 text.
+func TestRenderBodyLines_BinaryBase64Data(t *testing.T) {
+	raw := []byte{0x47, 0x49, 0x46, 0x38, 0x39, 0x61}
+	b := &BodyData{
+		Size:       int64(len(raw)),
+		IsBinary:   true,
+		Data:       base64.StdEncoding.EncodeToString(raw),
+		DataBase64: true,
+	}
+	out := strings.Join(renderBodyLines(b), "\n")
+	assert.Contains(t, out, "47 49 46 38 39 61")
+	assert.Contains(t, out, "|GIF89a|")
+}
+
+// TestRenderBodyLines_RawBytesThatLookLikeBase64 pins the deterministic-flag
+// rule (codex C10 review): LOCAL-mode raw bytes that happen to be valid
+// base64 (here the literal bytes "TWFu") must be previewed AS-IS, never
+// base64-decoded into different bytes ("Man").
+func TestRenderBodyLines_RawBytesThatLookLikeBase64(t *testing.T) {
+	b := &BodyData{
+		Size:     4,
+		IsBinary: true,
+		Data:     "TWFu",
+	}
+	out := strings.Join(renderBodyLines(b), "\n")
+	assert.Contains(t, out, "|TWFu|")
+	assert.NotContains(t, out, "|Man|")
+}
+
+// TestRenderBodyLines_BinaryRawData pins the local-mode path
+// (convertCapturedBodyToBodyData): binary bytes are stored directly, not
+// base64-encoded, so a failed base64 decode must fall back to previewing the
+// raw string bytes rather than dropping the body or erroring.
+func TestRenderBodyLines_BinaryRawData(t *testing.T) {
+	raw := []byte{0x00, 0x01, 0x02, 0xff, 0xfe}
+	b := &BodyData{
+		Size:     int64(len(raw)),
+		IsBinary: true,
+		Data:     string(raw), // not valid base64
+	}
+	out := strings.Join(renderBodyLines(b), "\n")
+	assert.Contains(t, out, "00 01 02 ff fe")
 }
 
 // TestRenderBodySection_NonJSONTextUnchanged pins that ordinary text renders
@@ -126,6 +193,92 @@ func TestRenderBodySection_ContentTypeAndEncodingInTitle(t *testing.T) {
 	}
 	out := joinBody(t, "Request Body", b)
 	assert.Contains(t, out, "Request Body (2048 bytes, application/json, gzip, truncated)")
+}
+
+// TestHexPreviewLines_ShortBody is a golden test for a partial line (< 16
+// bytes): the hex groups pad with blanks past the present bytes, but the
+// ASCII gutter only shows the bytes actually present. Bytes cover a null
+// byte, printable ASCII, 0xFF, an ESC control byte, and space/tilde (the
+// printable-range boundaries) to pin the '.' vs. literal-char rule.
+func TestHexPreviewLines_ShortBody(t *testing.T) {
+	data := []byte{0x00, 0x41, 0x42, 0x43, 0xff, 0x1b, 0x20, 0x7e}
+	got := hexPreviewLines(data, hexPreviewMaxBytes)
+	want := []string{
+		"00000000  00 41 42 43 ff 1b 20 7e                           |.ABC.. ~|",
+	}
+	assert.Equal(t, want, got)
+}
+
+// TestHexPreviewLines_Exact256Bytes is a golden test covering every byte
+// value 0x00-0xFF (16 full lines, 16 bytes each): no truncation, so no
+// "more bytes" trailer. Pins the offset column, the two 8-byte hex groups
+// with their extra separating space, and the full printable-ASCII-vs-'.'
+// gutter rule across the whole byte range (including the 0x7F DEL boundary
+// and the printable 0x20-0x7E range).
+func TestHexPreviewLines_Exact256Bytes(t *testing.T) {
+	data := make([]byte, 256)
+	for i := range data {
+		data[i] = byte(i)
+	}
+	got := hexPreviewLines(data, hexPreviewMaxBytes)
+	want := []string{
+		"00000000  00 01 02 03 04 05 06 07  08 09 0a 0b 0c 0d 0e 0f  |................|",
+		"00000010  10 11 12 13 14 15 16 17  18 19 1a 1b 1c 1d 1e 1f  |................|",
+		"00000020  20 21 22 23 24 25 26 27  28 29 2a 2b 2c 2d 2e 2f  | !\"#$%&'()*+,-./|",
+		"00000030  30 31 32 33 34 35 36 37  38 39 3a 3b 3c 3d 3e 3f  |0123456789:;<=>?|",
+		"00000040  40 41 42 43 44 45 46 47  48 49 4a 4b 4c 4d 4e 4f  |@ABCDEFGHIJKLMNO|",
+		"00000050  50 51 52 53 54 55 56 57  58 59 5a 5b 5c 5d 5e 5f  |PQRSTUVWXYZ[\\]^_|",
+		"00000060  60 61 62 63 64 65 66 67  68 69 6a 6b 6c 6d 6e 6f  |`abcdefghijklmno|",
+		"00000070  70 71 72 73 74 75 76 77  78 79 7a 7b 7c 7d 7e 7f  |pqrstuvwxyz{|}~.|",
+		"00000080  80 81 82 83 84 85 86 87  88 89 8a 8b 8c 8d 8e 8f  |................|",
+		"00000090  90 91 92 93 94 95 96 97  98 99 9a 9b 9c 9d 9e 9f  |................|",
+		"000000a0  a0 a1 a2 a3 a4 a5 a6 a7  a8 a9 aa ab ac ad ae af  |................|",
+		"000000b0  b0 b1 b2 b3 b4 b5 b6 b7  b8 b9 ba bb bc bd be bf  |................|",
+		"000000c0  c0 c1 c2 c3 c4 c5 c6 c7  c8 c9 ca cb cc cd ce cf  |................|",
+		"000000d0  d0 d1 d2 d3 d4 d5 d6 d7  d8 d9 da db dc dd de df  |................|",
+		"000000e0  e0 e1 e2 e3 e4 e5 e6 e7  e8 e9 ea eb ec ed ee ef  |................|",
+		"000000f0  f0 f1 f2 f3 f4 f5 f6 f7  f8 f9 fa fb fc fd fe ff  |................|",
+	}
+	assert.Equal(t, want, got)
+	// Exactly 256 bytes must not trigger the "more bytes" trailer.
+	for _, line := range got {
+		assert.NotContains(t, line, "more bytes")
+	}
+}
+
+// TestHexPreviewLines_TruncatedOver256 is a golden test for a body longer
+// than maxBytes: only the first maxBytes are dumped (16 lines here) and a
+// final "(… N more bytes)" line reports the exact remainder.
+func TestHexPreviewLines_TruncatedOver256(t *testing.T) {
+	data := make([]byte, 260)
+	for i := range data {
+		data[i] = byte(i)
+	}
+	got := hexPreviewLines(data, hexPreviewMaxBytes)
+	assert.Len(t, got, 17) // 16 hex lines + 1 trailer
+	assert.Equal(t, "000000f0  f0 f1 f2 f3 f4 f5 f6 f7  f8 f9 fa fb fc fd fe ff  |................|", got[15])
+	assert.Equal(t, "(… 4 more bytes)", got[16])
+}
+
+// TestHexPreviewLines_NonASCIIUTF8BytesAsDots is a golden test pinning that
+// the ASCII gutter operates on raw bytes, not UTF-8 runes: a multi-byte UTF-8
+// sequence (the 'é' in "café", encoded as 0xc3 0xa9) renders as two dots, one
+// per byte, never as a decoded/re-encoded character and never as a raw
+// non-ASCII byte.
+func TestHexPreviewLines_NonASCIIUTF8BytesAsDots(t *testing.T) {
+	data := []byte("café") // c3 a9 is the UTF-8 encoding of 'é'
+	got := hexPreviewLines(data, hexPreviewMaxBytes)
+	want := []string{
+		"00000000  63 61 66 c3 a9                                    |caf..|",
+	}
+	assert.Equal(t, want, got)
+}
+
+// TestHexPreviewLines_Empty pins that an empty slice yields no lines (no
+// zero-byte offset line, no trailer).
+func TestHexPreviewLines_Empty(t *testing.T) {
+	got := hexPreviewLines(nil, hexPreviewMaxBytes)
+	assert.Empty(t, got)
 }
 
 // TestRenderBodySection_Unavailable pins the existing (body no longer

--- a/internal/tui/base_render_test.go
+++ b/internal/tui/base_render_test.go
@@ -212,6 +212,28 @@ func TestFormatRequestDetail_InFlight_NoDetailsNote(t *testing.T) {
 	assert.Contains(t, out, "(request in flight — details arrive on completion)")
 }
 
+// TestFormatRequestDetail_Stale_ShowsStaleDurationAndNote verifies a stale
+// in-flight record (D8, #53) renders "stale?" on both the Duration line and
+// the in-flight note, distinct from an ordinary (fresh) in-flight record.
+func TestFormatRequestDetail_Stale_ShowsStaleDurationAndNote(t *testing.T) {
+	b := &BaseModel{
+		requestDetail: &RequestDetailData{
+			ID:         "req-1",
+			Timestamp:  "2026-07-18 00:00:00.000",
+			Method:     "GET",
+			URL:        "/api/v1/stream",
+			StatusCode: 200,
+			InFlight:   true,
+			Stale:      true,
+		},
+	}
+
+	out := strings.Join(b.formatRequestDetail(), "\n")
+	assert.Contains(t, out, "Duration: (in flight, stale?)")
+	assert.Contains(t, out, "stale? — the completion event may have been lost")
+	assert.NotContains(t, out, "Duration: (in flight)")
+}
+
 // TestFormatRequestDetail_Completed_NoInFlightNote verifies a completed
 // record with no captured Details (capture disabled) does NOT get the
 // in-flight note.

--- a/internal/tui/client.go
+++ b/internal/tui/client.go
@@ -298,12 +298,14 @@ func (m ClientModel) fetchRequestDetail(id string, seq int) tea.Cmd {
 // unavailable_reason marks an evicted body.
 func clientBodyToBodyData(body *api.CapturedBodyResponse) *BodyData {
 	return &BodyData{
-		Size:              body.Size,
-		Truncated:         body.Truncated,
-		ContentType:       body.ContentType,
-		ContentEncoding:   body.ContentEncoding,
-		IsBinary:          body.IsBinary,
-		Data:              body.Data,
+		Size:            body.Size,
+		Truncated:       body.Truncated,
+		ContentType:     body.ContentType,
+		ContentEncoding: body.ContentEncoding,
+		IsBinary:        body.IsBinary,
+		Data:            body.Data,
+		DataBase64:      body.IsBinary, // API base64-encodes binary body data
+
 		Unavailable:       body.UnavailableReason != "",
 		UnavailableReason: body.UnavailableReason,
 	}

--- a/internal/tui/client.go
+++ b/internal/tui/client.go
@@ -273,6 +273,7 @@ func (m ClientModel) fetchRequestDetail(id string, seq int) tea.Cmd {
 			DurationMs: resp.DurationMs,
 			RemoteAddr: resp.RemoteAddr,
 			InFlight:   resp.InFlight,
+			Stale:      resp.Stale,
 		}
 
 		if resp.Details != nil {

--- a/internal/tui/client_model_test.go
+++ b/internal/tui/client_model_test.go
@@ -150,6 +150,26 @@ func inFlightDetailFor(id string) *RequestDetailData {
 	return &RequestDetailData{ID: id, Method: "GET", URL: "/x", InFlight: true}
 }
 
+// TestClientModel_FetchRequestDetail_MapsStale verifies fetchRequestDetail
+// (attach mode) carries the API response's Stale field through to
+// RequestDetailData (D8, #53) — the only place where the server's
+// serve-time-computed staleness reaches the TUI in attach mode, since
+// RequestDetailData.Timestamp is a display string, not a time.Time the TUI
+// could re-derive staleness from itself.
+func TestClientModel_FetchRequestDetail_MapsStale(t *testing.T) {
+	stub := &stubTUIClient{detailResp: &api.ProxyRequestDetailResponse{
+		ProxyRequestResponse: api.ProxyRequestResponse{ID: "req-000", InFlight: true, Stale: true},
+	}}
+	m := NewClientModel(stub)
+
+	msg := m.fetchRequestDetail("req-000", 1)()
+	detailMsg, ok := msg.(RequestDetailMsg)
+	require.True(t, ok, "fetch command should produce a RequestDetailMsg")
+	require.NotNil(t, detailMsg.Details)
+	assert.True(t, detailMsg.Details.InFlight)
+	assert.True(t, detailMsg.Details.Stale)
+}
+
 // TestClientModel_DetailLiveRefresh_MatchingFinalReturnsFetchCmd pins the
 // live half of D16 end to end: opening the detail on an in-flight request via
 // Enter, then feeding the matching final ProxyRequestMsg, returns a re-fetch

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -125,7 +125,12 @@ type RequestDetailData struct {
 	// InFlight marks a request whose response is still streaming: Duration
 	// renders as "(in flight)" and a nil Details gets an explanatory note
 	// instead of being treated as "capture not enabled".
-	InFlight        bool
+	InFlight bool
+	// Stale marks an in-flight request that has been in-flight longer than
+	// constants.InFlightStaleAfter (D8, #53): the completion event may have
+	// been lost and the true outcome is unknown. Always false when InFlight
+	// is false.
+	Stale           bool
 	RequestHeaders  map[string][]string
 	ResponseHeaders map[string][]string
 	RequestBody     *BodyData

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -145,6 +145,11 @@ type BodyData struct {
 	ContentEncoding string
 	IsBinary        bool
 	Data            string
+	// DataBase64 marks Data as base64-encoded (the attach-mode wire format:
+	// the API base64-encodes binary bodies). Local mode stores raw bytes and
+	// leaves this false, so the hex preview never has to guess — raw bytes
+	// that merely LOOK like base64 must not be decoded.
+	DataBase64 bool
 	// Unavailable is true when the body existed but could no longer be loaded
 	// (e.g. its disk file was evicted); UnavailableReason explains why.
 	Unavailable       bool

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -511,6 +511,27 @@ func TestFormatProxyRequest_InFlight(t *testing.T) {
 	assert.Contains(t, formatted, "200", "status should show the real header-time code")
 }
 
+// TestFormatProxyRequest_Stale verifies a stale in-flight row (D8, #53: the
+// completion event may have been lost, true outcome unknown) renders
+// "stale?" in the duration column instead of the ordinary in-flight dots.
+func TestFormatProxyRequest_Stale(t *testing.T) {
+	model := newTestModel()
+
+	req := proxy.RequestRecord{
+		Timestamp:  time.Now().Add(-10 * time.Minute),
+		Subdomain:  "api",
+		Method:     "GET",
+		URL:        "/stream",
+		StatusCode: 200,
+		InFlight:   true,
+	}
+
+	formatted := model.formatProxyRequest(req)
+
+	assert.Contains(t, formatted, "stale?", "duration column should render 'stale?' for a stale in-flight row")
+	assert.NotContains(t, formatted, "...", "a stale row should not also render the fresh in-flight dots")
+}
+
 func TestFormatProxyRequest_Padding(t *testing.T) {
 	model := newTestModel()
 

--- a/skills/prox/SKILL.md
+++ b/skills/prox/SKILL.md
@@ -9,7 +9,7 @@ prox is a process manager for local development written in Go. It provides proce
 
 ## First Step: Read prox.yaml
 
-**Always read the project's `prox.yaml` before taking any action.** This file defines the project's local development topology — what processes exist, what commands they run, what ports they use, and whether proxy routing is enabled. Without reading this file you cannot help effectively.
+**Always read the project's `prox.yaml` before taking any action.** This file defines the project's process topology, commands, ports, and whether proxy routing is enabled — read it before doing anything else.
 
 If the config file is at a non-default path, the user or CLAUDE.md will specify it (the `--config` / `-c` flag overrides the default).
 
@@ -28,15 +28,17 @@ When a project has a `prox.yaml`, **use prox to manage processes** — do not ru
 | Check what's running | `prox status` |
 | Attach interactive TUI | `prox attach` |
 
-**Editing `prox.yaml`?** `prox restart <name>` (and `prox start <name>` after a `prox stop <name>`) re-reads the file and applies that process's current config — changed `cmd`, `healthcheck`, `stop_timeout`, and `env`/`env_file`. So the edit → restart loop needs no full `prox stop` + `prox up`. Adding/removing/renaming processes or changing `services`/`proxy` still requires `prox up`.
+**Editing `prox.yaml`?** `prox restart <name>` (or `prox start <name>` after `prox stop <name>`) re-reads the file and applies that process's current `cmd`, `healthcheck`, `stop_timeout`, and `env`/`env_file` — no full `prox stop` + `prox up` needed. Adding/removing/renaming processes or changing `services`/`proxy` still requires `prox up`.
 
-**Always use `-d` (daemon mode)** when starting prox so the CLI returns control immediately. Do not start prox in the foreground — it will block.
+**Always use `-d` (daemon mode)** when starting prox so the CLI returns control immediately. Do not start prox in the foreground — it will block. `prox up -d` now confirms real readiness: it exits non-zero with a `.prox/prox.log` tail if the daemon never becomes healthy (trust the exit code), and fails hard with remediation on a daemon/CLI version mismatch instead of silently degrading.
 
 **Never kill processes directly** (e.g., `kill <pid>`). Use prox commands so it can track state and handle restarts correctly.
 
+**Run client commands (`status`, `logs`, `requests`, etc.) from the project directory.** They auto-discover the instance via `.prox/prox.state`; outside a project directory they now error instead of silently falling back to `:5555` — pass `--addr host:port` if running from elsewhere.
+
 ## Shared Proxy and Multiple Projects
 
-When a project enables a proxy (see "Making HTTP Requests" below), prox serves its services through a single background **proxy daemon** shared across all projects on the machine. This is what lets several projects expose their domains on the same port (e.g. 443) without conflicts. Routing is by full hostname, so two projects can share one port as long as their hostnames differ.
+When a project enables a proxy (see "Making HTTP Requests" below), its services are served through a single background **proxy daemon** shared across all projects on the machine, letting several projects share one port (e.g. 443). Routing is by full hostname, so two projects can share a port as long as their hostnames differ.
 
 You normally never manage the daemon directly: `prox up` starts it (or registers with the already-running one) and `prox down` deregisters the project, stopping the daemon when the last project leaves.
 
@@ -51,7 +53,7 @@ prox proxy stop --force      # Stop anyway, disconnecting all projects
 
 If a proxied request returns a connection error or an unexpected 404, check `prox proxy routes` first to confirm the target hostname is actually registered.
 
-**Green `prox status` does not mean the proxy is up.** `prox status` reports only the *project* daemon and its processes — it does not check the shared proxy. If a proxied request is connection-refused (or `:443` is dead) while `prox status` still shows everything "running", run **`prox proxy status`**: the shared daemon can be down (killed by a reboot/logout, or `prox proxy stop --force`) while every project daemon keeps reporting healthy. If it's down, `prox up` re-starts it. (See prox#66.)
+**`prox status` now surfaces shared-proxy health itself.** When a proxy is configured, it prints a `Proxy: DOWN — shared proxy daemon unreachable` line and **exits 1** if the shared daemon is unreachable, even though every child process is still healthy — you don't need a separate check for this. The project also self-heals: it re-registers with a fresh or recovered daemon automatically (worst case ~45s), so a brief `DOWN` reading is often transient. Reach for `prox proxy status` / `prox proxy routes` for daemon-side detail `prox status` doesn't carry — which projects/routes the daemon holds, its version. (See prox#66.)
 
 ## Viewing Logs
 
@@ -61,13 +63,12 @@ prox aggregates output from all processes. When debugging, check logs first.
 prox logs --lines 50                          # Recent 50 lines, all processes
 prox logs --lines 50 --process api            # Recent 50 lines from "api"
 prox logs -f --process api                    # Stream logs from "api"
-prox logs --lines 100 --pattern ERROR         # Filter for "ERROR"
-prox logs --lines 100 --pattern "err.*" --regex  # Regex filter
+prox logs --lines 100 --pattern ERROR         # Filter for "ERROR" (add --regex for regex patterns)
 ```
 
 **Always use `--lines N`** to limit output. Without it, prox may return hundreds of lines that flood context.
 
-**Pipe through bash tools when needed** — prox's built-in `--pattern` handles most filtering, but for counting (`| grep -c ERROR`), multi-pattern matching (`| grep -E "ERROR|WARN"`), or extracting specific fields, pipe through standard unix tools.
+**Pipe through bash tools when needed** — `--pattern` handles most filtering, but for counting, multi-pattern matches, or field extraction, pipe through standard unix tools (`| grep -c ERROR`, `| grep -E "ERROR|WARN"`).
 
 For daemon startup issues, check the daemon log directly: `cat .prox/prox.log`
 
@@ -94,9 +95,7 @@ services:
   app: 3000
 ```
 
-Then:
-- `curl http://api.lvh.me:6788/endpoint` → reaches the api service on port 8000
-- `curl http://app.lvh.me:6788/` → reaches the app service on port 3000
+Then `curl http://api.lvh.me:6788/endpoint` reaches the api service (port 8000), and `curl http://app.lvh.me:6788/` reaches app (port 3000).
 
 For HTTPS, use `https://<service>.<domain>:<https_port>/path` (requires mkcert setup).
 
@@ -110,11 +109,15 @@ Use direct ports from the process commands in prox.yaml. For example, if a proce
 prox requests                                  # Recent requests
 prox requests -f                               # Stream in real-time
 prox requests --subdomain api --min-status 400 # Filter for errors on api
+prox requests --method POST --since 5m         # POST requests in the last 5 minutes
+prox requests --url /api/users --json          # URL substring match, machine-readable output
 prox requests <id>                             # Details for specific request
-prox requests <id> --body                      # Include captured bodies
+prox requests <id> --body                      # Include captured bodies (gzip/deflate/zstd/br decoded automatically)
 ```
 
 `prox requests` shows traffic that reached the proxy; if a request never arrives, use `prox proxy routes` (see "Shared Proxy and Multiple Projects") to check whether the service's hostname is registered at all.
+
+A request can show **`stale?`** instead of a duration: in-flight for over 5 minutes, meaning its completion event may have been lost and the outcome is unknown — not necessarily broken. Long-lived streams and large transfers can legitimately stay `stale?` while still live.
 
 ## Configuration (prox.yaml)
 
@@ -139,11 +142,7 @@ processes:
       start_period: 30s
 ```
 
-Environment variable precedence (later overrides earlier):
-1. System environment
-2. Global `env_file`
-3. Process-specific `env_file`
-4. Process-specific `env` map
+Environment variable precedence, later overrides earlier: system environment → global `env_file` → process-specific `env_file` → process-specific `env` map.
 
 For the full configuration reference including all proxy, service, and certificate fields, read `references/configuration.md`.
 

--- a/skills/prox/references/api.md
+++ b/skills/prox/references/api.md
@@ -52,6 +52,7 @@ All errors return JSON:
 | `STREAMING_NOT_SUPPORTED` | The server cannot provide an SSE stream for this request |
 | `REQUEST_NOT_FOUND` | Proxy request ID does not exist in the request buffer |
 | `MISSING_REQUEST_ID` | Request detail endpoint was called without an ID |
+| `CURSOR_GONE` | A `before_id` cursor's anchor record is unknown, evicted, or out of scope — restart pagination without a cursor |
 
 ## Endpoints
 
@@ -76,9 +77,34 @@ Supervisor status.
   "status": "running",
   "uptime_seconds": 7200,
   "config_file": "/path/to/prox.yaml",
-  "api_version": "v1"
+  "api_version": "v1",
+  "proxy": {
+    "mode": "shared",
+    "daemon_reachable": true,
+    "daemon_version": "0.2.0",
+    "consecutive_failures": 0,
+    "last_connected_at": "2025-01-19T10:32:01.123Z",
+    "dropped_events": 0,
+    "backfill_failures": 0,
+    "heal_state": "healthy"
+  }
 }
 ```
+
+`proxy` reports this project's shared-proxy health and is present whenever a proxy is configured (`mode` is `"disabled"` and the rest of the block is zero-valued when no proxy is configured):
+
+| Field | Description |
+|-------|--------------|
+| `mode` | `shared` (registered with the shared daemon), `standalone` (this process runs its own proxy listener), or `disabled` |
+| `daemon_reachable` | Result of a live `/health` probe against the shared daemon (500ms timeout, cached 2s); always `false` outside `shared` mode |
+| `daemon_version` | The shared daemon's reported version, when reachable |
+| `consecutive_failures` | The forwarder's current run of failed reconnects to the shared daemon |
+| `last_connected_at` | Last time the forwarder established an SSE stream to the shared daemon |
+| `dropped_events` | Request-stream events lost to a full subscriber channel |
+| `backfill_failures` | Post-connect ring snapshot fetch failures |
+| `heal_state` | `healthy`, `healing`, or `version_mismatch`; empty when not in shared mode |
+
+**When `mode` is `shared` and `daemon_reachable` is `false`, proxied routes are dead** — requests through the proxy will fail even though the project's own processes may be healthy. This is not necessarily an error to act on immediately: the project self-heals automatically (re-registers with a fresh or recovered daemon), worst case within ~45s. An agent polling status should treat a brief `daemon_reachable: false` as transient, retry rather than fail the task outright, and only surface it as a real problem if it persists past that window. `prox proxy status` gives daemon-side detail (routes, version) that this per-project block does not.
 
 ### GET /processes
 
@@ -256,6 +282,9 @@ Retrieve recent proxy requests (requires proxy to be enabled).
 | `method` | string | all | Filter by HTTP method (GET, POST, etc.) |
 | `min_status` | int | — | Minimum status code |
 | `max_status` | int | — | Maximum status code |
+| `since` | string | — | Only requests at or after this time (RFC3339 timestamp, e.g. `2025-01-19T10:00:00Z`) |
+| `url_contains` | string | — | Filter by URL substring (path+query, case-insensitive) |
+| `before_id` | string | — | Cursor: page strictly older than this request ID (see below) |
 | `limit` | int | 100 | Max requests to return (max 1000) |
 
 **Response:**
@@ -264,20 +293,26 @@ Retrieve recent proxy requests (requires proxy to be enabled).
 {
   "requests": [
     {
-      "id": "a1b2c3d",
+      "id": "a1b2c3d4e5f6",
       "timestamp": "2025-01-19T10:32:01.123Z",
       "method": "GET",
       "url": "/api/users",
       "subdomain": "api",
+      "hostname": "api.local.dev",
       "status_code": 200,
       "duration_ms": 45,
       "remote_addr": "127.0.0.1"
     }
   ],
   "filtered_count": 50,
-  "total_count": 250
+  "total_count": 250,
+  "next_before_id": "9f8e7d6c5b4a"
 }
 ```
+
+Request IDs are 12 hex characters. A record that's still streaming (recorded at response-header time, before the body finished) carries `"in_flight": true` and `duration_ms: 0` until the completion event replaces it in place; both fields are omitted once the request is complete. A record that has been in-flight for more than 5 minutes also carries `"stale": true` — see [In-flight and stale requests](#in-flight-and-stale-requests) below.
+
+**Cursor pagination (`before_id`):** pass the previous page's `next_before_id` as `before_id` to fetch the next older page. `next_before_id` is the ID of the *oldest scanned* record, not the oldest *returned* one — a page that got filtered down to zero results still advances the cursor instead of stalling. It's omitted when the scan reached the end of the ring (no more history). Ring order is arrival order, not strict timestamp order, so an unknown, evicted, or out-of-scope `before_id` (including a record from a different `?subdomain=`/project scope) returns **`410 Gone`** with code `CURSOR_GONE` — on that response, restart pagination without a cursor rather than retrying the same one.
 
 **Example:**
 
@@ -290,6 +325,9 @@ curl "http://localhost:5555/api/v1/proxy/requests?subdomain=api"
 
 # Filter for errors (5xx)
 curl "http://localhost:5555/api/v1/proxy/requests?min_status=500"
+
+# Page backward through history
+curl "http://localhost:5555/api/v1/proxy/requests?before_id=9f8e7d6c5b4a"
 ```
 
 ### GET /proxy/requests/{id}
@@ -306,11 +344,12 @@ Body data is available only when capture was enabled with `prox up --capture` or
 
 ```json
 {
-  "id": "a1b2c3d",
+  "id": "a1b2c3d4e5f6",
   "timestamp": "2025-01-19T10:32:01.123Z",
   "method": "POST",
   "url": "/api/users",
   "subdomain": "api",
+  "hostname": "api.local.dev",
   "status_code": 201,
   "duration_ms": 45,
   "remote_addr": "127.0.0.1",
@@ -320,8 +359,10 @@ Body data is available only when capture was enabled with `prox up --capture` or
     },
     "request_body": {
       "size": 27,
+      "captured_size": 27,
       "truncated": false,
       "content_type": "application/json",
+      "content_encoding": "",
       "is_binary": false,
       "data": "{\"name\":\"Ada\"}"
     }
@@ -329,11 +370,13 @@ Body data is available only when capture was enabled with `prox up --capture` or
 }
 ```
 
+`captured_size` is the bytes actually retained after any truncation (vs `size`, the original body size). `content_encoding` records the stored `Content-Encoding` (e.g. `gzip`); gzip/deflate/zstd/brotli bodies are decoded transparently, so `data`/`is_binary` reflect the decoded (served) bytes when `include=body` is used. If a body can no longer be loaded (e.g. its capture file was evicted), the body object carries `"unavailable_reason": "evicted"` instead of `data`.
+
 **Examples:**
 
 ```bash
-curl http://localhost:5555/api/v1/proxy/requests/a1b2c3d
-curl "http://localhost:5555/api/v1/proxy/requests/a1b2c3d?include=body"
+curl http://localhost:5555/api/v1/proxy/requests/a1b2c3d4e5f6
+curl "http://localhost:5555/api/v1/proxy/requests/a1b2c3d4e5f6?include=body"
 ```
 
 ### GET /proxy/requests/stream
@@ -349,7 +392,7 @@ The stream is long-lived: it is exempt from the 30s request-timeout class and en
 ```
 : connected
 
-data: {"id":"a1b2c3d","timestamp":"2025-01-19T10:32:01.123Z","method":"GET","url":"/api/users","subdomain":"api","status_code":200,"duration_ms":45,"remote_addr":"127.0.0.1"}
+data: {"id":"a1b2c3d4e5f6","timestamp":"2025-01-19T10:32:01.123Z","method":"GET","url":"/api/users","subdomain":"api","status_code":200,"duration_ms":45,"remote_addr":"127.0.0.1"}
 ```
 
 **Example:**
@@ -358,6 +401,10 @@ data: {"id":"a1b2c3d","timestamp":"2025-01-19T10:32:01.123Z","method":"GET","url
 curl -N http://localhost:5555/api/v1/proxy/requests/stream
 curl -N "http://localhost:5555/api/v1/proxy/requests/stream?subdomain=api"
 ```
+
+### In-flight and stale requests
+
+A request appears in `prox requests`/the API as soon as its response headers arrive, before the body finishes streaming, with `in_flight: true`. Normally the completion event replaces it in place once the body finishes. If a request stays `in_flight` for more than 5 minutes, it also gains `stale: true` — this means the completion event may have been lost and the true outcome is unknown, **not** that the request is broken: long-lived streams (SSE, WebSocket-over-HTTP) and large transfers can legitimately sit at `stale: true` for a long time while still live.
 
 ### POST /shutdown
 

--- a/skills/prox/references/configuration.md
+++ b/skills/prox/references/configuration.md
@@ -322,7 +322,7 @@ services:
 
 ### Request Capture
 
-Request capture records request and response body metadata for the `prox requests <id>` detail view. Bodies up to `proxy.capture.max_body_size` are retained; larger bodies are truncated.
+Request capture records request and response body metadata for the `prox requests <id>` detail view. Bodies up to `proxy.capture.max_body_size` are retained; larger bodies are truncated. This cap is enforced per project: when several projects share one proxy daemon, each project's `max_body_size` (sent to the daemon at registration) governs only that project's captures — one project cannot inflate or shrink another's capture limit.
 
 ```yaml
 proxy:

--- a/test/integration/capture_daemon_test.go
+++ b/test/integration/capture_daemon_test.go
@@ -133,8 +133,8 @@ func TestDaemonCapture_EndToEnd(t *testing.T) {
 	localRMB := proxy.NewRequestManager(constants.DefaultProxyRequestBufferSize)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go proxyd.ForwardRequests(ctx, socketPath, "/projects/a", localRMA)
-	go proxyd.ForwardRequests(ctx, socketPath, "/projects/b", localRMB)
+	go proxyd.ForwardRequests(ctx, socketPath, "/projects/a", localRMA, nil)
+	go proxyd.ForwardRequests(ctx, socketPath, "/projects/b", localRMB, nil)
 
 	// Confirm both bridges are live by pinging until each side observes a record.
 	// (Guards against subscribing after the real traffic was already published.)

--- a/test/integration/capture_daemon_test.go
+++ b/test/integration/capture_daemon_test.go
@@ -72,16 +72,17 @@ func TestDaemonCapture_EndToEnd(t *testing.T) {
 	socketPath := shortSocketPath(t)
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
 	registry := proxyd.NewRegistry()
-	requestMgr := proxy.NewRequestManager(constants.DefaultProxyRequestBufferSize)
 
 	captureMgr, err := proxy.NewCaptureManagerAt(daemonCaptureDir, constants.DefaultCaptureMaxBodySize)
 	if err != nil {
 		t.Fatalf("NewCaptureManagerAt: %v", err)
 	}
 	defer captureMgr.Cleanup()
-	requestMgr.SetEvictionCallback(captureMgr.CleanupRequest)
 
-	dynamicProxy := proxyd.NewDynamicProxy(registry, nil, requestMgr, captureMgr, logger)
+	// Per-project rings, wired like RunDaemon: each project's ring is created at
+	// register time with the capture eviction callback.
+	managers := proxyd.NewManagers(constants.DefaultProxyRequestBufferSize, captureMgr.CleanupRequest)
+	dynamicProxy := proxyd.NewDynamicProxy(registry, nil, managers, captureMgr, logger)
 
 	server := proxyd.NewServer(proxyd.ServerConfig{
 		SocketPath: socketPath,
@@ -90,7 +91,7 @@ func TestDaemonCapture_EndToEnd(t *testing.T) {
 	})
 	server.SetRegistry(registry)
 	server.SetProxy(dynamicProxy)
-	server.SetRequestManager(requestMgr)
+	server.SetManagers(managers)
 
 	go func() { _ = server.Start() }()
 	defer server.Shutdown(context.Background())

--- a/test/integration/capture_daemon_test.go
+++ b/test/integration/capture_daemon_test.go
@@ -133,8 +133,8 @@ func TestDaemonCapture_EndToEnd(t *testing.T) {
 	localRMB := proxy.NewRequestManager(constants.DefaultProxyRequestBufferSize)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go proxyd.ForwardRequests(ctx, socketPath, "/projects/a", localRMA, nil)
-	go proxyd.ForwardRequests(ctx, socketPath, "/projects/b", localRMB, nil)
+	go proxyd.ForwardRequests(ctx, socketPath, "/projects/a", localRMA, nil, nil)
+	go proxyd.ForwardRequests(ctx, socketPath, "/projects/b", localRMB, nil, nil)
 
 	// Confirm both bridges are live by pinging until each side observes a record.
 	// (Guards against subscribing after the real traffic was already published.)

--- a/test/integration/inflight_backfill_daemon_test.go
+++ b/test/integration/inflight_backfill_daemon_test.go
@@ -87,7 +87,7 @@ func TestInFlight_EndToEnd(t *testing.T) {
 	localRM := proxy.NewRequestManager(constants.DefaultProxyRequestBufferSize)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go proxyd.ForwardRequests(ctx, topo.socketPath, projectDir, localRM, nil)
+	go proxyd.ForwardRequests(ctx, topo.socketPath, projectDir, localRM, nil, nil)
 	waitBridgeLive(t, proxyPort, hostname, localRM)
 
 	// Drive the slow request in a background goroutine — it stays open until we
@@ -228,7 +228,7 @@ func TestBackfill_EndToEnd(t *testing.T) {
 	ctx1, cancel1 := context.WithCancel(context.Background())
 	done1 := make(chan struct{})
 	go func() {
-		proxyd.ForwardRequests(ctx1, topo.socketPath, projectDir, localRM, nil)
+		proxyd.ForwardRequests(ctx1, topo.socketPath, projectDir, localRM, nil, nil)
 		close(done1)
 	}()
 	waitBridgeLive(t, proxyPort, hostname, localRM)
@@ -271,7 +271,7 @@ func TestBackfill_EndToEnd(t *testing.T) {
 	// --- Restart the bridge with a fresh ctx and the SAME local manager ---
 	ctx2, cancel2 := context.WithCancel(context.Background())
 	defer cancel2()
-	go proxyd.ForwardRequests(ctx2, topo.socketPath, projectDir, localRM, nil)
+	go proxyd.ForwardRequests(ctx2, topo.socketPath, projectDir, localRM, nil, nil)
 
 	// Gap records appear locally via backfill.
 	gap1 := waitForRecord(t, localRM, func(r proxy.RequestRecord) bool {

--- a/test/integration/inflight_backfill_daemon_test.go
+++ b/test/integration/inflight_backfill_daemon_test.go
@@ -87,7 +87,7 @@ func TestInFlight_EndToEnd(t *testing.T) {
 	localRM := proxy.NewRequestManager(constants.DefaultProxyRequestBufferSize)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go proxyd.ForwardRequests(ctx, topo.socketPath, projectDir, localRM)
+	go proxyd.ForwardRequests(ctx, topo.socketPath, projectDir, localRM, nil)
 	waitBridgeLive(t, proxyPort, hostname, localRM)
 
 	// Drive the slow request in a background goroutine — it stays open until we
@@ -228,7 +228,7 @@ func TestBackfill_EndToEnd(t *testing.T) {
 	ctx1, cancel1 := context.WithCancel(context.Background())
 	done1 := make(chan struct{})
 	go func() {
-		proxyd.ForwardRequests(ctx1, topo.socketPath, projectDir, localRM)
+		proxyd.ForwardRequests(ctx1, topo.socketPath, projectDir, localRM, nil)
 		close(done1)
 	}()
 	waitBridgeLive(t, proxyPort, hostname, localRM)
@@ -271,7 +271,7 @@ func TestBackfill_EndToEnd(t *testing.T) {
 	// --- Restart the bridge with a fresh ctx and the SAME local manager ---
 	ctx2, cancel2 := context.WithCancel(context.Background())
 	defer cancel2()
-	go proxyd.ForwardRequests(ctx2, topo.socketPath, projectDir, localRM)
+	go proxyd.ForwardRequests(ctx2, topo.socketPath, projectDir, localRM, nil)
 
 	// Gap records appear locally via backfill.
 	gap1 := waitForRecord(t, localRM, func(r proxy.RequestRecord) bool {

--- a/test/integration/inflight_backfill_daemon_test.go
+++ b/test/integration/inflight_backfill_daemon_test.go
@@ -358,16 +358,17 @@ func newDaemonTopo(t *testing.T) daemonTopo {
 	socketPath := shortSocketPath(t)
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
 	registry := proxyd.NewRegistry()
-	requestMgr := proxy.NewRequestManager(constants.DefaultProxyRequestBufferSize)
 
 	captureMgr, err := proxy.NewCaptureManagerAt(daemonCaptureDir, constants.DefaultCaptureMaxBodySize)
 	if err != nil {
 		t.Fatalf("NewCaptureManagerAt: %v", err)
 	}
 	t.Cleanup(func() { captureMgr.Cleanup() })
-	requestMgr.SetEvictionCallback(captureMgr.CleanupRequest)
 
-	dynamicProxy := proxyd.NewDynamicProxy(registry, nil, requestMgr, captureMgr, logger)
+	// Per-project rings, wired like RunDaemon: each project's ring is created at
+	// register time with the capture eviction callback.
+	managers := proxyd.NewManagers(constants.DefaultProxyRequestBufferSize, captureMgr.CleanupRequest)
+	dynamicProxy := proxyd.NewDynamicProxy(registry, nil, managers, captureMgr, logger)
 
 	server := proxyd.NewServer(proxyd.ServerConfig{
 		SocketPath: socketPath,
@@ -376,7 +377,7 @@ func newDaemonTopo(t *testing.T) daemonTopo {
 	})
 	server.SetRegistry(registry)
 	server.SetProxy(dynamicProxy)
-	server.SetRequestManager(requestMgr)
+	server.SetManagers(managers)
 
 	go func() { _ = server.Start() }()
 	t.Cleanup(func() { _ = server.Shutdown(context.Background()) })

--- a/test/integration/proxy_daemon_test.go
+++ b/test/integration/proxy_daemon_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/charliek/prox/internal/proxy"
 	"github.com/charliek/prox/internal/proxyd"
 )
 
@@ -26,14 +25,13 @@ func startDaemonServer(t *testing.T) (*proxyd.Client, func()) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
 
 	registry := proxyd.NewRegistry()
-	requestMgr := proxy.NewRequestManager(100)
 	server := proxyd.NewServer(proxyd.ServerConfig{
 		SocketPath: socketPath,
 		Logger:     logger,
 		Version:    "test",
 	})
 	server.SetRegistry(registry)
-	server.SetRequestManager(requestMgr)
+	server.SetManagers(proxyd.NewManagers(100, nil))
 
 	errCh := make(chan error, 1)
 	go func() { errCh <- server.Start() }()

--- a/test/integration/proxy_daemon_test.go
+++ b/test/integration/proxy_daemon_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/charliek/prox/internal/constants"
 	"github.com/charliek/prox/internal/proxyd"
 )
 
@@ -31,7 +32,7 @@ func startDaemonServer(t *testing.T) (*proxyd.Client, func()) {
 		Version:    "test",
 	})
 	server.SetRegistry(registry)
-	server.SetManagers(proxyd.NewManagers(100, nil))
+	server.SetManagers(proxyd.NewManagers(constants.DefaultProxyRequestBufferSize, nil))
 
 	errCh := make(chan error, 1)
 	go func() { errCh <- server.Start() }()

--- a/test/integration/up_test.go
+++ b/test/integration/up_test.go
@@ -2,8 +2,10 @@ package integration
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -353,5 +355,38 @@ func TestUpCommand_GrandchildOutputCapture(t *testing.T) {
 		if !strings.Contains(output, marker) {
 			t.Errorf("expected output to contain %q, but it didn't.\nOutput:\n%s", marker, output)
 		}
+	}
+}
+
+// TestUpDetach_EarlyDeathReportsFailure exercises the real D2 parent
+// wait-and-report path end to end: `prox up -d` with an unreadable config makes
+// the detached child exit before it becomes ready, so the parent must block,
+// detect the early death, print a failure with the child's log tail, and exit
+// non-zero — no lingering daemon. This is the cheap, self-cleaning half of D2
+// (the never-ready/timeout half is covered by unit-level fakes with injectable
+// timings in internal/cli).
+func TestUpDetach_EarlyDeathReportsFailure(t *testing.T) {
+	skipShort(t)
+
+	binary := buildBinary(t)
+
+	// Isolated working dir so the child's .prox state never touches the repo
+	// root and is auto-removed with the temp dir.
+	dir := t.TempDir()
+	badCfg := filepath.Join(dir, "does-not-exist.yaml")
+
+	cmd := exec.Command(binary, "up", "-d", "-c", badCfg)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+
+	var ee *exec.ExitError
+	if !errors.As(err, &ee) {
+		t.Fatalf("expected a non-zero exit, got err=%v\nOutput:\n%s", err, out)
+	}
+	if ee.ExitCode() != 1 {
+		t.Fatalf("expected exit code 1, got %d\nOutput:\n%s", ee.ExitCode(), out)
+	}
+	if !strings.Contains(string(out), "failed to start") {
+		t.Errorf("expected failure diagnostics mentioning 'failed to start', got:\n%s", out)
 	}
 }


### PR DESCRIPTION
Plan 010 — the hardening pass discussed and scoped with the user: lifecycle signals an agent can trust, a dependable requests pipeline, and skill/docs that match reality. 15 gated commits; every commit ran `make lint && make test && make test-race && make build`, a conditional simplify pass, and a capped adversarial Codex review whose findings were fixed in-commit or dispositioned in the commit message. The plan itself was panel-reviewed (Codex + GLM 5.2 + CodeRabbit) before implementation; 10 convergent corrections were incorporated pre-build.

Closes #66. Closes #67. Closes #53. Closes #50. Closes #49.

## What changed

### Lifecycle — trustworthy signals (C1–C7)
- **Version skew** (C1): a mismatched shared daemon is no longer a silent proxy-less start. Busy daemon → fatal with both versions, registered projects, exact remediation. Idle daemon → auto-replaced (TOCTOU + PID-lock-window guarded). Standalone proxy failures are fatal too (`--no-proxy` is the escape hatch). Also fixes a pre-existing register-vs-shutdown race in the daemon's non-force shutdown gate.
- **SHUTTING_DOWN retry** (C2): `prox up` landing in the daemon's shutdown grace now drains and retries once automatically (two consecutive health misses required — transient blips don't burn the retry).
- **Truthful `prox up -d`** (C3): the parent exits 0 only after the child's state file (PID-matched) + `/health` confirm readiness; early death/timeout → exit 1 with a log tail, SIGTERM→SIGKILL escalation. API bind failures are now fatal in the child (previously a stranger on the port could answer the probe).
- **No `:5555` fallback** (C4, breaking): client commands outside a project dir error with guidance instead of silently dialing the default port. Nested `prox proxy status/stop` correctly exempt.
- **`prox status` shows shared-proxy health** (C5, #66, breaking exit code): a `Proxy: DOWN` line + exit 1 when the shared daemon is unreachable; forwarder failures/drops/backfill state surfaced via a status `proxy` JSON block (500ms probe, 2s cache).
- **Self-heal** (C6, #66): after ≥15s of daemon unreachability the project re-ensures + re-registers automatically (≥30s damping, persistent across outages). Daemon-side same-identity re-register is idempotent (no-op refresh preserves history; changed-config refresh is failure-atomic with snapshot restore). Heal and shutdown are mutually excluded (barrier mutex); shutdown deregisters through the healed client.
- **Boot-marker ledger guard** (C7, #67): the orphan-reap ledger records the Linux boot_id; cross-boot or legacy-markerless-on-Linux ledgers are discarded unsignaled, closing the killpg PID+tick collision. Transient marker-read failures self-repair at persist time.

### Requests pipeline (C8–C12)
- **`stale?` flag** (C8, #53): in-flight rows older than 5min surface as stale (API `stale:true`, CLI/TUI `stale?`) — completion-unknown, computed at serve time, no protocol change.
- **Decoders** (C9, #50): deflate (zlib-first, raw fallback on header error only), zstd, brotli — all bounded by the 10MB cap; zstd decodes synchronously with bounded window memory. New pure-Go deps: `klauspost/compress`, `andybalholm/brotli` (user-approved).
- **TUI hex preview** (C10, #50): binary bodies render a 256-byte `hexdump -C`-style preview with a strictly printable-ASCII gutter (0x00–0xFF golden tests). Also fixes a pre-existing bug where local-mode binary bodies never carried their bytes to the TUI.
- **Cursor pagination** (C11, #50): `before_id`/`next_before_id` (oldest-scanned semantics — filtered pages never stall), `410 CURSOR_GONE` for evicted/out-of-scope anchors.
- **Per-project rings + caps** (C12, #49): the daemon's global 1000-slot ring becomes one full ring per registered project (flooding cannot cross projects); per-project `capture.max_body_size` propagates through registration and applies per-call. Ring destroy latches writes so a completion racing a deregister can't leak capture files.

### Skill & docs (C13–C14)
- `skills/prox` refreshed to post-hardening reality (12-char IDs, all new params/fields/behaviors), validated against skill-creator best practices; body stays under the ~1300-word budget.
- README API table gains the `/proxy/requests` surface; architecture doc now covers proxyd/capture/forwarder; reference docs updated; CHANGELOG `Unreleased` section with an explicit **Breaking** list.

## Breaking changes
- `prox status` exits 1 when the project is registered with a shared proxy that is unreachable.
- Client commands no longer fall back to `http://127.0.0.1:5555` — run from the project dir or pass `--addr`.
- `prox up -d` exit code is now truthful (was unconditionally 0).
- Orphan-ledger format is now an envelope; pre-upgrade binaries can't read post-upgrade ledgers (downgrade-incompatible, never unsafe).

## Verification
- Full gate green on every commit; suite green at HEAD (`lint`, `test`, `test-race` incl. the ~70s integration suite, `build`).
- **Live pass on this machine** against real projects (slauth, slaudio, imgmcp), migrated from the live v0.1.2 daemon to this build: busy version-skew fatal verified foreground + detached (found and fixed a child-error-lost-on-log-close bug, c1d8273); `kill -9` of the shared daemon → `Proxy: DOWN` + exit 1 → **all three projects self-healed onto a fresh daemon in ~15s**; detach failure with a held API port → exit 1 with the real bind error in the log tail; live traffic → 12-char IDs, captured bodies, cursor paging with 410s, populated status proxy block. Artifacts: `~/.claude/plans/prox/010-hardening/`.
- Covered by automated tests only: cross-boot marker discard (marker-injection tests), hex-preview safety goldens, per-project flood isolation, burst drop counters, SHUTTING_DOWN retry fixtures.

## Dependency / privacy / secret impact
Two new pure-Go deps (`klauspost/compress` v1.19.1, `andybalholm/brotli` v1.2.2). No secrets, no data collection, no auth-model changes (localhost no-auth + 0700 socket unchanged, documented as accepted).

## Accepted risks (dispositioned in plan §9)
- Old-version daemons keep their shipped shutdown-gate race during upgrade windows (unfixable client-side; same-version daemons fixed).
- N×ring worst-case daemon memory (per #49's own accepted-risk note; per-project counts exposed in daemon status for diagnosability).
- Daemon-wide capture disk budget, sequence-numbered events/gap resync, and O(1) Upsert index deferred as follow-up issues; #34 (cgroups) deliberately deferred.

<details>
<summary>Plan 010 — design decisions (panel-reviewed)</summary>

See `~/.claude/plans/prox/010-hardening.md` for the full plan (current-state audit with file:line refs, pinned designs D1–D15, acceptance criteria, §Verified live-pass record). The panel (Codex gpt-5.6-sol, GLM 5.2, CodeRabbit) reviewed the plan pre-implementation; its 10 convergent corrections (idempotent re-register, auto-restart races, PersistentPreRunE, breaking-change treatment, D13 lifecycle contracts, shutdown latch, Linux legacy-ledger discard, cursor-stall semantics, standalone-failure fatality, ProxyStatusProvider hygiene) are recorded in the plan header and were all implemented. Per-commit adversarial Codex reviews then drove 10+ additional in-commit fixes, each recorded in its commit message.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EzL4XtcfwrRnNN4Za35cVv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shared-proxy health reporting in `prox status`, with automatic self-healing and version-mismatch recovery.
  * Cursor-based pagination for proxy requests (`before_id`), plus stale in-flight indicators.
  * Expanded captured-body decoding (deflate, zstd, Brotli) with bounded limits, and binary hex previews in the TUI.
  * Per-project request/response capture limits enforced on shared proxy daemons.
* **Bug Fixes**
  * `prox up -d` now fails non-zero when readiness isn’t achieved; improved orphan cleanup safety after reboot.
* **Breaking Changes**
  * `prox status` exits non-zero when the shared proxy is unreachable; no fallback to the old default address.
  * Orphan ledger format is forward-incompatible.
* **Documentation**
  * Updated CLI and HTTP API references, including cursor/pagination and decoding semantics, plus upgrade guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->