### PR TITLE
Strict config parsing: unknown keys are load errors everywhere (#83)

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -200,9 +200,32 @@ and returns an error.
 - **Names are unique across all three namespaces** — a name may appear in at
   most one of `processes`, `dependencies`, `tasks` (case-sensitive); a
   collision names every namespace it appears in.
-- **Unknown keys are rejected** in `dependencies:`/`tasks:` entries and
-  `check:` blocks (a typo like `on_faliure` is a load-time error, not a
-  silently-ignored field).
+- **Unknown keys are load-time errors everywhere in `prox.yaml`** — not just
+  `dependencies:`/`tasks:`. This covers the top level, `proxy:`,
+  `proxy.capture:`, `api:`, `certs:`, every `processes.<name>` entry
+  (including its nested `healthcheck:` block), every `services.<name>`
+  entry, and `dependencies:`/`tasks:` entries (including their `check:`
+  blocks). A typo like `stop_timout:` on a process fails with:
+
+  ```text
+  invalid configuration: processes.web: unknown field "stop_timout"
+  ```
+
+  A top-level typo uses the `config:` prefix instead of a dotted path (e.g.
+  `config: unknown field "prxoy"`). All structural errors found in one file
+  — across every block, not just the first one hit — are collected, sorted,
+  and reported together in a single `invalid configuration:` report.
+  (YAML-level defects — malformed syntax, literal duplicate keys — surface
+  immediately as a `parsing yaml:` error instead, since the document can't
+  be analyzed further.)
+- **Duplicate keys are rejected too, by two different layers.** A literal
+  duplicate key (the same key spelled twice in one mapping) is rejected by
+  the YAML parser itself, with a line number, before prox's own validation
+  ever runs. A duplicate created by *aliasing* a key node so it resolves to
+  the same value as an existing sibling key is also rejected — usually as
+  `<path>: duplicate key "<key>"`, though when the alias duplicates a known
+  field of a typed block the YAML decoder reports it first (as a
+  `parsing yaml:` error). Either way it never silently collapses.
 - **Exactly one of `check.tcp`/`check.url`/`check.cmd`** must be present —
   zero or more than one is an error. A key that is present but empty (e.g.
   `tcp: ""`) is its own distinct error, not silently treated as absent.
@@ -215,6 +238,40 @@ and returns an error.
   strongly-connected-components analysis, naming every task in the cycle.
   Dependencies are graph roots and processes are leaves, so only task→task
   edges can participate in a cycle.
+
+### YAML anchors and merge keys
+
+Strict key-checking does not give up standard YAML reuse — anchors,
+aliases, and `<<` merge keys are fully supported everywhere, including
+inside typed blocks like `processes.<name>` or `proxy:`. A merge cannot be
+used to smuggle an unknown key past a block's schema: the keys a merge
+brings in are validated against the schema of the block they land in, at
+the point they take effect.
+
+The standard "defaults" idiom works as YAML defines it:
+
+- `<<: *base` plus explicit keys in the same mapping — the explicit keys
+  win over anything the merge brought in.
+- `<<: [*a, *b]` — on overlap between sources, the first one wins.
+
+What is **not** supported is a separate top-level container built only to
+hold anchors (an `x-defaults:`/`_defaults:` idiom some other YAML-based
+tools allow). Every top-level key is checked against the fixed schema, so a
+scratch key like `x-defaults:` fails the same as any other unknown
+top-level key — there is no `x-` escape hatch. Instead, define each anchor
+at its first natural occurrence in the document and alias it from later
+occurrences:
+
+```yaml
+processes:
+  web:
+    cmd: ./web
+    env: &common
+      FOO: bar
+  worker:
+    cmd: ./worker
+    env: *common
+```
 
 ### Dependency Check and Start Semantics
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -217,11 +217,14 @@ and returns an error.
   and reported together in a single `invalid configuration:` report.
   (YAML-level defects — malformed syntax, literal duplicate keys — surface
   immediately as a `parsing yaml:` error instead, since the document can't
-  be analyzed further.)
+  be analyzed further.) A `prox.yaml` must be a single YAML document: a
+  stray `---` starting a second document is an error rather than silently
+  disabling everything below it.
 - **Duplicate keys are rejected too, by two different layers.** A literal
