### PR TITLE
CI reliability: fix two integration-test flakes, add PR-time mkdocs build (#82)

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -1,0 +1,27 @@
+name: Docs PR Build
+
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '.github/workflows/docs-pr.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-pr-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
+      - run: uv python install 3.13
+      - run: uv sync --locked --group docs
+      - run: uv run --locked mkdocs build --strict

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -19,6 +19,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v7

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,12 @@ site_dir: site-build
 
 dev_addr: '127.0.0.1:7070'
 
+validation:
+  links:
+    anchors: warn
+    absolute_links: warn
+    unrecognized_links: warn
+
 theme:
   name: material
   features:

--- a/test/integration/dependencies_test.go
+++ b/test/integration/dependencies_test.go
@@ -294,16 +294,20 @@ dependencies:
 		}
 	})
 
-	// A slow dependency (ready after ~5s via a start command) is served while
-	// resolving: `up -d` returns promptly and status observes gated waiting on
-	// slow (with waiting_on in JSON) comfortably inside the 5s window, then
-	// converges to running once the dependency is ready. The waiting observation
-	// stays in JSON so it never races the convergence the way a second table-mode
-	// request could; the STATUS-column `waiting(slow)` decoration is pinned by the
-	// statusField unit test instead.
+	// A slow dependency is held unready by a three-marker file barrier until
+	// the test has itself observed `waiting`, so that observation can never
+	// race convergence: `up -d` returns promptly while the dependency's start
+	// command blocks waiting for a release marker the test controls; the test
+	// observes gated waiting on slow (with waiting_on in JSON); the test then
+	// writes the release marker, which lets the start command touch the
+	// readiness marker the dependency's check polls for; and gated converges
+	// to running once the check passes. The STATUS-column `waiting(slow)`
+	// decoration is pinned by the statusField unit test instead.
 	t.Run("detached slow dependency: waiting then converges", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		marker := filepath.Join(tmpDir, "ready.marker")
+		invoked := filepath.Join(tmpDir, "invoked.marker")
+		release := filepath.Join(tmpDir, "release.marker")
+		ready := filepath.Join(tmpDir, "ready.marker")
 		configPath := filepath.Join(tmpDir, "prox.yaml")
 		config := fmt.Sprintf(`
 processes:
@@ -313,12 +317,15 @@ processes:
 dependencies:
   slow:
     check:
-      cmd: "test -f %s"
-      timeout: 30s
+      cmd: "test -f '%s'"
+      # Generous: the barrier holds the dependency unready until the test has
+      # observed waiting, so the budget must dominate the poll deadlines above
+      # it, not model a realistic startup time.
+      timeout: 60s
       interval: 200ms
-    start: "sh -c 'sleep 5; touch %s'"
+    start: "sh -c 'touch \"%s\"; while [ ! -f \"%s\" ]; do sleep 0.1; done; touch \"%s\"'"
     on_failure: fail
-`, marker, marker)
+`, ready, invoked, release, ready)
 		if err := os.WriteFile(configPath, []byte(config), 0644); err != nil {
 			t.Fatalf("write config: %v", err)
 		}
@@ -337,10 +344,15 @@ dependencies:
 			time.Sleep(300 * time.Millisecond)
 		})
 		waitForStateFile(t, filepath.Join(tmpDir, ".prox", "prox.state"), 10*time.Second)
-		// Detached start returns without waiting for the ~5s dependency.
-		if elapsed > 3*time.Second {
+		// Detached start returns without waiting for the dependency.
+		if elapsed > 5*time.Second {
 			t.Errorf("`up -d` took %v; it must return promptly while the dependency resolves", elapsed)
 		}
+
+		// The dependency's start command touches this the moment it actually
+		// launches, proving the start: command ran (not just that it was
+		// scheduled).
+		waitForStateFile(t, invoked, 10*time.Second)
 
 		runStatus := func(extra ...string) (string, string, int) {
 			t.Helper()
@@ -354,14 +366,22 @@ dependencies:
 			return stdout.String(), stderr.String(), exitCodeOf(t, err)
 		}
 
-		// Observe gated waiting on slow via JSON, comfortably inside the ~5s start
-		// window (poll deadline 4s < 5s so the observation cannot race convergence).
-		waiting := pollStatusJSON(t, runStatus, 4*time.Second, func(p statusJSONPayload) bool {
+		// Observe gated waiting on slow via JSON. The dependency cannot become
+		// ready before the test writes the release marker below, so this
+		// observation is race-free by construction; the deadline is generous
+		// headroom, not a load-bearing bound.
+		waiting := pollStatusJSON(t, runStatus, 10*time.Second, func(p statusJSONPayload) bool {
 			s, w, _, ok := procState(p, "gated")
 			return ok && s == "waiting" && len(w) == 1 && w[0] == "slow"
 		})
 		if s, w, _, ok := procState(waiting, "gated"); !ok || s != "waiting" || len(w) != 1 || w[0] != "slow" {
 			t.Fatalf("gated never observed waiting on slow; status=%q waiting_on=%v", s, w)
+		}
+
+		// Release the barrier: the start helper touches the ready marker and
+		// the 200ms check poll converges.
+		if err := os.WriteFile(release, nil, 0644); err != nil {
+			t.Fatalf("write release marker: %v", err)
 		}
 
 		// Then it converges to running once the dependency becomes ready.

--- a/test/integration/dependencies_test.go
+++ b/test/integration/dependencies_test.go
@@ -338,6 +338,10 @@ dependencies:
 		}
 		elapsed := time.Since(start)
 		t.Cleanup(func() {
+			// Self-release the barrier so the start helper's loop exits even if
+			// the test failed before the release step or `stop` cannot reach the
+			// daemon — otherwise the loop would spin on unfailingly at 10Hz.
+			_ = os.WriteFile(release, nil, 0644)
 			stop := exec.Command(binary, "stop", "-c", configPath)
 			stop.Dir = tmpDir
 			_, _ = stop.CombinedOutput()

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -83,11 +85,30 @@ func startProx(t *testing.T, binary string, args ...string) *exec.Cmd {
 	return cmd
 }
 
+// syncBuffer is a goroutine-safe bytes.Buffer: the exec copier goroutines
+// write while tests poll Output() before the process has exited.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
 // proxWithOutput holds a prox command and its captured output
 type proxWithOutput struct {
 	cmd    *exec.Cmd
-	stdout *bytes.Buffer
-	stderr *bytes.Buffer
+	stdout *syncBuffer
+	stderr *syncBuffer
 }
 
 // startProxWithOutput starts prox and captures its stdout/stderr
@@ -104,9 +125,10 @@ func startProxWithOutput(t *testing.T, binary string, args ...string) *proxWithO
 	cmd := exec.Command(binary, args...)
 	cmd.Dir = projectRoot
 
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+	stdout := &syncBuffer{}
+	stderr := &syncBuffer{}
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
 
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("failed to start prox: %v", err)
@@ -114,14 +136,35 @@ func startProxWithOutput(t *testing.T, binary string, args ...string) *proxWithO
 
 	return &proxWithOutput{
 		cmd:    cmd,
-		stdout: &stdout,
-		stderr: &stderr,
+		stdout: stdout,
+		stderr: stderr,
 	}
 }
 
 // Output returns the combined stdout and stderr
 func (p *proxWithOutput) Output() string {
 	return p.stdout.String() + p.stderr.String()
+}
+
+// waitForOutputContains polls the captured combined output until it contains
+// substr, or fails the test after timeout.
+func waitForOutputContains(t *testing.T, prox *proxWithOutput, substr string, timeout time.Duration) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	var last string
+	for time.Now().Before(deadline) {
+		last = prox.Output()
+		if strings.Contains(last, substr) {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	// Final sample: the marker may have arrived during the last sleep.
+	if last = prox.Output(); strings.Contains(last, substr) {
+		return
+	}
+	t.Fatalf("output did not contain %q within %v; captured output: %s", substr, timeout, last)
 }
 
 // stopProx sends shutdown request to prox via API

--- a/test/integration/up_test.go
+++ b/test/integration/up_test.go
@@ -320,8 +320,12 @@ func TestUpCommand_GrandchildOutputCapture(t *testing.T) {
 	// Wait for API to be ready
 	waitForAPI(t, grandchildAPIAddr, 10*time.Second)
 
-	// Give the process time to print its startup message
-	time.Sleep(500 * time.Millisecond)
+	// Wait until the grandchild's startup marker is visible in the SAME
+	// captured-output surface the post-exit assertions read (the terminal
+	// echo subscription starts after process launch, so the logs API is not
+	// an equivalent surface). This 15s startup deadline is independent of
+	// the 15s shutdown wait below.
+	waitForOutputContains(t, prox, "PROCESS_STARTED_PID=", 15*time.Second)
 
 	// Request graceful shutdown via API
 	err := stopProx(t, grandchildAPIAddr)


### PR DESCRIPTION
Fixes #82. Plan 014 (panel-reviewed: Codex + GLM 5.2 + CodeRabbit), first of the three-issue 0.2.x hardening sequence (#82 → #80 → #83).

## What changed

### 1. `TestUpCommand_GrandchildOutputCapture` flake (~1/10) — `c3091c4`

The test slept a fixed 500ms between `waitForAPI` and the graceful-shutdown request; Python interpreter startup occasionally lost that race, so the grandchild's markers never printed. The sleep is now a poll — and deliberately a poll of **the captured-output surface the test later asserts**, not `/api/v1/logs`: the terminal echo is a post-start subscription with no ring-buffer replay (`internal/cli/up.go:506`), so a marker can be API-visible yet missing from the captured stdout. To make polling `Output()` safe while the process runs, the capture buffers are now mutex-guarded (`syncBuffer`); every other `startProxWithOutput` caller reads only after exit and is unaffected.

### 2. `TestDependenciesStatus` detached-slow-dependency flake (rare, under `-race` load) — `bcd5bc2`

The subtest coupled a fixed 5s start command to a 4s observation poll whose clock starts late (after `up -d` returns and the state file appears) — under load the effective window compresses toward zero. Rather than widening margins (the panel showed the arithmetic still races), the timing coupling is removed entirely with a three-marker file barrier: the start command touches `invoked`, loops until the test writes `release`, then touches the `ready` marker the check polls. The test observes `waiting` *before* writing `release`, so observation can never race convergence. Also verifies the start command actually ran (`invoked` marker), and the subtest's happy path drops from ~5.8s to ~1.5s. Check timeout raised to 60s so the budget strictly dominates the poll deadlines that precede release.

### 3. PR-time mkdocs build — `98c6770`

`docs.yml` only triggers on push to `main`, so docs breakage surfaced first in the post-merge deploy run. New build-only workflow `docs-pr.yml` on `pull_request` (paths: `docs/**`, `mkdocs.yml`, `pyproject.toml`, `uv.lock`, and itself — so this PR exercises it live) running `uv sync --locked --group docs` + `uv run --locked mkdocs build --strict`. A separate file keeps PR builds out of the non-canceling `pages` concurrency group and leaves the deploy path untouched; `--locked` fails on a stale lockfile instead of silently re-locking. `mkdocs.yml` gains a `validation:` block raising `anchors`/`absolute_links`/`unrecognized_links` to warning so `--strict` catches them (verified passing on the current tree).

## Verification

- C1: focused `-count=20` plain **and** `-race` → 20/20 each. Full gate (`make lint && make test && make test-race && make build`) green per commit.
- C2: focused `-race -count=20` → 20/20 (~1.5s/run). Honest limit: "maximal parallel `-race` load" isn't reproducible on demand (fixed ports 15556/15561 forbid two concurrent suite processes); the barrier removes the timing coupling structurally instead of betting on wider margins.
- C3: `uv sync --locked` + strict build exit 0 locally; `actionlint` clean; live verification is this PR's own `Docs PR Build / build` check.
- External review per commit: Codex found one C1 poll-loop edge (fixed pre-commit: final sample after the last sleep); Cursor reviewed C2 (no findings; quoting verified against hostile temp paths); Codex reviewed C3 (no findings).

## Impact / accepted risks

- No dependencies added, no user-facing behavior changed, no CHANGELOG entry (test/CI only). Deploy workflow untouched.
- **Do not make `Docs PR Build` a required status check as-is** — it is path-filtered, so non-docs PRs would block on "Expected — waiting for status". Requiring it needs a trigger redesign first (recorded in plan §9).
- Direct pushes to `main` (version bumps touching `pyproject.toml`) still build non-strict in the deploy workflow — accepted, out of scope.
- Future work: sweep the remaining fixed-sleep idioms in the integration suite onto poll helpers.

<details>
<summary>Plan 014 — design decisions (panel-reviewed)</summary>

**Panel corrections that shaped the design:**
- *Codex (High):* the original C1 fix polled `/api/v1/logs` — the wrong surface, since the terminal echo subscription starts after process launch with no replay. Redesigned to synchronized buffers + polling `prox.Output()` itself.
- *Codex (High) + CodeRabbit (Medium):* the original C2 fix widened margins (5s→10s start, 4s→8s observe) — still arithmetically racy because the dependency clock starts at daemon boot while the poll clock starts after `up -d` + `waitForStateFile`. Redesigned to the deterministic barrier.
- *Codex (Medium):* `--locked` for uv; dead-link claim narrowed (`--strict` alone doesn't catch anchors/absolute links — hence the `validation:` block); "suitable for branch protection" claim removed.

**W1 pinned:** `syncBuffer` (mutex-guarded `bytes.Buffer`) in `startProxWithOutput`; `waitForOutputContains(t, prox, substr, timeout)` at the suite's 100ms poll convention; 15s startup deadline independent of the 15s shutdown wait. Rejected: logs-API poll (wrong surface), longer fixed sleep (still load-sensitive).

**W2 pinned:** barrier config `start: sh -c 'touch invoked; while [ ! -f release ]; do sleep 0.1; done; touch ready'`, `check: test -f ready` (60s/200ms). Sequence: `up -d` (≤5s) → state file → `invoked` (10s) → observe `waiting` (10s, race-free by construction) → write `release` → converge (30s) → exit 0. Grounded in the resolver contract (`internal/supervisor/deps.go:80-82,180-185`): start runs concurrently with check polling; the check, not the start command's exit, is the source of truth; prox kills a still-running start helper on teardown. Rejected: widened margins (unsound), clock injection (disproportionate).

**W3 pinned:** separate workflow file (concurrency isolation from `pages` group, deploy path untouched); `--locked` + `--strict`; `validation:` block kept iff strict stayed clean (it did); self-referencing paths filter for live verification on this PR.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QYoxAbd8V8ZsAiAYd7v8Fk