-  duplicate key (the same key spelled twice in one mapping) is rejected by
-  the YAML parser itself, with a line number, before prox's own validation
-  ever runs. A duplicate created by *aliasing* a key node so it resolves to
+  duplicate key (the same key spelled twice in one mapping) is normally
+  rejected by the YAML parser itself, with a line number, before prox's own
+  validation ever runs; one spelled inside a region the decoder skips (the
+  value of an unknown key) is caught by prox's structural pass instead. A duplicate created by *aliasing* a key node so it resolves to
   the same value as an existing sibling key is also rejected — usually as
   `<path>: duplicate key "<key>"`, though when the alias duplicates a known
   field of a typed block the YAML decoder reports it first (as a

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -114,11 +114,28 @@ type ProcessConfig struct {
 	StopTimeout string `yaml:"stop_timeout"`
 	// DependsOn lists dependencies: and/or tasks: names that must be ready
 	// before this process starts (plan 013 D1). Process names are NOT valid
-	// targets; validation rejects them. Unlike dependency/task blocks (which
-	// reject unknown keys), a process's other fields still follow the lenient
-	// re-marshal parse path, so depends_on is simply another known field here.
+	// targets; validation rejects them. Like every other process field it is
+	// listed in processAllowedKeys, the source of truth for what a process entry
+	// may contain -- anything else is a load error.
 	DependsOn []string `yaml:"depends_on"`
 }
+
+// Allowed key sets for strict unknown-key rejection on processes: and
+// services: entries (plan 016 W1), mirroring dependency.go's sets. Kept as
+// package vars so the parsers and their error messages share one source of
+// truth; each must stay in step with the struct tags above.
+var (
+	// env: is an open map -- its keys are user-defined environment variable
+	// names, so it is a known field here and is never itself key-checked.
+	processAllowedKeys = map[string]struct{}{
+		"cmd": {}, "env": {}, "env_file": {}, "healthcheck": {},
+		"stop_timeout": {}, "depends_on": {},
+	}
+	healthcheckAllowedKeys = map[string]struct{}{
+		"cmd": {}, "interval": {}, "timeout": {}, "retries": {}, "start_period": {},
+	}
+	serviceAllowedKeys = map[string]struct{}{"port": {}, "host": {}}
+)
 
 // HealthcheckConfig defines health check configuration in YAML
 type HealthcheckConfig struct {
@@ -253,41 +270,36 @@ func Parse(data []byte) (*Config, error) {
 		config.API.Host = constants.DefaultAPIHost
 	}
 
-	// Parse processes (can be string or expanded form)
-	for name, value := range raw.Processes {
-		proc, err := parseProcessConfig(name, value)
-		if err != nil {
-			return nil, fmt.Errorf("process %q: %w", name, err)
-		}
+	// Parse every block with STRICT unknown-key rejection (plan 013 D1, C1 for
+	// dependencies/tasks; plan 016 W1 for processes/services). These are
+	// structural errors (malformed shape / unknown keys): they must be reported
+	// before semantic Validate runs, because a half-formed entry cannot be
+	// meaningfully validated. Collected across all four blocks and sorted so the
+	// report is deterministic regardless of Go's map iteration order -- each
+	// parser also walks its own entries in sorted order.
+	//
+	// Accepted limitation: the strict parsers inspect the generic
+	// map[string]interface{} form, which yaml.v3 has already produced -- so a
+	// YAML alias key or a `<<` merge that resolves to a key already present is
+	// collapsed into one map entry BEFORE we see it, and a duplicate logical key
+	// can slip past duplicate detection here. Detecting that requires inspecting
+	// the yaml.Node tree.
+	var structuralErrs []string
+
+	// Processes (can be a command string or an expanded mapping)
+	for _, name := range sortedMapKeys(raw.Processes) {
+		proc, errs := parseProcessConfig(name, raw.Processes[name])
+		structuralErrs = append(structuralErrs, errs...)
 		config.Processes[name] = proc
 	}
 
-	// Parse services (can be int port or expanded form)
-	for name, value := range raw.Services {
-		svc, err := parseServiceConfig(name, value)
-		if err != nil {
-			return nil, fmt.Errorf("service %q: %w", name, err)
-		}
+	// Services (can be a port number or an expanded mapping)
+	for _, name := range sortedMapKeys(raw.Services) {
+		svc, errs := parseServiceConfig(name, raw.Services[name])
+		structuralErrs = append(structuralErrs, errs...)
 		config.Services[name] = svc
 	}
 
-	// Parse dependencies and tasks with STRICT unknown-key rejection (plan 013
-	// D1, C1). These are structural errors (malformed shape / unknown keys):
-	// they must be reported before semantic Validate runs, because a
-	// half-formed check block cannot be meaningfully validated. Collected across
-	// both blocks and sorted so the report is deterministic regardless of Go's
-	// map iteration order.
-	//
-	// Accepted limitation (plan 013 D1, C1): the strict parsers inspect the
-	// generic map[string]interface{} form, which yaml.v3 has already produced --
-	// so a YAML anchor/alias or a `<<` merge key that resolves to a key already
-	// present is collapsed into one map entry BEFORE we see it, and a duplicate
-	// logical key can slip past unknown-key/duplicate detection. Detecting that
-	// would require re-parsing at the yaml.Node level. We accept it: this is the
-	// same behavior the legacy processes:/services: re-marshal path has always
-	// had, prox config is local developer-authored input (not a security
-	// boundary), and the failure mode is a last-write-wins merge, not a crash.
-	var structuralErrs []string
 	structuralErrs = append(structuralErrs, parseDependencies(raw.Dependencies, config.Dependencies)...)
 	structuralErrs = append(structuralErrs, parseTasks(raw.Tasks, config.Tasks)...)
 	if len(structuralErrs) > 0 {
@@ -328,54 +340,73 @@ func Parse(data []byte) (*Config, error) {
 	return config, nil
 }
 
-// parseProcessConfig handles both simple and expanded process definitions
-func parseProcessConfig(name string, value interface{}) (ProcessConfig, error) {
+// parseProcessConfig handles both simple and expanded process definitions,
+// rejecting unknown keys in the expanded form (plan 016 W1). Like the
+// dependency/task parsers it returns structural error strings rather than a
+// fatal first error, so Parse can batch every structural problem in the config
+// into one sorted report. The entry is still populated best-effort when errors
+// are returned; Parse discards it by returning before Validate.
+func parseProcessConfig(name string, value interface{}) (ProcessConfig, []string) {
 	switch v := value.(type) {
 	case string:
 		// Simple form: web: npm run dev
 		return ProcessConfig{Cmd: v}, nil
 	case map[string]interface{}:
-		// Expanded form: re-marshal and unmarshal to struct
-		data, err := yaml.Marshal(v)
-		if err != nil {
-			return ProcessConfig{}, fmt.Errorf("marshaling process config: %w", err)
+		prefix := "processes." + name
+		errs := rejectUnknownKeys(prefix, v, processAllowedKeys)
+		// healthcheck: is the one nested schema block under a process, so it
+		// gets its own key check; a non-mapping value is named explicitly rather
+		// than left to the re-marshal path's opaque type error. An explicit null
+		// (a bare `healthcheck:` key, e.g. with all subfields commented out)
+		// means "absent", exactly as before strict parsing.
+		if hcRaw, ok := v["healthcheck"]; ok && hcRaw != nil {
+			if hcMap, ok := hcRaw.(map[string]interface{}); ok {
+				errs = append(errs, rejectUnknownKeys(prefix+".healthcheck", hcMap, healthcheckAllowedKeys)...)
+			} else {
+				// Return without re-marshalling: the round-trip would choke on
+				// the same bad value and add a second, opaque error for the
+				// one defect. Parse discards the config on structural errors.
+				errs = append(errs, fmt.Sprintf("%s.healthcheck: must be a mapping", prefix))
+				return ProcessConfig{}, errs
+			}
 		}
+		// Expanded form: re-marshal to coerce values into the typed struct.
+		// Unknown-key rejection has already happened above.
 		var proc ProcessConfig
-		if err := yaml.Unmarshal(data, &proc); err != nil {
-			return ProcessConfig{}, fmt.Errorf("unmarshaling process config: %w", err)
+		if err := remarshal(v, &proc); err != nil {
+			errs = append(errs, fmt.Sprintf("%s: %s", prefix, err))
 		}
-		return proc, nil
+		return proc, errs
 	default:
-		return ProcessConfig{}, fmt.Errorf("invalid process configuration type: %T", value)
+		return ProcessConfig{}, []string{fmt.Sprintf("processes.%s: must be a command string or a mapping", name)}
 	}
 }
 
-// parseServiceConfig handles both simple (port only) and expanded service definitions
-func parseServiceConfig(name string, value interface{}) (ServiceConfig, error) {
+// parseServiceConfig handles both simple (port only) and expanded service
+// definitions, rejecting unknown keys in the expanded form (plan 016 W1). Same
+// structural-error contract as parseProcessConfig.
+func parseServiceConfig(name string, value interface{}) (ServiceConfig, []string) {
 	switch v := value.(type) {
 	case int:
 		// Simple form: app: 3000
 		return ServiceConfig{Port: v, Host: "localhost"}, nil
 	case float64:
-		// YAML may parse integers as float64
+		// YAML may parse integers as float64 (e.g. `3000.0`)
 		return ServiceConfig{Port: int(v), Host: "localhost"}, nil
 	case map[string]interface{}:
-		// Expanded form: re-marshal and unmarshal to struct
-		data, err := yaml.Marshal(v)
-		if err != nil {
-			return ServiceConfig{}, fmt.Errorf("marshaling service config: %w", err)
-		}
+		prefix := "services." + name
+		errs := rejectUnknownKeys(prefix, v, serviceAllowedKeys)
 		var svc ServiceConfig
-		if err := yaml.Unmarshal(data, &svc); err != nil {
-			return ServiceConfig{}, fmt.Errorf("unmarshaling service config: %w", err)
+		if err := remarshal(v, &svc); err != nil {
+			errs = append(errs, fmt.Sprintf("%s: %s", prefix, err))
 		}
 		// Apply default host if not specified
 		if svc.Host == "" {
 			svc.Host = "localhost"
 		}
-		return svc, nil
+		return svc, errs
 	default:
-		return ServiceConfig{}, fmt.Errorf("invalid service configuration type: %T", value)
+		return ServiceConfig{}, []string{fmt.Sprintf("services.%s: must be a port number or a mapping", name)}
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -278,13 +278,25 @@ func Parse(data []byte) (*Config, error) {
 	// report is deterministic regardless of Go's map iteration order -- each
 	// parser also walks its own entries in sorted order.
 	//
-	// Accepted limitation: the strict parsers inspect the generic
-	// map[string]interface{} form, which yaml.v3 has already produced -- so a
-	// YAML alias key or a `<<` merge that resolves to a key already present is
-	// collapsed into one map entry BEFORE we see it, and a duplicate logical key
-	// can slip past duplicate detection here. Detecting that requires inspecting
-	// the yaml.Node tree.
+	// The strict parsers below inspect the generic map[string]interface{} form,
+	// which cannot show duplicate keys (yaml.v3 has already collapsed them) and
+	// covers only the name-keyed blocks. checkDocumentStructure closes both gaps
+	// from the yaml.Node tree (plan 016 W2), and it runs FIRST here purely for
+	// readability -- the batch is sorted before it is reported. Together the
+	// layers guarantee, for every key in prox.yaml:
+	//   - literal duplicate keys anywhere are rejected by the raw decode above,
+	//     with the offending line numbers, before any of this runs;
+	//   - an alias key that resolves onto a sibling key -- the case a generic map
+	//     silently collapses, last write winning -- is a `duplicate key` error;
+	//   - unknown keys in the fixed-schema blocks (top level, proxy,
+	//     proxy.capture, api, certs) are rejected, including keys smuggled in
+	//     through a `<<` merge, which is validated against the DESTINATION's
+	//     schema;
+	//   - spec-valid merges still parse: `<<: *base` with an explicit override
+	//     (explicit wins) and `<<: [*a, *b]` overlap (first wins) are legitimate
+	//     YAML, never duplicates.
 	var structuralErrs []string
+	structuralErrs = append(structuralErrs, checkDocumentStructure(data)...)
 
 	// Processes (can be a command string or an expanded mapping)
 	for _, name := range sortedMapKeys(raw.Processes) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -714,6 +714,201 @@ services:
 	})
 }
 
+// --- Strict processes: / services: parsing (plan 016 W1) -------------------
+
+// TestParse_NullHealthcheckMeansAbsent pins that a bare `healthcheck:` key
+// (explicit YAML null, e.g. every subfield commented out) still parses as "no
+// healthcheck" rather than tripping the strict must-be-a-mapping error.
+func TestParse_NullHealthcheckMeansAbsent(t *testing.T) {
+	cfg, err := Parse([]byte("processes:\n  web:\n    cmd: ./web\n    healthcheck:\n"))
+	require.NoError(t, err)
+	assert.Nil(t, cfg.Processes["web"].Healthcheck)
+}
+
+func TestParse_Processes_Errors(t *testing.T) {
+	cases := []struct {
+		name      string
+		yaml      string
+		wantSub   string
+		wantExact string
+	}{
+		{
+			name: "typo'd process field",
+			yaml: `
+processes:
+  web:
+    cmd: ./web
+    stop_timout: 5s
+`,
+			wantSub: `processes.web: unknown field "stop_timout"`,
+		},
+		{
+			name: "unknown healthcheck subfield",
+			yaml: `
+processes:
+  web:
+    cmd: ./web
+    healthcheck:
+      cmd: ./check
+      intervall: 10s
+`,
+			wantSub: `processes.web.healthcheck: unknown field "intervall"`,
+		},
+		{
+			name: "healthcheck is not a mapping",
+			yaml: `
+processes:
+  web:
+    cmd: ./web
+    healthcheck: ./check
+`,
+			// Exact match: the shape defect must yield exactly this one error,
+			// not a second opaque re-marshal error for the same value.
+			wantExact: `invalid configuration: processes.web.healthcheck: must be a mapping`,
+		},
+		{
+			name: "process entry is a list",
+			yaml: `
+processes:
+  web:
+    - ./web
+`,
+			wantSub: "processes.web: must be a command string or a mapping",
+		},
+		{
+			name: "process entry has a non-string key",
+			yaml: `
+processes:
+  web:
+    cmd: ./web
+    3: oops
+`,
+			wantSub: "processes.web: must be a command string or a mapping",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Parse([]byte(tc.yaml))
+			require.Error(t, err)
+			if tc.wantExact != "" {
+				assert.Equal(t, tc.wantExact, err.Error())
+			} else {
+				assert.Contains(t, err.Error(), tc.wantSub)
+			}
+		})
+	}
+}
+
+func TestParse_Services_Errors(t *testing.T) {
+	cases := []struct {
+		name    string
+		yaml    string
+		wantSub string
+	}{
+		{
+			name: "typo'd service field",
+			yaml: `
+processes: {web: ./web}
+proxy: {enabled: true, domain: local.test.dev}
+services:
+  app:
+    prot: 3000
+`,
+			wantSub: `services.app: unknown field "prot"`,
+		},
+		{
+			name: "service entry is a list",
+			yaml: `
+processes: {web: ./web}
+proxy: {enabled: true, domain: local.test.dev}
+services:
+  app:
+    - 3000
+`,
+			wantSub: "services.app: must be a port number or a mapping",
+		},
+		{
+			name: "service entry is a string",
+			yaml: `
+processes: {web: ./web}
+proxy: {enabled: true, domain: local.test.dev}
+services:
+  app: "3000"
+`,
+			wantSub: "services.app: must be a port number or a mapping",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Parse([]byte(tc.yaml))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantSub)
+		})
+	}
+}
+
+// TestParse_StructuralErrors_BatchedDeterministically pins that unknown keys
+// from every strict block (processes, services, dependencies, tasks) are
+// reported TOGETHER, once each, in sorted order under ErrInvalidConfig -- not
+// one fatal first error per block.
+func TestParse_StructuralErrors_BatchedDeterministically(t *testing.T) {
+	yaml := `
+processes:
+  web:
+    cmd: ./web
+    stop_timout: 5s
+proxy: {enabled: true, domain: local.test.dev}
+services:
+  app:
+    port: 3000
+    prot: 8080
+dependencies:
+  redis:
+    check:
+      tcp: localhost:6379
+    on_failur: warn
+tasks:
+  build:
+    cmd: ./build
+    timeut: 5s
+`
+	_, err := Parse([]byte(yaml))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, domain.ErrInvalidConfig)
+	assert.Equal(t,
+		`invalid configuration: dependencies.redis: unknown field "on_failur"; `+
+			`processes.web: unknown field "stop_timout"; `+
+			`services.app: unknown field "prot"; tasks.build: unknown field "timeut"`,
+		err.Error())
+
+	_, err2 := Parse([]byte(yaml))
+	require.Error(t, err2)
+	assert.Equal(t, err.Error(), err2.Error(), "error string must not depend on map iteration order")
+}
+
+// TestParse_ServiceShorthand_Float64Port covers the float64 branch of
+// parseServiceConfig for real: `3000.0` decodes to float64, unlike the plain
+// `3000` case (which yaml.v3 decodes as int) exercised in TestParse_ProxyConfig.
+func TestParse_ServiceShorthand_Float64Port(t *testing.T) {
+	yaml := `
+processes:
+  web: npm run dev
+
+proxy:
+  enabled: true
+  domain: local.test.dev
+
+services:
+  app: 3000.0
+`
+	cfg, err := Parse([]byte(yaml))
+	require.NoError(t, err)
+	assert.Equal(t, 3000, cfg.Services["app"].Port)
+	assert.Equal(t, "localhost", cfg.Services["app"].Host)
+}
+
 func TestParseSize(t *testing.T) {
 	t.Run("empty string returns zero", func(t *testing.T) {
 		size, err := ParseSize("")

--- a/internal/config/strictyaml.go
+++ b/internal/config/strictyaml.go
@@ -1,0 +1,344 @@
+package config
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Allowed key sets for the typed top-level blocks (plan 016 W2). These mirror
+// the struct tags on Config/rawProxyConfig/rawCaptureConfig/APIConfig/
+// CertsConfig, which decode leniently (unknown keys are silently dropped), so
+// each set must stay in step with its struct. The per-entry sets for
+// processes:/services:/dependencies:/tasks: live with their parsers
+// (config.go, dependency.go) -- those blocks are keyed by user-chosen NAMES
+// and are never key-checked by this pass.
+var (
+	topLevelAllowedKeys = map[string]struct{}{
+		"api": {}, "env_file": {}, "processes": {}, "proxy": {}, "services": {},
+		"certs": {}, "dependencies": {}, "tasks": {}, "shutdown_timeout": {},
+	}
+	proxyAllowedKeys = map[string]struct{}{
+		"enabled": {}, "http_port": {}, "https_port": {}, "domain": {}, "capture": {},
+	}
+	captureAllowedKeys = map[string]struct{}{
+		"enabled": {}, "max_body_size": {}, "disk_budget": {},
+	}
+	apiAllowedKeys   = map[string]struct{}{"port": {}, "host": {}, "auth": {}}
+	certsAllowedKeys = map[string]struct{}{"dir": {}, "auto_generate": {}}
+
+	// schemaAllowedKeys is the complete list of document paths that carry a
+	// FIXED schema, keyed by dotted path ("" is the top level). The walk
+	// descends through the whole document to find aliased duplicate keys, but
+	// key-checks only at these five paths: everything else is either
+	// user-named (processes.<name>, services.<name>, env vars) or owned by
+	// another strict parser (dependencies/tasks, and the process/service
+	// entries themselves).
+	schemaAllowedKeys = map[string]map[string]struct{}{
+		"":              topLevelAllowedKeys,
+		"proxy":         proxyAllowedKeys,
+		"proxy.capture": captureAllowedKeys,
+		"api":           apiAllowedKeys,
+		"certs":         certsAllowedKeys,
+	}
+)
+
+// maxAliasHops bounds alias-chain dereferencing. yaml.v3 resolves an alias to
+// its anchor node in one hop, so this is pure belt-and-braces against a
+// malformed node graph -- the real cycle protection is structuralWalker.active.
+const maxAliasHops = 100
+
+// checkDocumentStructure walks the yaml.Node tree of an already-decoded config
+// and reports the structural defects the generic map form cannot show (plan 016
+// W2). It runs only AFTER the raw decode in Parse has succeeded (the W0
+// ordering contract), so everything it can reach is YAML that yaml.v3 itself
+// accepted. Two jobs:
+//
+//  1. Aliased duplicate keys, ANYWHERE in the document: a key node that is an
+//     alias resolves to its anchor's scalar value, and a generic map silently
+//     collapses it onto an existing sibling (last write wins). Reported as
+//     `<path>: duplicate key %q`. Literal duplicates never reach here -- the
+//     raw decode already rejected them with a line number.
+//  2. Unknown keys in the five fixed-schema blocks (see schemaAllowedKeys),
+//     reported as `<path>: unknown field %q` in dependency.go's exact format.
+//     Keys are checked wherever they take effect, so a `<<` merge is expanded
+//     (see walkMapping) and cannot be used to smuggle a typo -- or a whole
+//     typo'd sub-block -- past its destination's schema.
+//
+// Errors come back as strings for Parse to batch and sort with the rest of the
+// structural errors. A yaml.Node decode failure returns no errors rather than a
+// second opinion on YAML syntax: the raw decode owns that error (W0).
+func checkDocumentStructure(data []byte) []string {
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil
+	}
+	root := &doc
+	if root.Kind == yaml.DocumentNode {
+		if len(root.Content) == 0 {
+			return nil
+		}
+		root = root.Content[0]
+	}
+	// An empty document (or a comment-only one) decodes to the zero Node.
+	if root.Kind == 0 {
+		return nil
+	}
+	w := &structuralWalker{
+		active:     make(map[*yaml.Node]bool),
+		merging:    make(map[*yaml.Node]bool),
+		dupChecked: make(map[*yaml.Node]bool),
+	}
+	w.walkValue(root, "")
+	return w.errs
+}
+
+// structuralWalker carries the state of one checkDocumentStructure pass.
+//
+// active is the set of container nodes currently on the walk stack, which is
+// what makes a cyclic alias (`proxy: &x {capture: *x}` -- accepted by the raw
+// decode when it lands in a typed block) terminate instead of hang. merging is
+// the same guard for merge expansion.
+//
+// dupChecked records the mapping nodes whose own keys have already been scanned
+// for duplicates, so one defect is reported once even when the mapping is
+// reachable from several places: an anchored mapping is walked at its natural
+// position AND wherever it is aliased or merged in. It gates duplicate
+// reporting only -- schema checks are per-path and must run at every
+// destination.
+type structuralWalker struct {
+	errs       []string
+	active     map[*yaml.Node]bool
+	merging    map[*yaml.Node]bool
+	dupChecked map[*yaml.Node]bool
+}
+
+// keyIdent is the identity of a mapping key for duplicate detection: the
+// resolved tag AND value. Tag-blind comparison would be wrong -- `"1"` (!!str)
+// and an alias resolving to `1` (!!int) are DISTINCT keys per the YAML spec,
+// and flagging them would break valid config.
+type keyIdent struct {
+	tag   string
+	value string
+}
+
+func (w *structuralWalker) errf(format string, args ...interface{}) {
+	w.errs = append(w.errs, fmt.Sprintf(format, args...))
+}
+
+// walkValue descends into one value node at the given path, dereferencing a
+// whole-block alias (`proxy: *shared`) first so the target is checked against
+// the path it was aliased INTO. Scalars are leaves. The active-set guard is the
+// single cycle break for the whole walk.
+func (w *structuralWalker) walkValue(node *yaml.Node, path string) {
+	target, ok := derefAlias(node)
+	if !ok || (target.Kind != yaml.MappingNode && target.Kind != yaml.SequenceNode) {
+		return
+	}
+	if w.active[target] {
+		return
+	}
+	w.active[target] = true
+	defer delete(w.active, target)
+
+	if target.Kind == yaml.SequenceNode {
+		// Nothing in the schema is a sequence of mappings, but the walk still
+		// descends for job 1. Indexing the path keeps duplicate-key errors
+		// unambiguous and can never collide with a schema path.
+		for i, item := range target.Content {
+			w.walkValue(item, fmt.Sprintf("%s[%d]", path, i))
+		}
+		return
+	}
+	w.walkMapping(target, path)
+}
+
+// walkMapping runs both jobs on one mapping node (Content alternates key,
+// value) in two passes, because YAML merge precedence runs that way: a mapping's
+// OWN keys always win over anything a `<<` brings in.
+//
+// Pass 1 takes the explicit keys -- duplicate detection, schema check, descend.
+// Pass 2 expands each merge in order and treats the keys that actually TAKE
+// EFFECT (not shadowed by an explicit key or an earlier merge source) exactly
+// like explicit keys of this mapping: same schema check, same descent at the
+// destination's child path. That is what stops a typo from hiding behind a
+// merge, at any depth -- a merged-in `proxy:` block is validated as `proxy`.
+func (w *structuralWalker) walkMapping(node *yaml.Node, path string) {
+	allowed, schema := schemaAllowedKeys[path]
+	claimed := make(map[keyIdent]struct{}, len(node.Content)/2)
+	reportDupes := !w.dupChecked[node]
+	w.dupChecked[node] = true
+
+	var merges []*yaml.Node
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		keyNode, valueNode := node.Content[i], node.Content[i+1]
+
+		// A real merge key: yaml.v3 tags it !!merge, whereas a quoted "<<" is
+		// an ordinary string key and falls through to the checks below. The
+		// token itself is never an unknown field. Deferred to pass 2.
+		if isMergeKey(keyNode) {
+			merges = append(merges, valueNode)
+			continue
+		}
+
+		ident, ok := resolveKeyIdent(keyNode)
+		if !ok {
+			// A non-scalar key (e.g. an alias to a mapping) -- yaml.v3 rejects
+			// those at the raw decode, so this is unreachable defensive code.
+			continue
+		}
+		if _, dup := claimed[ident]; dup {
+			// Only reachable when one of the two keys is an alias: literal
+			// duplicates errored at the raw decode (W0). The schema check is
+			// skipped here because the first occurrence already made it -- one
+			// report per distinct defect.
+			if reportDupes {
+				w.errf("%s: duplicate key %q", pathLabel(path), ident.value)
+			}
+			w.walkValue(valueNode, childPath(path, ident.value))
+			continue
+		}
+		claimed[ident] = struct{}{}
+		w.checkKey(ident, path, allowed, schema)
+		w.walkValue(valueNode, childPath(path, ident.value))
+	}
+
+	for _, mergeValue := range merges {
+		w.expandMerge(mergeValue, path, claimed, allowed, schema)
+	}
+}
+
+// expandMerge applies one merge value to the destination mapping at path. The
+// value may be a mapping, an alias to one, or a sequence of either (a
+// multi-source merge, where the FIRST source wins); nested merges inside a
+// merged mapping expand too, after that mapping's own keys.
+//
+// claimed carries the destination's precedence state and is updated as sources
+// are consumed, so overlap with an explicit key or an earlier source is
+// silently skipped -- that overlap is the spec-defined defaults idiom, never a
+// duplicate. Duplicates WITHIN one source mapping are a different matter and
+// are reported (at the destination path, where the collapse is felt), since a
+// merge source is otherwise never scanned for aliased duplicate keys.
+func (w *structuralWalker) expandMerge(node *yaml.Node, path string, claimed map[keyIdent]struct{}, allowed map[string]struct{}, schema bool) {
+	target, ok := derefAlias(node)
+	if !ok || w.merging[target] {
+		return
+	}
+	w.merging[target] = true
+	defer delete(w.merging, target)
+
+	if target.Kind == yaml.SequenceNode {
+		for _, item := range target.Content {
+			w.expandMerge(item, path, claimed, allowed, schema)
+		}
+		return
+	}
+	if target.Kind != yaml.MappingNode {
+		return
+	}
+
+	reportDupes := !w.dupChecked[target]
+	w.dupChecked[target] = true
+	sourceSeen := make(map[keyIdent]struct{}, len(target.Content)/2)
+	var nested []*yaml.Node
+	for i := 0; i+1 < len(target.Content); i += 2 {
+		keyNode, valueNode := target.Content[i], target.Content[i+1]
+		if isMergeKey(keyNode) {
+			nested = append(nested, valueNode)
+			continue
+		}
+		ident, ok := resolveKeyIdent(keyNode)
+		if !ok {
+			continue
+		}
+		if _, dup := sourceSeen[ident]; dup {
+			if reportDupes {
+				w.errf("%s: duplicate key %q", pathLabel(path), ident.value)
+			}
+			continue
+		}
+		sourceSeen[ident] = struct{}{}
+		if _, taken := claimed[ident]; taken {
+			// Shadowed by an explicit key or an earlier merge source: it does
+			// not take effect here, so it is neither checked nor descended into
+			// at this path. (It is still checked wherever it DOES take effect.)
+			continue
+		}
+		claimed[ident] = struct{}{}
+		w.checkKey(ident, path, allowed, schema)
+		w.walkValue(valueNode, childPath(path, ident.value))
+	}
+	for _, nestedValue := range nested {
+		w.expandMerge(nestedValue, path, claimed, allowed, schema)
+	}
+}
+
+// checkKey reports a key that is not in the destination's allowed set, for the
+// five fixed-schema paths only.
+func (w *structuralWalker) checkKey(ident keyIdent, path string, allowed map[string]struct{}, schema bool) {
+	if !schema {
+		return
+	}
+	if _, ok := allowed[ident.value]; !ok {
+		w.errf("%s: unknown field %q", pathLabel(path), ident.value)
+	}
+}
+
+// isMergeKey reports whether a key node is a YAML merge key by yaml.v3's own
+// rule: the resolved !!merge tag on a plain `<<` scalar. A quoted "<<" resolves
+// to !!str and is therefore an ordinary (and, in a typed block, unknown) field.
+func isMergeKey(node *yaml.Node) bool {
+	return node != nil && node.Kind == yaml.ScalarNode && node.Tag == "!!merge" && node.Value == "<<"
+}
+
+// resolveKeyIdent returns the identity of a mapping key, dereferencing an alias
+// key node to its anchor's scalar node. ok is false for a key that does not
+// resolve to a scalar. Identity uses yaml.v3's own resolver (Decode) so
+// equivalent spellings of one value -- `01`, `0x1`, and `1` as ints, `yes` and
+// `true` as bools -- share an identity, while `"1"` (!!str) and `1` (!!int)
+// stay distinct via the decoded Go type.
+func resolveKeyIdent(node *yaml.Node) (keyIdent, bool) {
+	target, ok := derefAlias(node)
+	if !ok || target.Kind != yaml.ScalarNode {
+		return keyIdent{}, false
+	}
+	var v interface{}
+	if err := target.Decode(&v); err != nil {
+		// Undecodable scalar: fall back to the raw spelling.
+		return keyIdent{tag: target.Tag, value: target.Value}, true
+	}
+	return keyIdent{tag: fmt.Sprintf("%T", v), value: fmt.Sprintf("%v", v)}, true
+}
+
+// derefAlias follows an alias node to the node it points at, bounded by
+// maxAliasHops. ok is false for a nil node or a dangling alias.
+func derefAlias(node *yaml.Node) (*yaml.Node, bool) {
+	for hops := 0; node != nil && node.Kind == yaml.AliasNode; hops++ {
+		if node.Alias == nil || hops >= maxAliasHops {
+			return nil, false
+		}
+		node = node.Alias
+	}
+	if node == nil {
+		return nil, false
+	}
+	return node, true
+}
+
+// pathLabel renders a document path for an error message. The top level has no
+// path of its own and is named `config`, matching the dotted style the nested
+// paths (and dependency.go's messages) use.
+func pathLabel(path string) string {
+	if path == "" {
+		return "config"
+	}
+	return path
+}
+
+// childPath extends a document path with one key.
+func childPath(path, key string) string {
+	if path == "" {
+		return key
+	}
+	return path + "." + key
+}

--- a/internal/config/strictyaml.go
+++ b/internal/config/strictyaml.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"fmt"
 
 	"gopkg.in/yaml.v3"
@@ -57,8 +58,10 @@ const maxAliasHops = 100
 //  1. Aliased duplicate keys, ANYWHERE in the document: a key node that is an
 //     alias resolves to its anchor's scalar value, and a generic map silently
 //     collapses it onto an existing sibling (last write wins). Reported as
-//     `<path>: duplicate key %q`. Literal duplicates never reach here -- the
-//     raw decode already rejected them with a line number.
+//     `<path>: duplicate key %q`. Literal duplicates in decoded regions are
+//     rejected earlier by the raw decode (with a line number); inside regions
+//     the raw decode skips -- the value of an unknown field -- this pass is
+//     the layer that catches them.
 //  2. Unknown keys in the five fixed-schema blocks (see schemaAllowedKeys),
 //     reported as `<path>: unknown field %q` in dependency.go's exact format.
 //     Keys are checked wherever they take effect, so a `<<` merge is expanded
@@ -69,25 +72,33 @@ const maxAliasHops = 100
 // structural errors. A yaml.Node decode failure returns no errors rather than a
 // second opinion on YAML syntax: the raw decode owns that error (W0).
 func checkDocumentStructure(data []byte) []string {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
 	var doc yaml.Node
-	if err := yaml.Unmarshal(data, &doc); err != nil {
-		return nil
-	}
-	root := &doc
-	if root.Kind == yaml.DocumentNode {
-		if len(root.Content) == 0 {
-			return nil
-		}
-		root = root.Content[0]
-	}
-	// An empty document (or a comment-only one) decodes to the zero Node.
-	if root.Kind == 0 {
+	if err := dec.Decode(&doc); err != nil {
 		return nil
 	}
 	w := &structuralWalker{
 		active:     make(map[*yaml.Node]bool),
 		merging:    make(map[*yaml.Node]bool),
 		dupChecked: make(map[*yaml.Node]bool),
+	}
+	// A prox.yaml is one YAML document. The raw decode reads only the first,
+	// so a stray `---` would otherwise silently disable everything below it --
+	// the exact silent-ignore class this pass exists to close.
+	var extra yaml.Node
+	if err := dec.Decode(&extra); err == nil {
+		w.errs = append(w.errs, "config: multiple YAML documents are not supported")
+	}
+	root := &doc
+	if root.Kind == yaml.DocumentNode {
+		if len(root.Content) == 0 {
+			return w.errs
+		}
+		root = root.Content[0]
+	}
+	// An empty document (or a comment-only one) decodes to the zero Node.
+	if root.Kind == 0 {
+		return w.errs
 	}
 	w.walkValue(root, "")
 	return w.errs
@@ -111,6 +122,29 @@ type structuralWalker struct {
 	active     map[*yaml.Node]bool
 	merging    map[*yaml.Node]bool
 	dupChecked map[*yaml.Node]bool
+	// visits counts every walkValue/expandMerge entry. The active/merging sets
+	// break true cycles, but an alias DAG (each level aliasing the previous
+	// twice) is walked once per reference -- 2^N visits -- and yaml.v3's own
+	// alias-expansion guard never sees it when the fan-out hides under an
+	// unknown key (the struct decoder skips unknown fields entirely). Past the
+	// budget the walk stops with a single error instead of spinning; real
+	// configs are a few thousand nodes at most.
+	visits int
+}
+
+// maxWalkVisits bounds the structural walk. Generous: ~three orders of
+// magnitude above any real prox.yaml, small enough that a pathological alias
+// DAG errors in milliseconds instead of hanging `prox up` or a daemon reload.
+const maxWalkVisits = 1 << 20
+
+// spendVisit consumes one unit of walk budget; the first exhaustion appends
+// the diagnostic. Callers return immediately on false.
+func (w *structuralWalker) spendVisit() bool {
+	w.visits++
+	if w.visits == maxWalkVisits {
+		w.errs = append(w.errs, "config: excessive YAML aliasing")
+	}
+	return w.visits < maxWalkVisits
 }
 
 // keyIdent is the identity of a mapping key for duplicate detection: the
@@ -134,6 +168,9 @@ func (w *structuralWalker) errf(format string, args ...interface{}) {
 // alias. That is never a meaningful config (and its contents could not be
 // schema-checked), so it is an error rather than a silent skip.
 func (w *structuralWalker) walkValue(node *yaml.Node, path string) {
+	if !w.spendVisit() {
+		return
+	}
 	target, ok := derefAlias(node)
 	if !ok || (target.Kind != yaml.MappingNode && target.Kind != yaml.SequenceNode) {
 		return
@@ -192,8 +229,11 @@ func (w *structuralWalker) walkMapping(node *yaml.Node, path string) {
 			continue
 		}
 		if _, dup := claimed[ident]; dup {
-			// Only reachable when one of the two keys is an alias: literal
-			// duplicates errored at the raw decode (W0). The schema check is
+			// Reached for alias-key duplicates anywhere, AND for literal
+			// duplicates inside regions the raw decode skipped (the struct
+			// decoder never unmarshals an unknown field's value, so W0's
+			// duplicate check does not run there) -- this branch is what
+			// keeps those from silently collapsing. The schema check is
 			// skipped here because the first occurrence already made it -- one
 			// report per distinct defect.
 			if reportDupes {
@@ -224,6 +264,9 @@ func (w *structuralWalker) walkMapping(node *yaml.Node, path string) {
 // are reported (at the destination path, where the collapse is felt), since a
 // merge source is otherwise never scanned for aliased duplicate keys.
 func (w *structuralWalker) expandMerge(node *yaml.Node, path string, claimed map[keyIdent]struct{}, allowed map[string]struct{}, schema bool) {
+	if !w.spendVisit() {
+		return
+	}
 	target, ok := derefAlias(node)
 	if !ok || w.merging[target] {
 		return

--- a/internal/config/strictyaml.go
+++ b/internal/config/strictyaml.go
@@ -129,13 +129,17 @@ func (w *structuralWalker) errf(format string, args ...interface{}) {
 // walkValue descends into one value node at the given path, dereferencing a
 // whole-block alias (`proxy: *shared`) first so the target is checked against
 // the path it was aliased INTO. Scalars are leaves. The active-set guard is the
-// single cycle break for the whole walk.
+// single cycle break for the whole walk: `active` holds only the current
+// descent stack, so hitting a member is a true back-edge — a self-referential
+// alias. That is never a meaningful config (and its contents could not be
+// schema-checked), so it is an error rather than a silent skip.
 func (w *structuralWalker) walkValue(node *yaml.Node, path string) {
 	target, ok := derefAlias(node)
 	if !ok || (target.Kind != yaml.MappingNode && target.Kind != yaml.SequenceNode) {
 		return
 	}
 	if w.active[target] {
+		w.errf("%s: circular alias", path)
 		return
 	}
 	w.active[target] = true

--- a/internal/config/strictyaml_test.go
+++ b/internal/config/strictyaml_test.go
@@ -1,7 +1,10 @@
 package config
 
 import (
+	"fmt"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/charliek/prox/internal/domain"
 	"github.com/stretchr/testify/assert"
@@ -372,4 +375,46 @@ func TestParse_CyclicAlias_Rejected(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), `proxy.capture: circular alias`)
 	})
+}
+
+// TestParse_AliasFanOut_BudgetedNotHung pins the walk's visit budget: an alias
+// DAG that doubles per level (2^N visits under the pre-budget walk) hides
+// under an unknown key, so yaml.v3's own alias-expansion guard never sees it
+// (the struct decoder skips unknown fields). The walk must error quickly, not
+// spin. Depth 40 would be ~2^18x the measured 2.4s at depth 22 without the
+// budget -- an effective hang on `prox up` and the daemon reload path.
+func TestParse_AliasFanOut_BudgetedNotHung(t *testing.T) {
+	var b strings.Builder
+	b.WriteString("processes: {web: ./web}\n")
+	b.WriteString("z0: &a0 [1, 2]\n")
+	depth := 40
+	for i := 1; i <= depth; i++ {
+		fmt.Fprintf(&b, "z%d: &a%d [*a%d, *a%d]\n", i, i, i-1, i-1)
+	}
+	start := time.Now()
+	_, err := Parse([]byte(b.String()))
+	elapsed := time.Since(start)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "config: excessive YAML aliasing")
+	assert.Less(t, elapsed, 5*time.Second, "budget must stop the walk quickly")
+}
+
+// TestParse_MultipleDocuments_Rejected pins that a stray `---` starting a
+// second YAML document is an error rather than silently disabling everything
+// below it (both decode layers read only the first document).
+func TestParse_MultipleDocuments_Rejected(t *testing.T) {
+	_, err := Parse([]byte("processes: {web: ./web}\n---\nporxy: {enabled: true}\n"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "config: multiple YAML documents are not supported")
+}
+
+// TestParse_LiteralDupeUnderUnknownKey pins the walker's ownership of literal
+// duplicates inside regions the raw decode skips: the struct decoder never
+// unmarshals an unknown field's value, so W0's duplicate check does not run
+// there and the structural walk is what stops the silent collapse.
+func TestParse_LiteralDupeUnderUnknownKey(t *testing.T) {
+	_, err := Parse([]byte("processes: {web: ./web}\nnope: {a: 1, a: 2}\n"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `config: unknown field "nope"`)
+	assert.Contains(t, err.Error(), `nope: duplicate key "a"`)
 }

--- a/internal/config/strictyaml_test.go
+++ b/internal/config/strictyaml_test.go
@@ -350,11 +350,13 @@ api: {port: 9000}
 	})
 }
 
-// TestParse_CyclicAlias_Terminates pins that a self-referential anchor -- which
-// the raw decode accepts when it lands in a typed or ignored block -- cannot
-// hang or panic the structural walk. The exact outcome is pinned rather than
-// designed: the walk's active-node guard simply stops descending at the cycle.
-func TestParse_CyclicAlias_Terminates(t *testing.T) {
+// TestParse_CyclicAlias_Rejected pins that a self-referential anchor -- which
+// the raw decode accepts when it lands in a typed or ignored block -- is
+// rejected by the structural walk. The active set holds only the current
+// descent stack, so hitting a member is a true back-edge; such an alias is
+// never a meaningful config and its contents could not be schema-checked, so
+// reporting it beats silently skipping it (and trivially cannot hang).
+func TestParse_CyclicAlias_Rejected(t *testing.T) {
 	t.Run("cycle under an unknown top-level key", func(t *testing.T) {
 		_, err := Parse([]byte("processes: {web: ./web}\nnope: &x\n  b: *x\n"))
 		require.Error(t, err)
@@ -365,13 +367,9 @@ func TestParse_CyclicAlias_Terminates(t *testing.T) {
 		// proxy: &x { capture: *x } -- capture resolves back to the proxy
 		// mapping itself. yaml.v3 rejects a self-referential anchor when it
 		// decodes into a generic map ("anchor 'x' value contains itself"), but
-		// not when it lands in a typed block like this one, so the walk is what
-		// has to terminate. Pinned outcome: the active-node guard stops at the
-		// cycle, which also means the keys inside it are not schema-checked --
-		// termination is worth more than a check on a self-referential block.
-		cfg, err := Parse([]byte("processes: {web: ./web}\nproxy: &x\n  enabled: true\n  domain: local.test.dev\n  capture: *x\n"))
-		require.NoError(t, err)
-		require.NotNil(t, cfg.Proxy)
-		assert.True(t, cfg.Proxy.Enabled)
+		// not when it lands in a typed block like this one, so the walk owns it.
+		_, err := Parse([]byte("processes: {web: ./web}\nproxy: &x\n  enabled: true\n  domain: local.test.dev\n  capture: *x\n"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `proxy.capture: circular alias`)
 	})
 }

--- a/internal/config/strictyaml_test.go
+++ b/internal/config/strictyaml_test.go
@@ -1,0 +1,377 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/charliek/prox/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- yaml.Node structural pass (plan 016 W2) -------------------------------
+
+// TestParse_StructuralWalk_Errors covers the two jobs of the yaml.Node pass:
+// unknown keys in the five fixed-schema blocks (including keys smuggled in via
+// a `<<` merge) and aliased duplicate keys anywhere in the document.
+func TestParse_StructuralWalk_Errors(t *testing.T) {
+	cases := []struct {
+		name    string
+		yaml    string
+		wantSub string
+	}{
+		{
+			name: "top-level typo",
+			yaml: `
+processes: {web: ./web}
+porxy:
+  enabled: true
+`,
+			wantSub: `config: unknown field "porxy"`,
+		},
+		{
+			// The #80 upgrade case: capture redaction was removed, so a config
+			// still carrying `redact: true` (or redact_headers/redact_bodies)
+			// must now fail at load naming the stale key, not silently ignore it.
+			name: "stale redact key under proxy.capture",
+			yaml: `
+processes: {web: ./web}
+proxy:
+  enabled: true
+  domain: local.test.dev
+  capture:
+    enabled: true
+    redact: true
+`,
+			wantSub: `proxy.capture: unknown field "redact"`,
+		},
+		{
+			name: "proxy typo",
+			yaml: `
+processes: {web: ./web}
+proxy:
+  enabled: true
+  domain: local.test.dev
+  htp_port: 8080
+`,
+			wantSub: `proxy: unknown field "htp_port"`,
+		},
+		{
+			name: "api typo",
+			yaml: `
+processes: {web: ./web}
+api:
+  prot: 9000
+`,
+			wantSub: `api: unknown field "prot"`,
+		},
+		{
+			name: "certs typo",
+			yaml: `
+processes: {web: ./web}
+certs:
+  dirr: ./certs
+`,
+			wantSub: `certs: unknown field "dirr"`,
+		},
+		{
+			// A merge cannot be used to smuggle a key past the destination's
+			// schema: the merged-in keys are checked against proxy's own set.
+			name: "unknown field merged into proxy via an alias",
+			yaml: `
+processes: {web: ./web}
+api: &shared
+  port: 9000
+proxy:
+  <<: *shared
+  enabled: true
+  domain: local.test.dev
+`,
+			wantSub: `proxy: unknown field "port"`,
+		},
+		{
+			// A merge does not just import scalars: a whole schema BLOCK
+			// arriving through a top-level merge is validated at its
+			// destination path like any other proxy: block.
+			name: "nested schema block smuggled in via a top-level merge",
+			yaml: `
+processes: {web: ./web}
+<<: {proxy: {enabled: true, domain: local.test.dev, htp_port: 8080}}
+`,
+			wantSub: `proxy: unknown field "htp_port"`,
+		},
+		{
+			name: "capture block smuggled in via a proxy merge",
+			yaml: `
+processes: {web: ./web}
+proxy:
+  enabled: true
+  domain: local.test.dev
+  <<: {capture: {enabled: true, redact: true}}
+`,
+			wantSub: `proxy.capture: unknown field "redact"`,
+		},
+		{
+			// The merge source is a mapping in its own right, so its OWN
+			// aliased duplicate key is reported -- at the destination path,
+			// where the silent collapse is felt.
+			name: "alias-key duplicate inside a merge source",
+			yaml: `
+processes:
+  web:
+    <<: {cmd: &k cmd, *k : ./other}
+`,
+			wantSub: `processes.web: duplicate key "cmd"`,
+		},
+		{
+			// A QUOTED "<<" is an ordinary string key, not a merge token.
+			name: "quoted << key under proxy",
+			yaml: `
+processes: {web: ./web}
+proxy:
+  enabled: true
+  domain: local.test.dev
+  "<<": 1
+`,
+			wantSub: `proxy: unknown field "<<"`,
+		},
+		{
+			// The core gap: the generic map form collapses the aliased key onto
+			// the literal one (last write wins) with no complaint from yaml.v3.
+			name: "alias-key duplicate inside a process entry",
+			yaml: `
+processes:
+  web:
+    cmd: ./web
+    env_file: &k cmd
+    *k : ./other
+`,
+			wantSub: `processes.web: duplicate key "cmd"`,
+		},
+		{
+			name: "alias-key duplicate at the top level",
+			yaml: `
+processes: {web: ./web}
+env_file: &k porxy
+porxy: 1
+*k : 2
+`,
+			wantSub: `config: duplicate key "porxy"`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Parse([]byte(tc.yaml))
+			require.Error(t, err)
+			assert.ErrorIs(t, err, domain.ErrInvalidConfig)
+			assert.Contains(t, err.Error(), tc.wantSub)
+		})
+	}
+}
+
+// TestParse_MergesAndAliases_Valid is the regression guard for spec-valid YAML:
+// none of these are duplicates or unknown fields, and all of them must still
+// parse exactly as YAML defines them.
+func TestParse_MergesAndAliases_Valid(t *testing.T) {
+	t.Run("merge with an explicit override under a process", func(t *testing.T) {
+		cfg, err := Parse([]byte(`
+processes:
+  base: &base
+    cmd: ./base
+    stop_timeout: 30s
+  web:
+    <<: *base
+    cmd: ./web
+`))
+		require.NoError(t, err)
+		assert.Equal(t, "./web", cfg.Processes["web"].Cmd, "explicit key wins over the merge")
+		assert.Equal(t, "30s", cfg.Processes["web"].StopTimeout, "merged key survives")
+	})
+
+	t.Run("merge into proxy with only allowed keys", func(t *testing.T) {
+		cfg, err := Parse([]byte(`
+processes: {web: ./web}
+proxy:
+  <<: {enabled: true, http_port: 8080}
+  domain: local.test.dev
+`))
+		require.NoError(t, err)
+		require.NotNil(t, cfg.Proxy)
+		assert.True(t, cfg.Proxy.Enabled)
+		assert.Equal(t, 8080, cfg.Proxy.HTTPPort)
+	})
+
+	t.Run("multi-source merge with overlapping keys", func(t *testing.T) {
+		cfg, err := Parse([]byte(`
+processes:
+  base: &base
+    cmd: ./base
+    stop_timeout: 30s
+  alt: &alt
+    cmd: ./alt
+    stop_timeout: 45s
+  web:
+    <<: [*base, *alt]
+`))
+		require.NoError(t, err)
+		assert.Equal(t, "./base", cfg.Processes["web"].Cmd, "first merge source wins")
+		assert.Equal(t, "30s", cfg.Processes["web"].StopTimeout)
+	})
+
+	t.Run("benign anchors and aliases on values", func(t *testing.T) {
+		cfg, err := Parse([]byte(`
+processes:
+  web:
+    cmd: ./web
+    env: &common
+      FOO: bar
+  worker:
+    cmd: ./worker
+    env: *common
+`))
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"FOO": "bar"}, cfg.Processes["web"].Env)
+		assert.Equal(t, map[string]string{"FOO": "bar"}, cfg.Processes["worker"].Env)
+	})
+}
+
+// TestParse_ProcessTypo_ReportedExactlyOnce pins that a typo'd process field is
+// reported by the process parser ALONE: the structural walk descends into
+// processes: for duplicate keys but must never key-check user-named entries.
+func TestParse_ProcessTypo_ReportedExactlyOnce(t *testing.T) {
+	_, err := Parse([]byte(`
+processes:
+  web:
+    cmd: ./web
+    stop_timout: 5s
+`))
+	require.Error(t, err)
+	assert.Equal(t, `invalid configuration: processes.web: unknown field "stop_timout"`, err.Error())
+}
+
+// TestCheckDocumentStructure_TagDistinctKeys pins that duplicate identity is
+// tag-aware: `"1"` (!!str) and an alias resolving to `1` (!!int) are DISTINCT
+// keys per the YAML spec and must NOT be reported. The walk is exercised
+// directly here because such a mapping cannot survive the typed decode Parse
+// does around it (a non-string key never coerces into map[string]string).
+func TestCheckDocumentStructure_TagDistinctKeys(t *testing.T) {
+	distinct := `
+processes:
+  web:
+    cmd: ./web
+    env:
+      n: &n 1
+      "1": one
+      *n : int-one
+`
+	assert.Empty(t, checkDocumentStructure([]byte(distinct)))
+
+	// Same shape, but the anchor is a string: now the keys really do collide.
+	same := `
+processes:
+  web:
+    cmd: ./web
+    env:
+      n: &n "1"
+      "1": one
+      *n : also-one
+`
+	assert.Equal(t, []string{`processes.web.env: duplicate key "1"`}, checkDocumentStructure([]byte(same)))
+
+	// Identity is canonical, not spelling-based: `01` and `1` are the same
+	// !!int key even though the raw scalars differ.
+	canonical := `
+processes:
+  web:
+    cmd: ./web
+    env:
+      n: &n 01
+      1: one
+      *n : int-one
+`
+	assert.Equal(t, []string{`processes.web.env: duplicate key "1"`}, checkDocumentStructure([]byte(canonical)))
+}
+
+// TestParse_WalkAndEntryErrors_BatchedTogether pins that a structural-walk
+// error and a process-entry error from the C1 parsers land in ONE sorted,
+// deterministic report rather than shadowing each other.
+func TestParse_WalkAndEntryErrors_BatchedTogether(t *testing.T) {
+	_, err := Parse([]byte(`
+porxy:
+  enabled: true
+processes:
+  web:
+    cmd: ./web
+    stop_timout: 5s
+`))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, domain.ErrInvalidConfig)
+	assert.Equal(t,
+		`invalid configuration: config: unknown field "porxy"; `+
+			`processes.web: unknown field "stop_timout"`,
+		err.Error())
+}
+
+// TestParse_YAMLLevelDefects pins the defects yaml.v3 itself rejects at the raw
+// decode (the W0 ordering contract): they surface as `parsing yaml:` errors,
+// NOT as a structural batch, and none of them panics or hangs.
+func TestParse_YAMLLevelDefects(t *testing.T) {
+	t.Run("literal duplicate key canary", func(t *testing.T) {
+		_, err := Parse([]byte("processes:\n  web: ./a\n  web: ./b\n"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "parsing yaml:")
+		assert.Contains(t, err.Error(), `mapping key "web" already defined`)
+		assert.NotErrorIs(t, err, domain.ErrInvalidConfig)
+	})
+
+	t.Run("alias to a mapping used as a key", func(t *testing.T) {
+		_, err := Parse([]byte(`
+api: &m
+  port: 9000
+processes:
+  *m : ./web
+`))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "parsing yaml:")
+		assert.NotErrorIs(t, err, domain.ErrInvalidConfig)
+	})
+
+	t.Run("alias-key duplicate of a known typed field", func(t *testing.T) {
+		// A typed struct notices an aliased duplicate of a field it knows and
+		// errors at the raw decode, before the walk ever runs.
+		_, err := Parse([]byte(`
+processes: {web: ./web}
+env_file: &k api
+api: {port: 9000}
+*k : {port: 9001}
+`))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "parsing yaml:")
+	})
+}
+
+// TestParse_CyclicAlias_Terminates pins that a self-referential anchor -- which
+// the raw decode accepts when it lands in a typed or ignored block -- cannot
+// hang or panic the structural walk. The exact outcome is pinned rather than
+// designed: the walk's active-node guard simply stops descending at the cycle.
+func TestParse_CyclicAlias_Terminates(t *testing.T) {
+	t.Run("cycle under an unknown top-level key", func(t *testing.T) {
+		_, err := Parse([]byte("processes: {web: ./web}\nnope: &x\n  b: *x\n"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `config: unknown field "nope"`)
+	})
+
+	t.Run("cycle through proxy.capture", func(t *testing.T) {
+		// proxy: &x { capture: *x } -- capture resolves back to the proxy
+		// mapping itself. yaml.v3 rejects a self-referential anchor when it
+		// decodes into a generic map ("anchor 'x' value contains itself"), but
+		// not when it lands in a typed block like this one, so the walk is what
+		// has to terminate. Pinned outcome: the active-node guard stops at the
+		// cycle, which also means the keys inside it are not schema-checked --
+		// termination is worth more than a check on a self-referential block.
+		cfg, err := Parse([]byte("processes: {web: ./web}\nproxy: &x\n  enabled: true\n  domain: local.test.dev\n  capture: *x\n"))
+		require.NoError(t, err)
+		require.NotNil(t, cfg.Proxy)
+		assert.True(t, cfg.Proxy.Enabled)
+	})
+}

--- a/skills/prox/SKILL.md
+++ b/skills/prox/SKILL.md
@@ -217,6 +217,8 @@ tasks:
 
 Environment variable precedence, later overrides earlier: system environment → global `env_file` → process-specific `env_file` → process-specific `env` map.
 
+**Unknown or typo'd keys anywhere in `prox.yaml` fail at load** with a precise per-key error (e.g. `processes.web: unknown field "stop_timout"`) — if a project won't start, check for a rejected config before looking elsewhere.
+
 For the full configuration reference including all proxy, service, and certificate fields, read `references/configuration.md`.
 
 ## CLI Help

--- a/skills/prox/references/configuration.md
+++ b/skills/prox/references/configuration.md
@@ -196,7 +196,8 @@ instance — any resolution failure leaves it untouched.
 - Duplicate keys are rejected too: a literal duplicate is a YAML parse error
   (line-numbered); a duplicate created by an *aliased* key node is caught
   as `<path>: duplicate key "<key>"` (or by the YAML decoder itself when it
-  duplicates a known typed-block field) — never silently collapsed.
+  duplicates a known typed-block field) — never silently collapsed. A
+  prox.yaml must be a single YAML document (a stray `---` is an error).
 - Anchors/aliases/`<<` merges are fully supported, including into typed
   blocks — a merge can't smuggle an unknown key past the destination's
   schema, and explicit keys win over merged ones (standard defaults idiom).

--- a/skills/prox/references/configuration.md
+++ b/skills/prox/references/configuration.md
@@ -185,7 +185,25 @@ instance — any resolution failure leaves it untouched.
 
 - Names are unique across `processes`, `dependencies`, `tasks`
   (case-sensitive).
-- Unknown keys in `dependencies:`/`tasks:`/`check:` are rejected.
+- **Unknown keys error everywhere in `prox.yaml`**, not just
+  `dependencies:`/`tasks:`/`check:` — top level, `proxy:`, `proxy.capture:`,
+  `api:`, `certs:`, every `processes.<name>` (incl. `healthcheck:`), every
+  `services.<name>`. Format: `<path>: unknown field "<key>"`, e.g.
+  `processes.web: unknown field "stop_timout"` (top level uses `config:` as
+  the path). All structural errors in a file batch together under one
+  `invalid configuration:` report; YAML-level defects (syntax, literal
+  duplicate keys) surface immediately as `parsing yaml:` instead.
+- Duplicate keys are rejected too: a literal duplicate is a YAML parse error
+  (line-numbered); a duplicate created by an *aliased* key node is caught
+  as `<path>: duplicate key "<key>"` (or by the YAML decoder itself when it
+  duplicates a known typed-block field) — never silently collapsed.
+- Anchors/aliases/`<<` merges are fully supported, including into typed
+  blocks — a merge can't smuggle an unknown key past the destination's
+  schema, and explicit keys win over merged ones (standard defaults idiom).
+  Define an anchor at its first natural occurrence, not in a top-level
+  `x-defaults:`-style container (top-level keys are schema-checked too, so
+  that idiom is rejected) — e.g. `processes.a.env: &common {...}` then
+  `processes.b.env: *common`.
 - Exactly one of `check.tcp`/`check.url`/`check.cmd` must be present.
 - `depends_on` targets must be dependencies or tasks — a process name or an
   unknown name is a load-time error.


### PR DESCRIPTION
Fixes #83. Plan 016 (panel-reviewed: Codex + GLM 5.2 + CodeRabbit — all three independently probed yaml.v3's actual behavior), last of the three-issue 0.2.x hardening sequence (#82 ✅ → #80 ✅ → **#83**).

## What changed

**prox.yaml parsing is now fully strict.** Unknown keys anywhere — top level, `proxy:`, `proxy.capture:`, `api:`, `certs:`, every `processes.<name>` (incl. `healthcheck:`), every `services.<name>`, plus the already-strict `dependencies:`/`tasks:` — are load-time errors, batched into one sorted report:

```
invalid configuration: config: unknown field "porxy"; processes.web: unknown field "stop_timout"; proxy.capture: unknown field "redact"
```

### 1. Strict `processes:` / `services:` entries — `b1ae644`

The legacy re-marshal path silently dropped typo'd fields. Entries now run the same `rejectUnknownKeys` machinery `dependencies:`/`tasks:` established, and the parse loops feed one batched structural-error report instead of failing on the first error. Shorthands are untouched (string processes; int and float64 service ports — the float64 branch now has a test that actually feeds a float). A bare `healthcheck:` (explicit null) still means "absent."

### 2. `yaml.Node` structural pass — `bef239e` + `ee06cc5`

A document-level walk (new `internal/config/strictyaml.go`) closes what the generic-map intake can't see: unknown keys in the typed blocks (top level / `proxy` / `proxy.capture` / `api` / `certs`) and duplicate keys smuggled via **alias key nodes**. Facts pinned by the panel's four independent probes: literal duplicate keys were *already* rejected by yaml.v3 itself (line-numbered errors — canary-pinned); merge keys are spec-legit and stay fully supported — `<<: *base` + explicit override (defaults idiom, explicit wins), multi-source merges (first wins), merges into typed blocks — while a merge can no longer smuggle an unknown key past a destination schema (merged-in blocks are walked at their destination path with real precedence). Duplicate identity is canonical and tag-aware (`"1"` str and `1` int are distinct keys; `01` and `1` are the same int). Self-referential alias cycles are rejected (`<path>: circular alias`) rather than silently skipped.

### 3. Docs — `8caec3b`

Both configuration references state the unified rule, the two-layer error model (`parsing yaml:` for YAML-level defects vs the batched `invalid configuration:` report), and a new "YAML anchors and merge keys" section documenting the supported idioms and the first-natural-occurrence anchor pattern.

## Breaking changes (v0.2.4 CHANGELOG will carry these together with #80's)

- A previously-working config with any stray/typo'd key now fails at load, with the error naming the exact key — that's the point (agent/startup failures from silently-dropped config were part of this cycle's motivation).
- **Stale `redact:`/`redact_headers:`/`redact_query_params:` keys (removed in #80) now error precisely** (`proxy.capture: unknown field "redact"`) — covered by a named upgrade test.
- Top-level anchor-container keys (`x-defaults:`/`_defaults:` style) are rejected; define anchors at their first natural occurrence (`processes.a.env: &common {…}` … `processes.b.env: *common`). No repo/testdata/docs config used them.

## Verification

- Full gate green on all four commits. ~30 new test cases: entry/typed-block/error-batching tables, merge-legality regression table (valid merges must parse; smuggled keys must error), duplicate-identity matrix, literal-dupe canary, circular-alias rejection, exactly-once reporting.
- Manual smoke (artifact archived): dev binary against a config with all three error classes → exit 1 with the exact batched message above.
- All 15 testdata configs, the root prox.yaml, and every docs YAML example parse unchanged (audited by three reviewers independently).
- Adversarial `codex exec` reviews per commit: C1 — 3 findings fixed pre-commit (incl. a real regression: explicit-null `healthcheck:` must stay valid); C2 round 1 — 2 High + 1 Medium fixed (merged blocks evaded destination schemas; merge sources skipped by dup detection; tag-blind identity), round 2 re-verification confirmed fixes and caught a canonical-identity gap (`01` vs `1`), fixed; C3 docs review — 3 findings (cyclic-alias hole closed in code, two wording qualifications).

<details>
<summary>Plan 016 — design decisions (panel-reviewed)</summary>

**Panel-shaped decisions:** merge overlap is never a duplicate (spec-defined override idiom — CodeRabbit's stricter "any key twice" alternative rejected with rationale); decoder-ordering contract: raw map decode first (owns YAML-level defects, incl. literal dupes), Node walk second (owns alias-key dupes + typed-block schemas, batching with entry-level errors); merge recognition by `!!merge` tag, never by `<<` spelling (a quoted `"<<"` is an ordinary unknown field); anchor-container break accepted deliberately, no `x-` escape (one rule: every key must be known); alias-key duplicates of *known* typed fields are reported by the YAML decoder itself — layer pinned by test.

**Two-mechanism architecture:** map-based `rejectUnknownKeys` for name-keyed entries (mirrors the established dependencies/tasks pattern) + the Node walk for document structure and typed blocks. Deps/tasks deliberately not migrated (no churn).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QYoxAbd8V8ZsAiAYd7v8Fk


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added strict validation for unknown or misspelled keys throughout `prox.yaml`.
  * Configuration errors are now collected and reported together in a deterministic order.
  * Added support for YAML anchors, aliases, and merge keys while preserving schema validation.
  * Duplicate keys and multiple YAML documents are now rejected with clear errors.
  * Improved handling of service shorthand port values and optional health checks.

* **Documentation**
  * Expanded configuration references with validation, duplicate-key, and YAML reuse guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->