### PR TITLE
Unified push data plane: SSE heartbeats, reconnect, backfill everywhere, polls eliminated (plan 017)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ failures.
 ## Plans
 
 Panel-reviewed plans live OUTSIDE this repo, at
-`~/.claude/plans/prox/NNN-<slug>.md` (next free number: 017). One plan → one
+`~/.claude/plans/prox/NNN-<slug>.md` (next free number: 018). One plan → one
 PR of small gated commits. The plan file is never committed here, so the PR
 body must carry the plan's substance — reviewers and future readers only
 have the PR, not the plan file.

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"log"
 	"net/http"
 	"strconv"
@@ -46,6 +45,23 @@ type Handlers struct {
 	configFile     string
 	shutdown       ShutdownController
 	proxyStatus    ProxyStatusProvider
+
+	// sseHeartbeatInterval overrides constants.SSEHeartbeatInterval for the SSE
+	// handlers (StreamLogs, StreamProxyRequests). Zero means "use the default";
+	// tests in this package set it directly to a short interval instead of
+	// mutating a package-level var, which would race across parallel tests
+	// (mirrors the forwarderConfig injectable-value idiom in
+	// internal/proxyd/forwarder.go).
+	sseHeartbeatInterval time.Duration
+}
+
+// heartbeatInterval returns the SSE heartbeat interval to use: the injected
+// test override if set, otherwise the production default.
+func (h *Handlers) heartbeatInterval() time.Duration {
+	if h.sseHeartbeatInterval > 0 {
+		return h.sseHeartbeatInterval
+	}
+	return constants.SSEHeartbeatInterval
 }
 
 // NewHandlers creates new HTTP handlers. shutdown may be nil in tests that never
@@ -611,8 +627,7 @@ func (h *Handlers) StreamProxyRequests(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	flusher, ok := w.(http.Flusher)
-	if !ok {
+	if _, ok := w.(http.Flusher); !ok {
 		writeJSON(w, http.StatusInternalServerError, ErrorResponse{
 			Error: "streaming not supported",
 			Code:  domain.ErrCodeStreamingNotSupported,
@@ -630,14 +645,25 @@ func (h *Handlers) StreamProxyRequests(w http.ResponseWriter, r *http.Request) {
 	sub := h.requestManager.Subscribe(filter)
 	defer h.requestManager.Unsubscribe(sub.ID)
 
+	// rc lets each SSE write set a per-write deadline (see sseWrite in sse.go).
+	rc := http.NewResponseController(w)
+
 	// Send initial comment to establish connection
-	fmt.Fprintf(w, ": connected\n\n")
-	flusher.Flush()
+	if err := sseWrite(rc, w, []byte(": connected\n\n")); err != nil {
+		return
+	}
+
+	ticker := time.NewTicker(h.heartbeatInterval())
+	defer ticker.Stop()
 
 	for {
 		select {
 		case <-r.Context().Done():
 			return
+		case <-ticker.C:
+			if err := sseWrite(rc, w, []byte(": ping\n\n")); err != nil {
+				return
+			}
 		case req, ok := <-sub.Ch:
 			if !ok {
 				return
@@ -650,10 +676,9 @@ func (h *Handlers) StreamProxyRequests(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 
-			if _, err := w.Write([]byte("data: " + string(data) + "\n\n")); err != nil {
+			if err := sseWrite(rc, w, []byte("data: "), data, []byte("\n\n")); err != nil {
 				return
 			}
-			flusher.Flush()
 		}
 	}
 }

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -48,13 +48,29 @@ type Handlers struct {
 	proxyStatus    ProxyStatusProvider
 
 	// sseHeartbeatInterval overrides constants.SSEHeartbeatInterval for the SSE
-	// handlers (StreamLogs, StreamProxyRequests). Zero means "use the default";
-	// tests in this package set it directly to a short interval instead of
-	// mutating a package-level var, which would race across parallel tests
-	// (mirrors the forwarderConfig injectable-value idiom in
+	// handlers (StreamLogs, StreamProxyRequests, StreamProcesses). Zero means
+	// "use the default"; tests in this package set it directly to a short
+	// interval instead of mutating a package-level var, which would race across
+	// parallel tests (mirrors the forwarderConfig injectable-value idiom in
 	// internal/proxyd/forwarder.go).
 	sseHeartbeatInterval time.Duration
+
+	// processStreamDebounceInterval is the trailing-edge debounce window
+	// StreamProcesses waits (while absorbing further wakes) after a
+	// process-change before it snapshots and sends (plan 017 C11). Unlike
+	// sseHeartbeatInterval, this field is seeded with the production default at
+	// construction (see NewHandlers), so ZERO is unambiguous test territory: a
+	// test that wants every wake to snapshot immediately (no coalescing) sets
+	// this to 0 directly, and a test exercising the debounce itself sets it to
+	// a short interval instead of the production ~100ms.
+	processStreamDebounceInterval time.Duration
 }
+
+// processStreamDebounceDefault is the production trailing-edge debounce window
+// for StreamProcesses (plan 017 C11): a burst of rapid process transitions
+// (several processes starting together, a flapping health check, ...)
+// coalesces into one snapshot instead of one event per change.
+const processStreamDebounceDefault = 100 * time.Millisecond
 
 // heartbeatInterval returns the SSE heartbeat interval to use: the injected
 // test override if set, otherwise the production default.
@@ -65,14 +81,23 @@ func (h *Handlers) heartbeatInterval() time.Duration {
 	return constants.SSEHeartbeatInterval
 }
 
+// processStreamDebounce returns the trailing-edge debounce window
+// StreamProcesses applies after a wake, before it snapshots and sends. See the
+// processStreamDebounceInterval field comment for why 0 here is a real,
+// deliberate "no debounce" value rather than an unset sentinel.
+func (h *Handlers) processStreamDebounce() time.Duration {
+	return h.processStreamDebounceInterval
+}
+
 // NewHandlers creates new HTTP handlers. shutdown may be nil in tests that never
 // exercise POST /shutdown; the handler guards against it.
 func NewHandlers(sup *supervisor.Supervisor, logMgr *logs.Manager, configFile string, shutdown ShutdownController) *Handlers {
 	return &Handlers{
-		supervisor: sup,
-		logManager: logMgr,
-		configFile: configFile,
-		shutdown:   shutdown,
+		supervisor:                    sup,
+		logManager:                    logMgr,
+		configFile:                    configFile,
+		shutdown:                      shutdown,
+		processStreamDebounceInterval: processStreamDebounceDefault,
 	}
 }
 
@@ -158,17 +183,25 @@ func summarizeCheck(kind, target string) string {
 
 // GetProcesses handles GET /api/v1/processes
 func (h *Handlers) GetProcesses(w http.ResponseWriter, r *http.Request) {
-	processes := h.supervisor.Processes()
+	writeJSON(w, http.StatusOK, processListResponse(h.supervisor))
+}
+
+// processListResponse converts the supervisor's current process set to a
+// ProcessListResponse. Factored out (plan 017 C11) so GetProcesses (REST) and
+// StreamProcesses (SSE, sse.go) share ONE conversion -- they cannot drift
+// apart, and every event on the stream is exactly what a poll of GetProcesses
+// would return at that instant.
+func processListResponse(sup *supervisor.Supervisor) ProcessListResponse {
+	processes := sup.Processes()
 
 	resp := ProcessListResponse{
 		Processes: make([]ProcessResponse, len(processes)),
 	}
-
 	for i, p := range processes {
 		resp.Processes[i] = ToProcessResponse(p)
 	}
 
-	writeJSON(w, http.StatusOK, resp)
+	return resp
 }
 
 // GetProcess handles GET /api/v1/processes/{name}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log"
 	"net/http"
 	"strconv"
@@ -231,18 +232,58 @@ func (h *Handlers) RestartProcess(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, SuccessResponse{Success: true})
 }
 
-// GetLogs handles GET /api/v1/logs
+// GetLogs handles GET /api/v1/logs.
+//
+// Response ordering: without since_seq, Logs holds the newest `lines`
+// matching entries in the ring buffer's own chronological (oldest-first)
+// order -- unchanged from before this cursor API existed. With since_seq,
+// Logs holds every matching entry with Seq > since_seq, oldest-first BY
+// CONSTRUCTION (logs.Manager.QueryFromSeq deliberately keeps the OLDEST
+// entries when `lines` caps the result, so a resuming client advances its
+// cursor contiguously instead of being handed a slice with a gap in it). Both
+// paths therefore render oldest-first, but for different reasons -- do not
+// assume the last-N path's order is incidental.
+//
+// StreamID/OldestSeq/LatestSeq are populated on EVERY response (plan 017 C8),
+// not just since_seq requests, so a client can detect a daemon restart
+// (StreamID changed) or a buffer rollover past its held cursor (OldestSeq >
+// since_seq+1) from a plain poll. Both paths source Logs and the bounds from
+// ONE logs.Manager buffer snapshot (via QueryFromSeq) so they can never
+// describe different moments.
 func (h *Handlers) GetLogs(w http.ResponseWriter, r *http.Request) {
-	filter, limit, err := parseLogParams(r)
+	filter, limit, sinceSeq, hasSinceSeq, err := parseLogParams(r)
 	if err != nil {
 		writeJSON(w, http.StatusBadRequest, ErrorResponse{
 			Error: err.Error(),
-			Code:  domain.ErrCodeInvalidPattern,
+			Code:  domain.ErrCodeInvalidSinceSeq,
 		})
 		return
 	}
 
-	entries, total, err := h.logManager.QueryLast(filter, limit)
+	var (
+		entries              []domain.LogEntry
+		total                int
+		oldestSeq, latestSeq uint64
+	)
+	if hasSinceSeq {
+		entries, oldestSeq, latestSeq, err = h.logManager.QueryFromSeq(filter, sinceSeq, limit)
+		total = len(entries)
+	} else {
+		// QueryFromSeq(sinceSeq=0) is uncapped (limit=0) here so it returns
+		// every matching entry oldest-first from ONE buffer snapshot; trimming
+		// to the newest `limit` below reproduces the historical QueryLast
+		// behavior while still sourcing entries and bounds from that same
+		// snapshot (see doc comment above).
+		var all []domain.LogEntry
+		all, oldestSeq, latestSeq, err = h.logManager.QueryFromSeq(filter, 0, 0)
+		if err == nil {
+			total = len(all)
+			entries = all
+			if limit > 0 && len(entries) > limit {
+				entries = entries[len(entries)-limit:]
+			}
+		}
+	}
 	if err != nil {
 		writeError(w, err)
 		return
@@ -252,6 +293,9 @@ func (h *Handlers) GetLogs(w http.ResponseWriter, r *http.Request) {
 		Logs:          make([]LogEntryResponse, len(entries)),
 		FilteredCount: len(entries),
 		TotalCount:    total,
+		StreamID:      h.logManager.StreamID(),
+		OldestSeq:     oldestSeq,
+		LatestSeq:     latestSeq,
 	}
 
 	for i, e := range entries {
@@ -329,10 +373,16 @@ func shutdownFailures(outcome *domain.ProcessStopError) []ShutdownFailureRespons
 	return failures
 }
 
-// parseLogParams extracts log filter parameters from request
-func parseLogParams(r *http.Request) (domain.LogFilter, int, error) {
-	filter := domain.LogFilter{}
-
+// parseLogParams extracts log filter parameters from the request: the
+// process/pattern/regex filter, the "lines" limit (default
+// constants.DefaultLogLimit, capped at constants.MaxLogLines; a malformed or
+// non-positive value silently falls back to the default -- preserved
+// unchanged for backward compatibility), and the optional "since_seq" resume
+// cursor (plan 017 C8, hasSinceSeq reports whether it was present at all).
+// Unlike "lines", a present-but-unparseable since_seq is a hard error: it
+// names a specific cursor the caller believes is valid, so silently
+// substituting a default would silently change what "resume from here" means.
+func parseLogParams(r *http.Request) (filter domain.LogFilter, limit int, sinceSeq uint64, hasSinceSeq bool, err error) {
 	// Process filter
 	if processes := r.URL.Query().Get("process"); processes != "" {
 		filter.Processes = strings.Split(processes, ",")
@@ -347,9 +397,9 @@ func parseLogParams(r *http.Request) (domain.LogFilter, int, error) {
 	}
 
 	// Lines limit (default 100, max 10000 to prevent DoS)
-	limit := constants.DefaultLogLimit
+	limit = constants.DefaultLogLimit
 	if linesStr := r.URL.Query().Get("lines"); linesStr != "" {
-		if l, err := strconv.Atoi(linesStr); err == nil && l > 0 {
+		if l, perr := strconv.Atoi(linesStr); perr == nil && l > 0 {
 			if l > constants.MaxLogLines {
 				limit = constants.MaxLogLines
 			} else {
@@ -358,7 +408,24 @@ func parseLogParams(r *http.Request) (domain.LogFilter, int, error) {
 		}
 	}
 
-	return filter, limit, nil
+	// since_seq resume cursor. Presence is checked via the query map, not a
+	// non-empty Get: an explicitly empty `?since_seq=` is a malformed resume
+	// request and must 400 rather than silently degrade to the last-N path,
+	// which could hand a resuming client a page with a hidden gap.
+	if sinceVals, present := r.URL.Query()["since_seq"]; present {
+		sinceStr := ""
+		if len(sinceVals) > 0 {
+			sinceStr = sinceVals[0]
+		}
+		v, perr := strconv.ParseUint(sinceStr, 10, 64)
+		if perr != nil {
+			return domain.LogFilter{}, 0, 0, false, fmt.Errorf("invalid since_seq %q: %w", sinceStr, perr)
+		}
+		sinceSeq = v
+		hasSinceSeq = true
+	}
+
+	return filter, limit, sinceSeq, hasSinceSeq, nil
 }
 
 // writeJSON writes a JSON response

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -995,6 +995,96 @@ func TestStreamProxyRequests(t *testing.T) {
 	})
 }
 
+// TestStreamProxyRequests_Heartbeat mirrors TestStreamLogs_Heartbeat: a real
+// httptest.Server with a short injected heartbeat interval, asserting an idle
+// stream still emits ": ping" on cadence and that a record published
+// mid-stream arrives interleaved with the heartbeats.
+func TestStreamProxyRequests_Heartbeat(t *testing.T) {
+	logMgr := logs.NewManager(logs.ManagerConfig{BufferSize: 100})
+	defer logMgr.Close()
+
+	cfg := &config.Config{
+		API:       config.APIConfig{Port: 0},
+		Processes: map[string]config.ProcessConfig{},
+	}
+	sup := supervisor.New(cfg, logMgr, nil, supervisor.DefaultSupervisorConfig())
+	handlers := NewHandlers(sup, logMgr, "prox.yaml", nil)
+	handlers.sseHeartbeatInterval = 20 * time.Millisecond
+
+	rm := proxy.NewRequestManager(100)
+	handlers.SetRequestManager(rm)
+
+	srv := httptest.NewServer(http.HandlerFunc(handlers.StreamProxyRequests))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	reader := readSSEConnected(t, resp)
+
+	go func() {
+		time.Sleep(4 * handlers.sseHeartbeatInterval)
+		rm.Record(proxy.RequestRecord{
+			Timestamp:  time.Now(),
+			Method:     "GET",
+			URL:        "/heartbeat-interleave",
+			Subdomain:  "test",
+			StatusCode: 200,
+			Duration:   time.Millisecond,
+			RemoteAddr: "127.0.0.1",
+		})
+	}()
+
+	// 3 pings within 1s at a 20ms interval: generous 16× margin against CI
+	// scheduling, yet a cadence regression to even 500ms/ping cannot pass.
+	requireSSEHeartbeats(t, reader, "/heartbeat-interleave", 3, time.Second)
+}
+
+// TestStreamProxyRequests_ClientDisconnect_ReturnsHandler covers the teardown
+// path with a real connection close, complementing the "SSE headers set
+// correctly" context-cancellation subtest in TestStreamProxyRequests: once the
+// client closes its side of the connection, the handler's next write must
+// fail and it must return, freeing the subscription via its deferred
+// Unsubscribe.
+func TestStreamProxyRequests_ClientDisconnect_ReturnsHandler(t *testing.T) {
+	logMgr := logs.NewManager(logs.ManagerConfig{BufferSize: 100})
+	defer logMgr.Close()
+
+	cfg := &config.Config{
+		API:       config.APIConfig{Port: 0},
+		Processes: map[string]config.ProcessConfig{},
+	}
+	sup := supervisor.New(cfg, logMgr, nil, supervisor.DefaultSupervisorConfig())
+	handlers := NewHandlers(sup, logMgr, "prox.yaml", nil)
+	handlers.sseHeartbeatInterval = 10 * time.Millisecond
+
+	rm := proxy.NewRequestManager(100)
+	handlers.SetRequestManager(rm)
+
+	done := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlers.StreamProxyRequests(w, r)
+		close(done)
+	}))
+	defer srv.Close()
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+
+	readSSEConnected(t, resp)
+
+	require.NoError(t, resp.Body.Close())
+
+	requireSSEHandlerReturns(t, done, "StreamProxyRequests")
+}
+
 func TestStreamProxyRequests_ProxyNotEnabled(t *testing.T) {
 	logMgr := logs.NewManager(logs.ManagerConfig{BufferSize: 100})
 	defer logMgr.Close()

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -222,6 +222,15 @@ func TestGetLogs(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Len(t, resp.Logs, 10)
+
+		// Cursor metadata (plan 017 C8) is populated on every response, even
+		// the plain last-N path that never touched since_seq.
+		assert.Equal(t, logMgr.StreamID(), resp.StreamID)
+		assert.Equal(t, uint64(1), resp.OldestSeq)
+		assert.Equal(t, uint64(10), resp.LatestSeq)
+		for i, e := range resp.Logs {
+			assert.Equal(t, uint64(i+1), e.Seq, "entry %d should carry its manager-assigned seq", i)
+		}
 	})
 
 	t.Run("get logs with limit", func(t *testing.T) {
@@ -356,6 +365,129 @@ func TestGetLogs_InvalidRegexPattern(t *testing.T) {
 	err := json.NewDecoder(w.Body).Decode(&resp)
 	require.NoError(t, err)
 	assert.Equal(t, domain.ErrCodeInvalidPattern, resp.Code)
+}
+
+// TestGetLogs_SinceSeq covers the new since_seq resume path (plan 017 C8):
+// exactly the entries newer than the cursor come back, oldest-first, with
+// bounds describing the whole buffer.
+func TestGetLogs_SinceSeq(t *testing.T) {
+	logMgr := logs.NewManager(logs.ManagerConfig{BufferSize: 100})
+	defer logMgr.Close()
+
+	for i := 0; i < 10; i++ {
+		logMgr.Write(domain.LogEntry{
+			Timestamp: time.Now(),
+			Process:   "web",
+			Stream:    domain.StreamStdout,
+			Line:      fmt.Sprintf("line %d", i),
+		})
+	}
+
+	cfg := &config.Config{
+		API:       config.APIConfig{Port: 0},
+		Processes: map[string]config.ProcessConfig{},
+	}
+	sup := supervisor.New(cfg, logMgr, nil, supervisor.DefaultSupervisorConfig())
+	handlers := NewHandlers(sup, logMgr, "prox.yaml", nil)
+
+	req := httptest.NewRequest("GET", "/api/v1/logs?since_seq=5", nil)
+	w := httptest.NewRecorder()
+
+	handlers.GetLogs(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp LogsResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+
+	require.Len(t, resp.Logs, 5, "expected only entries with seq > 5")
+	assert.Equal(t, logMgr.StreamID(), resp.StreamID)
+	assert.Equal(t, uint64(1), resp.OldestSeq)
+	assert.Equal(t, uint64(10), resp.LatestSeq)
+
+	// Oldest-first by construction, exactly seq 6..10.
+	for i, e := range resp.Logs {
+		assert.Equal(t, uint64(6+i), e.Seq)
+	}
+}
+
+// TestGetLogs_SinceSeq_RolledBuffer covers the gap-detection case: the buffer
+// has evicted entries older than since_seq, so the client can tell it missed
+// some (OldestSeq > since_seq+1) rather than mistake a short result for
+// "caught up" (plan 017 C8).
+func TestGetLogs_SinceSeq_RolledBuffer(t *testing.T) {
+	logMgr := logs.NewManager(logs.ManagerConfig{BufferSize: 5})
+	defer logMgr.Close()
+
+	for i := 0; i < 10; i++ {
+		logMgr.Write(domain.LogEntry{
+			Timestamp: time.Now(),
+			Process:   "web",
+			Stream:    domain.StreamStdout,
+			Line:      fmt.Sprintf("line %d", i),
+		})
+	}
+	// Capacity 5, 10 writes: only seq 6..10 remain in the ring.
+
+	cfg := &config.Config{
+		API:       config.APIConfig{Port: 0},
+		Processes: map[string]config.ProcessConfig{},
+	}
+	sup := supervisor.New(cfg, logMgr, nil, supervisor.DefaultSupervisorConfig())
+	handlers := NewHandlers(sup, logMgr, "prox.yaml", nil)
+
+	req := httptest.NewRequest("GET", "/api/v1/logs?since_seq=1", nil)
+	w := httptest.NewRecorder()
+
+	handlers.GetLogs(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp LogsResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+
+	assert.Equal(t, uint64(6), resp.OldestSeq)
+	assert.Equal(t, uint64(10), resp.LatestSeq)
+	assert.Greater(t, resp.OldestSeq, uint64(1)+1, "oldestSeq should be detectably past since_seq+1")
+	assert.Len(t, resp.Logs, 5)
+}
+
+// TestGetLogs_SinceSeq_ParseError asserts an unparseable since_seq is a hard
+// 400, distinct from the invalid-regex 400 (plan 017 C8).
+func TestGetLogs_SinceSeq_ParseError(t *testing.T) {
+	logMgr := logs.NewManager(logs.ManagerConfig{BufferSize: 100})
+	defer logMgr.Close()
+
+	cfg := &config.Config{
+		API:       config.APIConfig{Port: 0},
+		Processes: map[string]config.ProcessConfig{},
+	}
+	sup := supervisor.New(cfg, logMgr, nil, supervisor.DefaultSupervisorConfig())
+	handlers := NewHandlers(sup, logMgr, "prox.yaml", nil)
+
+	req := httptest.NewRequest("GET", "/api/v1/logs?since_seq=not-a-number", nil)
+	w := httptest.NewRecorder()
+
+	handlers.GetLogs(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	var resp ErrorResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, domain.ErrCodeInvalidSinceSeq, resp.Code)
+
+	// An explicitly EMPTY since_seq is present-but-malformed: it must 400 too,
+	// not silently degrade to the last-N path (which could hand a resuming
+	// client a page with a hidden gap) — codex C8 finding.
+	req = httptest.NewRequest("GET", "/api/v1/logs?since_seq=", nil)
+	w = httptest.NewRecorder()
+
+	handlers.GetLogs(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	var emptyResp ErrorResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&emptyResp))
+	assert.Equal(t, domain.ErrCodeInvalidSinceSeq, emptyResp.Code)
 }
 
 func TestProcessControl_NotFound(t *testing.T) {

--- a/internal/api/process_stream_test.go
+++ b/internal/api/process_stream_test.go
@@ -1,0 +1,401 @@
+package api
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/charliek/prox/internal/config"
+	"github.com/charliek/prox/internal/domain"
+	"github.com/charliek/prox/internal/logs"
+	"github.com/charliek/prox/internal/supervisor"
+)
+
+// streamProcess is a fully controllable supervisor.Process for StreamProcesses
+// tests: it dies synchronously and cleanly on SIGTERM (or SIGKILL), so
+// Supervisor.StopProcess/StartProcess/RestartProcess settle -- and therefore
+// notify the change bus (plan 017 C10) -- instantly and deterministically,
+// with no real process spawn and no real stop_timeout wait.
+type streamProcess struct {
+	mu     sync.Mutex
+	alive  bool
+	waitCh chan struct{}
+	closed bool
+}
+
+func newStreamProcess() *streamProcess {
+	return &streamProcess{alive: true, waitCh: make(chan struct{})}
+}
+
+func (p *streamProcess) PID() int          { return 1 }
+func (p *streamProcess) PGID() int         { return 1 }
+func (p *streamProcess) StartToken() int64 { return 1 }
+
+func (p *streamProcess) Wait() error {
+	<-p.waitCh
+	return nil
+}
+
+func (p *streamProcess) Signal(sig os.Signal) error {
+	if sig == syscall.SIGTERM || sig == syscall.SIGKILL {
+		p.mu.Lock()
+		p.alive = false
+		if !p.closed {
+			p.closed = true
+			close(p.waitCh)
+		}
+		p.mu.Unlock()
+	}
+	return nil
+}
+
+func (p *streamProcess) GroupAlive() (bool, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.alive, nil
+}
+
+func (p *streamProcess) Stdout() io.Reader { return strings.NewReader("") }
+func (p *streamProcess) Stderr() io.Reader { return strings.NewReader("") }
+
+// streamRunner is a supervisor.ProcessRunner that hands out streamProcess
+// instances, one per Start call.
+type streamRunner struct{}
+
+func (streamRunner) Start(_ context.Context, _ domain.ProcessConfig, _ map[string]string) (supervisor.Process, error) {
+	return newStreamProcess(), nil
+}
+
+// setupProcessStreamServer builds a real Supervisor (one process, "web",
+// started) wired to real Handlers, using streamRunner so
+// StartProcess/StopProcess/RestartProcess settle instantly and reliably
+// notify the change bus without a real process or a real stop_timeout wait.
+func setupProcessStreamServer(t *testing.T) (*Handlers, *supervisor.Supervisor, func()) {
+	t.Helper()
+	logMgr := logs.NewManager(logs.ManagerConfig{BufferSize: 100})
+
+	cfg := &config.Config{
+		API:       config.APIConfig{Port: 0, Host: "127.0.0.1"},
+		Processes: map[string]config.ProcessConfig{"web": {Cmd: "unused"}},
+	}
+	sup := supervisor.New(cfg, logMgr, streamRunner{}, supervisor.DefaultSupervisorConfig())
+	_, err := sup.Start(context.Background())
+	require.NoError(t, err)
+
+	handlers := NewHandlers(sup, logMgr, "test.yaml", nil)
+
+	cleanup := func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = sup.Stop(stopCtx) // idempotent; harmless if a test already stopped it
+		logMgr.Close()
+	}
+	return handlers, sup, cleanup
+}
+
+// readSSEProcessSnapshot reads SSE lines from reader until it finds the next
+// "data: " line and decodes it as a ProcessListResponse, skipping any ": ping"
+// or other comment lines along the way. It returns an error rather than
+// failing via *testing.T so it is also safe to call from a helper goroutine
+// that races a test timeout (see the debounce test below).
+func readSSEProcessSnapshot(reader *bufio.Reader) (ProcessListResponse, error) {
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return ProcessListResponse{}, err
+		}
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		var resp ProcessListResponse
+		if err := json.Unmarshal([]byte(strings.TrimPrefix(line, "data: ")), &resp); err != nil {
+			return ProcessListResponse{}, err
+		}
+		return resp, nil
+	}
+}
+
+// requireProcessSnapshot is readSSEProcessSnapshot's *testing.T-failing
+// wrapper, for tests that read on the main goroutine only (no concurrent
+// timeout race).
+func requireProcessSnapshot(t *testing.T, reader *bufio.Reader) ProcessListResponse {
+	t.Helper()
+	resp, err := readSSEProcessSnapshot(reader)
+	require.NoError(t, err)
+	return resp
+}
+
+// readUntilWebStatus reads snapshots from reader (via a background goroutine,
+// so it is safe to race a timeout) until it sees the "web" process reach
+// wantStatus or the deadline elapses, and returns the last snapshot observed
+// and how many were seen. A single supervisor call can itself produce more
+// than one underlying change-bus wake (e.g. a stop settles through an
+// intermediate "stopping" state before its terminal "stopped" -- see
+// ManagedProcess.stop), so a caller-visible "the change eventually shows up"
+// assertion must tolerate one or more snapshots, not exactly one -- exactly
+// the convergence guarantee the trailing-edge debounce documents (plan 017
+// C11).
+func readUntilWebStatus(reader *bufio.Reader, wantStatus string, timeout time.Duration) (last ProcessListResponse, seen int) {
+	snapshots := make(chan ProcessListResponse, 8)
+	go func() {
+		for {
+			snap, err := readSSEProcessSnapshot(reader)
+			if err != nil {
+				close(snapshots)
+				return
+			}
+			snapshots <- snap
+		}
+	}()
+
+	deadline := time.After(timeout)
+	for {
+		select {
+		case snap, ok := <-snapshots:
+			if !ok {
+				return last, seen
+			}
+			last = snap
+			seen++
+			if len(last.Processes) > 0 && last.Processes[0].Status == wantStatus {
+				return last, seen
+			}
+		case <-deadline:
+			return last, seen
+		}
+	}
+}
+
+// TestStreamProcesses_ConnectAndInitialSnapshot asserts the connect sequence:
+// ": connected", then the initial snapshot as a normal data event carrying the
+// current process list (plan 017 C11).
+func TestStreamProcesses_ConnectAndInitialSnapshot(t *testing.T) {
+	handlers, _, cleanup := setupProcessStreamServer(t)
+	defer cleanup()
+
+	srv := httptest.NewServer(http.HandlerFunc(handlers.StreamProcesses))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, "text/event-stream", resp.Header.Get("Content-Type"))
+	require.Equal(t, "no-cache", resp.Header.Get("Cache-Control"))
+
+	reader := readSSEConnected(t, resp)
+
+	snap := requireProcessSnapshot(t, reader)
+	require.Len(t, snap.Processes, 1)
+	require.Equal(t, "web", snap.Processes[0].Name)
+	require.Equal(t, "running", snap.Processes[0].Status)
+}
+
+// TestStreamProcesses_ChangeYieldsNewSnapshot drives one process transition
+// and asserts a new snapshot arrives reflecting it. A short (rather than
+// zero) debounce is used deliberately: ManagedProcess.stop itself commits an
+// intermediate "stopping" state (and its own change-bus wake) before its
+// terminal "stopped" (see process.go), so with debounce disabled a single
+// StopProcess call can legitimately surface as two snapshots ("stopping" then
+// "stopped") -- both correct, undropped state, per the "every event is a full
+// snapshot, no deltas" contract. The short debounce coalesces that
+// same-call-stack pair into the one the caller actually wants to assert on:
+// the final, settled state.
+func TestStreamProcesses_ChangeYieldsNewSnapshot(t *testing.T) {
+	handlers, sup, cleanup := setupProcessStreamServer(t)
+	defer cleanup()
+	handlers.processStreamDebounceInterval = 20 * time.Millisecond
+
+	srv := httptest.NewServer(http.HandlerFunc(handlers.StreamProcesses))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	reader := readSSEConnected(t, resp)
+
+	initial := requireProcessSnapshot(t, reader)
+	require.Equal(t, "running", initial.Processes[0].Status)
+
+	require.NoError(t, sup.StopProcess(context.Background(), "web"))
+
+	updated, seen := readUntilWebStatus(reader, "stopped", 2*time.Second)
+	require.GreaterOrEqual(t, seen, 1, "expected at least one snapshot after the change")
+	require.Equal(t, "stopped", updated.Processes[0].Status)
+}
+
+// TestStreamProcesses_DebounceTrailingEdge_ConvergesOnFinalState drives a
+// rapid burst of transitions (stop, start, stop) well within one debounce
+// window and asserts convergence: however many snapshots the coalescing
+// window yields (one, if the whole burst lands inside a single absorb window;
+// occasionally two, if a wake lands just after one closes), at least one
+// arrives, and the LAST one always reflects the FINAL state -- the last
+// change of a burst is never lost, only ever reported on a later tick (plan
+// 017 C11).
+func TestStreamProcesses_DebounceTrailingEdge_ConvergesOnFinalState(t *testing.T) {
+	handlers, sup, cleanup := setupProcessStreamServer(t)
+	defer cleanup()
+	handlers.processStreamDebounceInterval = 50 * time.Millisecond
+
+	srv := httptest.NewServer(http.HandlerFunc(handlers.StreamProcesses))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	reader := readSSEConnected(t, resp)
+	_ = requireProcessSnapshot(t, reader) // initial snapshot
+
+	// Rapid burst, well within one 50ms debounce window.
+	require.NoError(t, sup.StopProcess(context.Background(), "web"))
+	require.NoError(t, sup.StartProcess(context.Background(), "web"))
+	require.NoError(t, sup.StopProcess(context.Background(), "web"))
+
+	last, seen := readUntilWebStatus(reader, "stopped", 2*time.Second)
+	require.GreaterOrEqual(t, seen, 1, "expected at least one snapshot after the burst")
+	require.Equal(t, "stopped", last.Processes[0].Status,
+		"the last snapshot observed must reflect the final (converged) state")
+}
+
+// TestStreamProcesses_Heartbeat asserts an idle stream (no process
+// transitions) still emits ": ping" comments on the configured cadence. The
+// initial snapshot itself is the "data" line requireSSEHeartbeats looks for
+// (it carries the process name "web"), so this test needs no further data
+// event beyond connect.
+func TestStreamProcesses_Heartbeat(t *testing.T) {
+	handlers, _, cleanup := setupProcessStreamServer(t)
+	defer cleanup()
+	handlers.sseHeartbeatInterval = 20 * time.Millisecond
+
+	srv := httptest.NewServer(http.HandlerFunc(handlers.StreamProcesses))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	reader := readSSEConnected(t, resp)
+
+	requireSSEHeartbeats(t, reader, "web", 3, time.Second)
+}
+
+// TestStreamProcesses_SupervisorStop_HandlerReturns asserts that when the
+// supervisor stops (CloseEvents closes every change-bus subscriber channel),
+// the handler observes the closed wake channel and returns promptly rather
+// than hanging forever.
+func TestStreamProcesses_SupervisorStop_HandlerReturns(t *testing.T) {
+	handlers, sup, cleanup := setupProcessStreamServer(t)
+	defer cleanup()
+
+	done := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlers.StreamProcesses(w, r)
+		close(done)
+	}))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	reader := readSSEConnected(t, resp)
+	_ = requireProcessSnapshot(t, reader)
+
+	stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	require.NoError(t, sup.Stop(stopCtx))
+
+	requireSSEHandlerReturns(t, done, "StreamProcesses")
+}
+
+// TestStreamProcesses_NoFlusher_ReturnsJSONError mirrors
+// TestStreamLogs_NoFlusher_ReturnsJSONError: a ResponseWriter that does not
+// implement http.Flusher must get a clean JSON error before any SSE header is
+// written, exactly like the sibling streams.
+func TestStreamProcesses_NoFlusher_ReturnsJSONError(t *testing.T) {
+	handlers, _, cleanup := setupProcessStreamServer(t)
+	defer cleanup()
+
+	req := httptest.NewRequest("GET", "/api/v1/processes/stream", nil)
+	w := &noFlushWriter{}
+
+	handlers.StreamProcesses(w, req)
+
+	require.Equal(t, http.StatusInternalServerError, w.status)
+	require.Equal(t, "application/json", w.Header().Get("Content-Type"))
+	for _, header := range []string{"Cache-Control", "Connection", "X-Accel-Buffering"} {
+		require.Empty(t, w.Header().Get(header), "expected %s to be unset on the error path", header)
+	}
+
+	var errResp ErrorResponse
+	require.NoError(t, json.Unmarshal(w.body, &errResp))
+	require.Equal(t, domain.ErrCodeStreamingNotSupported, errResp.Code)
+}
+
+// TestStreamProcesses_ContinuousWakesCannotStarveSnapshots pins the debounce's
+// max-latency bound (codex C11 finding): a wake stream that never goes quiet —
+// here a tight stop/start loop against the instantly-settling streamRunner —
+// must still yield snapshots, not silence.
+func TestStreamProcesses_ContinuousWakesCannotStarveSnapshots(t *testing.T) {
+	handlers, sup, cleanup := setupProcessStreamServer(t)
+	defer cleanup()
+	handlers.processStreamDebounceInterval = 30 * time.Millisecond
+
+	server := httptest.NewServer(http.HandlerFunc(handlers.StreamProcesses))
+	defer server.Close()
+
+	resp, err := http.Get(server.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	reader := readSSEConnected(t, resp)
+
+	// Continuous churn: each stop/start settles instantly and notifies the
+	// bus, restarting a pure trailing-edge debounce forever. The 5×d deadline
+	// must force snapshots through regardless.
+	stop := make(chan struct{})
+	churnDone := make(chan struct{})
+	go func() {
+		defer close(churnDone)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = sup.StopProcess(context.Background(), "web")
+				_ = sup.StartProcess(context.Background(), "web")
+			}
+		}
+	}()
+	defer func() { close(stop); <-churnDone }()
+
+	// Initial snapshot plus at least two forced ones within a bounded window
+	// (deadline fires at 150ms per absorb with a 30ms debounce; 5s is ample).
+	deadline := time.Now().Add(5 * time.Second)
+	snapshots := 0
+	for snapshots < 3 {
+		require.True(t, time.Now().Before(deadline),
+			"only %d snapshots under continuous churn; debounce starved the stream", snapshots)
+		line, err := reader.ReadString('\n')
+		require.NoError(t, err)
+		if strings.HasPrefix(line, "data: ") {
+			snapshots++
+		}
+	}
+}

--- a/internal/api/responses.go
+++ b/internal/api/responses.go
@@ -146,6 +146,20 @@ type LogsResponse struct {
 	Logs          []LogEntryResponse `json:"logs"`
 	FilteredCount int                `json:"filtered_count"`
 	TotalCount    int                `json:"total_count"`
+	// StreamID identifies the logs.Manager lifetime Logs and the two bounds
+	// below came from (plan 017 C8). A client comparing this against a
+	// StreamID it saw earlier learns whether the daemon restarted underneath
+	// it, in which case every Seq it holds belongs to a dead epoch and it must
+	// re-sync from scratch rather than ask for "everything after seq N".
+	StreamID string `json:"stream_id"`
+	// OldestSeq and LatestSeq describe the CURRENT BUFFER as a whole --
+	// ignoring both the filter and any since_seq cursor -- at the moment Logs
+	// was read, taken from the SAME buffer snapshot as Logs (see
+	// logs.Manager.QueryFromSeq). Both are 0 when the buffer is empty. They
+	// let a caller tell "caught up" apart from "the buffer rolled past me":
+	// OldestSeq > since_seq+1 means entries in between were evicted.
+	OldestSeq uint64 `json:"oldest_seq"`
+	LatestSeq uint64 `json:"latest_seq"`
 }
 
 // LogEntryResponse represents a single log entry
@@ -154,6 +168,30 @@ type LogEntryResponse struct {
 	Process   string `json:"process"`
 	Stream    string `json:"stream"`
 	Line      string `json:"line"`
+	// Seq is the server ingest sequence (domain.LogEntry.Seq), copied through
+	// unchanged so a client can resume a query or an SSE stream with
+	// since_seq=Seq (plan 017 C8). Zero on an entry that never passed through
+	// logs.Manager.Write.
+	Seq uint64 `json:"seq"`
+}
+
+// HandshakeResponse is the body of the "handshake" SSE event StreamLogs sends
+// immediately after the ": connected" comment, before any log data (plan 017
+// C8). A reconnecting client must learn the CURRENT stream epoch before it can
+// decide how to backfill: if StreamID differs from the one it last resumed
+// against, every Seq it holds belongs to a dead logs.Manager lifetime and it
+// must re-sync from scratch instead of asking for "everything after seq N".
+//
+// This rides a named "event: handshake" frame rather than a bare "data:"
+// line specifically so it is NOT mistaken for a log entry: the generic SSE
+// reader (internal/cli/client.go readSSE) ignores "event:" lines and would
+// otherwise hand this payload's "data:" line straight to parseSSELogEntry,
+// which unmarshals into LogEntryResponse leniently (unknown fields ignored)
+// and would produce a phantom empty log row. parseSSELogEntry guards against
+// exactly that by rejecting any parse whose Process, Line, and Seq are all
+// zero-valued -- a real log entry never has all three empty.
+type HandshakeResponse struct {
+	StreamID string `json:"stream_id"`
 }
 
 // SuccessResponse represents a simple success response
@@ -271,6 +309,7 @@ func ToLogEntryResponse(entry domain.LogEntry) LogEntryResponse {
 		Process:   entry.Process,
 		Stream:    string(entry.Stream),
 		Line:      entry.Line,
+		Seq:       entry.Seq,
 	}
 }
 

--- a/internal/api/responses_test.go
+++ b/internal/api/responses_test.go
@@ -454,6 +454,7 @@ func TestToLogEntryResponse(t *testing.T) {
 		Process:   "web",
 		Stream:    domain.StreamStdout,
 		Line:      "Server started on port 3000",
+		Seq:       42,
 	}
 
 	resp := ToLogEntryResponse(entry)
@@ -470,6 +471,9 @@ func TestToLogEntryResponse(t *testing.T) {
 	// Verify timestamp is in RFC3339Nano format
 	if resp.Timestamp != now.Format(time.RFC3339Nano) {
 		t.Errorf("expected Timestamp %q, got %q", now.Format(time.RFC3339Nano), resp.Timestamp)
+	}
+	if resp.Seq != 42 {
+		t.Errorf("expected Seq 42, got %d", resp.Seq)
 	}
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -179,11 +179,12 @@ func authMiddleware(authEnabled bool, token string) func(http.Handler) http.Hand
 //     (11m). The supervisor bounds start/stop/restart internally per-process by
 //     the configured stop budget; /shutdown?wait=true blocks for the whole drain.
 //     This router ceiling is hang protection only.
-//   - SSE group (/logs/stream, /proxy/requests/stream): NO timeout middleware.
-//     The streams are long-lived by design (WriteTimeout is 0 for the same
-//     reason); they end when the client disconnects (r.Context() is cancelled
-//     on connection close) or when the daemon shuts down (the log manager
-//     closes subscriber channels at shutdown). (#42)
+//   - SSE group (/logs/stream, /proxy/requests/stream, /processes/stream): NO
+//     timeout middleware. The streams are long-lived by design (WriteTimeout
+//     is 0 for the same reason); they end when the client disconnects
+//     (r.Context() is cancelled on connection close) or when the daemon
+//     shuts down (the log manager / supervisor change bus close subscriber
+//     channels at shutdown). (#42)
 //   - Default group (everything else): defaultRequestTimeout (30s).
 func (s *Server) registerRoutes() {
 	// Health check at root (no auth required). Kept under the default 30s
@@ -224,6 +225,9 @@ func (s *Server) registerRoutes() {
 			// /proxy/requests/{id} lives in the default group below; chi routes
 			// the literal "stream" segment ahead of the {id} parameter.
 			r.Get("/proxy/requests/stream", s.handlers.StreamProxyRequests)
+			// Same precedence note applies: /processes/stream (here) vs.
+			// /processes/{name} (default group below).
+			r.Get("/processes/stream", s.handlers.StreamProcesses)
 		})
 
 		// Everything else keeps the default 30s ceiling.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -48,10 +48,15 @@ type Server struct {
 func NewServer(config ServerConfig, handlers *Handlers) *Server {
 	r := chi.NewRouter()
 
-	// Middleware
+	// Middleware. No request logger: chi's middleware.Logger printed every
+	// control-plane request straight to stdout (drowning `prox up` process
+	// logs), and its wrapped ResponseWriter implements an errorless Flush,
+	// which http.ResponseController prefers over Unwrap — masking the SSE
+	// flush errors sseWrite relies on to detect dead clients. Any future
+	// writer-wrapping middleware on the SSE routes must implement FlushError
+	// or Unwrap-without-Flush to preserve that detection.
 	r.Use(middleware.RequestID)
 	r.Use(middleware.RealIP)
-	r.Use(middleware.Logger)
 	r.Use(middleware.Recoverer)
 	// NOTE: the request timeout is applied per route group in registerRoutes,
 	// not globally here. Most routes get defaultRequestTimeout (30s); the

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -405,6 +405,7 @@ func TestRouteGroupTimeoutWiring(t *testing.T) {
 	var lifecycleBudget, defaultBudget, idBudget time.Duration
 	sseLogsSawDeadline := true
 	sseProxySawDeadline := true
+	sseProcessesSawDeadline := true
 
 	r := chi.NewRouter()
 	r.Group(func(r chi.Router) {
@@ -420,6 +421,10 @@ func TestRouteGroupTimeoutWiring(t *testing.T) {
 			_, sseProxySawDeadline = r.Context().Deadline()
 			w.WriteHeader(http.StatusOK)
 		})
+		r.Get("/processes/stream", func(w http.ResponseWriter, r *http.Request) {
+			_, sseProcessesSawDeadline = r.Context().Deadline()
+			w.WriteHeader(http.StatusOK)
+		})
 	})
 	r.Group(func(r chi.Router) {
 		r.Use(middleware.Timeout(defaultRequestTimeout))
@@ -432,6 +437,7 @@ func TestRouteGroupTimeoutWiring(t *testing.T) {
 		httptest.NewRequest("GET", "/status", nil),
 		httptest.NewRequest("GET", "/logs/stream", nil),
 		httptest.NewRequest("GET", "/proxy/requests/stream", nil),
+		httptest.NewRequest("GET", "/processes/stream", nil),
 	} {
 		rec := httptest.NewRecorder()
 		r.ServeHTTP(rec, req)
@@ -447,6 +453,7 @@ func TestRouteGroupTimeoutWiring(t *testing.T) {
 	// SSE routes carry no deadline at all (#42).
 	assert.False(t, sseLogsSawDeadline, "/logs/stream must have no context deadline")
 	assert.False(t, sseProxySawDeadline, "/proxy/requests/stream must have no context deadline")
+	assert.False(t, sseProcessesSawDeadline, "/processes/stream must have no context deadline")
 	// GET /proxy/requests/stream resolved to the SSE probe, so the {id} probe
 	// under the timed group must never have run.
 	assert.Zero(t, idBudget, "/proxy/requests/stream must not match /proxy/requests/{id}")

--- a/internal/api/sse.go
+++ b/internal/api/sse.go
@@ -117,6 +117,154 @@ func (h *Handlers) StreamLogs(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// StreamProcesses handles GET /api/v1/processes/stream (SSE), built on the
+// supervisor's process-change bus (plan 017 C10/C11).
+//
+// Every event on this stream -- the initial send and every subsequent one -- is
+// a FULL ProcessListResponse snapshot (the same conversion GET /processes
+// uses, via processListResponse in handlers.go). There are no deltas: a client
+// that misses an event just waits for the next one, which is self-describing
+// current state rather than a diff that needs a base to apply against
+// (pinned; poll semantics with push timing).
+//
+// Subscribe-before-snapshot: the change-bus subscription is registered BEFORE
+// the initial snapshot is read below, so a transition landing in that exact
+// window is never silently missed -- it sets this subscriber's dirty latch,
+// and the main loop's very first wake re-snapshots and resends (a possibly-
+// redundant extra event, never a lost one).
+func (h *Handlers) StreamProcesses(w http.ResponseWriter, r *http.Request) {
+	if _, ok := w.(http.Flusher); !ok {
+		writeJSON(w, http.StatusInternalServerError, ErrorResponse{
+			Error: "streaming not supported",
+			Code:  domain.ErrCodeStreamingNotSupported,
+		})
+		return
+	}
+
+	// Set SSE headers
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	// Subscribe FIRST (see doc comment above): a change landing between this
+	// call and the initial snapshot below still lands on this subscriber's
+	// latch and is picked up by the loop's first wake.
+	subID, wake := h.supervisor.Subscribe()
+	defer h.supervisor.Unsubscribe(subID)
+
+	// rc lets each SSE write set a per-write deadline (see sseWrite).
+	rc := http.NewResponseController(w)
+
+	// Send initial comment to establish connection
+	if err := sseWrite(rc, w, []byte(": connected\n\n")); err != nil {
+		return
+	}
+
+	// Initial snapshot, as a normal data event -- same shape as every later one.
+	if !h.writeProcessSnapshot(rc, w) {
+		return
+	}
+
+	ticker := time.NewTicker(h.heartbeatInterval())
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-ticker.C:
+			if err := sseWrite(rc, w, []byte(": ping\n\n")); err != nil {
+				return
+			}
+		case _, ok := <-wake:
+			if !ok {
+				// Supervisor stopped (CloseEvents): there is no more state to
+				// report. End the stream; a reconnecting client gets connection
+				// refused until a new daemon is up.
+				return
+			}
+
+			// Trailing-edge debounce: absorb further wakes for the debounce
+			// window before snapshotting, so a burst of transitions (several
+			// processes changing together) collapses into one send instead of
+			// one per change. wake is a capacity-1 dirty latch (level, not
+			// edge): a change that lands after this absorb window closes but
+			// before the snapshot below is taken re-arms the latch and is
+			// picked up on the NEXT trip through this case -- so the LAST
+			// change of any burst always yields a snapshot, just possibly on a
+			// later tick, never lost.
+			if d := h.processStreamDebounce(); d > 0 {
+				if !h.absorbProcessWakes(r, wake, d) {
+					return
+				}
+			}
+
+			if !h.writeProcessSnapshot(rc, w) {
+				return
+			}
+		}
+	}
+}
+
+// processStreamMaxDebounceStretch bounds how long a continuous wake stream can
+// keep restarting the trailing-edge debounce: after stretch×d of absorbing, a
+// snapshot is forced even though the bus never went quiet. Without this cap, a
+// process flapping faster than the debounce window (a sub-100ms crash/restart
+// loop, a hot health check) would starve the stream of snapshots AND
+// heartbeats indefinitely (codex C11 finding).
+const processStreamMaxDebounceStretch = 5
+
+// absorbProcessWakes implements StreamProcesses' trailing-edge debounce: it
+// waits d after the wake that triggered it, restarting the wait on every
+// further wake absorbed during that window, so the caller only snapshots once
+// the bus has been quiet for a full window — or once the non-resetting
+// max-latency bound (processStreamMaxDebounceStretch×d) fires, whichever comes
+// first. Returns false if the request ended or the change bus closed while
+// absorbing (the caller must then return without sending a final snapshot).
+func (h *Handlers) absorbProcessWakes(r *http.Request, wake <-chan struct{}, d time.Duration) bool {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	deadline := time.NewTimer(processStreamMaxDebounceStretch * d)
+	defer deadline.Stop()
+	for {
+		select {
+		case <-r.Context().Done():
+			return false
+		case _, ok := <-wake:
+			if !ok {
+				return false
+			}
+			// Another change landed inside the window: restart the debounce
+			// so the eventual snapshot reflects the LATEST member of the burst.
+			if !timer.Stop() {
+				<-timer.C
+			}
+			timer.Reset(d)
+		case <-timer.C:
+			return true
+		case <-deadline.C:
+			// The bus never went quiet: snapshot anyway. The level latch keeps
+			// any change landing after this point armed for the next trip.
+			return true
+		}
+	}
+}
+
+// writeProcessSnapshot sends the current process list as one SSE data event.
+// It reports false on a write failure (the caller must then tear the stream
+// down); a JSON marshal failure -- unreachable in practice, since
+// ProcessListResponse is all plain/marshalable fields -- is treated as a
+// skip-this-tick no-op (mirrors StreamProxyRequests' marshal-error handling)
+// rather than tearing down the whole stream over it.
+func (h *Handlers) writeProcessSnapshot(rc *http.ResponseController, w http.ResponseWriter) bool {
+	data, err := json.Marshal(processListResponse(h.supervisor))
+	if err != nil {
+		return true
+	}
+	return sseWrite(rc, w, []byte("data: "), data, []byte("\n\n")) == nil
+}
+
 // sseWrite writes an SSE line (a comment or a "data: ..." event, given as one
 // or more byte-slice parts so callers never need to build an intermediate
 // string) under a per-write deadline, then flushes and surfaces both the
@@ -130,7 +278,7 @@ func (h *Handlers) StreamLogs(w http.ResponseWriter, r *http.Request) {
 // deadline deliberately bounds the whole frame, not each part: an SSE frame
 // is a few hundred bytes, so a client that cannot absorb one within
 // SSEWriteTimeout is dead and teardown is the desired outcome. Shared by
-// StreamLogs and StreamProxyRequests (handlers.go).
+// StreamLogs, StreamProxyRequests (handlers.go) and StreamProcesses.
 func sseWrite(rc *http.ResponseController, w http.ResponseWriter, parts ...[]byte) error {
 	_ = rc.SetWriteDeadline(time.Now().Add(constants.SSEWriteTimeout))
 	for _, p := range parts {

--- a/internal/api/sse.go
+++ b/internal/api/sse.go
@@ -2,11 +2,12 @@ package api
 
 import (
 	"encoding/json"
-	"fmt"
 	"log"
 	"net/http"
 	"strings"
+	"time"
 
+	"github.com/charliek/prox/internal/constants"
 	"github.com/charliek/prox/internal/domain"
 )
 
@@ -14,8 +15,7 @@ import (
 func (h *Handlers) StreamLogs(w http.ResponseWriter, r *http.Request) {
 	// Check if flusher is available before writing any SSE headers, so the
 	// error path can return a clean JSON error (matching StreamProxyRequests).
-	flusher, ok := w.(http.Flusher)
-	if !ok {
+	if _, ok := w.(http.Flusher); !ok {
 		writeJSON(w, http.StatusInternalServerError, ErrorResponse{
 			Error: "streaming not supported",
 			Code:  domain.ErrCodeStreamingNotSupported,
@@ -50,9 +50,17 @@ func (h *Handlers) StreamLogs(w http.ResponseWriter, r *http.Request) {
 	}
 	defer h.logManager.Unsubscribe(subID)
 
+	// rc lets each SSE write set a per-write deadline (see sseWrite below).
+	rc := http.NewResponseController(w)
+
 	// Send initial comment to establish connection
-	fmt.Fprintf(w, ": connected\n\n")
-	flusher.Flush()
+	if err := sseWrite(rc, w, []byte(": connected\n\n")); err != nil {
+		log.Printf("SSE write error (client likely disconnected): %v", err)
+		return
+	}
+
+	ticker := time.NewTicker(h.heartbeatInterval())
+	defer ticker.Stop()
 
 	// Stream logs
 	// Protection against slow clients:
@@ -64,6 +72,11 @@ func (h *Handlers) StreamLogs(w http.ResponseWriter, r *http.Request) {
 		select {
 		case <-ctx.Done():
 			return
+		case <-ticker.C:
+			if err := sseWrite(rc, w, []byte(": ping\n\n")); err != nil {
+				log.Printf("SSE write error (client likely disconnected): %v", err)
+				return
+			}
 		case entry, ok := <-ch:
 			if !ok {
 				return
@@ -77,12 +90,35 @@ func (h *Handlers) StreamLogs(w http.ResponseWriter, r *http.Request) {
 			}
 
 			// Send SSE event - handle write errors to detect slow/disconnected clients
-			if _, err := fmt.Fprintf(w, "data: %s\n\n", data); err != nil {
+			if err := sseWrite(rc, w, []byte("data: "), data, []byte("\n\n")); err != nil {
 				// Client disconnected or write failed - logged for debugging
 				log.Printf("SSE write error (client likely disconnected): %v", err)
 				return
 			}
-			flusher.Flush()
 		}
 	}
+}
+
+// sseWrite writes an SSE line (a comment or a "data: ..." event, given as one
+// or more byte-slice parts so callers never need to build an intermediate
+// string) under a per-write deadline, then flushes and surfaces both the
+// write and the flush error. A plain http.Flusher.Flush() cannot report a
+// failed flush, which is why every SSE write goes through a
+// *http.ResponseController instead of calling w.Write/flusher.Flush
+// directly. The deadline error is deliberately ignored: a ResponseWriter
+// that doesn't support write deadlines (e.g. httptest.ResponseRecorder)
+// returns http.ErrNotSupported here, which is not itself a failed write —
+// the subsequent Write/Flush still surfaces a real I/O problem. The single
+// deadline deliberately bounds the whole frame, not each part: an SSE frame
+// is a few hundred bytes, so a client that cannot absorb one within
+// SSEWriteTimeout is dead and teardown is the desired outcome. Shared by
+// StreamLogs and StreamProxyRequests (handlers.go).
+func sseWrite(rc *http.ResponseController, w http.ResponseWriter, parts ...[]byte) error {
+	_ = rc.SetWriteDeadline(time.Now().Add(constants.SSEWriteTimeout))
+	for _, p := range parts {
+		if _, err := w.Write(p); err != nil {
+			return err
+		}
+	}
+	return rc.Flush()
 }

--- a/internal/api/sse.go
+++ b/internal/api/sse.go
@@ -59,6 +59,24 @@ func (h *Handlers) StreamLogs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Send the handshake event immediately after: a reconnecting client must
+	// learn the current stream epoch BEFORE deciding how to backfill (see
+	// HandshakeResponse). It rides a named "event: handshake" frame, not a
+	// bare "data:" line, precisely so it cannot be mistaken for a log entry by
+	// an old client -- see HandshakeResponse's doc comment for the full
+	// reasoning and the parseSSELogEntry guard that backs it up.
+	handshake, err := json.Marshal(HandshakeResponse{StreamID: h.logManager.StreamID()})
+	if err != nil {
+		// StreamID is a plain string; Marshal cannot fail for this shape in
+		// practice. Guard anyway rather than risk writing a broken frame.
+		log.Printf("failed to marshal handshake: %v", err)
+		return
+	}
+	if err := sseWrite(rc, w, []byte("event: handshake\n"), []byte("data: "), handshake, []byte("\n\n")); err != nil {
+		log.Printf("SSE write error (client likely disconnected): %v", err)
+		return
+	}
+
 	ticker := time.NewTicker(h.heartbeatInterval())
 	defer ticker.Stop()
 

--- a/internal/api/sse_test.go
+++ b/internal/api/sse_test.go
@@ -176,17 +176,36 @@ func TestStreamLogs_DataFormat(t *testing.T) {
 		t.Fatal("handler did not finish")
 	}
 
-	// Parse SSE events
+	// Parse SSE events. The stream now also carries the handshake event (plan
+	// 017 C8) as its own "data: " line immediately preceded by "event:
+	// handshake" -- track the previous line so that payload isn't mistaken
+	// for a log entry.
 	body := rec.Body.String()
 	scanner := bufio.NewScanner(strings.NewReader(body))
 
-	foundData := false
+	var (
+		foundData      bool
+		foundHandshake bool
+		prevLine       string
+	)
 	for scanner.Scan() {
 		line := scanner.Text()
 		if strings.HasPrefix(line, "data: ") {
-			foundData = true
 			data := strings.TrimPrefix(line, "data: ")
 
+			if strings.TrimSpace(prevLine) == "event: handshake" {
+				var hs HandshakeResponse
+				if err := json.Unmarshal([]byte(data), &hs); err != nil {
+					t.Errorf("failed to parse handshake data line: %v", err)
+				} else if hs.StreamID != logMgr.StreamID() {
+					t.Errorf("expected handshake stream_id %q, got %q", logMgr.StreamID(), hs.StreamID)
+				}
+				foundHandshake = true
+				prevLine = line
+				continue
+			}
+
+			foundData = true
 			var entry LogEntryResponse
 			if err := json.Unmarshal([]byte(data), &entry); err != nil {
 				t.Errorf("failed to parse data line: %v", err)
@@ -200,13 +219,73 @@ func TestStreamLogs_DataFormat(t *testing.T) {
 				if entry.Line != "test message" {
 					t.Errorf("expected Line 'test message', got %q", entry.Line)
 				}
+				if entry.Seq == 0 {
+					t.Error("expected the streamed entry to carry a non-zero Seq")
+				}
 			}
 		}
+		prevLine = line
 	}
 
+	if !foundHandshake {
+		t.Error("expected to find the handshake data line in SSE response")
+	}
 	if !foundData {
 		t.Error("expected to find data line in SSE response")
 	}
+}
+
+// TestStreamLogs_Handshake asserts the "event: handshake" frame is written
+// immediately after the ": connected" comment and carries the manager's
+// current stream ID (plan 017 C8): a reconnecting client must learn the
+// epoch before it can decide how to backfill.
+func TestStreamLogs_Handshake(t *testing.T) {
+	logMgr := logs.NewManager(logs.ManagerConfig{
+		BufferSize:         100,
+		SubscriptionBuffer: 10,
+	})
+	defer logMgr.Close()
+
+	handlers := NewHandlers(nil, logMgr, "test.yaml", nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequest("GET", "/api/v1/logs/stream", nil).WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		handlers.StreamLogs(rec, req)
+		close(done)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("handler did not finish")
+	}
+
+	body := rec.Body.String()
+
+	// Drop blank lines (SSE frame separators) so the adjacency check is
+	// robust to the ": connected\n\n" / "event:...\ndata:...\n\n" framing.
+	var nonEmpty []string
+	for _, l := range strings.Split(body, "\n") {
+		if strings.TrimSpace(l) != "" {
+			nonEmpty = append(nonEmpty, l)
+		}
+	}
+
+	require.GreaterOrEqual(t, len(nonEmpty), 3, "expected the connected comment, the handshake event line and its data line")
+	require.Contains(t, nonEmpty[0], ": connected")
+	require.Equal(t, "event: handshake", nonEmpty[1])
+	require.True(t, strings.HasPrefix(nonEmpty[2], "data: "))
+
+	var hs HandshakeResponse
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimPrefix(nonEmpty[2], "data: ")), &hs))
+	require.Equal(t, logMgr.StreamID(), hs.StreamID)
 }
 
 func TestStreamLogs_InvalidPattern(t *testing.T) {

--- a/internal/api/sse_test.go
+++ b/internal/api/sse_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/charliek/prox/internal/domain"
 	"github.com/charliek/prox/internal/logs"
 )
@@ -297,4 +299,138 @@ func TestStreamLogs_NoFlusher_ReturnsJSONError(t *testing.T) {
 	if errResp.Code != domain.ErrCodeStreamingNotSupported {
 		t.Errorf("expected code %q, got %q", domain.ErrCodeStreamingNotSupported, errResp.Code)
 	}
+}
+
+// readSSEConnected reads the ": connected" comment every SSE handler writes
+// on subscribe and returns a buffered reader positioned right after it, ready
+// for the caller to keep reading SSE lines from. Shared by the StreamLogs and
+// StreamProxyRequests heartbeat/disconnect tests below.
+func readSSEConnected(t *testing.T, resp *http.Response) *bufio.Reader {
+	t.Helper()
+	reader := bufio.NewReader(resp.Body)
+	line, err := reader.ReadString('\n')
+	require.NoError(t, err)
+	require.Contains(t, line, ": connected")
+	return reader
+}
+
+// requireSSEHeartbeats reads SSE lines from reader until it has seen minPings
+// ": ping" heartbeats and one "data: " line containing dataMarker, failing if
+// that takes longer than window. window is the cadence assertion, not just a
+// hang guard: callers pick a small multiple of the injected heartbeat
+// interval, so an implementation whose real cadence grossly exceeds the
+// configured interval cannot pass on scheduling luck, while the margin stays
+// wide enough not to flake under CI load. Shared by the StreamLogs and
+// StreamProxyRequests heartbeat tests to also assert heartbeats and data
+// events interleave rather than one starving the other.
+func requireSSEHeartbeats(t *testing.T, reader *bufio.Reader, dataMarker string, minPings int, window time.Duration) {
+	t.Helper()
+	start := time.Now()
+	pings, sawData := 0, false
+	for pings < minPings || !sawData {
+		if elapsed := time.Since(start); elapsed > window {
+			t.Fatalf("saw %d/%d pings, data=%v after %v (window %v)",
+				pings, minPings, sawData, elapsed, window)
+		}
+		l, err := reader.ReadString('\n')
+		require.NoError(t, err)
+		switch {
+		case strings.TrimSpace(l) == ": ping":
+			pings++
+		case strings.HasPrefix(l, "data: ") && strings.Contains(l, dataMarker):
+			sawData = true
+		}
+	}
+}
+
+// requireSSEHandlerReturns waits for done to close (an SSE handler returning
+// after its deferred cleanup), failing the test if it doesn't within 2s.
+// Shared by the StreamLogs and StreamProxyRequests client-disconnect tests.
+func requireSSEHandlerReturns(t *testing.T, done <-chan struct{}, handlerName string) {
+	t.Helper()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("%s did not return after the client closed the connection", handlerName)
+	}
+}
+
+// TestStreamLogs_Heartbeat drives StreamLogs behind a real httptest.Server (an
+// httptest.ResponseRecorder never streams to a reader in real time, so a
+// heartbeat cadence can't be observed against one) with a short injected
+// heartbeat interval. It asserts an idle stream still emits ": ping" comments
+// on that cadence, and that a data event published mid-stream is delivered
+// interleaved with the heartbeats rather than starving one or the other.
+func TestStreamLogs_Heartbeat(t *testing.T) {
+	logMgr := logs.NewManager(logs.ManagerConfig{
+		BufferSize:         100,
+		SubscriptionBuffer: 10,
+	})
+	defer logMgr.Close()
+
+	handlers := NewHandlers(nil, logMgr, "test.yaml", nil)
+	handlers.sseHeartbeatInterval = 20 * time.Millisecond
+
+	srv := httptest.NewServer(http.HandlerFunc(handlers.StreamLogs))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	reader := readSSEConnected(t, resp)
+
+	// Publish a data event partway through the read loop so it must interleave
+	// with the heartbeat ticks rather than block on them.
+	go func() {
+		time.Sleep(4 * handlers.sseHeartbeatInterval)
+		logMgr.Write(domain.LogEntry{
+			Timestamp: time.Now(),
+			Process:   "hb",
+			Stream:    domain.StreamStdout,
+			Line:      "interleaved",
+		})
+	}()
+
+	// 3 pings within 1s at a 20ms interval: generous 16× margin against CI
+	// scheduling, yet a cadence regression to even 500ms/ping cannot pass.
+	requireSSEHeartbeats(t, reader, "interleaved", 3, time.Second)
+}
+
+// TestStreamLogs_ClientDisconnect_ReturnsHandler covers the teardown path with
+// a real connection close (as opposed to the context-cancellation simulation
+// used by TestStreamLogs_Headers et al.): once the client closes its side of
+// the connection, the handler's next write must fail and it must return,
+// freeing the log subscription via its deferred Unsubscribe.
+func TestStreamLogs_ClientDisconnect_ReturnsHandler(t *testing.T) {
+	logMgr := logs.NewManager(logs.ManagerConfig{
+		BufferSize:         100,
+		SubscriptionBuffer: 10,
+	})
+	defer logMgr.Close()
+
+	handlers := NewHandlers(nil, logMgr, "test.yaml", nil)
+	handlers.sseHeartbeatInterval = 10 * time.Millisecond
+
+	done := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlers.StreamLogs(w, r)
+		close(done)
+	}))
+	defer srv.Close()
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+
+	readSSEConnected(t, resp)
+
+	require.NoError(t, resp.Body.Close())
+
+	requireSSEHandlerReturns(t, done, "StreamLogs")
 }

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -275,8 +275,13 @@ type APIError struct {
 // status-specific fallback. The text is user-facing: CLI commands surface it
 // verbatim through clientError.
 func (e *APIError) Error() string {
-	if e.Message != "" {
+	// Code is optional on the wire: a handler that writes {"error":"..."}
+	// without a code must not render a bare ": msg" (CodeRabbit PR #87).
+	if e.Message != "" && e.Code != "" {
 		return fmt.Sprintf("%s: %s", e.Code, e.Message)
+	}
+	if e.Message != "" {
+		return e.Message
 	}
 
 	switch e.Status {

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -216,12 +216,16 @@ func (c *Client) GetLogs(params domain.LogParams) (*api.LogsResponse, error) {
 	return &resp, nil
 }
 
-// GetProxyRequests gets recent proxy requests with optional filtering
-func (c *Client) GetProxyRequests(params domain.ProxyRequestParams) (*api.ProxyRequestsResponse, error) {
+// GetProxyRequests gets recent proxy requests with optional filtering.
+//
+// It takes a context because the TUI's requests-stream sync calls it once per
+// connect and must abandon an in-flight snapshot fetch the moment its stream
+// attempt ends (tui.TUIClient).
+func (c *Client) GetProxyRequests(ctx context.Context, params domain.ProxyRequestParams) (*api.ProxyRequestsResponse, error) {
 	path := pathWithQuery("/api/v1/proxy/requests", buildProxyRequestQueryParams(params))
 
 	var resp api.ProxyRequestsResponse
-	if err := c.get(path, &resp); err != nil {
+	if err := c.getCtx(ctx, path, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil
@@ -294,11 +298,11 @@ func httpStatusError(statusCode int, errResp *api.ErrorResponse) *APIError {
 }
 
 func (c *Client) doRequest(method, path string, v interface{}) error {
-	return c.doRequestWith(c.httpClient, method, path, v)
+	return c.doRequestWith(context.Background(), c.httpClient, method, path, v)
 }
 
-func (c *Client) doRequestWith(client *http.Client, method, path string, v interface{}) error {
-	req, err := http.NewRequest(method, c.baseURL+path, nil)
+func (c *Client) doRequestWith(ctx context.Context, client *http.Client, method, path string, v interface{}) error {
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, nil)
 	if err != nil {
 		return fmt.Errorf("creating request: %w", err)
 	}
@@ -331,6 +335,12 @@ func (c *Client) get(path string, v interface{}) error {
 	return c.doRequest("GET", path, v)
 }
 
+// getCtx is get with a caller-supplied context, so a cancellable caller aborts
+// its request rather than waiting out the client's 30s timeout.
+func (c *Client) getCtx(ctx context.Context, path string, v interface{}) error {
+	return c.doRequestWith(ctx, c.httpClient, "GET", path, v)
+}
+
 func (c *Client) post(path string, v interface{}) error {
 	return c.doRequest("POST", path, v)
 }
@@ -339,7 +349,7 @@ func (c *Client) post(path string, v interface{}) error {
 // tolerates a stop/restart that the daemon holds open up to a configured stop
 // budget (#35, D2).
 func (c *Client) postLifecycle(path string, v interface{}) error {
-	return c.doRequestWith(c.lifecycleClient, "POST", path, v)
+	return c.doRequestWith(context.Background(), c.lifecycleClient, "POST", path, v)
 }
 
 // addAuthHeader adds the Authorization header if a token is available

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -361,11 +361,27 @@ func (c *Client) addAuthHeader(req *http.Request) {
 
 // parseSSELogEntry parses a single SSE data line into a log entry.
 // Returns the parsed entry and true if successful, or an empty entry and false if parsing failed.
+//
+// readSSE (below) does not look at "event:" lines at all -- it only inspects
+// blank lines, comments, and "data:" lines -- so the "event: handshake" frame
+// StreamLogs sends right after ": connected" (plan 017 C8, see
+// api.HandshakeResponse) is invisible to it, but the "data: {"stream_id":...}"
+// line that follows still reaches this parser. json.Unmarshal ignores unknown
+// fields, so that payload decodes into an api.LogEntryResponse without error,
+// leaving every field at its zero value. Reject that shape explicitly: a real
+// log entry always has either a non-empty Process, a non-empty Line, or a
+// manager-assigned Seq >= 1, so Process=="" && Line=="" && Seq==0 can only be
+// a non-log payload riding the same "data:" convention (today, the
+// handshake). Without this guard it would surface as a phantom empty log row
+// in the attach TUI.
 func parseSSELogEntry(data string) (api.LogEntryResponse, bool) {
 	var entry api.LogEntryResponse
 	if err := json.Unmarshal([]byte(data), &entry); err != nil {
 		fmt.Fprintf(os.Stderr, "warning: failed to parse SSE log entry: %v\n", err)
 		return entry, false
+	}
+	if entry.Process == "" && entry.Line == "" && entry.Seq == 0 {
+		return api.LogEntryResponse{}, false
 	}
 	return entry, true
 }

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -275,6 +275,13 @@ func (e *APIError) Error() string {
 	}
 }
 
+// StatusCode and ErrorCode expose the two discriminating fields as methods so
+// consumers that cannot name this type can still classify it structurally:
+// internal/cli imports internal/tui, so the TUI's reconnect policies match on
+// the tui.APIStatusError interface these satisfy rather than on *APIError.
+func (e *APIError) StatusCode() int   { return e.Status }
+func (e *APIError) ErrorCode() string { return e.Code }
+
 // httpStatusError builds the *APIError for a non-2xx response. errResp is nil
 // when the body was absent or unparseable.
 func httpStatusError(statusCode int, errResp *api.ErrorResponse) *APIError {
@@ -497,14 +504,21 @@ func readSSE[T any](ctx context.Context, s *sseStream, parse func(string) (T, bo
 }
 
 // consumeSSE connects and delivers events via onEvent until the stream ends;
-// returns the terminal error (nil only on ctx cancellation).
-func consumeSSE[T any](ctx context.Context, c *Client, path string, parse func(string) (T, bool), onEvent func(T)) error {
+// returns the terminal error (nil only on ctx cancellation). onConnect (may
+// be nil) fires exactly once, after the dial fully succeeded (headers +
+// content type validated) and before the first read — it exists so a
+// reconnect loop can mark the attempt healthy only once a connection
+// actually stands, never for a dead-on-arrival dial.
+func consumeSSE[T any](ctx context.Context, c *Client, path string, parse func(string) (T, bool), onConnect func(), onEvent func(T)) error {
 	s, err := dialSSE(ctx, c, path)
 	if err != nil {
 		if ctx.Err() != nil {
 			return nil
 		}
 		return err
+	}
+	if onConnect != nil {
+		onConnect()
 	}
 	return readSSE(ctx, s, parse, onEvent)
 }
@@ -549,6 +563,20 @@ func logsStreamPath(params domain.LogParams) string {
 // as query string.
 func proxyRequestsStreamPath(params domain.ProxyRequestParams) string {
 	return pathWithQuery("/api/v1/proxy/requests/stream", buildProxyRequestQueryParams(params))
+}
+
+// ConsumeLogs delivers streamed log entries to onEvent until the stream ends,
+// returning the error that ended it (nil on ctx cancellation). onConnect
+// (nilable) fires once after the connection is established, before the first
+// read. It is the attempt form the TUI's reconnect loop drives; the channel
+// form below serves the one-shot --follow commands.
+func (c *Client) ConsumeLogs(ctx context.Context, params domain.LogParams, onConnect func(), onEvent func(api.LogEntryResponse)) error {
+	return consumeSSE(ctx, c, logsStreamPath(params), parseSSELogEntry, onConnect, onEvent)
+}
+
+// ConsumeProxyRequests is the proxy-request counterpart of ConsumeLogs.
+func (c *Client) ConsumeProxyRequests(ctx context.Context, params domain.ProxyRequestParams, onConnect func(), onEvent func(api.ProxyRequestResponse)) error {
+	return consumeSSE(ctx, c, proxyRequestsStreamPath(params), parseSSEProxyRequest, onConnect, onEvent)
 }
 
 // StreamProxyRequestsChannel returns a channel that streams proxy requests via SSE.

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -166,6 +166,18 @@ func buildLogQueryParams(params domain.LogParams) url.Values {
 	if params.Regex {
 		query.Set("regex", "true")
 	}
+	// since_seq is sent only when it names a real cursor. A zero SinceSeq means
+	// the caller has consumed nothing, and sending `since_seq=0` would flip the
+	// server onto its resume path (every entry in the buffer, oldest-first,
+	// capped at `lines` from the OLDEST end) when what a cursorless caller wants
+	// is the last-`lines` path. The two agree only when the buffer holds fewer
+	// than `lines` entries, so the distinction is load-bearing (plan 017 C9).
+	//
+	// This builder is shared with logsStreamPath: the SSE endpoint ignores
+	// since_seq today, and no stream subscription sets it.
+	if params.SinceSeq > 0 {
+		query.Set("since_seq", fmt.Sprintf("%d", params.SinceSeq))
+	}
 	return query
 }
 
@@ -205,12 +217,16 @@ func pathWithQuery(path string, query url.Values) string {
 	return path + "?" + query.Encode()
 }
 
-// GetLogs gets logs with optional filtering
-func (c *Client) GetLogs(params domain.LogParams) (*api.LogsResponse, error) {
+// GetLogs gets logs with optional filtering.
+//
+// It takes a context for the same reason GetProxyRequests does: the TUI's
+// logs-stream sync calls it once per connect and must abandon an in-flight
+// backfill the moment that stream attempt ends (tui.TUIClient, plan 017 C9).
+func (c *Client) GetLogs(ctx context.Context, params domain.LogParams) (*api.LogsResponse, error) {
 	path := pathWithQuery("/api/v1/logs", buildLogQueryParams(params))
 
 	var resp api.LogsResponse
-	if err := c.get(path, &resp); err != nil {
+	if err := c.getCtx(ctx, path, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil
@@ -362,18 +378,16 @@ func (c *Client) addAuthHeader(req *http.Request) {
 // parseSSELogEntry parses a single SSE data line into a log entry.
 // Returns the parsed entry and true if successful, or an empty entry and false if parsing failed.
 //
-// readSSE (below) does not look at "event:" lines at all -- it only inspects
-// blank lines, comments, and "data:" lines -- so the "event: handshake" frame
-// StreamLogs sends right after ": connected" (plan 017 C8, see
-// api.HandshakeResponse) is invisible to it, but the "data: {"stream_id":...}"
-// line that follows still reaches this parser. json.Unmarshal ignores unknown
-// fields, so that payload decodes into an api.LogEntryResponse without error,
-// leaving every field at its zero value. Reject that shape explicitly: a real
-// log entry always has either a non-empty Process, a non-empty Line, or a
-// manager-assigned Seq >= 1, so Process=="" && Line=="" && Seq==0 can only be
-// a non-log payload riding the same "data:" convention (today, the
-// handshake). Without this guard it would surface as a phantom empty log row
-// in the attach TUI.
+// readSSE (below) now tracks "event:" lines and routes an "event: handshake"
+// frame's payload to the handshake hook instead of this parser (plan 017 C9),
+// so the handshake no longer reaches it in practice. The guard below stays
+// regardless, as defense against any other non-entry payload riding the
+// "data:" convention: json.Unmarshal ignores unknown fields, so such a payload
+// decodes into an api.LogEntryResponse without error, leaving every field at
+// its zero value. A real log entry always has either a non-empty Process, a
+// non-empty Line, or a manager-assigned Seq >= 1, so Process=="" && Line=="" &&
+// Seq==0 can only be a non-log payload — without this it would surface as a
+// phantom empty log row in the attach TUI.
 func parseSSELogEntry(data string) (api.LogEntryResponse, bool) {
 	var entry api.LogEntryResponse
 	if err := json.Unmarshal([]byte(data), &entry); err != nil {
@@ -384,6 +398,23 @@ func parseSSELogEntry(data string) (api.LogEntryResponse, bool) {
 		return api.LogEntryResponse{}, false
 	}
 	return entry, true
+}
+
+// sseHandshakeEvent is the SSE event name carrying api.HandshakeResponse. The
+// logs stream sends exactly one, immediately after ": connected" and before any
+// entry (internal/api/sse.go).
+const sseHandshakeEvent = "handshake"
+
+// parseSSEHandshake parses the payload of an "event: handshake" frame. A
+// malformed payload warns and is dropped: the consumer then behaves exactly as
+// it does against a server that sends no handshake at all.
+func parseSSEHandshake(data string) (api.HandshakeResponse, bool) {
+	var hs api.HandshakeResponse
+	if err := json.Unmarshal([]byte(data), &hs); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to parse SSE handshake: %v\n", err)
+		return hs, false
+	}
+	return hs, true
 }
 
 // parseSSEProxyRequest parses a single SSE data line into a proxy request.
@@ -496,7 +527,20 @@ func dialSSE(ctx context.Context, c *Client, path string) (*sseStream, error) {
 // event to onEvent. It returns the terminal read error, or nil when ctx was
 // cancelled. Reads carry constants.SSEReadTimeout as a deadline so a server
 // that dies without closing the connection cannot hang the reader forever.
-func readSSE[T any](ctx context.Context, s *sseStream, parse func(string) (T, bool), onEvent func(T)) error {
+//
+// Frames are read as name+payload: an "event: <name>" line names the frame that
+// the next "data:" line carries, and the blank line terminating a frame clears
+// the name (comments never do — they are not frames). Only one named event
+// exists today: "handshake" (plan 017 C8), whose payload goes to onHandshake
+// (nilable; nil means "ignore the frame") and NEVER to the entry parser, which
+// would otherwise see a payload that is not an event of type T. An unnamed
+// frame is a plain data event, exactly as before this hook existed, so a server
+// that sends no handshake simply never fires it.
+//
+// A server MAY send more than one handshake on a stream; each one is delivered.
+// Consumers treat a repeat as harmless (the TUI's logs sync latches the first —
+// see logsSyncState.noteHandshake).
+func readSSE[T any](ctx context.Context, s *sseStream, parse func(string) (T, bool), onHandshake func(api.HandshakeResponse), onEvent func(T)) error {
 	defer s.close()
 
 	bodyReader := &deadlineReader{
@@ -505,6 +549,10 @@ func readSSE[T any](ctx context.Context, s *sseStream, parse func(string) (T, bo
 		timeout: constants.SSEReadTimeout,
 	}
 	reader := bufio.NewReader(bodyReader)
+
+	// event names the frame currently being read; "" is an unnamed (plain data)
+	// frame.
+	event := ""
 
 	for {
 		line, err := reader.ReadString('\n')
@@ -516,12 +564,32 @@ func readSSE[T any](ctx context.Context, s *sseStream, parse func(string) (T, bo
 		}
 
 		line = strings.TrimSpace(line)
-		if line == "" || strings.HasPrefix(line, ":") {
+		if line == "" {
+			event = "" // end of frame: the name does not carry into the next one
+			continue
+		}
+		if strings.HasPrefix(line, ":") {
+			continue // comment (": connected", ": ping") — not a frame
+		}
+
+		if name, ok := strings.CutPrefix(line, "event: "); ok {
+			event = name
 			continue
 		}
 
-		if strings.HasPrefix(line, "data: ") {
-			data := strings.TrimPrefix(line, "data: ")
+		if data, ok := strings.CutPrefix(line, "data: "); ok {
+			// A data line consumes the pending event name (codex C9 finding):
+			// per the SSE model one event field names one dispatch, so a
+			// following data line without its own event: prefix is a plain
+			// entry, even before any blank-line frame delimiter arrives.
+			frameEvent := event
+			event = ""
+			if frameEvent == sseHandshakeEvent {
+				if hs, ok := parseSSEHandshake(data); ok && onHandshake != nil {
+					onHandshake(hs)
+				}
+				continue
+			}
 			if item, ok := parse(data); ok {
 				onEvent(item)
 			}
@@ -534,8 +602,9 @@ func readSSE[T any](ctx context.Context, s *sseStream, parse func(string) (T, bo
 // be nil) fires exactly once, after the dial fully succeeded (headers +
 // content type validated) and before the first read — it exists so a
 // reconnect loop can mark the attempt healthy only once a connection
-// actually stands, never for a dead-on-arrival dial.
-func consumeSSE[T any](ctx context.Context, c *Client, path string, parse func(string) (T, bool), onConnect func(), onEvent func(T)) error {
+// actually stands, never for a dead-on-arrival dial. onHandshake (may be nil)
+// receives the stream's handshake frame, if it sends one; see readSSE.
+func consumeSSE[T any](ctx context.Context, c *Client, path string, parse func(string) (T, bool), onConnect func(), onHandshake func(api.HandshakeResponse), onEvent func(T)) error {
 	s, err := dialSSE(ctx, c, path)
 	if err != nil {
 		if ctx.Err() != nil {
@@ -546,7 +615,7 @@ func consumeSSE[T any](ctx context.Context, c *Client, path string, parse func(s
 	if onConnect != nil {
 		onConnect()
 	}
-	return readSSE(ctx, s, parse, onEvent)
+	return readSSE(ctx, s, parse, onHandshake, onEvent)
 }
 
 // streamSSE is the channel form of an SSE attempt: connect-time failures come
@@ -567,7 +636,10 @@ func streamSSE[T any](ctx context.Context, c *Client, path string, parse func(st
 	ch := make(chan T, 100)
 	go func() {
 		defer close(ch)
-		_ = readSSE(ctx, s, parse, func(item T) {
+		// nil handshake hook: the channel form carries one element type and has
+		// no way to surface a handshake, so the frame is ignored (as it was
+		// before C9 taught the reader to recognize it).
+		_ = readSSE(ctx, s, parse, nil, func(item T) {
 			// Never block past cancellation: a consumer that stopped reading
 			// would otherwise pin this goroutine.
 			select {
@@ -594,15 +666,20 @@ func proxyRequestsStreamPath(params domain.ProxyRequestParams) string {
 // ConsumeLogs delivers streamed log entries to onEvent until the stream ends,
 // returning the error that ended it (nil on ctx cancellation). onConnect
 // (nilable) fires once after the connection is established, before the first
-// read. It is the attempt form the TUI's reconnect loop drives; the channel
-// form below serves the one-shot --follow commands.
-func (c *Client) ConsumeLogs(ctx context.Context, params domain.LogParams, onConnect func(), onEvent func(api.LogEntryResponse)) error {
-	return consumeSSE(ctx, c, logsStreamPath(params), parseSSELogEntry, onConnect, onEvent)
+// read. onHandshake (nilable) receives the stream's handshake frame, which
+// carries the server's current log epoch — the attach TUI's log sync needs it
+// to decide how to backfill (plan 017 C9); a pre-C8 daemon sends none and the
+// hook simply never fires. It is the attempt form the TUI's reconnect loop
+// drives; the channel form below serves the one-shot --follow commands.
+func (c *Client) ConsumeLogs(ctx context.Context, params domain.LogParams, onConnect func(), onHandshake func(api.HandshakeResponse), onEvent func(api.LogEntryResponse)) error {
+	return consumeSSE(ctx, c, logsStreamPath(params), parseSSELogEntry, onConnect, onHandshake, onEvent)
 }
 
-// ConsumeProxyRequests is the proxy-request counterpart of ConsumeLogs.
+// ConsumeProxyRequests is the proxy-request counterpart of ConsumeLogs. The
+// requests stream sends no handshake (it has no epoch/cursor protocol), so it
+// passes a nil hook.
 func (c *Client) ConsumeProxyRequests(ctx context.Context, params domain.ProxyRequestParams, onConnect func(), onEvent func(api.ProxyRequestResponse)) error {
-	return consumeSSE(ctx, c, proxyRequestsStreamPath(params), parseSSEProxyRequest, onConnect, onEvent)
+	return consumeSSE(ctx, c, proxyRequestsStreamPath(params), parseSSEProxyRequest, onConnect, nil, onEvent)
 }
 
 // StreamProxyRequestsChannel returns a channel that streams proxy requests via SSE.

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -428,6 +428,21 @@ func parseSSEProxyRequest(data string) (api.ProxyRequestResponse, bool) {
 	return req, true
 }
 
+// parseSSEProcessList parses a single SSE data line of the processes stream
+// into a full process snapshot. Every event on that stream is a complete
+// api.ProcessListResponse (internal/api/sse.go) — there are no deltas — so an
+// empty Processes slice is a legitimate payload ("nothing is configured or
+// running") rather than a frame to filter out, and no zero-value guard like
+// parseSSELogEntry's applies here.
+func parseSSEProcessList(data string) (api.ProcessListResponse, bool) {
+	var resp api.ProcessListResponse
+	if err := json.Unmarshal([]byte(data), &resp); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to parse SSE process snapshot: %v\n", err)
+		return resp, false
+	}
+	return resp, true
+}
+
 // sseErrorBodyLimit bounds how much of a non-200 SSE connect body is read
 // before parsing it as an api.ErrorResponse.
 const sseErrorBodyLimit = 8 << 10
@@ -680,6 +695,24 @@ func (c *Client) ConsumeLogs(ctx context.Context, params domain.LogParams, onCon
 // passes a nil hook.
 func (c *Client) ConsumeProxyRequests(ctx context.Context, params domain.ProxyRequestParams, onConnect func(), onEvent func(api.ProxyRequestResponse)) error {
 	return consumeSSE(ctx, c, proxyRequestsStreamPath(params), parseSSEProxyRequest, onConnect, nil, onEvent)
+}
+
+// processesStreamPath is the process-state SSE endpoint. Unlike the logs and
+// requests streams it takes no query parameters: every event is the full
+// process list, unfiltered.
+const processesStreamPath = "/api/v1/processes/stream"
+
+// ConsumeProcesses delivers full process-list snapshots to onEvent until the
+// stream ends, returning the error that ended it (nil on ctx cancellation).
+// onConnect (nilable) fires once after the connection is established, before
+// the first read.
+//
+// The stream sends no handshake (it has no epoch/cursor protocol — each event
+// is self-describing current state), so it passes a nil hook. It is the
+// attempt form the attach TUI's reconnect loop drives; there is no channel
+// form because no --follow command consumes process state.
+func (c *Client) ConsumeProcesses(ctx context.Context, onConnect func(), onEvent func(api.ProcessListResponse)) error {
+	return consumeSSE(ctx, c, processesStreamPath, parseSSEProcessList, onConnect, nil, onEvent)
 }
 
 // StreamProxyRequestsChannel returns a channel that streams proxy requests via SSE.

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -18,11 +18,6 @@ import (
 	"github.com/charliek/prox/internal/domain"
 )
 
-// sseReadTimeout is the timeout for SSE reads. If no data is received within
-// this duration, the connection is considered dead. SSE servers send heartbeats,
-// so this should be longer than the heartbeat interval.
-const sseReadTimeout = 60 * time.Second
-
 // deadlineReader wraps an io.Reader and sets a read deadline on each read.
 // This prevents indefinite hangs when the server dies without closing the connection.
 type deadlineReader struct {
@@ -387,7 +382,7 @@ func streamSSE[T any](req *http.Request, parse func(string) (T, bool)) (<-chan T
 		bodyReader := &deadlineReader{
 			r:       resp.Body,
 			conn:    conn,
-			timeout: sseReadTimeout,
+			timeout: constants.SSEReadTimeout,
 		}
 		reader := bufio.NewReader(bodyReader)
 

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime"
 	"net"
 	"net/http"
 	"net/url"
@@ -195,14 +196,18 @@ func buildProxyRequestQueryParams(params domain.ProxyRequestParams) url.Values {
 	return query
 }
 
+// pathWithQuery appends query to path as a query string, leaving path
+// untouched when there is nothing to encode.
+func pathWithQuery(path string, query url.Values) string {
+	if len(query) == 0 {
+		return path
+	}
+	return path + "?" + query.Encode()
+}
+
 // GetLogs gets logs with optional filtering
 func (c *Client) GetLogs(params domain.LogParams) (*api.LogsResponse, error) {
-	query := buildLogQueryParams(params)
-
-	path := "/api/v1/logs"
-	if len(query) > 0 {
-		path += "?" + query.Encode()
-	}
+	path := pathWithQuery("/api/v1/logs", buildLogQueryParams(params))
 
 	var resp api.LogsResponse
 	if err := c.get(path, &resp); err != nil {
@@ -213,12 +218,7 @@ func (c *Client) GetLogs(params domain.LogParams) (*api.LogsResponse, error) {
 
 // GetProxyRequests gets recent proxy requests with optional filtering
 func (c *Client) GetProxyRequests(params domain.ProxyRequestParams) (*api.ProxyRequestsResponse, error) {
-	query := buildProxyRequestQueryParams(params)
-
-	path := "/api/v1/proxy/requests"
-	if len(query) > 0 {
-		path += "?" + query.Encode()
-	}
+	path := pathWithQuery("/api/v1/proxy/requests", buildProxyRequestQueryParams(params))
 
 	var resp api.ProxyRequestsResponse
 	if err := c.get(path, &resp); err != nil {
@@ -241,26 +241,49 @@ func (c *Client) GetProxyRequest(id string, includeBody bool) (*api.ProxyRequest
 	return &resp, nil
 }
 
-// httpStatusError maps HTTP status codes to user-friendly error messages
-func httpStatusError(statusCode int, errResp *api.ErrorResponse) error {
-	if errResp != nil && errResp.Error != "" {
-		return fmt.Errorf("%s: %s", errResp.Code, errResp.Error)
+// APIError is a non-2xx API response. Status is the HTTP status; Code is the
+// machine-readable error code from the JSON error body (empty if the body
+// wasn't parseable). Callers that need to discriminate on a specific failure
+// (e.g. a 503 PROXY_NOT_ENABLED) use errors.As rather than string matching.
+type APIError struct {
+	Status  int
+	Code    string
+	Message string
+}
+
+// Error renders the daemon's own message when it sent one, and otherwise a
+// status-specific fallback. The text is user-facing: CLI commands surface it
+// verbatim through clientError.
+func (e *APIError) Error() string {
+	if e.Message != "" {
+		return fmt.Sprintf("%s: %s", e.Code, e.Message)
 	}
 
-	switch statusCode {
+	switch e.Status {
 	case http.StatusUnauthorized:
-		return fmt.Errorf("authentication failed: invalid or missing token")
+		return "authentication failed: invalid or missing token"
 	case http.StatusForbidden:
-		return fmt.Errorf("access denied: insufficient permissions")
+		return "access denied: insufficient permissions"
 	case http.StatusNotFound:
-		return fmt.Errorf("not found: the requested resource does not exist")
+		return "not found: the requested resource does not exist"
 	case http.StatusInternalServerError:
-		return fmt.Errorf("server error: the prox daemon encountered an internal error")
+		return "server error: the prox daemon encountered an internal error"
 	case http.StatusServiceUnavailable:
-		return fmt.Errorf("service unavailable: the prox daemon is not ready")
+		return "service unavailable: the prox daemon is not ready"
 	default:
-		return fmt.Errorf("request failed with status %d", statusCode)
+		return fmt.Sprintf("request failed with status %d", e.Status)
 	}
+}
+
+// httpStatusError builds the *APIError for a non-2xx response. errResp is nil
+// when the body was absent or unparseable.
+func httpStatusError(statusCode int, errResp *api.ErrorResponse) *APIError {
+	e := &APIError{Status: statusCode}
+	if errResp != nil {
+		e.Code = errResp.Code
+		e.Message = errResp.Error
+	}
+	return e
 }
 
 func (c *Client) doRequest(method, path string, v interface{}) error {
@@ -341,10 +364,49 @@ func parseSSEProxyRequest(data string) (api.ProxyRequestResponse, bool) {
 	return req, true
 }
 
-// streamSSE creates an SSE connection and returns a channel of parsed events.
-// The channel is closed when the connection ends or times out.
-func streamSSE[T any](req *http.Request, parse func(string) (T, bool)) (<-chan T, error) {
-	// Custom transport to capture connection for read deadlines
+// sseErrorBodyLimit bounds how much of a non-200 SSE connect body is read
+// before parsing it as an api.ErrorResponse.
+const sseErrorBodyLimit = 8 << 10
+
+// sseContentType is the media type an SSE endpoint must answer with. The
+// response may append parameters (e.g. "; charset=utf-8"), so it is matched as
+// a prefix.
+const sseContentType = "text/event-stream"
+
+// sseStream is one dialed SSE attempt: the live response plus the conn that
+// carried it. conn is captured by the per-attempt transport so deadlineReader
+// can set a read deadline on the exact connection this response is reading
+// from -- the transport must therefore dial at most once per attempt.
+type sseStream struct {
+	resp      *http.Response
+	conn      net.Conn
+	transport *http.Transport
+}
+
+// close releases the body and the attempt's idle connections. Each attempt owns
+// its transport, so nothing is shared with a later attempt.
+func (s *sseStream) close() {
+	s.resp.Body.Close()
+	s.transport.CloseIdleConnections()
+}
+
+// dialSSE opens an SSE connection to path and validates the response. A non-200
+// answer is returned as *APIError, parsed from the (bounded) JSON error body
+// when possible.
+func dialSSE(ctx context.Context, c *Client, path string) (*sseStream, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", c.baseURL+path, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", sseContentType)
+	c.addAuthHeader(req)
+
+	// Custom transport to capture connection for read deadlines. The capture
+	// is only sound while exactly one dial serves the response, so redirects
+	// are refused below (a redirect chain can hand the response to a reused
+	// idle connection while conn points at the redirect hop's dial — the
+	// deadline would then arm the wrong socket). An SSE endpoint never
+	// legitimately redirects; a 3xx falls through to the non-200 error path.
 	var conn net.Conn
 	dialer := &net.Dialer{
 		Timeout:   30 * time.Second,
@@ -356,93 +418,149 @@ func streamSSE[T any](req *http.Request, parse func(string) (T, bool)) (<-chan T
 			conn, err = dialer.DialContext(ctx, network, addr)
 			return conn, err
 		},
+		// The deadlineReader only guards body reads; without this a server
+		// that accepts TCP but never sends response headers would hang the
+		// dial forever (http.Client.Timeout is 0 for SSE by design).
+		ResponseHeaderTimeout: constants.DefaultRequestTimeout,
 	}
 
 	client := &http.Client{
 		Transport: transport,
 		Timeout:   0, // SSE streams are long-lived
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
 	}
 
 	resp, err := client.Do(req)
 	if err != nil {
+		transport.CloseIdleConnections()
 		return nil, err
 	}
 
+	stream := &sseStream{resp: resp, conn: conn, transport: transport}
+
 	if resp.StatusCode != http.StatusOK {
-		resp.Body.Close()
+		defer stream.close()
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, sseErrorBodyLimit))
+		var errResp api.ErrorResponse
+		if err := json.Unmarshal(body, &errResp); err == nil {
+			return nil, httpStatusError(resp.StatusCode, &errResp)
+		}
 		return nil, httpStatusError(resp.StatusCode, nil)
 	}
 
+	if mt, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type")); err != nil || mt != sseContentType {
+		ct := resp.Header.Get("Content-Type")
+		stream.close()
+		return nil, fmt.Errorf("unexpected content type %q from %s (want %s)", ct, path, sseContentType)
+	}
+
+	return stream, nil
+}
+
+// readSSE reads events off a dialed stream until it ends, handing each parsed
+// event to onEvent. It returns the terminal read error, or nil when ctx was
+// cancelled. Reads carry constants.SSEReadTimeout as a deadline so a server
+// that dies without closing the connection cannot hang the reader forever.
+func readSSE[T any](ctx context.Context, s *sseStream, parse func(string) (T, bool), onEvent func(T)) error {
+	defer s.close()
+
+	bodyReader := &deadlineReader{
+		r:       s.resp.Body,
+		conn:    s.conn,
+		timeout: constants.SSEReadTimeout,
+	}
+	reader := bufio.NewReader(bodyReader)
+
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			return err
+		}
+
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, ":") {
+			continue
+		}
+
+		if strings.HasPrefix(line, "data: ") {
+			data := strings.TrimPrefix(line, "data: ")
+			if item, ok := parse(data); ok {
+				onEvent(item)
+			}
+		}
+	}
+}
+
+// consumeSSE connects and delivers events via onEvent until the stream ends;
+// returns the terminal error (nil only on ctx cancellation).
+func consumeSSE[T any](ctx context.Context, c *Client, path string, parse func(string) (T, bool), onEvent func(T)) error {
+	s, err := dialSSE(ctx, c, path)
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil
+		}
+		return err
+	}
+	return readSSE(ctx, s, parse, onEvent)
+}
+
+// streamSSE is the channel form of an SSE attempt: connect-time failures come
+// back synchronously, and the channel closes when the stream ends for any reason.
+// The terminal error is dropped here on purpose -- consumers of the channel API
+// only observe the close.
+//
+// Contract: a consumer that abandons the channel MUST cancel ctx. Cancellation
+// is the only unblock for the reader once the channel buffer fills; abandoning
+// without cancelling pins the reader goroutine and its connection until the
+// buffer's next send would occur — forever, on a quiet stream.
+func streamSSE[T any](ctx context.Context, c *Client, path string, parse func(string) (T, bool)) (<-chan T, error) {
+	s, err := dialSSE(ctx, c, path)
+	if err != nil {
+		return nil, err
+	}
+
 	ch := make(chan T, 100)
-
 	go func() {
-		defer resp.Body.Close()
 		defer close(ch)
-
-		bodyReader := &deadlineReader{
-			r:       resp.Body,
-			conn:    conn,
-			timeout: constants.SSEReadTimeout,
-		}
-		reader := bufio.NewReader(bodyReader)
-
-		for {
-			line, err := reader.ReadString('\n')
-			if err != nil {
-				return
+		_ = readSSE(ctx, s, parse, func(item T) {
+			// Never block past cancellation: a consumer that stopped reading
+			// would otherwise pin this goroutine.
+			select {
+			case ch <- item:
+			case <-ctx.Done():
 			}
-
-			line = strings.TrimSpace(line)
-			if line == "" || strings.HasPrefix(line, ":") {
-				continue
-			}
-
-			if strings.HasPrefix(line, "data: ") {
-				data := strings.TrimPrefix(line, "data: ")
-				if item, ok := parse(data); ok {
-					ch <- item
-				}
-			}
-		}
+		})
 	}()
 
 	return ch, nil
 }
 
+// logsStreamPath builds the log SSE path with params applied as query string.
+func logsStreamPath(params domain.LogParams) string {
+	return pathWithQuery("/api/v1/logs/stream", buildLogQueryParams(params))
+}
+
+// proxyRequestsStreamPath builds the proxy-request SSE path with params applied
+// as query string.
+func proxyRequestsStreamPath(params domain.ProxyRequestParams) string {
+	return pathWithQuery("/api/v1/proxy/requests/stream", buildProxyRequestQueryParams(params))
+}
+
 // StreamProxyRequestsChannel returns a channel that streams proxy requests via SSE.
-// The channel is closed when the connection ends or the read times out.
-func (c *Client) StreamProxyRequestsChannel(params domain.ProxyRequestParams) (<-chan api.ProxyRequestResponse, error) {
-	query := buildProxyRequestQueryParams(params)
-
-	path := "/api/v1/proxy/requests/stream"
-	if len(query) > 0 {
-		path += "?" + query.Encode()
-	}
-
-	req, err := http.NewRequest("GET", c.baseURL+path, nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Accept", "text/event-stream")
-	c.addAuthHeader(req)
-	return streamSSE(req, parseSSEProxyRequest)
+// The channel is closed when the connection ends, the read times out, or ctx is
+// cancelled.
+func (c *Client) StreamProxyRequestsChannel(ctx context.Context, params domain.ProxyRequestParams) (<-chan api.ProxyRequestResponse, error) {
+	return streamSSE(ctx, c, proxyRequestsStreamPath(params), parseSSEProxyRequest)
 }
 
 // StreamLogsChannel returns a channel that streams log entries via SSE.
-// The channel is closed when the connection ends or the read times out.
-func (c *Client) StreamLogsChannel(params domain.LogParams) (<-chan api.LogEntryResponse, error) {
-	query := buildLogQueryParams(params)
-
-	path := "/api/v1/logs/stream"
-	if len(query) > 0 {
-		path += "?" + query.Encode()
-	}
-
-	req, err := http.NewRequest("GET", c.baseURL+path, nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Accept", "text/event-stream")
-	c.addAuthHeader(req)
-	return streamSSE(req, parseSSELogEntry)
+// The channel is closed when the connection ends, the read times out, or ctx is
+// cancelled.
+func (c *Client) StreamLogsChannel(ctx context.Context, params domain.LogParams) (<-chan api.LogEntryResponse, error) {
+	return streamSSE(ctx, c, logsStreamPath(params), parseSSELogEntry)
 }

--- a/internal/cli/client_test.go
+++ b/internal/cli/client_test.go
@@ -1,7 +1,9 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -888,7 +890,7 @@ func TestClient_StreamLogsChannel_QueryParams(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient(server.URL)
-	_, err := client.StreamLogsChannel(domain.LogParams{
+	_, err := client.StreamLogsChannel(context.Background(), domain.LogParams{
 		Process: "web",
 		Lines:   50,
 		Pattern: "error",
@@ -914,5 +916,297 @@ func TestClient_StreamLogsChannel_QueryParams(t *testing.T) {
 	}
 	if !strings.Contains(receivedQuery, "regex=true") {
 		t.Errorf("expected regex=true in query, got %s", receivedQuery)
+	}
+}
+
+// TestClient_APIError pins the typed error surfaced for every non-2xx response:
+// callers can errors.As it for the status/code, and the rendered text still
+// matches the human-readable format the CLI printed before APIError existed.
+func TestClient_APIError(t *testing.T) {
+	tests := []struct {
+		name        string
+		status      int
+		contentType string
+		body        string
+		wantCode    string
+		wantMessage string
+		wantText    string
+	}{
+		{
+			name:     "unauthorized without body",
+			status:   http.StatusUnauthorized,
+			wantText: "authentication failed: invalid or missing token",
+		},
+		{
+			name:     "forbidden without body",
+			status:   http.StatusForbidden,
+			wantText: "access denied: insufficient permissions",
+		},
+		{
+			name:        "not found with error body",
+			status:      http.StatusNotFound,
+			contentType: "application/json",
+			body:        `{"error":"process not found","code":"PROCESS_NOT_FOUND"}`,
+			wantCode:    "PROCESS_NOT_FOUND",
+			wantMessage: "process not found",
+			wantText:    "PROCESS_NOT_FOUND: process not found",
+		},
+		{
+			name:        "service unavailable with proxy code",
+			status:      http.StatusServiceUnavailable,
+			contentType: "application/json",
+			body:        `{"error":"proxy is not enabled","code":"PROXY_NOT_ENABLED"}`,
+			wantCode:    "PROXY_NOT_ENABLED",
+			wantMessage: "proxy is not enabled",
+			wantText:    "PROXY_NOT_ENABLED: proxy is not enabled",
+		},
+		{
+			name:        "internal error with unparseable body",
+			status:      http.StatusInternalServerError,
+			contentType: "text/html",
+			body:        "<html>boom</html>",
+			wantText:    "server error: the prox daemon encountered an internal error",
+		},
+		{
+			name:     "unmapped status",
+			status:   http.StatusTeapot,
+			wantText: "request failed with status 418",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tt.contentType != "" {
+					w.Header().Set("Content-Type", tt.contentType)
+				}
+				w.WriteHeader(tt.status)
+				if tt.body != "" {
+					w.Write([]byte(tt.body))
+				}
+			}))
+			defer server.Close()
+
+			client := NewClient(server.URL)
+			_, err := client.GetStatus()
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+
+			var apiErr *APIError
+			if !errors.As(err, &apiErr) {
+				t.Fatalf("expected *APIError, got %T: %v", err, err)
+			}
+			if apiErr.Status != tt.status {
+				t.Errorf("expected Status %d, got %d", tt.status, apiErr.Status)
+			}
+			if apiErr.Code != tt.wantCode {
+				t.Errorf("expected Code %q, got %q", tt.wantCode, apiErr.Code)
+			}
+			if apiErr.Message != tt.wantMessage {
+				t.Errorf("expected Message %q, got %q", tt.wantMessage, apiErr.Message)
+			}
+			if err.Error() != tt.wantText {
+				t.Errorf("expected error text %q, got %q", tt.wantText, err.Error())
+			}
+		})
+	}
+}
+
+// TestClient_StreamProxyRequestsChannel_ProxyNotEnabled proves a 503 connect
+// response is discriminable: the stream error carries Status 503 and the
+// machine-readable PROXY_NOT_ENABLED code, which the reconnect policy needs.
+func TestClient_StreamProxyRequestsChannel_ProxyNotEnabled(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		json.NewEncoder(w).Encode(api.ErrorResponse{
+			Error: "proxy is not enabled",
+			Code:  "PROXY_NOT_ENABLED",
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	_, err := client.StreamProxyRequestsChannel(context.Background(), domain.ProxyRequestParams{})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected *APIError, got %T: %v", err, err)
+	}
+	if apiErr.Status != http.StatusServiceUnavailable {
+		t.Errorf("expected Status 503, got %d", apiErr.Status)
+	}
+	if apiErr.Code != "PROXY_NOT_ENABLED" {
+		t.Errorf("expected Code PROXY_NOT_ENABLED, got %q", apiErr.Code)
+	}
+}
+
+// TestClient_StreamLogsChannel_RejectsNonEventStream fails the connect when the
+// daemon answers 200 with something that is not an SSE stream.
+func TestClient_StreamLogsChannel_RejectsNonEventStream(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("<html>not a stream</html>"))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	_, err := client.StreamLogsChannel(context.Background(), domain.LogParams{})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "content type") || !strings.Contains(err.Error(), "text/event-stream") {
+		t.Errorf("expected descriptive content-type error, got %q", err.Error())
+	}
+}
+
+// TestDialSSE_AcceptsContentTypeParameters accepts the media type with
+// parameters appended, which is what net/http writes by default.
+func TestDialSSE_AcceptsContentTypeParameters(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	s, err := dialSSE(context.Background(), client, logsStreamPath(domain.LogParams{}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	s.close()
+}
+
+// sseHangupServer writes one log event and then returns, ending the stream.
+func sseHangupServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(": heartbeat\n\n"))
+		w.Write([]byte("data: {\"timestamp\":\"2024-01-01T00:00:00Z\",\"process\":\"web\",\"stream\":\"stdout\",\"line\":\"one\"}\n\n"))
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}))
+}
+
+// TestConsumeSSE_ReturnsTerminalError is the attempt-level contract the
+// reconnect loop depends on: a stream that ends surfaces the read error rather
+// than disappearing silently, and events delivered before the end are kept.
+func TestConsumeSSE_ReturnsTerminalError(t *testing.T) {
+	server := sseHangupServer(t)
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	var got []api.LogEntryResponse
+	err := consumeSSE(context.Background(), client, logsStreamPath(domain.LogParams{}), parseSSELogEntry,
+		func(entry api.LogEntryResponse) { got = append(got, entry) })
+
+	if err == nil {
+		t.Fatal("expected terminal error when the server ends the stream, got nil")
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 delivered event, got %d", len(got))
+	}
+	if got[0].Line != "one" {
+		t.Errorf("expected line %q, got %q", "one", got[0].Line)
+	}
+}
+
+// drainUntilClosed reads ch to completion and returns everything it delivered,
+// failing the test with failMsg if the channel is not closed within 5s.
+func drainUntilClosed(t *testing.T, ch <-chan api.LogEntryResponse, failMsg string) []api.LogEntryResponse {
+	t.Helper()
+	var got []api.LogEntryResponse
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case entry, ok := <-ch:
+			if !ok {
+				return got
+			}
+			got = append(got, entry)
+		case <-deadline:
+			t.Fatal(failMsg)
+		}
+	}
+}
+
+// TestClient_StreamLogsChannel_ClosesOnHangup keeps the existing consumer
+// contract: the channel variant only closes, it does not surface the error.
+func TestClient_StreamLogsChannel_ClosesOnHangup(t *testing.T) {
+	server := sseHangupServer(t)
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	ch, err := client.StreamLogsChannel(context.Background(), domain.LogParams{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := drainUntilClosed(t, ch, "channel was not closed after the server ended the stream")
+	if len(got) != 1 {
+		t.Fatalf("expected 1 event before close, got %d", len(got))
+	}
+}
+
+// TestClient_StreamLogsChannel_ContextCancel proves cancellation tears the
+// stream down immediately -- well inside constants.SSEReadTimeout -- and that
+// the reader goroutine exits (it closes the channel on its way out).
+func TestClient_StreamLogsChannel_ContextCancel(t *testing.T) {
+	handlerDone := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer close(handlerDone)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("data: {\"timestamp\":\"2024-01-01T00:00:00Z\",\"process\":\"web\",\"stream\":\"stdout\",\"line\":\"one\"}\n\n"))
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		// Hold the stream open until the client goes away.
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client := NewClient(server.URL)
+	ch, err := client.StreamLogsChannel(ctx, domain.LogParams{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	select {
+	case entry, ok := <-ch:
+		if !ok {
+			t.Fatal("channel closed before the first event")
+		}
+		if entry.Line != "one" {
+			t.Fatalf("expected line %q, got %q", "one", entry.Line)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the first event")
+	}
+
+	start := time.Now()
+	cancel()
+
+	drainUntilClosed(t, ch, "channel was not closed within 5s of cancellation")
+
+	if elapsed := time.Since(start); elapsed >= constants.SSEReadTimeout {
+		t.Errorf("cancellation took %v, expected well under the %v read deadline", elapsed, constants.SSEReadTimeout)
+	}
+
+	select {
+	case <-handlerDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("server handler still holding the cancelled connection")
 	}
 }

--- a/internal/cli/client_test.go
+++ b/internal/cli/client_test.go
@@ -1155,6 +1155,109 @@ func TestDialSSE_AcceptsContentTypeParameters(t *testing.T) {
 }
 
 // sseHangupServer writes one log event and then returns, ending the stream.
+// TestParseSSEProcessList_ValidSnapshot pins the processes-stream parser: a
+// full snapshot decodes field for field.
+func TestParseSSEProcessList_ValidSnapshot(t *testing.T) {
+	resp, ok := parseSSEProcessList(`{"processes":[{"name":"web","status":"running","pid":42,"restarts":1,"health":"healthy","kind":"process"}]}`)
+	if !ok {
+		t.Fatal("expected a valid snapshot to parse")
+	}
+	if len(resp.Processes) != 1 {
+		t.Fatalf("expected 1 process, got %d", len(resp.Processes))
+	}
+	if resp.Processes[0].Name != "web" || resp.Processes[0].PID != 42 {
+		t.Errorf("unexpected process %+v", resp.Processes[0])
+	}
+}
+
+// TestParseSSEProcessList_EmptyIsValid pins that an empty list is a real
+// snapshot ("nothing running"), not a frame to drop — unlike the logs parser,
+// whose all-zero guard filters non-entry payloads.
+func TestParseSSEProcessList_EmptyIsValid(t *testing.T) {
+	resp, ok := parseSSEProcessList(`{"processes":[]}`)
+	if !ok {
+		t.Fatal("an empty process list is a legitimate snapshot")
+	}
+	if len(resp.Processes) != 0 {
+		t.Errorf("expected no processes, got %d", len(resp.Processes))
+	}
+}
+
+// TestParseSSEProcessList_InvalidJSON drops the frame rather than failing the
+// stream.
+func TestParseSSEProcessList_InvalidJSON(t *testing.T) {
+	if _, ok := parseSSEProcessList("{not json"); ok {
+		t.Error("expected malformed JSON to be rejected")
+	}
+}
+
+// TestClient_ConsumeProcesses_DeliversSnapshots is the attempt-level contract
+// the attach TUI's processes loop depends on: onConnect fires once, every data
+// frame is delivered as a full snapshot, and the read error that ends the
+// stream is returned rather than swallowed.
+func TestClient_ConsumeProcesses_DeliversSnapshots(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/processes/stream" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		if r.URL.RawQuery != "" {
+			t.Errorf("the processes stream takes no params, got %q", r.URL.RawQuery)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(": connected\n\n"))
+		w.Write([]byte("data: {\"processes\":[{\"name\":\"web\",\"status\":\"starting\"}]}\n\n"))
+		w.Write([]byte("data: {\"processes\":[{\"name\":\"web\",\"status\":\"running\"}]}\n\n"))
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	connected := 0
+	var got []api.ProcessListResponse
+	err := client.ConsumeProcesses(context.Background(),
+		func() { connected++ },
+		func(resp api.ProcessListResponse) { got = append(got, resp) })
+
+	if err == nil {
+		t.Fatal("expected the terminal read error when the server ends the stream")
+	}
+	if connected != 1 {
+		t.Errorf("expected onConnect exactly once, got %d", connected)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 snapshots, got %d", len(got))
+	}
+	if got[0].Processes[0].Status != "starting" || got[1].Processes[0].Status != "running" {
+		t.Errorf("snapshots delivered out of order or mangled: %+v", got)
+	}
+}
+
+// TestClient_ConsumeProcesses_NotFoundSurfacesStatus pins the version-skew
+// signal the TUI classifier keys on: a daemon without the endpoint answers 404,
+// and that status must reach the caller discriminably.
+func TestClient_ConsumeProcesses_NotFoundSurfacesStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	err := client.ConsumeProcesses(context.Background(),
+		func() { t.Error("onConnect must not fire for a failed dial") },
+		func(api.ProcessListResponse) { t.Error("no event should be delivered") })
+
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected *APIError, got %T (%v)", err, err)
+	}
+	if apiErr.StatusCode() != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", apiErr.StatusCode())
+	}
+}
+
 func sseHangupServer(t *testing.T) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/cli/client_test.go
+++ b/internal/cli/client_test.go
@@ -447,7 +447,7 @@ func TestClient_GetLogs(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient(server.URL)
-	logs, err := client.GetLogs(domain.LogParams{
+	logs, err := client.GetLogs(context.Background(), domain.LogParams{
 		Process: "web",
 		Lines:   50,
 		Pattern: "error",
@@ -1180,6 +1180,7 @@ func TestClient_ConsumeLogs_ReturnsTerminalError(t *testing.T) {
 	connected := false
 	err := client.ConsumeLogs(context.Background(), domain.LogParams{},
 		func() { connected = true },
+		nil, // no handshake hook: this server sends none
 		func(entry api.LogEntryResponse) { got = append(got, entry) })
 
 	if err == nil {
@@ -1285,5 +1286,174 @@ func TestClient_StreamLogsChannel_ContextCancel(t *testing.T) {
 	case <-handlerDone:
 	case <-time.After(5 * time.Second):
 		t.Fatal("server handler still holding the cancelled connection")
+	}
+}
+
+// sseHandshakeServer writes the exact frame sequence the logs endpoint sends
+// (plan 017 C8): the ": connected" comment, a named handshake frame, log
+// entries, and — to pin the event-name tracking — a SECOND handshake mid-stream
+// followed by one more entry. It then returns, ending the stream.
+func sseHandshakeServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(": connected\n\n"))
+		w.Write([]byte("event: handshake\ndata: {\"stream_id\":\"epoch-1\"}\n\n"))
+		w.Write([]byte("data: {\"timestamp\":\"2024-01-01T00:00:00Z\",\"process\":\"web\",\"stream\":\"stdout\",\"line\":\"one\",\"seq\":1}\n\n"))
+		w.Write([]byte(": ping\n\n"))
+		w.Write([]byte("data: {\"timestamp\":\"2024-01-01T00:00:00Z\",\"process\":\"web\",\"stream\":\"stdout\",\"line\":\"two\",\"seq\":2}\n\n"))
+		w.Write([]byte("event: handshake\ndata: {\"stream_id\":\"epoch-1\"}\n\n"))
+		w.Write([]byte("data: {\"timestamp\":\"2024-01-01T00:00:00Z\",\"process\":\"web\",\"stream\":\"stdout\",\"line\":\"three\",\"seq\":3}\n\n"))
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}))
+}
+
+// TestClient_ConsumeLogs_HandshakeReachesHookNotEntryParser pins the C9 reader
+// contract: a handshake frame is delivered to the handshake hook and never to
+// the entry parser, the entries around it still parse (with their seq), and a
+// repeated handshake mid-stream is delivered again — harmless, and the frame
+// name must not leak into the entry that follows it.
+func TestClient_ConsumeLogs_HandshakeReachesHookNotEntryParser(t *testing.T) {
+	server := sseHandshakeServer(t)
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	var handshakes []api.HandshakeResponse
+	var got []api.LogEntryResponse
+	err := client.ConsumeLogs(context.Background(), domain.LogParams{},
+		nil,
+		func(hs api.HandshakeResponse) { handshakes = append(handshakes, hs) },
+		func(entry api.LogEntryResponse) { got = append(got, entry) })
+
+	if err == nil {
+		t.Fatal("expected terminal error when the server ends the stream, got nil")
+	}
+	if len(handshakes) != 2 {
+		t.Fatalf("expected 2 handshakes delivered, got %d (%v)", len(handshakes), handshakes)
+	}
+	for i, hs := range handshakes {
+		if hs.StreamID != "epoch-1" {
+			t.Errorf("handshake %d: expected stream_id %q, got %q", i, "epoch-1", hs.StreamID)
+		}
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 log entries, got %d (%v)", len(got), got)
+	}
+	for i, want := range []string{"one", "two", "three"} {
+		if got[i].Line != want {
+			t.Errorf("entry %d: expected line %q, got %q", i, want, got[i].Line)
+		}
+		if got[i].Seq != uint64(i+1) {
+			t.Errorf("entry %d: expected seq %d, got %d", i, i+1, got[i].Seq)
+		}
+	}
+}
+
+// TestClient_ConsumeLogs_NilHandshakeHookDropsFrame pins the nilable hook: a
+// consumer that does not care about the epoch (the --follow commands, the
+// channel form) sees the handshake frame dropped, never a phantom log entry.
+func TestClient_ConsumeLogs_NilHandshakeHookDropsFrame(t *testing.T) {
+	server := sseHandshakeServer(t)
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	var got []api.LogEntryResponse
+	_ = client.ConsumeLogs(context.Background(), domain.LogParams{}, nil, nil,
+		func(entry api.LogEntryResponse) { got = append(got, entry) })
+
+	if len(got) != 3 {
+		t.Fatalf("expected 3 log entries with a nil handshake hook, got %d (%v)", len(got), got)
+	}
+}
+
+// TestClient_GetLogs_SinceSeqAndCursorMetadata covers the resume half of the
+// cursor API on the client: since_seq rides the query when set, and the
+// response's cursor metadata is decoded for the sync protocol to compare
+// against.
+func TestClient_GetLogs_SinceSeqAndCursorMetadata(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("since_seq"); got != "7" {
+			t.Errorf("expected since_seq=7, got %q", got)
+		}
+		if got := r.URL.Query().Get("lines"); got != "1000" {
+			t.Errorf("expected lines=1000, got %q", got)
+		}
+		resp := api.LogsResponse{
+			Logs:      []api.LogEntryResponse{{Line: "eight", Seq: 8}},
+			StreamID:  "epoch-1",
+			OldestSeq: 3,
+			LatestSeq: 8,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	logs, err := client.GetLogs(context.Background(), domain.LogParams{Lines: 1000, SinceSeq: 7})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if logs.StreamID != "epoch-1" {
+		t.Errorf("expected stream_id %q, got %q", "epoch-1", logs.StreamID)
+	}
+	if logs.OldestSeq != 3 || logs.LatestSeq != 8 {
+		t.Errorf("expected bounds 3..8, got %d..%d", logs.OldestSeq, logs.LatestSeq)
+	}
+	if len(logs.Logs) != 1 || logs.Logs[0].Seq != 8 {
+		t.Errorf("expected one entry with seq 8, got %v", logs.Logs)
+	}
+}
+
+// TestBuildLogQueryParams_OmitsZeroSinceSeq pins the one wire subtlety of the
+// cursor: a zero SinceSeq must not be sent, because `since_seq=0` selects the
+// server's resume path (oldest-first from the start of the ring) rather than
+// the last-`lines` path a cursorless caller wants.
+func TestBuildLogQueryParams_OmitsZeroSinceSeq(t *testing.T) {
+	query := buildLogQueryParams(domain.LogParams{Lines: 1000})
+	if _, present := query["since_seq"]; present {
+		t.Errorf("expected no since_seq for a zero cursor, got %q", query.Get("since_seq"))
+	}
+
+	query = buildLogQueryParams(domain.LogParams{Lines: 1000, SinceSeq: 1})
+	if got := query.Get("since_seq"); got != "1" {
+		t.Errorf("expected since_seq=1, got %q", got)
+	}
+}
+
+// TestClient_ConsumeLogs_DataLineConsumesEventName pins the SSE dispatch rule
+// (codex C9 review): one event: field names ONE dispatch. A data line following
+// the handshake's data line without its own event: prefix — and before any
+// blank-line frame delimiter — is a plain log entry, not a second handshake.
+func TestClient_ConsumeLogs_DataLineConsumesEventName(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		// Deliberately NO blank line between the handshake's data and the entry.
+		w.Write([]byte("event: handshake\n"))
+		w.Write([]byte("data: {\"stream_id\":\"epoch-x\"}\n"))
+		w.Write([]byte("data: {\"timestamp\":\"2024-01-01T00:00:00Z\",\"process\":\"web\",\"stream\":\"stdout\",\"line\":\"after-handshake\",\"seq\":7}\n\n"))
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	var handshakes []api.HandshakeResponse
+	var entries []api.LogEntryResponse
+	_ = client.ConsumeLogs(context.Background(), domain.LogParams{},
+		nil,
+		func(hs api.HandshakeResponse) { handshakes = append(handshakes, hs) },
+		func(e api.LogEntryResponse) { entries = append(entries, e) })
+
+	if len(handshakes) != 1 || handshakes[0].StreamID != "epoch-x" {
+		t.Fatalf("expected exactly one handshake for epoch-x, got %+v", handshakes)
+	}
+	if len(entries) != 1 || entries[0].Line != "after-handshake" {
+		t.Fatalf("expected the follow-on data line to parse as a log entry, got %+v", entries)
 	}
 }

--- a/internal/cli/client_test.go
+++ b/internal/cli/client_test.go
@@ -811,7 +811,7 @@ func TestClient_GetProxyRequests(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient(server.URL)
-	resp, err := client.GetProxyRequests(domain.ProxyRequestParams{
+	resp, err := client.GetProxyRequests(context.Background(), domain.ProxyRequestParams{
 		Subdomain: "api",
 		Method:    "GET",
 		MinStatus: 400,

--- a/internal/cli/client_test.go
+++ b/internal/cli/client_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/charliek/prox/internal/api"
 	"github.com/charliek/prox/internal/constants"
 	"github.com/charliek/prox/internal/domain"
+	"github.com/charliek/prox/internal/tui"
 )
 
 func TestNewClient(t *testing.T) {
@@ -1013,36 +1014,72 @@ func TestClient_APIError(t *testing.T) {
 	}
 }
 
-// TestClient_StreamProxyRequestsChannel_ProxyNotEnabled proves a 503 connect
-// response is discriminable: the stream error carries Status 503 and the
-// machine-readable PROXY_NOT_ENABLED code, which the reconnect policy needs.
-func TestClient_StreamProxyRequestsChannel_ProxyNotEnabled(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+// proxyNotEnabledServer answers every request with the 503 the daemon sends
+// when it is running without the proxy.
+func proxyNotEnabledServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusServiceUnavailable)
 		json.NewEncoder(w).Encode(api.ErrorResponse{
 			Error: "proxy is not enabled",
-			Code:  "PROXY_NOT_ENABLED",
+			Code:  domain.ErrCodeProxyNotEnabled,
 		})
 	}))
-	defer server.Close()
+}
 
-	client := NewClient(server.URL)
-	_, err := client.StreamProxyRequestsChannel(context.Background(), domain.ProxyRequestParams{})
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-
+// requireProxyNotEnabledError asserts err is the discriminable connect failure
+// the TUI's requests reconnect policy parks on: an *APIError carrying both the
+// 503 status and the machine-readable code.
+func requireProxyNotEnabledError(t *testing.T, err error) {
+	t.Helper()
 	var apiErr *APIError
 	if !errors.As(err, &apiErr) {
 		t.Fatalf("expected *APIError, got %T: %v", err, err)
 	}
-	if apiErr.Status != http.StatusServiceUnavailable {
-		t.Errorf("expected Status 503, got %d", apiErr.Status)
+	if apiErr.Status != http.StatusServiceUnavailable || apiErr.Code != domain.ErrCodeProxyNotEnabled {
+		t.Errorf("expected 503/%s, got %d/%s", domain.ErrCodeProxyNotEnabled, apiErr.Status, apiErr.Code)
 	}
-	if apiErr.Code != "PROXY_NOT_ENABLED" {
-		t.Errorf("expected Code PROXY_NOT_ENABLED, got %q", apiErr.Code)
+}
+
+// TestClient_StreamProxyRequestsChannel_ProxyNotEnabled proves the channel form
+// surfaces the 503 synchronously, at connect time.
+func TestClient_StreamProxyRequestsChannel_ProxyNotEnabled(t *testing.T) {
+	server := proxyNotEnabledServer(t)
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	_, err := client.StreamProxyRequestsChannel(context.Background(), domain.ProxyRequestParams{})
+	requireProxyNotEnabledError(t, err)
+}
+
+// TestAPIError_SatisfiesTUIStatusError pins the structural contract the TUI's
+// reconnect policies classify on: internal/tui cannot import internal/cli, so
+// it matches *APIError through this interface.
+func TestAPIError_SatisfiesTUIStatusError(t *testing.T) {
+	var statusErr tui.APIStatusError = &APIError{
+		Status: http.StatusServiceUnavailable,
+		Code:   domain.ErrCodeProxyNotEnabled,
 	}
+	if statusErr.StatusCode() != http.StatusServiceUnavailable {
+		t.Errorf("expected StatusCode 503, got %d", statusErr.StatusCode())
+	}
+	if statusErr.ErrorCode() != domain.ErrCodeProxyNotEnabled {
+		t.Errorf("expected ErrorCode %q, got %q", domain.ErrCodeProxyNotEnabled, statusErr.ErrorCode())
+	}
+}
+
+// TestClient_ConsumeProxyRequests_ProxyNotEnabled proves the attempt form
+// returns the same discriminable error rather than swallowing it.
+func TestClient_ConsumeProxyRequests_ProxyNotEnabled(t *testing.T) {
+	server := proxyNotEnabledServer(t)
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	err := client.ConsumeProxyRequests(context.Background(), domain.ProxyRequestParams{},
+		func() { t.Error("onConnect must not fire for a failed dial") },
+		func(api.ProxyRequestResponse) { t.Error("no event should be delivered") })
+	requireProxyNotEnabledError(t, err)
 }
 
 // TestClient_StreamLogsChannel_RejectsNonEventStream fails the connect when the
@@ -1096,20 +1133,25 @@ func sseHangupServer(t *testing.T) *httptest.Server {
 	}))
 }
 
-// TestConsumeSSE_ReturnsTerminalError is the attempt-level contract the
+// TestClient_ConsumeLogs_ReturnsTerminalError is the attempt-level contract the
 // reconnect loop depends on: a stream that ends surfaces the read error rather
 // than disappearing silently, and events delivered before the end are kept.
-func TestConsumeSSE_ReturnsTerminalError(t *testing.T) {
+func TestClient_ConsumeLogs_ReturnsTerminalError(t *testing.T) {
 	server := sseHangupServer(t)
 	defer server.Close()
 
 	client := NewClient(server.URL)
 	var got []api.LogEntryResponse
-	err := consumeSSE(context.Background(), client, logsStreamPath(domain.LogParams{}), parseSSELogEntry,
+	connected := false
+	err := client.ConsumeLogs(context.Background(), domain.LogParams{},
+		func() { connected = true },
 		func(entry api.LogEntryResponse) { got = append(got, entry) })
 
 	if err == nil {
 		t.Fatal("expected terminal error when the server ends the stream, got nil")
+	}
+	if !connected {
+		t.Error("onConnect must fire once the dial succeeds")
 	}
 	if len(got) != 1 {
 		t.Fatalf("expected 1 delivered event, got %d", len(got))

--- a/internal/cli/client_test.go
+++ b/internal/cli/client_test.go
@@ -572,16 +572,51 @@ func TestParseSSELogEntry_InvalidJSON(t *testing.T) {
 	}
 }
 
+// TestParseSSELogEntry_EmptyObject documents the plan 017 C8 guard: an empty
+// object unmarshals into a zero-valued LogEntryResponse without a JSON error
+// (unknown/missing fields are simply left at their zero value), but a real
+// log entry can never have empty Process AND empty Line AND Seq==0 all at
+// once, so this shape is rejected rather than surfaced as a phantom log row.
 func TestParseSSELogEntry_EmptyObject(t *testing.T) {
 	data := `{}`
+
+	_, ok := parseSSELogEntry(data)
+
+	if ok {
+		t.Fatal("expected parsing to reject an empty object")
+	}
+}
+
+// TestParseSSELogEntry_HandshakePayload asserts the guard specifically
+// against the stream handshake event's body (api.HandshakeResponse): its
+// only field, stream_id, is not a LogEntryResponse field, so it unmarshals
+// the same as an empty object and must be rejected the same way (plan 017
+// C8) -- this is what keeps the "event: handshake" frame StreamLogs sends
+// from materializing as a phantom empty log row in the attach TUI.
+func TestParseSSELogEntry_HandshakePayload(t *testing.T) {
+	data := `{"stream_id":"deadbeefcafef00d"}`
+
+	_, ok := parseSSELogEntry(data)
+
+	if ok {
+		t.Fatal("expected parsing to reject a handshake-shaped payload")
+	}
+}
+
+// TestParseSSELogEntry_SeqOnlyRealEntry guards the other side of the fix: a
+// real entry with an empty Line (a blank log line is legitimate output) must
+// still be accepted as long as Process or Seq is non-zero, so the guard
+// cannot be loosened to reject on Line alone.
+func TestParseSSELogEntry_SeqOnlyRealEntry(t *testing.T) {
+	data := `{"process":"web","stream":"stdout","line":"","seq":7}`
 
 	entry, ok := parseSSELogEntry(data)
 
 	if !ok {
-		t.Fatal("expected parsing to succeed for empty object")
+		t.Fatal("expected parsing to succeed for a real entry with an empty line")
 	}
-	if entry.Process != "" || entry.Line != "" {
-		t.Errorf("expected empty fields, got process=%q, line=%q", entry.Process, entry.Line)
+	if entry.Seq != 7 {
+		t.Errorf("expected seq 7, got %d", entry.Seq)
 	}
 }
 

--- a/internal/cli/client_test.go
+++ b/internal/cli/client_test.go
@@ -979,6 +979,14 @@ func TestClient_APIError(t *testing.T) {
 			wantText: "access denied: insufficient permissions",
 		},
 		{
+			name:        "message without code renders bare message",
+			status:      http.StatusServiceUnavailable,
+			contentType: "application/json",
+			body:        `{"error":"proxy is not enabled"}`,
+			wantMessage: "proxy is not enabled",
+			wantText:    "proxy is not enabled",
+		},
+		{
 			name:        "not found with error body",
 			status:      http.StatusNotFound,
 			contentType: "application/json",

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -380,38 +380,25 @@ func runLogs(cmd *cobra.Command, args []string) error {
 	printer := NewLogPrinter()
 
 	if logsFollow {
-		// Stream logs via channel
-		ch, err := client.StreamLogsChannel(commandContext(cmd), params)
-		if err != nil {
-			return clientError(err, "Is prox running? Try 'prox up' first.")
-		}
-		for entry := range ch {
-			if logsJSON {
-				if err := json.NewEncoder(os.Stdout).Encode(entry); err != nil {
-					fmt.Fprintf(os.Stderr, "Warning: failed to encode log entry: %v\n", err)
-				}
-			} else {
-				printer.PrintAPIEntry(entry)
-			}
+		return followLogs(cmd, client, params, logsJSON, printer)
+	}
+
+	// Get logs
+	logs, err := client.GetLogs(commandContext(cmd), params)
+	if err != nil {
+		return clientError(err, "Is prox running? Try 'prox up' first.")
+	}
+
+	if logsJSON {
+		if err := json.NewEncoder(os.Stdout).Encode(logs); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to encode logs: %v\n", err)
 		}
 	} else {
-		// Get logs
-		logs, err := client.GetLogs(commandContext(cmd), params)
-		if err != nil {
-			return clientError(err, "Is prox running? Try 'prox up' first.")
+		for _, entry := range logs.Logs {
+			printer.PrintAPIEntry(entry)
 		}
-
-		if logsJSON {
-			if err := json.NewEncoder(os.Stdout).Encode(logs); err != nil {
-				fmt.Fprintf(os.Stderr, "Warning: failed to encode logs: %v\n", err)
-			}
-		} else {
-			for _, entry := range logs.Logs {
-				printer.PrintAPIEntry(entry)
-			}
-			if logs.FilteredCount < logs.TotalCount {
-				fmt.Printf("\n(showing %d of %d entries)\n", logs.FilteredCount, logs.TotalCount)
-			}
+		if logs.FilteredCount < logs.TotalCount {
+			fmt.Printf("\n(showing %d of %d entries)\n", logs.FilteredCount, logs.TotalCount)
 		}
 	}
 	return nil
@@ -758,62 +745,49 @@ func runRequests(cmd *cobra.Command, args []string) error {
 	}
 
 	if requestsFollow {
-		// Stream requests via SSE
-		ch, err := client.StreamProxyRequestsChannel(commandContext(cmd), params)
-		if err != nil {
-			return clientError(err, "Is prox running with proxy enabled? Try 'prox up' first.")
-		}
-		for req := range ch {
-			if requestsJSON {
-				if err := json.NewEncoder(os.Stdout).Encode(req); err != nil {
-					fmt.Fprintf(os.Stderr, "Warning: failed to encode request: %v\n", err)
-				}
-			} else {
-				printProxyRequest(req)
-			}
+		return followRequests(cmd, client, params, requestsJSON)
+	}
+
+	// Get recent requests
+	resp, err := client.GetProxyRequests(commandContext(cmd), params)
+	if err != nil {
+		return clientError(err, "Is prox running with proxy enabled? Try 'prox up' first.")
+	}
+
+	if requestsJSON {
+		if err := json.NewEncoder(os.Stdout).Encode(resp); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to encode requests: %v\n", err)
 		}
 	} else {
-		// Get recent requests
-		resp, err := client.GetProxyRequests(commandContext(cmd), params)
-		if err != nil {
-			return clientError(err, "Is prox running with proxy enabled? Try 'prox up' first.")
+		if len(resp.Requests) == 0 {
+			fmt.Println("No proxy requests recorded")
+			return nil
 		}
 
-		if requestsJSON {
-			if err := json.NewEncoder(os.Stdout).Encode(resp); err != nil {
-				fmt.Fprintf(os.Stderr, "Warning: failed to encode requests: %v\n", err)
-			}
-		} else {
-			if len(resp.Requests) == 0 {
-				fmt.Println("No proxy requests recorded")
-				return nil
-			}
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "ID\tTIME\tMETHOD\tSTATUS\tDURATION\tURL")
+		fmt.Fprintln(w, "-------\t--------\t------\t------\t--------\t---")
 
-			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-			fmt.Fprintln(w, "ID\tTIME\tMETHOD\tSTATUS\tDURATION\tURL")
-			fmt.Fprintln(w, "-------\t--------\t------\t------\t--------\t---")
-
-			for _, req := range resp.Requests {
-				ts, _ := time.Parse(time.RFC3339Nano, req.Timestamp)
-				timeStr := ts.Format("15:04:05")
-				duration := fmt.Sprintf("%dms", req.DurationMs)
-				if req.InFlight {
-					duration = "..."
-					if req.Stale {
-						// Completion event may have been lost; true outcome
-						// unknown (D8, #53). Long-lived streams/transfers can
-						// legitimately still be live past this point.
-						duration = "stale?"
-					}
+		for _, req := range resp.Requests {
+			ts, _ := time.Parse(time.RFC3339Nano, req.Timestamp)
+			timeStr := ts.Format("15:04:05")
+			duration := fmt.Sprintf("%dms", req.DurationMs)
+			if req.InFlight {
+				duration = "..."
+				if req.Stale {
+					// Completion event may have been lost; true outcome
+					// unknown (D8, #53). Long-lived streams/transfers can
+					// legitimately still be live past this point.
+					duration = "stale?"
 				}
-				fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%s\t%s\n",
-					req.ID, timeStr, req.Method, req.StatusCode, duration, req.URL)
 			}
-			w.Flush()
+			fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%s\t%s\n",
+				req.ID, timeStr, req.Method, req.StatusCode, duration, req.URL)
+		}
+		w.Flush()
 
-			if resp.FilteredCount < resp.TotalCount {
-				fmt.Printf("\n(showing %d of %d requests)\n", resp.FilteredCount, resp.TotalCount)
-			}
+		if resp.FilteredCount < resp.TotalCount {
+			fmt.Printf("\n(showing %d of %d requests)\n", resp.FilteredCount, resp.TotalCount)
 		}
 	}
 	return nil

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -396,7 +396,7 @@ func runLogs(cmd *cobra.Command, args []string) error {
 		}
 	} else {
 		// Get logs
-		logs, err := client.GetLogs(params)
+		logs, err := client.GetLogs(commandContext(cmd), params)
 		if err != nil {
 			return clientError(err, "Is prox running? Try 'prox up' first.")
 		}

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -774,7 +774,7 @@ func runRequests(cmd *cobra.Command, args []string) error {
 		}
 	} else {
 		// Get recent requests
-		resp, err := client.GetProxyRequests(params)
+		resp, err := client.GetProxyRequests(commandContext(cmd), params)
 		if err != nil {
 			return clientError(err, "Is prox running with proxy enabled? Try 'prox up' first.")
 		}

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -380,7 +381,7 @@ func runLogs(cmd *cobra.Command, args []string) error {
 
 	if logsFollow {
 		// Stream logs via channel
-		ch, err := client.StreamLogsChannel(params)
+		ch, err := client.StreamLogsChannel(commandContext(cmd), params)
 		if err != nil {
 			return clientError(err, "Is prox running? Try 'prox up' first.")
 		}
@@ -758,7 +759,7 @@ func runRequests(cmd *cobra.Command, args []string) error {
 
 	if requestsFollow {
 		// Stream requests via SSE
-		ch, err := client.StreamProxyRequestsChannel(params)
+		ch, err := client.StreamProxyRequestsChannel(commandContext(cmd), params)
 		if err != nil {
 			return clientError(err, "Is prox running with proxy enabled? Try 'prox up' first.")
 		}
@@ -1090,6 +1091,16 @@ func init() {
 	_ = logsCmd.RegisterFlagCompletionFunc("process", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return getProcessNames(), cobra.ShellCompDirectiveNoFileComp
 	})
+}
+
+// commandContext returns the command's context, falling back to Background when
+// the command was invoked outside Execute (e.g. a test calling RunE directly),
+// which leaves cobra's context nil.
+func commandContext(cmd *cobra.Command) context.Context {
+	if ctx := cmd.Context(); ctx != nil {
+		return ctx
+	}
+	return context.Background()
 }
 
 // clientError wraps an error with an optional hint for the user.

--- a/internal/cli/follow.go
+++ b/internal/cli/follow.go
@@ -1,0 +1,266 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/charliek/prox/internal/api"
+	"github.com/charliek/prox/internal/domain"
+	"github.com/charliek/prox/internal/stream"
+	"github.com/spf13/cobra"
+)
+
+// This file implements the CLI's --follow reconnect behavior (plan 017 C13,
+// W2+W7), shared by `prox logs --follow` and `prox requests --follow`.
+//
+// Shape, chosen deliberately for the smallest change against today's
+// behavior: the FIRST connect is made exactly as before this landed — the
+// channel form (Client.StreamLogsChannel / StreamProxyRequestsChannel),
+// synchronously, with its error returned straight to the caller (PINNED:
+// fail-fast + today's error text + non-zero exit, UNCHANGED). Only once that
+// channel CLOSES — meaning at least one connect already succeeded and the
+// stream then ended for any reason — does control hand off to a
+// stream.Loop, built from the consume* attempt forms, for every subsequent
+// attempt. There is no backfill across the handoff or across any later
+// reconnect: the stderr notices mark the gap instead, and duplicates on
+// stdout are avoided by never re-fetching history.
+//
+// Ctrl-C is wired via signal.NotifyContext around the whole follow session
+// (both the first connect and the reconnect loop), so an interactive quit
+// cancels ctx and unwinds cleanly to exit 0, exactly like today's Ctrl-C.
+
+// followStreamDisconnected / followStreamReconnected are the stderr notices
+// for a --follow reconnect. They print on TRANSITIONS only (first drop of an
+// outage, and the OK that ends one) — never on every retry attempt — mirrored
+// on the TUI's streamDropped latch (internal/tui/stream_health.go). stdout
+// carries only rendered events, so `prox logs --follow --json | jq` etc. never
+// sees these.
+const (
+	followStreamDisconnected = "prox: stream disconnected, reconnecting..."
+	followStreamReconnected  = "prox: stream reconnected"
+)
+
+// runFollowLoop drains an already-connected --follow channel (first) to
+// completion, printing each event via printEvent exactly as the pre-reconnect
+// channel loop did, then — once first closes — keeps the stream going across
+// drops with a stream.Loop built from attempt/classify until ctx is cancelled
+// or an attempt error is classified terminal.
+//
+// It returns nil when ctx was cancelled (Ctrl-C: exit 0, matching today), and
+// the terminal error otherwise (non-zero exit via cobra's RunE contract).
+// Status transitions print to stderr per followStatusPrinter; stdout is left
+// to printEvent/attempt alone so it stays machine-clean under --json.
+func runFollowLoop[T any](ctx context.Context, first <-chan T, printEvent func(T), attempt func(context.Context, func()) error, classify func(error) stream.Classification) error {
+	for entry := range first {
+		printEvent(entry)
+	}
+	// The channel closes either because ctx was cancelled (Ctrl-C) or because
+	// the stream ended out from under us. Only the latter engages the
+	// reconnect loop; a cancelled ctx must return immediately with no further
+	// output.
+	if ctx.Err() != nil {
+		return nil
+	}
+
+	// Reaching here IS the disconnect: the first connection, established
+	// outside any loop, just ended. Announce it once, unconditionally, before
+	// the reconnect loop takes over — the loop's own first attempt reports
+	// StateConnecting (it has no memory of the connection that preceded it),
+	// so nothing downstream would ever print this notice otherwise. Passing
+	// dropped=true into followStatusPrinter latches it immediately, so the
+	// loop's first OK (whether on its first attempt or after some retries)
+	// prints exactly one matching followStreamReconnected.
+	fmt.Fprintln(os.Stderr, followStreamDisconnected)
+
+	var termErr error
+	loop := stream.NewLoop(stream.Config{
+		Attempt:  attempt,
+		Classify: classify,
+		OnStatus: followStatusPrinter(&termErr, true),
+	})
+	loop.Run(ctx)
+
+	if ctx.Err() != nil {
+		return nil
+	}
+	return termErr
+}
+
+// followStatusPrinter builds the OnStatus callback for a --follow
+// stream.Loop. dropped starts pre-latched to true (runFollowLoop already
+// printed followStreamDisconnected for the handoff itself), and from there it
+// tracks exactly like the TUI's streamDropped latch
+// (internal/tui/stream_health.go): a LATER StateReconnecting prints the
+// disconnected notice again only if a reconnected notice cleared the latch in
+// between, and the OK that ends any drop prints followStreamReconnected
+// exactly once. A terminal StateClosed (a classified error, not a cancelled
+// ctx) prints the error and stashes it in *termErr for runFollowLoop to
+// return.
+func followStatusPrinter(termErr *error, dropped bool) func(stream.Status) {
+	return func(s stream.Status) {
+		switch s.State {
+		case stream.StateReconnecting:
+			if !dropped {
+				dropped = true
+				fmt.Fprintln(os.Stderr, followStreamDisconnected)
+			}
+		case stream.StateOK:
+			if dropped {
+				dropped = false
+				fmt.Fprintln(os.Stderr, followStreamReconnected)
+			}
+		case stream.StateClosed:
+			// StateClosed also fires on context cancellation with Err ==
+			// ctx.Err() — that is a clean Ctrl-C, not a failure, and must not
+			// write "prox: context canceled" to the terminal (codex C13
+			// finding). Only a real terminal error is recorded and printed.
+			if s.Err != nil && !errors.Is(s.Err, context.Canceled) {
+				*termErr = s.Err
+				fmt.Fprintf(os.Stderr, "prox: %v\n", s.Err)
+			}
+		}
+	}
+}
+
+// followSignalContext wraps ctx with signal.NotifyContext(SIGINT, SIGTERM) for
+// a --follow session, so Ctrl-C (or a TERM) cancels the connect/reconnect loop
+// cleanly instead of the process dying mid-stream. Callers must defer the
+// returned stop func.
+func followSignalContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+}
+
+// classifyLogsFollowError is the CLI --follow reconnect policy for the logs
+// stream: an authentication/authorization failure will not fix itself by
+// retrying, so it ends the loop (exit non-zero); everything else (dial
+// failures, hangups, 5xx) is transient and worth reconnecting.
+func classifyLogsFollowError(err error) stream.Classification {
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		switch apiErr.Status {
+		case http.StatusUnauthorized, http.StatusForbidden:
+			return stream.ClassTerminal
+		}
+	}
+	return stream.ClassTransient
+}
+
+// followLogs implements `prox logs --follow` (plan 017 C13). The first
+// connect is the plain channel form on a signal-wired ctx, so a connect
+// failure fails fast with today's error and non-zero exit (PINNED). Once that
+// channel closes, runFollowLoop hands off to a reconnect loop built from
+// ConsumeLogs; onHandshake is nil because --follow has no cursor/backfill
+// protocol to resume (no backfill on reconnect is the deliberate contract —
+// see the file comment). markSynced rides ConsumeLogs' onConnect, matching
+// the attach TUI's pure-consumer streams (internal/tui/app.go
+// consumeProcesses).
+func followLogs(cmd *cobra.Command, client *Client, params domain.LogParams, jsonOutput bool, printer *LogPrinter) error {
+	ctx, stop := followSignalContext(commandContext(cmd))
+	defer stop()
+
+	ch, err := client.StreamLogsChannel(ctx, params)
+	if err != nil {
+		// Ctrl-C during the initial dial cancels the request and surfaces as
+		// a connect error — that is a clean exit, not a failure (codex C13
+		// finding). Genuine connect failures keep today's fail-fast error.
+		if ctx.Err() != nil {
+			return nil
+		}
+		return clientError(err, "Is prox running? Try 'prox up' first.")
+	}
+
+	printEvent := func(entry api.LogEntryResponse) {
+		printLogEntry(entry, jsonOutput, printer)
+	}
+	attempt := func(attemptCtx context.Context, markSynced func()) error {
+		return client.ConsumeLogs(attemptCtx, params, markSynced, nil, printEvent)
+	}
+
+	return runFollowLoop(ctx, ch, printEvent, attempt, classifyLogsFollowError)
+}
+
+// printLogEntry renders one streamed log entry exactly as the pre-C13 channel
+// loop did — JSON-encoded to stdout under --json, or through the LogPrinter's
+// colorized/plain rendering otherwise. Factored out so the first connection's
+// drain loop and every reconnect attempt share identical rendering.
+func printLogEntry(entry api.LogEntryResponse, jsonOutput bool, printer *LogPrinter) {
+	if jsonOutput {
+		if err := json.NewEncoder(os.Stdout).Encode(entry); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to encode log entry: %v\n", err)
+		}
+		return
+	}
+	printer.PrintAPIEntry(entry)
+}
+
+// followRequests implements `prox requests --follow` (plan 017 C13). The
+// first connect is the plain channel form on a signal-wired ctx, so a connect
+// failure fails fast with today's error and non-zero exit (PINNED). Once that
+// channel closes, runFollowLoop hands off to a reconnect loop built from
+// ConsumeProxyRequests. markSynced rides onConnect, exactly as consumeProcesses
+// does for the attach TUI's processes stream (internal/tui/app.go): the
+// requests stream has no sync protocol to reconcile, so connect IS sync.
+func followRequests(cmd *cobra.Command, client *Client, params domain.ProxyRequestParams, jsonOutput bool) error {
+	ctx, stop := followSignalContext(commandContext(cmd))
+	defer stop()
+
+	ch, err := client.StreamProxyRequestsChannel(ctx, params)
+	if err != nil {
+		// Same clean-exit rule as followLogs: a signal-cancelled initial dial
+		// is not a failure.
+		if ctx.Err() != nil {
+			return nil
+		}
+		return clientError(err, "Is prox running with proxy enabled? Try 'prox up' first.")
+	}
+
+	printEvent := func(req api.ProxyRequestResponse) {
+		printProxyRequestEvent(req, jsonOutput)
+	}
+	attempt := func(attemptCtx context.Context, markSynced func()) error {
+		return client.ConsumeProxyRequests(attemptCtx, params, markSynced, printEvent)
+	}
+
+	return runFollowLoop(ctx, ch, printEvent, attempt, classifyRequestsFollowError)
+}
+
+// printProxyRequestEvent renders one streamed proxy request exactly as the
+// pre-C13 channel loop did — JSON-encoded to stdout under --json, or through
+// printProxyRequest's line format otherwise. Factored out for the same reason
+// as printLogEntry.
+func printProxyRequestEvent(req api.ProxyRequestResponse, jsonOutput bool) {
+	if jsonOutput {
+		if err := json.NewEncoder(os.Stdout).Encode(req); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to encode request: %v\n", err)
+		}
+		return
+	}
+	printProxyRequest(req)
+}
+
+// classifyRequestsFollowError extends classifyLogsFollowError with the one
+// condition unique to the requests stream: the daemon runs fine with the
+// proxy disabled, and a 503 PROXY_NOT_ENABLED means "no such feed" rather than
+// a transient outage. Unlike the TUI's attach-mode policy (which parks the
+// loop passively, StateUnavailable, behind a status bar), a --follow CLI
+// command has no passive display to fall back to, so this is ALSO terminal
+// here: print the error and exit non-zero rather than retry forever against a
+// feed that will never come back without a config/restart change.
+func classifyRequestsFollowError(err error) stream.Classification {
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		switch {
+		case apiErr.Status == http.StatusUnauthorized, apiErr.Status == http.StatusForbidden:
+			return stream.ClassTerminal
+		case apiErr.Status == http.StatusServiceUnavailable && apiErr.Code == domain.ErrCodeProxyNotEnabled:
+			return stream.ClassTerminal
+		}
+	}
+	return stream.ClassTransient
+}

--- a/internal/cli/follow_test.go
+++ b/internal/cli/follow_test.go
@@ -1,0 +1,380 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/charliek/prox/internal/api"
+	"github.com/charliek/prox/internal/domain"
+)
+
+// followTestCmd returns a bare *cobra.Command carrying ctx, standing in for
+// the real rootCmd wiring so followLogs/followRequests's commandContext(cmd)
+// call resolves to a context the test can cancel (simulating Ctrl-C via
+// followSignalContext's parent-cancellation path).
+func followTestCmd(ctx context.Context) *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.SetContext(ctx)
+	return cmd
+}
+
+// resetLogsFollowFlags and resetRequestsFollowFlags restore the package-level
+// flag vars these tests mutate, matching the save/restore pattern the rest of
+// commands_test.go uses for the same vars.
+func resetLogsFollowFlags(t *testing.T) {
+	t.Helper()
+	origAddr, origFollow, origJSON := apiAddr, logsFollow, logsJSON
+	origProcess, origPattern, origRegex, origLines := logsProcess, logsPattern, logsRegex, logsLines
+	t.Cleanup(func() {
+		apiAddr, logsFollow, logsJSON = origAddr, origFollow, origJSON
+		logsProcess, logsPattern, logsRegex, logsLines = origProcess, origPattern, origRegex, origLines
+	})
+	logsProcess, logsPattern, logsRegex, logsLines = "", "", false, 100
+}
+
+func resetRequestsFollowFlags(t *testing.T) {
+	t.Helper()
+	origAddr, origFollow, origJSON := apiAddr, requestsFollow, requestsJSON
+	t.Cleanup(func() {
+		apiAddr, requestsFollow, requestsJSON = origAddr, origFollow, origJSON
+	})
+}
+
+// sseLogFrame renders one logs-stream SSE data frame for a raw httptest
+// handler (below the Client, which is what's under test in this file).
+func sseLogFrame(line string) string {
+	entry := api.LogEntryResponse{
+		Timestamp: time.Now().Format(time.RFC3339Nano),
+		Process:   "web",
+		Stream:    "stdout",
+		Line:      line,
+	}
+	data, _ := json.Marshal(entry)
+	return fmt.Sprintf("data: %s\n\n", data)
+}
+
+// sseRequestFrame renders one requests-stream SSE data frame.
+func sseRequestFrame(id string) string {
+	req := api.ProxyRequestResponse{
+		ID:        id,
+		Timestamp: time.Now().Format(time.RFC3339Nano),
+		Method:    "GET",
+		URL:       "/" + id,
+	}
+	data, _ := json.Marshal(req)
+	return fmt.Sprintf("data: %s\n\n", data)
+}
+
+// TestRunLogs_FollowReconnectsAfterMidStreamDrop proves the C13 shape: the
+// first connect succeeds and delivers entry1, the server then ends that
+// stream (a mid-stream drop), and the reconnect loop transparently opens a
+// second connection that delivers entry2 — with both entries reaching stdout
+// and the disconnected/reconnected notices reaching stderr, transitions only.
+func TestRunLogs_FollowReconnectsAfterMidStreamDrop(t *testing.T) {
+	resetLogsFollowFlags(t)
+
+	var attempts int32
+	attempt3 := make(chan struct{})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&attempts, 1)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher := w.(http.Flusher)
+
+		switch n {
+		case 1:
+			// One entry, then the handler returns: the connection closes and
+			// the first (channel-form) attempt ends cleanly — the mid-stream
+			// drop.
+			w.Write([]byte(sseLogFrame("entry1")))
+			flusher.Flush()
+		case 2:
+			// The reconnect loop's attempt: one more entry, then close again.
+			// onEvent prints synchronously inside the read loop, so attempt 3
+			// ARRIVING server-side proves entry2 was already printed — the
+			// deterministic sync point the old fixed sleep lacked (codex C13
+			// finding).
+			w.Write([]byte(sseLogFrame("entry2")))
+			flusher.Flush()
+		default:
+			close(attempt3)
+			<-r.Context().Done()
+		}
+	}))
+	defer server.Close()
+
+	apiAddr = server.URL
+	logsFollow = true
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := followTestCmd(ctx)
+
+	go func() {
+		<-attempt3
+		cancel()
+	}()
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := runLogs(cmd, []string{}); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(stdout, "entry1") {
+		t.Errorf("expected entry1 on stdout, got %q", stdout)
+	}
+	if !strings.Contains(stdout, "entry2") {
+		t.Errorf("expected entry2 on stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, followStreamDisconnected) {
+		t.Errorf("expected disconnect notice on stderr, got %q", stderr)
+	}
+	if !strings.Contains(stderr, followStreamReconnected) {
+		t.Errorf("expected reconnect notice on stderr, got %q", stderr)
+	}
+	// Two outages (after attempt 1 and after attempt 2), so exactly two
+	// disconnect notices — one per outage, never one per retry. The second
+	// reconnect notice races the cancel, so only the first is guaranteed.
+	if n := strings.Count(stderr, followStreamDisconnected); n != 2 {
+		t.Errorf("expected exactly 2 disconnect notices, got %d in %q", n, stderr)
+	}
+	if n := strings.Count(stderr, followStreamReconnected); n < 1 {
+		t.Errorf("expected at least 1 reconnect notice, got %d in %q", n, stderr)
+	}
+	// A clean Ctrl-C teardown must never surface as an error (codex C13).
+	if strings.Contains(stderr, "context canceled") {
+		t.Errorf("cancellation leaked onto stderr: %q", stderr)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 3 {
+		t.Errorf("expected exactly 3 connect attempts, got %d", got)
+	}
+}
+
+// TestRunLogs_FollowInitialConnectFailureFailsFast pins the UNCHANGED
+// behavior for a failed FIRST connect (plan 017 C13 requirement 1): no
+// reconnect loop ever engages, and the error text/hint are byte-for-byte what
+// `prox logs --follow` returned before this landed.
+func TestRunLogs_FollowInitialConnectFailureFailsFast(t *testing.T) {
+	resetLogsFollowFlags(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	apiAddr = server.URL
+	logsFollow = true
+
+	var err error
+	_, _ = captureOutput(t, func() {
+		err = runLogs(logsCmd, []string{})
+	})
+
+	if err == nil {
+		t.Fatal("expected an error from a failed initial connect")
+	}
+	const wantText = "server error: the prox daemon encountered an internal error\nIs prox running? Try 'prox up' first."
+	if err.Error() != wantText {
+		t.Errorf("expected fail-fast error %q, got %q", wantText, err.Error())
+	}
+}
+
+// TestRunLogs_FollowTerminalErrorExitsNonZero proves a 401 raised by a
+// RECONNECT attempt (never by the first connect, which already succeeded) is
+// classified terminal: the loop ends, the error reaches stderr, and runLogs
+// returns a non-zero error rather than retrying forever.
+func TestRunLogs_FollowTerminalErrorExitsNonZero(t *testing.T) {
+	resetLogsFollowFlags(t)
+
+	var attempts int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&attempts, 1)
+		if n == 1 {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(sseLogFrame("entry1")))
+			w.(http.Flusher).Flush()
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(api.ErrorResponse{Error: "invalid token", Code: "UNAUTHORIZED"})
+	}))
+	defer server.Close()
+
+	apiAddr = server.URL
+	logsFollow = true
+
+	cmd := followTestCmd(context.Background())
+
+	var err error
+	stdout, stderr := captureOutput(t, func() {
+		err = runLogs(cmd, []string{})
+	})
+
+	if err == nil {
+		t.Fatal("expected a terminal error")
+	}
+	const wantErr = "UNAUTHORIZED: invalid token"
+	if !strings.Contains(err.Error(), wantErr) {
+		t.Errorf("expected error to contain %q, got %q", wantErr, err.Error())
+	}
+	if !strings.Contains(stderr, wantErr) {
+		t.Errorf("expected stderr to carry the terminal error, got %q", stderr)
+	}
+	if !strings.Contains(stdout, "entry1") {
+		t.Errorf("expected entry1 printed before the terminal failure, got %q", stdout)
+	}
+}
+
+// TestRunRequests_FollowReconnectsAfterMidStreamDrop is the requests-command
+// counterpart of TestRunLogs_FollowReconnectsAfterMidStreamDrop, proving the
+// shared runFollowLoop wiring works identically for `prox requests --follow`
+// with its own event type and rendering.
+func TestRunRequests_FollowReconnectsAfterMidStreamDrop(t *testing.T) {
+	resetRequestsFollowFlags(t)
+
+	var attempts int32
+	attempt3 := make(chan struct{})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&attempts, 1)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher := w.(http.Flusher)
+
+		switch n {
+		case 1:
+			w.Write([]byte(sseRequestFrame("req1")))
+			flusher.Flush()
+		case 2:
+			// Close after req2; attempt 3 arriving proves req2 was printed
+			// (see the logs counterpart for the full reasoning).
+			w.Write([]byte(sseRequestFrame("req2")))
+			flusher.Flush()
+		default:
+			close(attempt3)
+			<-r.Context().Done()
+		}
+	}))
+	defer server.Close()
+
+	apiAddr = server.URL
+	requestsFollow = true
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := followTestCmd(ctx)
+
+	go func() {
+		<-attempt3
+		cancel()
+	}()
+
+	stdout, stderr := captureOutput(t, func() {
+		if err := runRequests(cmd, []string{}); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(stdout, "req1") || !strings.Contains(stdout, "req2") {
+		t.Errorf("expected both requests rendered on stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, followStreamDisconnected) || !strings.Contains(stderr, followStreamReconnected) {
+		t.Errorf("expected both notices on stderr, got %q", stderr)
+	}
+	if strings.Contains(stderr, "context canceled") {
+		t.Errorf("cancellation leaked onto stderr: %q", stderr)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 3 {
+		t.Errorf("expected exactly 3 connect attempts, got %d", got)
+	}
+}
+
+// TestRunLogs_FollowSignalDuringInitialDialExitsClean pins the clean-Ctrl-C
+// contract for the FIRST connect (codex C13 finding): a signal that cancels
+// the initial dial is a clean exit 0, not the fail-fast connect error.
+func TestRunLogs_FollowSignalDuringInitialDialExitsClean(t *testing.T) {
+	resetLogsFollowFlags(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done() // never answer: only cancellation ends the dial
+	}))
+	defer server.Close()
+
+	apiAddr = server.URL
+	logsFollow = true
+
+	// A pre-cancelled parent stands in for the signal firing mid-dial: the
+	// NotifyContext child is born cancelled, exactly as after a Ctrl-C.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	cmd := followTestCmd(ctx)
+
+	_, stderr := captureOutput(t, func() {
+		if err := runLogs(cmd, []string{}); err != nil {
+			t.Errorf("a signal-cancelled initial dial must exit clean, got: %v", err)
+		}
+	})
+	if strings.Contains(stderr, "Is prox running") {
+		t.Errorf("fail-fast error leaked for a cancelled dial: %q", stderr)
+	}
+}
+
+// TestRunRequests_FollowTerminalProxyDisabledExitsNonZero proves the
+// requests-specific reconnect policy: a 503 PROXY_NOT_ENABLED raised by a
+// RECONNECT attempt is terminal for the CLI (unlike the TUI's passive
+// StateUnavailable park — a --follow command has no status bar to fall back
+// to), so it exits non-zero with the error on stderr instead of retrying
+// forever against a feed that will never come back without a config change.
+func TestRunRequests_FollowTerminalProxyDisabledExitsNonZero(t *testing.T) {
+	resetRequestsFollowFlags(t)
+
+	var attempts int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&attempts, 1)
+		if n == 1 {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(sseRequestFrame("req1")))
+			w.(http.Flusher).Flush()
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		json.NewEncoder(w).Encode(api.ErrorResponse{
+			Error: "proxy is not enabled",
+			Code:  domain.ErrCodeProxyNotEnabled,
+		})
+	}))
+	defer server.Close()
+
+	apiAddr = server.URL
+	requestsFollow = true
+
+	cmd := followTestCmd(context.Background())
+
+	var err error
+	_, stderr := captureOutput(t, func() {
+		err = runRequests(cmd, []string{})
+	})
+
+	if err == nil {
+		t.Fatal("expected a terminal error")
+	}
+	if !strings.Contains(err.Error(), domain.ErrCodeProxyNotEnabled) {
+		t.Errorf("expected error to name %s, got %q", domain.ErrCodeProxyNotEnabled, err.Error())
+	}
+	if !strings.Contains(stderr, domain.ErrCodeProxyNotEnabled) {
+		t.Errorf("expected stderr to carry the terminal error, got %q", stderr)
+	}
+}

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -738,6 +738,14 @@ func performShutdown(deps shutdownDeps) *domain.ProcessStopError {
 			}
 		}
 		deps.sup.SystemLog("shutdown complete")
+		// Release any /processes/stream subscribers, for the same reason the log and
+		// request managers are closed below: the no-timeout SSE routes only end when
+		// their data source closes. Stage 2's sup.Stop already latched the change bus
+		// closed (Supervisor.Stop defers CloseEvents on every path), so this is
+		// idempotent -- it is kept explicit here so the ordering requirement (every
+		// stream source closes BEFORE the stage-5 API shutdown) is visible in the
+		// shutdown sequence itself.
+		deps.sup.CloseEvents()
 	}
 	// Give the terminal log printer a moment to drain the final lines before Close.
 	time.Sleep(logFlushDelay)

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -138,6 +138,31 @@ const (
 	InFlightStaleAfter = 5 * time.Minute
 )
 
+// SSE (Server-Sent Events) timing
+const (
+	// SSEHeartbeatInterval is how often an idle SSE stream (StreamLogs,
+	// StreamProxyRequests) writes a ": ping" comment to keep the connection
+	// observably alive and to surface a dead client via a failed write. The
+	// server's http.Server.WriteTimeout is deliberately 0 for these routes (a
+	// long-lived stream cannot carry a fixed connection-lifetime deadline), so
+	// the heartbeat's per-write deadline (SSEWriteTimeout) is the only bound on
+	// a stalled write.
+	SSEHeartbeatInterval = 15 * time.Second
+
+	// SSEWriteTimeout is the per-write deadline for an SSE write (connect
+	// comment, data event, or heartbeat), set via
+	// http.ResponseController.SetWriteDeadline before each write. It stands in
+	// for the connection-lifetime WriteTimeout the SSE routes forgo.
+	SSEWriteTimeout = 10 * time.Second
+
+	// SSEReadTimeout is the CLI SSE client's read deadline: if no byte (data or
+	// heartbeat) arrives within this window, the connection is declared dead.
+	// Invariant: SSEReadTimeout > 3*SSEHeartbeatInterval, so the client
+	// tolerates at least 3 consecutive missed heartbeats (a transient stall,
+	// not just a single delayed tick) before giving up.
+	SSEReadTimeout = 60 * time.Second
+)
+
 // Log configuration
 const (
 	// DefaultLogLimit is the default number of log lines to return

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -197,9 +197,11 @@ const (
 // TUI timing
 const (
 	// TUILocalTickInterval drives the local-mode TUI's periodic process-list
-	// refresh. Local mode reads the in-process supervisor directly, so a
-	// fast tick costs nothing; attach mode reuses this interval only until
-	// its poll is replaced by the processes SSE stream (plan 017 C12).
+	// refresh, and only local mode's: it reads the in-process supervisor
+	// directly, so a fast tick costs nothing. Attach mode used to share the
+	// interval for an HTTP poll; C12 deleted that poll in favor of the
+	// processes SSE stream, so nothing in attach mode ticks any more
+	// (plan 017 C12).
 	TUILocalTickInterval = 500 * time.Millisecond
 )
 

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -163,6 +163,15 @@ const (
 	SSEReadTimeout = 60 * time.Second
 )
 
+// TUI timing
+const (
+	// TUILocalTickInterval drives the local-mode TUI's periodic process-list
+	// refresh. Local mode reads the in-process supervisor directly, so a
+	// fast tick costs nothing; attach mode reuses this interval only until
+	// its poll is replaced by the processes SSE stream (plan 017 C12).
+	TUILocalTickInterval = 500 * time.Millisecond
+)
+
 // Log configuration
 const (
 	// DefaultLogLimit is the default number of log lines to return

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -163,6 +163,37 @@ const (
 	SSEReadTimeout = 60 * time.Second
 )
 
+// Stream reconnection
+//
+// These bound the generic SSE reconnect runner in internal/stream, which every
+// prox stream consumer (TUI attach streams, CLI --follow commands) drives. They
+// are deliberately NOT shared with the proxyd forwarder's own reconnect loop:
+// the forwarder predates this package and keeps its local constants so the two
+// can be retuned independently.
+const (
+	// StreamReconnectBaseBackoff is the wait before the first reconnect
+	// attempt after a stream ends, and the value the backoff resets to once an
+	// attempt has survived StreamReconnectFlapThreshold.
+	StreamReconnectBaseBackoff = 500 * time.Millisecond
+
+	// StreamReconnectMaxBackoff caps the exponential reconnect backoff. The
+	// wait doubles per failed cycle (500ms, 1s, 2s, 4s) and is then clamped
+	// here, so a server that is down for a long time is re-probed at a steady
+	// 5s rather than drifting toward minutes.
+	StreamReconnectMaxBackoff = 5 * time.Second
+
+	// StreamReconnectFlapThreshold is the minimum lifetime an attempt must
+	// reach before its end counts as a recovery (i.e. resets the backoff to
+	// StreamReconnectBaseBackoff). A connect that dies instantly is a flap, not
+	// a recovery: without the guard, a crash-looping server that accepts and
+	// immediately EOFs would reset the backoff on every cycle and be hammered
+	// at the base rate forever. This mirrors the proxyd forwarder's
+	// streamFlapThreshold precedent (see internal/proxyd/forwarder.go), but is
+	// a SEPARATE knob by plan decision — the forwarder keeps its own constant
+	// and does not read this one.
+	StreamReconnectFlapThreshold = 1 * time.Second
+)
+
 // TUI timing
 const (
 	// TUILocalTickInterval drives the local-mode TUI's periodic process-list

--- a/internal/constants/constants_test.go
+++ b/internal/constants/constants_test.go
@@ -1,0 +1,13 @@
+package constants
+
+import "testing"
+
+// TestSSEReadTimeout_ExceedsThreeHeartbeats pins the invariant documented on
+// SSEReadTimeout: the CLI's SSE read deadline must outlast at least 3 missed
+// server heartbeats, so a single delayed tick (GC pause, scheduling jitter)
+// never trips a false "connection dead" verdict.
+func TestSSEReadTimeout_ExceedsThreeHeartbeats(t *testing.T) {
+	if SSEReadTimeout <= 3*SSEHeartbeatInterval {
+		t.Fatalf("SSEReadTimeout (%s) must exceed 3*SSEHeartbeatInterval (%s)", SSEReadTimeout, 3*SSEHeartbeatInterval)
+	}
+}

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -91,6 +91,11 @@ const (
 	ErrCodeProcessAlreadyWaiting = "PROCESS_ALREADY_WAITING"
 	ErrCodeProcessNotRunning     = "PROCESS_NOT_RUNNING"
 	ErrCodeInvalidPattern        = "INVALID_PATTERN"
+	// ErrCodeInvalidSinceSeq marks a GET /api/v1/logs?since_seq=... value that
+	// failed to parse as a uint64 (plan 017 C8). Distinct from
+	// ErrCodeInvalidPattern (a bad regex) so callers can tell which parameter
+	// was rejected.
+	ErrCodeInvalidSinceSeq       = "INVALID_SINCE_SEQ"
 	ErrCodeShutdownInProgress    = "SHUTDOWN_IN_PROGRESS"
 	ErrCodeEnvReloadFailed       = "ENV_RELOAD_FAILED"
 	ErrCodeProcessGroupNotReaped = "PROCESS_GROUP_NOT_REAPED"

--- a/internal/domain/log.go
+++ b/internal/domain/log.go
@@ -21,14 +21,29 @@ type LogEntry struct {
 	Process   string    `json:"process"`
 	Stream    Stream    `json:"stream"`
 	Line      string    `json:"line"`
-	// Seq is a TUI-session-local monotonic sequence number assigned on ingest
-	// (BaseModel.handleLogEntry). It anchors the logs-view `/`-search cursor
-	// across the 1000-entry front-eviction ring, where a bare slice index would
-	// drift as old entries are dropped. It is deliberately json:"-": session-
-	// local UI state that must NOT ride the socket wire to the attach client
-	// (which stamps its own on ingest). The wire itself carries LogEntry only
-	// via api.LogEntryResponse, which has no Seq field.
-	Seq int64 `json:"-"`
+	// Seq is the SERVER ingest sequence: assigned by logs.Manager, monotonic
+	// per manager instance, starting at 1. Zero means unset — an entry that
+	// never passed through Manager.Write (e.g. one built by a client or a test).
+	//
+	// Invariant: Manager assigns Seq inside the SAME critical section that
+	// appends the entry to the ring buffer and broadcasts it to subscribers, so
+	// ring order == seq order == per-subscriber delivery order. That is what
+	// lets a client resume with "everything after seq N" and detect a gap by
+	// seq arithmetic alone. Seq is only meaningful paired with the manager's
+	// StreamID: a new manager lifetime restarts the counter at 1.
+	Seq uint64 `json:"seq"`
+	// DisplaySeq is a TUI-session-local monotonic sequence number assigned on
+	// ingest (BaseModel.handleLogEntry). It anchors the logs-view `/`-search
+	// cursor across the 1000-entry front-eviction ring, where a bare slice index
+	// would drift as old entries are dropped. It is deliberately json:"-":
+	// session-local UI state that must NOT ride the socket wire to the attach
+	// client (which stamps its own on ingest).
+	//
+	// DisplaySeq and Seq are NEVER mixed: DisplaySeq counts what one TUI session
+	// has displayed, Seq counts what one server manager has ingested. A client
+	// stamps DisplaySeq over entries that may already carry a server Seq, and
+	// neither value constrains the other.
+	DisplaySeq int64 `json:"-"`
 }
 
 // LogFilter defines criteria for filtering log entries

--- a/internal/domain/log_params.go
+++ b/internal/domain/log_params.go
@@ -11,11 +11,17 @@ import "time"
 //   - Pattern: Text pattern for filtering log lines. Empty string means no filtering.
 //   - Regex: If true, Pattern is treated as a regular expression. If false, Pattern
 //     is treated as a literal substring match. Has no effect when Pattern is empty.
+//   - SinceSeq: Resume cursor for GET /logs — return only entries whose server
+//     ingest sequence (LogEntry.Seq) is greater than this (plan 017 C8). 0 means
+//     "no cursor": the request falls back to the last-Lines path. A caller that
+//     genuinely holds cursor 0 (it has consumed nothing) wants exactly that
+//     fallback, so 0 is never sent on the wire — see buildLogQueryParams.
 type LogParams struct {
-	Process string
-	Lines   int
-	Pattern string
-	Regex   bool
+	Process  string
+	Lines    int
+	Pattern  string
+	Regex    bool
+	SinceSeq uint64
 }
 
 // ProxyRequestParams holds parameters for proxy request retrieval and streaming.

--- a/internal/logs/manager.go
+++ b/internal/logs/manager.go
@@ -1,8 +1,17 @@
 package logs
 
 import (
+	"crypto/rand"
+	"encoding/hex"
+	"sync"
+
 	"github.com/charliek/prox/internal/domain"
 )
+
+// streamIDBytes is the entropy behind a manager's stream ID (rendered as twice
+// as many hex characters). It only has to make an accidental collision between
+// two manager lifetimes implausible, not resist an attacker.
+const streamIDBytes = 8
 
 // ManagerConfig holds configuration for the log manager
 type ManagerConfig struct {
@@ -22,6 +31,26 @@ func DefaultManagerConfig() ManagerConfig {
 type Manager struct {
 	buffer        *RingBuffer
 	subscriptions *SubscriptionManager
+
+	// streamID identifies THIS manager lifetime. It is generated once at
+	// construction and never changes, so a client that sees a stream ID
+	// different from the one it last resumed against knows every sequence
+	// number it holds belongs to a dead epoch and must re-sync from scratch
+	// rather than ask for "everything after seq N".
+	streamID string
+
+	// ingestMu serializes Write end-to-end. Seq assignment, the ring append and
+	// the subscriber broadcast all happen under it, which is what makes the
+	// LogEntry.Seq invariant hold: ring order == seq order == per-subscriber
+	// delivery order. Without it, concurrent per-process scanner goroutines
+	// could assign 1,2 and then append/broadcast 2,1.
+	//
+	// The buffer and the subscription manager keep their own inner locks (they
+	// are used on read paths that do NOT take ingestMu); ingestMu is strictly
+	// outside them and nothing under it calls back into Manager, so there is no
+	// lock-ordering cycle. Log volume does not warrant anything cleverer.
+	ingestMu sync.Mutex
+	seq      uint64
 }
 
 // NewManager creates a new log manager
@@ -36,11 +65,35 @@ func NewManager(config ManagerConfig) *Manager {
 	return &Manager{
 		buffer:        NewRingBuffer(config.BufferSize),
 		subscriptions: NewSubscriptionManager(config.SubscriptionBuffer),
+		streamID:      newStreamID(),
 	}
 }
 
-// Write adds a log entry to the buffer and broadcasts to subscribers
+// newStreamID returns a random hex token for one manager lifetime. crypto/rand
+// Read never fails on the platforms we support (it panics internally instead),
+// so there is no error path to surface here.
+func newStreamID() string {
+	var b [streamIDBytes]byte
+	_, _ = rand.Read(b[:])
+	return hex.EncodeToString(b[:])
+}
+
+// StreamID returns the token identifying this manager lifetime. It is stable
+// for the life of the manager. See Manager.streamID.
+func (m *Manager) StreamID() string {
+	return m.streamID
+}
+
+// Write stamps the entry with the next ingest sequence number, appends it to
+// the ring buffer and broadcasts it to subscribers — all under ingestMu, so
+// every observer sees the same order. The caller's copy is not modified; the
+// stamped copy is the one that is stored and delivered.
 func (m *Manager) Write(entry domain.LogEntry) {
+	m.ingestMu.Lock()
+	defer m.ingestMu.Unlock()
+
+	m.seq++
+	entry.Seq = m.seq
 	m.buffer.Write(entry)
 	m.subscriptions.Broadcast(entry)
 }
@@ -66,6 +119,52 @@ func (m *Manager) QueryLast(filter domain.LogFilter, n int) ([]domain.LogEntry, 
 	}
 
 	return filtered, total, nil
+}
+
+// QueryFromSeq returns the buffered entries NEWER than sinceSeq (Seq >
+// sinceSeq) that match the filter, oldest-first and capped at limit (limit <= 0
+// means uncapped). It is the resume primitive behind "give me everything after
+// sequence N".
+//
+// When the cap bites it keeps the OLDEST matching entries, deliberately unlike
+// Query/QueryLast which keep the newest: a resuming caller must advance its
+// cursor contiguously from sinceSeq and come back for the rest, and handing it
+// the newest slice would manufacture the very gap the sequence exists to rule
+// out.
+//
+// oldestSeq/latestSeq describe the CURRENT BUFFER as a whole — every entry in
+// the ring, ignoring both the filter and sinceSeq — and are 0, 0 when the buffer
+// is empty. They are what lets a caller tell "caught up" apart from "the buffer
+// rolled past me": an empty result with latestSeq == sinceSeq means caught up,
+// while oldestSeq > sinceSeq+1 means the entries in between were evicted and the
+// caller has a real gap. Bounds and entries come from ONE buffer snapshot, so
+// they can never describe different moments.
+func (m *Manager) QueryFromSeq(filter domain.LogFilter, sinceSeq uint64, limit int) ([]domain.LogEntry, uint64, uint64, error) {
+	snapshot := m.buffer.Read()
+
+	var oldestSeq, latestSeq uint64
+	if n := len(snapshot); n > 0 {
+		oldestSeq = snapshot[0].Seq
+		latestSeq = snapshot[n-1].Seq
+	}
+
+	filtered, err := FilterEntries(snapshot, filter)
+	if err != nil {
+		return nil, 0, 0, err
+	}
+
+	result := make([]domain.LogEntry, 0, len(filtered))
+	for _, entry := range filtered {
+		if entry.Seq <= sinceSeq {
+			continue
+		}
+		result = append(result, entry)
+		if limit > 0 && len(result) >= limit {
+			break
+		}
+	}
+
+	return result, oldestSeq, latestSeq, nil
 }
 
 // Subscribe creates a subscription for log entries matching the filter

--- a/internal/logs/manager_test.go
+++ b/internal/logs/manager_test.go
@@ -196,6 +196,233 @@ func TestManager_Concurrent(t *testing.T) {
 	assert.Equal(t, 500, stats.TotalEntries) // 5 writers * 100 writes
 }
 
+func TestManager_WriteAssignsSeq(t *testing.T) {
+	m := NewManager(ManagerConfig{BufferSize: 10})
+	defer m.Close()
+
+	// An entry that never passed through Write carries the unset sentinel.
+	assert.Zero(t, makeEntry("unwritten").Seq)
+
+	// Write stamps monotonically from 1, overwriting whatever the caller set.
+	m.Write(makeEntry("first"))
+	m.Write(makeEntry("second"))
+	preset := makeEntry("third")
+	preset.Seq = 999
+	m.Write(preset)
+
+	entries, _, err := m.Query(domain.LogFilter{}, 0)
+	require.NoError(t, err)
+	require.Len(t, entries, 3)
+	assert.Equal(t, uint64(1), entries[0].Seq)
+	assert.Equal(t, uint64(2), entries[1].Seq)
+	assert.Equal(t, uint64(3), entries[2].Seq)
+
+	// The caller's copy is untouched by the stamp.
+	assert.Equal(t, uint64(999), preset.Seq)
+}
+
+func TestManager_StreamID(t *testing.T) {
+	m := NewManager(ManagerConfig{BufferSize: 10})
+	defer m.Close()
+
+	id := m.StreamID()
+	assert.Len(t, id, 2*streamIDBytes, "hex encoding of the random token")
+
+	// Stable for the manager's lifetime, including across writes.
+	m.Write(makeEntry("line"))
+	assert.Equal(t, id, m.StreamID())
+
+	// A second manager is a different epoch.
+	other := NewManager(ManagerConfig{BufferSize: 10})
+	defer other.Close()
+	assert.NotEqual(t, id, other.StreamID())
+}
+
+// TestManager_ConcurrentWriteSequencing is the reason Write holds ingestMu
+// end-to-end: with concurrent writers, seq assignment, the ring append and the
+// broadcast must not interleave, so ring order == seq order == every
+// subscriber's delivery order, with no gaps.
+func TestManager_ConcurrentWriteSequencing(t *testing.T) {
+	const (
+		writers          = 8
+		writesPerWriter  = 100
+		total            = writers * writesPerWriter
+		subscriberCount  = 3
+		subscriptionSize = total + 10 // never overflow: overflow ends the sub (C6)
+	)
+
+	m := NewManager(ManagerConfig{BufferSize: total, SubscriptionBuffer: subscriptionSize})
+
+	channels := make([]<-chan domain.LogEntry, 0, subscriberCount)
+	for i := 0; i < subscriberCount; i++ {
+		_, ch, err := m.Subscribe(domain.LogFilter{})
+		require.NoError(t, err)
+		channels = append(channels, ch)
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < writers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < writesPerWriter; j++ {
+				m.Write(makeEntry("concurrent"))
+			}
+		}()
+	}
+	wg.Wait()
+
+	// Close so the subscription channels terminate; buffered entries are still
+	// drainable from a closed channel.
+	m.Close()
+
+	// Ring order is strictly seq-ascending and gap-free over 1..total.
+	entries, _, err := m.Query(domain.LogFilter{}, 0)
+	require.NoError(t, err)
+	require.Len(t, entries, total)
+	for i, e := range entries {
+		require.Equal(t, uint64(i+1), e.Seq, "ring entry %d", i)
+	}
+
+	// Every subscriber saw the same strictly ascending, gap-free sequence.
+	for i, ch := range channels {
+		var seqs []uint64
+		for e := range ch {
+			seqs = append(seqs, e.Seq)
+		}
+		require.Len(t, seqs, total, "subscriber %d delivery count", i)
+		for j, seq := range seqs {
+			require.Equal(t, uint64(j+1), seq, "subscriber %d delivery %d", i, j)
+		}
+	}
+}
+
+func TestManager_QueryFromSeq(t *testing.T) {
+	t.Run("empty buffer reports zero bounds", func(t *testing.T) {
+		m := NewManager(ManagerConfig{BufferSize: 10})
+		defer m.Close()
+
+		entries, oldest, latest, err := m.QueryFromSeq(domain.LogFilter{}, 0, 0)
+		require.NoError(t, err)
+		assert.Empty(t, entries)
+		assert.Equal(t, uint64(0), oldest)
+		assert.Equal(t, uint64(0), latest)
+	})
+
+	t.Run("resume from mid-buffer", func(t *testing.T) {
+		m := NewManager(ManagerConfig{BufferSize: 100})
+		defer m.Close()
+		for i := 0; i < 10; i++ {
+			m.Write(makeEntry("line"))
+		}
+
+		entries, oldest, latest, err := m.QueryFromSeq(domain.LogFilter{}, 6, 0)
+		require.NoError(t, err)
+		require.Len(t, entries, 4)
+		assert.Equal(t, uint64(7), entries[0].Seq)
+		assert.Equal(t, uint64(10), entries[3].Seq)
+		assert.Equal(t, uint64(1), oldest)
+		assert.Equal(t, uint64(10), latest)
+	})
+
+	t.Run("sinceSeq zero returns everything buffered", func(t *testing.T) {
+		m := NewManager(ManagerConfig{BufferSize: 100})
+		defer m.Close()
+		for i := 0; i < 5; i++ {
+			m.Write(makeEntry("line"))
+		}
+
+		entries, oldest, latest, err := m.QueryFromSeq(domain.LogFilter{}, 0, 0)
+		require.NoError(t, err)
+		require.Len(t, entries, 5)
+		assert.Equal(t, uint64(1), entries[0].Seq)
+		assert.Equal(t, uint64(1), oldest)
+		assert.Equal(t, uint64(5), latest)
+	})
+
+	t.Run("sinceSeq at or beyond latest returns nothing", func(t *testing.T) {
+		m := NewManager(ManagerConfig{BufferSize: 100})
+		defer m.Close()
+		for i := 0; i < 5; i++ {
+			m.Write(makeEntry("line"))
+		}
+
+		entries, _, latest, err := m.QueryFromSeq(domain.LogFilter{}, 5, 0)
+		require.NoError(t, err)
+		assert.Empty(t, entries, "caught up")
+		assert.Equal(t, uint64(5), latest, "and latest == sinceSeq proves it")
+
+		entries, _, latest, err = m.QueryFromSeq(domain.LogFilter{}, 99, 0)
+		require.NoError(t, err)
+		assert.Empty(t, entries)
+		assert.Equal(t, uint64(5), latest)
+	})
+
+	t.Run("rolled buffer is detectable via oldestSeq", func(t *testing.T) {
+		m := NewManager(ManagerConfig{BufferSize: 10})
+		defer m.Close()
+		for i := 0; i < 50; i++ {
+			m.Write(makeEntry("line"))
+		}
+
+		// The client last saw seq 5, but only 41..50 survive: seqs 6..40 are gone.
+		entries, oldest, latest, err := m.QueryFromSeq(domain.LogFilter{}, 5, 0)
+		require.NoError(t, err)
+		require.Len(t, entries, 10)
+		assert.Equal(t, uint64(41), entries[0].Seq)
+		assert.Equal(t, uint64(41), oldest)
+		assert.Equal(t, uint64(50), latest)
+		assert.Greater(t, oldest, uint64(5)+1, "gap is detectable: oldestSeq > sinceSeq+1")
+	})
+
+	t.Run("limit keeps the oldest matching entries", func(t *testing.T) {
+		m := NewManager(ManagerConfig{BufferSize: 100})
+		defer m.Close()
+		for i := 0; i < 20; i++ {
+			m.Write(makeEntry("line"))
+		}
+
+		entries, _, latest, err := m.QueryFromSeq(domain.LogFilter{}, 4, 3)
+		require.NoError(t, err)
+		require.Len(t, entries, 3)
+		assert.Equal(t, uint64(5), entries[0].Seq, "contiguous with sinceSeq, not the newest slice")
+		assert.Equal(t, uint64(7), entries[2].Seq)
+		assert.Equal(t, uint64(20), latest)
+	})
+
+	t.Run("filter and sinceSeq combine", func(t *testing.T) {
+		m := NewManager(ManagerConfig{BufferSize: 100})
+		defer m.Close()
+		for i := 0; i < 10; i++ {
+			m.Write(makeEntryWithProcess("web", "web line"))
+			m.Write(makeEntryWithProcess("api", "api line"))
+		}
+		// Interleaved: web has odd seqs 1,3,...,19; api has even seqs.
+
+		entries, oldest, latest, err := m.QueryFromSeq(domain.LogFilter{Processes: []string{"web"}}, 10, 0)
+		require.NoError(t, err)
+		require.Len(t, entries, 5)
+		for _, e := range entries {
+			assert.Equal(t, "web", e.Process)
+			assert.Greater(t, e.Seq, uint64(10))
+		}
+		assert.Equal(t, uint64(11), entries[0].Seq)
+		assert.Equal(t, uint64(19), entries[4].Seq)
+		// Bounds describe the whole buffer, not the filtered view.
+		assert.Equal(t, uint64(1), oldest)
+		assert.Equal(t, uint64(20), latest)
+	})
+
+	t.Run("invalid pattern surfaces the filter error", func(t *testing.T) {
+		m := NewManager(ManagerConfig{BufferSize: 10})
+		defer m.Close()
+		m.Write(makeEntry("line"))
+
+		_, _, _, err := m.QueryFromSeq(domain.LogFilter{Pattern: "[", IsRegex: true}, 0, 0)
+		require.Error(t, err)
+	})
+}
+
 func TestManager_DefaultConfig(t *testing.T) {
 	m := NewManager(ManagerConfig{})
 	defer m.Close()

--- a/internal/logs/subscription.go
+++ b/internal/logs/subscription.go
@@ -62,8 +62,12 @@ func (s *Subscription) Channel() <-chan domain.LogEntry {
 	return s.ch
 }
 
-// Send attempts to send an entry to the subscriber
-// Returns false if the channel is full or closed
+// Send attempts to send an entry to the subscriber.
+// Returns false if the channel is full or closed — Broadcast turns that into
+// the subscription's removal (see its doc comment). Send deliberately does NOT
+// close the channel itself: it runs under the manager's read lock alongside
+// concurrent senders, and closing there could race a send into a closed
+// channel.
 func (s *Subscription) Send(entry domain.LogEntry) bool {
 	if s.closed.Load() {
 		return false
@@ -78,8 +82,10 @@ func (s *Subscription) Send(entry domain.LogEntry) bool {
 	case s.ch <- entry:
 		return true
 	default:
-		// Channel full, drop message - log for debugging slow clients
-		log.Printf("Subscription %s: dropped message from process %s (channel full)", s.id, entry.Process)
+		// Channel full - log for debugging slow clients. One line per
+		// subscription: Broadcast ends the subscription on this first
+		// overflow, so there is no flood to guard against.
+		log.Printf("Subscription %s: overflowed on a message from process %s and was closed (channel full)", s.id, entry.Process)
 		return false
 	}
 }
@@ -148,14 +154,55 @@ func (m *SubscriptionManager) Unsubscribe(id string) {
 	}
 }
 
-// Broadcast sends an entry to all subscribers
+// Broadcast sends an entry to all subscribers and ends the ones that
+// overflowed.
+//
+// Overflow is NOT a silent drop (C6): a subscriber whose channel is full has
+// lost a line it can never be handed later, so the subscription is closed and
+// removed. The SSE handler sees the closed channel as end-of-stream and
+// returns; the client reconnects and re-syncs. The local TUI subscribes to the
+// same manager, so a local overflow likewise ends its feed and is surfaced as
+// "logs: disconnected" — strictly better than silently showing an incomplete
+// log pane.
+//
+// The close runs after deliver has released the read lock, never inside it:
+// Send runs under the read lock alongside concurrent senders, and closing there
+// could race a send into a closed channel.
 func (m *SubscriptionManager) Broadcast(entry domain.LogEntry) {
+	for _, sub := range m.deliver(entry) {
+		m.dropSubscription(sub)
+	}
+}
+
+// deliver attempts the send to every subscription under the read lock and
+// returns those that overflowed (or were already closed).
+func (m *SubscriptionManager) deliver(entry domain.LogEntry) []*Subscription {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
+	var overflowed []*Subscription
 	for _, sub := range m.subscriptions {
-		sub.Send(entry)
+		if !sub.Send(entry) {
+			overflowed = append(overflowed, sub)
+		}
 	}
+	return overflowed
+}
+
+// dropSubscription removes an overflowed subscription and closes it, in that
+// order and matching Unsubscribe: removing under the write lock first means no
+// later deliver can see the subscription, so the close that follows cannot race
+// a send. The map entry is compared by pointer so a straggling drop cannot
+// evict a different subscription, and Close's latch makes a doubled drop a
+// no-op.
+func (m *SubscriptionManager) dropSubscription(sub *Subscription) {
+	m.mu.Lock()
+	if cur, ok := m.subscriptions[sub.id]; ok && cur == sub {
+		delete(m.subscriptions, sub.id)
+	}
+	m.mu.Unlock()
+
+	sub.Close()
 }
 
 // Count returns the number of active subscriptions

--- a/internal/logs/subscription_test.go
+++ b/internal/logs/subscription_test.go
@@ -117,6 +117,67 @@ func TestSubscriptionManager_Broadcast(t *testing.T) {
 	assert.Equal(t, "broadcast", msg2.Line)
 }
 
+// TestSubscriptionManager_BroadcastOverflowClosesSubscription pins C6: a
+// subscriber whose channel fills has lost a line it can never be handed later,
+// so Broadcast closes and removes the subscription instead of dropping
+// silently. The SSE handler sees that close as end-of-stream and the client
+// reconnects.
+func TestSubscriptionManager_BroadcastOverflowClosesSubscription(t *testing.T) {
+	m := NewSubscriptionManager(2)
+	_, ch, err := m.Subscribe(domain.LogFilter{})
+	require.NoError(t, err)
+
+	for i := 0; i < 5; i++ {
+		m.Broadcast(makeEntry("line"))
+	}
+
+	assert.Equal(t, 0, m.Count(), "the overflowed subscription is removed")
+
+	// The buffered entries are still readable, then the channel reports
+	// end-of-stream.
+	drained := 0
+	for range ch {
+		drained++
+		require.LessOrEqual(t, drained, 5, "channel never closed")
+	}
+	assert.Equal(t, 2, drained, "the full buffer is drained before the close")
+
+	// A send on a closed channel would panic; broadcasting must stay safe.
+	m.Broadcast(makeEntry("after"))
+	// Unsubscribe/Close must not double-close the latched channel either.
+	m.Unsubscribe("sub-1")
+	m.Close()
+}
+
+// TestSubscriptionManager_BroadcastOverflowSparesOtherSubscribers pins that the
+// close is per-subscription: a healthy subscriber keeps its stream.
+func TestSubscriptionManager_BroadcastOverflowSparesOtherSubscribers(t *testing.T) {
+	m := NewSubscriptionManager(2)
+	_, slowCh, err := m.Subscribe(domain.LogFilter{Processes: []string{"web"}})
+	require.NoError(t, err)
+	// The healthy subscriber filters the burst out entirely, so only the
+	// unread one can overflow — no scheduling race.
+	_, fastCh, err := m.Subscribe(domain.LogFilter{Processes: []string{"api"}})
+	require.NoError(t, err)
+
+	for i := 0; i < 5; i++ {
+		m.Broadcast(makeEntryWithProcess("web", "burst"))
+	}
+	assert.Equal(t, 1, m.Count(), "only the overflowed subscription is removed")
+
+	for range slowCh {
+	}
+
+	m.Broadcast(makeEntryWithProcess("api", "still here"))
+	select {
+	case entry, ok := <-fastCh:
+		require.True(t, ok, "the healthy subscriber's channel was closed")
+		assert.Equal(t, "still here", entry.Line)
+	case <-time.After(2 * time.Second):
+		t.Fatal("healthy subscriber received nothing after the slow one was dropped")
+	}
+}
+
 func TestSubscriptionManager_BroadcastWithFilter(t *testing.T) {
 	m := NewSubscriptionManager(10)
 

--- a/internal/proxy/requests.go
+++ b/internal/proxy/requests.go
@@ -130,11 +130,27 @@ type RequestFilter struct {
 // when notifySubscribers tried to deliver (D9). It is an atomic so
 // notifySubscribers can bump it under the manager's read lock; the first drop
 // (0→1 transition) logs once so a slow subscriber is visible without spamming.
+//
+// closed latches the channel close so the several paths that can end a
+// subscription — Unsubscribe, manager Close, and the overflow drop (C6) —
+// can never double-close it.
 type RequestSubscription struct {
 	ID      string
 	Filter  RequestFilter
 	Ch      chan RequestRecord
 	dropped atomic.Int64
+	closed  atomic.Bool
+}
+
+// closeLatched closes the subscription's channel exactly once. Every close path
+// goes through it. Callers must hold the manager's subMu WRITE lock (or own the
+// subscription outright, as Subscribe does before publishing it), so a close can
+// never race a non-blocking send in notifySubscribers — those run under the read
+// lock.
+func (s *RequestSubscription) closeLatched() {
+	if s.closed.CompareAndSwap(false, true) {
+		close(s.Ch)
+	}
 }
 
 // EvictionCallback is called when a request is evicted from the ring buffer.
@@ -293,9 +309,10 @@ func (m *RequestManager) appendRecord(record RequestRecord) (evictedID string, o
 //
 // Unlike Record, subscribers are notified INSIDE the ring critical section:
 // same-ID notifications can never be observed out of transition order.
-// notifySubscribers only performs non-blocking channel sends under subMu,
-// and no path acquires mu while holding subMu, so this cannot block or
-// deadlock. The eviction callback (disk IO) still runs after unlock.
+// notifySubscribers only performs non-blocking channel sends (plus, on
+// overflow, a subscription removal) under subMu, and no path acquires mu
+// while holding subMu, so this cannot block or deadlock. The eviction
+// callback (disk IO) still runs after unlock.
 // Upsert reports whether the record was accepted; false means the manager was
 // already Closed (writesClosed) and the caller owns capture-file cleanup.
 func (m *RequestManager) Upsert(record RequestRecord) bool {
@@ -454,7 +471,7 @@ func (m *RequestManager) Subscribe(filter RequestFilter) *RequestSubscription {
 		Ch:     make(chan RequestRecord, 100),
 	}
 	if m.closed {
-		close(sub.Ch)
+		sub.closeLatched()
 		return sub
 	}
 	m.subs[sub.ID] = sub
@@ -468,7 +485,7 @@ func (m *RequestManager) Unsubscribe(id string) {
 	defer m.subMu.Unlock()
 
 	if sub, ok := m.subs[id]; ok {
-		close(sub.Ch)
+		sub.closeLatched()
 		delete(m.subs, id)
 	}
 }
@@ -495,35 +512,84 @@ func (m *RequestManager) Close() {
 
 	m.closed = true
 	for id, sub := range m.subs {
-		close(sub.Ch)
+		sub.closeLatched()
 		delete(m.subs, id)
 	}
 }
 
+// notifySubscribers delivers record to every matching subscription and ends the
+// ones that overflowed.
+//
+// Overflow is NOT a silent drop (C6): a subscriber whose channel is full has
+// lost a record, and there is no way to hand it that record later, so the
+// subscription is closed and removed instead. The SSE handlers see the closed
+// channel as end-of-stream and return; the client reconnects and re-syncs from
+// a fresh snapshot, which is the only repair that actually restores the missing
+// record. The local TUI subscribes to the same manager, so a local overflow
+// likewise closes its feed — surfaced by the local close-reporting path as
+// "requests: disconnected", which is strictly better than silently showing an
+// incomplete list.
+//
+// The close runs OUTSIDE the read lock, under the write lock: sends happen
+// under the read lock, so taking the write lock is what guarantees no send can
+// be in flight while a channel is being closed. No path acquires the ring mutex
+// while holding subMu, so this still cannot deadlock with the Upsert caller
+// that holds it.
 func (m *RequestManager) notifySubscribers(record RequestRecord) {
+	for _, sub := range m.deliver(record) {
+		m.dropSubscription(sub)
+	}
+}
+
+// deliver performs the non-blocking sends under the read lock and returns the
+// subscriptions whose channels were full. Caller must not hold subMu.
+//
+// Sending to a subscription still present in m.subs is safe without a
+// closed check: every close path removes the subscription from the map and
+// closes it in the same write-lock critical section, so a subscription visible
+// here cannot be closed. Two concurrent deliveries may both report the same
+// overflowed subscription; dropSubscription is idempotent.
+func (m *RequestManager) deliver(record RequestRecord) []*RequestSubscription {
 	m.subMu.RLock()
 	defer m.subMu.RUnlock()
 
+	var overflowed []*RequestSubscription
 	for _, sub := range m.subs {
-		if m.matchesFilter(record, sub.Filter) {
-			select {
-			case sub.Ch <- record:
-			default:
-				// Channel full: drop the message and count it (D9). The
-				// manager-wide total feeds DroppedEvents(); the per-subscription
-				// count logs once on the first drop so a persistently slow
-				// subscriber is visible without a per-drop log flood. The log
-				// itself runs on a goroutine: notifySubscribers is called with
-				// the ring mutex held on the Upsert path (ordering guarantee),
-				// and logger I/O must not stall the SSE hot path under that
-				// lock.
-				m.droppedTotal.Add(1)
-				if sub.dropped.Add(1) == 1 {
-					go log.Printf("prox: request subscription %s is dropping events (subscriber not keeping up)", sub.ID)
-				}
+		if !m.matchesFilter(record, sub.Filter) {
+			continue
+		}
+		select {
+		case sub.Ch <- record:
+		default:
+			// Channel full: count the overflow (D9) and mark the subscription
+			// for closure. The manager-wide total feeds DroppedEvents(); the
+			// per-subscription count logs once on the first drop so a slow
+			// subscriber is visible without a per-drop log flood. The log
+			// itself runs on a goroutine: notifySubscribers is called with the
+			// ring mutex held on the Upsert path (ordering guarantee), and
+			// logger I/O must not stall the SSE hot path under that lock.
+			m.droppedTotal.Add(1)
+			if sub.dropped.Add(1) == 1 {
+				go log.Printf("prox: request subscription %s overflowed and was closed (subscriber not keeping up)", sub.ID)
 			}
+			overflowed = append(overflowed, sub)
 		}
 	}
+	return overflowed
+}
+
+// dropSubscription removes an overflowed subscription and closes its channel.
+// The map entry is compared by pointer so a re-Subscribe that reused the ID
+// (impossible today, nextID is monotonic — but cheap insurance) is not evicted
+// by a straggling drop, and the latched close makes a doubled drop a no-op.
+func (m *RequestManager) dropSubscription(sub *RequestSubscription) {
+	m.subMu.Lock()
+	defer m.subMu.Unlock()
+
+	if cur, ok := m.subs[sub.ID]; ok && cur == sub {
+		delete(m.subs, sub.ID)
+	}
+	sub.closeLatched()
 }
 
 // DroppedEvents returns the manager-wide number of subscriber notifications

--- a/internal/proxy/requests_drop_test.go
+++ b/internal/proxy/requests_drop_test.go
@@ -31,11 +31,13 @@ func (b *syncBuffer) String() string {
 	return b.buf.String()
 }
 
-// TestRequestManager_DroppedEventsUnderBurst pins D9: a burst larger than a
-// subscriber's channel buffer against a subscriber that never reads yields a
-// non-zero DroppedEvents total, and the per-subscription first drop logs exactly
-// once (not per-drop).
-func TestRequestManager_DroppedEventsUnderBurst(t *testing.T) {
+// TestRequestManager_OverflowClosesSubscription pins D9 as revised by C6: a
+// burst larger than a subscriber's channel buffer against a subscriber that
+// never reads CLOSES that subscription rather than silently dropping records
+// forever. The overflow that forced the close is still counted
+// (DroppedEvents), the close logs exactly once, and the manager keeps
+// accepting writes afterwards.
+func TestRequestManager_OverflowClosesSubscription(t *testing.T) {
 	logBuf := &syncBuffer{}
 	prev := log.Writer()
 	log.SetOutput(logBuf)
@@ -43,7 +45,7 @@ func TestRequestManager_DroppedEventsUnderBurst(t *testing.T) {
 
 	m := NewRequestManager(1000)
 	// Subscribe with the default 100-slot channel and never read it, so a burst
-	// past 100 forces the non-blocking send in notifySubscribers to drop.
+	// past 100 forces the non-blocking send in notifySubscribers to overflow.
 	sub := m.Subscribe(RequestFilter{})
 	if sub == nil {
 		t.Fatal("Subscribe returned nil")
@@ -54,21 +56,76 @@ func TestRequestManager_DroppedEventsUnderBurst(t *testing.T) {
 		m.Record(RequestRecord{ID: fmt.Sprintf("r%03d", i), Method: "GET", URL: "/x"})
 	}
 
-	if got := m.DroppedEvents(); got <= 0 {
-		t.Fatalf("DroppedEvents() = %d, want > 0 after a %d-event burst against an unread subscriber", got, burst)
-	}
-	// Expect roughly burst-100 drops (the first 100 fill the buffer).
-	if got := m.DroppedEvents(); got < int64(burst-100) {
-		t.Errorf("DroppedEvents() = %d, want >= %d", got, burst-100)
+	// The overflow event itself is still counted; everything after it is not,
+	// because the subscription no longer exists.
+	if got := m.DroppedEvents(); got != 1 {
+		t.Errorf("DroppedEvents() = %d, want exactly 1 (the overflow that forced the close)", got)
 	}
 
-	// The first-drop log is asynchronous (goroutine); wait for it to land,
-	// then confirm no further lines arrive (exactly-once).
+	// The channel is closed: the buffered records are still readable, then the
+	// receive reports end-of-stream. That close is what the SSE handlers see,
+	// and what makes the client reconnect and re-sync.
+	drained := 0
+	for range sub.Ch {
+		drained++
+		if drained > burst {
+			t.Fatalf("channel never closed after %d receives", drained)
+		}
+	}
+	if drained != 100 {
+		t.Errorf("drained %d buffered records before close, want the full 100-slot buffer", drained)
+	}
+
+	// The manager must keep working: a send on the closed channel would panic.
+	if !m.Record(RequestRecord{ID: "after", Method: "GET", URL: "/y"}) {
+		t.Error("Record after an overflow close was rejected")
+	}
+	if !m.Upsert(RequestRecord{ID: "after2", Method: "GET", URL: "/z"}) {
+		t.Error("Upsert after an overflow close was rejected")
+	}
+	// Unsubscribe/Close must not double-close the latched channel.
+	m.Unsubscribe(sub.ID)
+	m.Close()
+
+	// The close log is asynchronous (goroutine); wait for it to land, then
+	// confirm no further lines arrive (exactly-once).
 	deadline := time.Now().Add(2 * time.Second)
-	for strings.Count(logBuf.String(), "is dropping events") == 0 && time.Now().Before(deadline) {
+	for strings.Count(logBuf.String(), "overflowed and was closed") == 0 && time.Now().Before(deadline) {
 		time.Sleep(5 * time.Millisecond)
 	}
-	if n := strings.Count(logBuf.String(), "is dropping events"); n != 1 {
-		t.Errorf("first-drop log lines = %d, want exactly 1 (first drop per subscription logs once); log:\n%s", n, logBuf.String())
+	if n := strings.Count(logBuf.String(), "overflowed and was closed"); n != 1 {
+		t.Errorf("overflow log lines = %d, want exactly 1; log:\n%s", n, logBuf.String())
+	}
+}
+
+// TestRequestManager_OverflowLeavesOtherSubscribersAlone pins that the close is
+// per-subscription: a healthy reader keeps its stream when a slow one is
+// dropped.
+func TestRequestManager_OverflowLeavesOtherSubscribersAlone(t *testing.T) {
+	m := NewRequestManager(1000)
+	slow := m.Subscribe(RequestFilter{})
+	// The healthy subscriber filters the burst out entirely, so the test is
+	// deterministic: only the unread catch-all subscription can overflow.
+	fast := m.Subscribe(RequestFilter{Subdomain: "quiet"})
+
+	const burst = 150
+	for i := 0; i < burst; i++ {
+		m.Record(RequestRecord{ID: fmt.Sprintf("r%03d", i), Method: "GET", URL: "/x"})
+	}
+
+	// slow is closed and gone; fast is still live and still delivered to.
+	for range slow.Ch {
+	}
+	m.Record(RequestRecord{ID: "later", Method: "GET", URL: "/later", Subdomain: "quiet"})
+	select {
+	case rec, ok := <-fast.Ch:
+		if !ok {
+			t.Fatal("the healthy subscriber's channel was closed")
+		}
+		if rec.ID != "later" {
+			t.Errorf("healthy subscriber got %q, want \"later\"", rec.ID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("healthy subscriber received nothing after the slow one was dropped")
 	}
 }

--- a/internal/stream/loop.go
+++ b/internal/stream/loop.go
@@ -1,0 +1,369 @@
+// Package stream provides the generic reconnect runner shared by every prox
+// stream consumer: the TUI's attach-mode SSE streams and the CLI's --follow
+// commands. It owns the connect/backoff/reconnect state machine and the status
+// reporting; callers supply only a single "connect and consume until the stream
+// ends" attempt function plus a policy for classifying attempt errors.
+//
+// This package is a leaf on purpose. internal/cli imports internal/tui, so the
+// runner has to be importable by both; it therefore depends on nothing beyond
+// the standard library and internal/constants.
+package stream
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/charliek/prox/internal/constants"
+)
+
+// State is the reconnect loop's externally visible condition. Consumers render
+// it directly (a TUI status line, a CLI stderr notice).
+//
+// The constants are prefixed State* because Classification below needs an
+// Unavailable member too, and the two enums share this package's namespace.
+type State int
+
+const (
+	// StateConnecting means the very first attempt is in progress. Nothing has
+	// been delivered yet and no reconnect has happened.
+	StateConnecting State = iota
+
+	// StateSyncing means an attempt is in progress and has not yet reported
+	// that it is synchronized. It deliberately covers dial, handshake AND
+	// snapshot synchronization as one phase: the loop only learns about the
+	// attempt's progress through markSynced, and consumers render Connecting
+	// and Syncing identically anyway.
+	StateSyncing
+
+	// StateOK means the current attempt called markSynced: it is connected and
+	// whatever synchronization the consumer defines (usually a snapshot fetch
+	// followed by live events) has completed.
+	StateOK
+
+	// StateReconnecting means an attempt ended and a backoff wait is in
+	// progress. Status.Err carries the error that ended it, or nil when the
+	// attempt ended cleanly (the server closed the stream).
+	StateReconnecting
+
+	// StateUnavailable means the policy classified the attempt's error as not
+	// worth retrying aggressively (for example: the server is not running at
+	// all). The loop parks — no timed retries — and stays latched in this state
+	// until an external re-probe via (*Loop).Probe or context cancellation.
+	StateUnavailable
+
+	// StateClosed means the loop has ended, either because the context was
+	// cancelled or because the policy classified an error as terminal. It is
+	// always the last status a Loop reports, and it is reported exactly once.
+	StateClosed
+)
+
+// String implements fmt.Stringer for readable logs and test failures.
+func (s State) String() string {
+	switch s {
+	case StateConnecting:
+		return "connecting"
+	case StateSyncing:
+		return "syncing"
+	case StateOK:
+		return "ok"
+	case StateReconnecting:
+		return "reconnecting"
+	case StateUnavailable:
+		return "unavailable"
+	case StateClosed:
+		return "closed"
+	default:
+		return "unknown"
+	}
+}
+
+// Status is one state transition delivered to Config.OnStatus.
+type Status struct {
+	State State
+
+	// Err carries the cause for StateReconnecting (the error that ended the
+	// attempt, nil for a clean end), StateUnavailable (the error the policy
+	// declined to retry aggressively) and StateClosed (the terminal error, or
+	// the context's error when the loop was cancelled). It is always nil for
+	// StateConnecting, StateSyncing and StateOK.
+	Err error
+}
+
+// Classification decides how the loop treats an attempt error.
+type Classification int
+
+const (
+	// ClassTransient retries with the exponential backoff. This is the default
+	// for every error when Config.Classify is nil, and for an attempt that
+	// returned nil (a cleanly ended stream is still something to reconnect).
+	ClassTransient Classification = iota
+
+	// ClassUnavailable parks the loop in StateUnavailable with no timed retry
+	// until (*Loop).Probe or context cancellation.
+	ClassUnavailable
+
+	// ClassTerminal ends the loop: it reports StateClosed carrying the error
+	// and Run returns.
+	ClassTerminal
+)
+
+// Config configures a Loop. Only Attempt is required.
+type Config struct {
+	// Attempt connects and consumes the stream until it ends, calling
+	// markSynced once the caller-defined synchronization completes (a pure
+	// stream consumer, with no snapshot to reconcile, calls it immediately
+	// after connecting). It must honor ctx: the loop only observes
+	// cancellation between attempts, so an attempt that ignores ctx delays
+	// shutdown for as long as it runs.
+	//
+	// The return value is the error that ended the attempt; nil means the
+	// stream ended cleanly, which the loop treats as a transient end and
+	// reconnects from. A cancelled context ends the loop regardless of what
+	// the attempt returns.
+	//
+	// markSynced may be called more than once (repeats are deduplicated) and
+	// is ignored once the attempt has returned, so a straggling goroutine
+	// cannot flip a later attempt's state. It must be called from the attempt
+	// itself rather than from a goroutine that outlives it; see the OnStatus
+	// serialization note below.
+	Attempt func(ctx context.Context, markSynced func()) error
+
+	// Classify maps an attempt error to a Classification. It is called only on
+	// non-nil errors. A nil Classify treats everything as ClassTransient.
+	Classify func(error) Classification
+
+	// OnStatus receives every state transition. It is never called
+	// concurrently, and in normal use every call comes from the goroutine
+	// running Run (markSynced is expected to be called synchronously from
+	// within Attempt). Consecutive duplicates are suppressed: the loop never
+	// delivers the same State twice in a row with the same error text. A nil
+	// OnStatus discards the transitions.
+	OnStatus func(Status)
+
+	// Now and After inject time for tests (nil means real time), following the
+	// forwarderConfig idiom in internal/proxyd. Now is sampled exactly twice
+	// per attempt (immediately before and immediately after) to drive the flap
+	// guard; After is called once per backoff wait and never while parked in
+	// StateUnavailable.
+	Now   func() time.Time
+	After func(time.Duration) <-chan time.Time
+}
+
+// errNoAttempt is reported as the terminal error when a Loop is run without an
+// Attempt function, rather than panicking inside a consumer's goroutine.
+var errNoAttempt = errors.New("stream: Config.Attempt is nil")
+
+// Loop is a reconnect runner. Create one with NewLoop, drive it with Run, and
+// wake a parked one with Probe. A Loop is single-use: Run must be called at
+// most once.
+type Loop struct {
+	cfg Config
+
+	// probe is a capacity-1 channel, so Probe is non-blocking and coalescing:
+	// N probes delivered before the loop consumes one wake it exactly once.
+	probe chan struct{}
+
+	// mu serializes status delivery and the attempt-epoch bookkeeping, so a
+	// markSynced call is safe (and correctly ordered) no matter which
+	// goroutine makes it.
+	mu       sync.Mutex
+	epoch    uint64 // bumped when an attempt starts and again when it returns
+	last     Status // previous delivered status, for consecutive-duplicate suppression
+	hasLast  bool
+	finished bool // set once StateClosed is delivered; suppresses anything later
+}
+
+// NewLoop returns a Loop for cfg.
+func NewLoop(cfg Config) *Loop {
+	return &Loop{
+		cfg:   cfg,
+		probe: make(chan struct{}, 1),
+	}
+}
+
+// Probe wakes a loop parked in StateUnavailable for one immediate retry, and
+// short-circuits an in-progress backoff wait for the same effect. It is safe to
+// call from any goroutine, never blocks, and coalesces: probes delivered while
+// the loop is busy collapse into a single retry. A probe raised while an
+// attempt is in flight is retained and short-circuits the next backoff wait. A
+// probe does not reset the backoff — an external nudge should not let a caller
+// defeat the backoff by probing in a tight loop.
+func (l *Loop) Probe() {
+	select {
+	case l.probe <- struct{}{}:
+	default:
+	}
+}
+
+// Run drives the reconnect loop — attempt, flap-guarded backoff, attempt — and
+// blocks until ctx is done or an error is classified ClassTerminal. It reports
+// exactly one StateClosed status before returning.
+func (l *Loop) Run(ctx context.Context) {
+	if l.cfg.Attempt == nil {
+		l.emit(Status{State: StateClosed, Err: errNoAttempt})
+		return
+	}
+
+	now := l.cfg.Now
+	if now == nil {
+		now = time.Now
+	}
+	after := l.cfg.After
+	if after == nil {
+		after = time.After
+	}
+	classify := l.cfg.Classify
+	if classify == nil {
+		classify = func(error) Classification { return ClassTransient }
+	}
+
+	backoff := constants.StreamReconnectBaseBackoff
+	first := true
+
+	for {
+		if ctx.Err() != nil {
+			l.emit(Status{State: StateClosed, Err: ctx.Err()})
+			return
+		}
+
+		if first {
+			l.emit(Status{State: StateConnecting})
+			first = false
+		} else {
+			l.emit(Status{State: StateSyncing})
+		}
+
+		start := now()
+		err := l.attempt(ctx)
+		if ctx.Err() != nil {
+			l.emit(Status{State: StateClosed, Err: ctx.Err()})
+			return
+		}
+		lived := now().Sub(start)
+
+		class := ClassTransient
+		if err != nil {
+			class = classify(err)
+		}
+		if class == ClassTerminal {
+			l.emit(Status{State: StateClosed, Err: err})
+			return
+		}
+
+		// Flap guard (mirrors internal/proxyd/forwarder.go): only an attempt
+		// that survived the threshold counts as a recovery. A connect that
+		// dies instantly leaves the backoff where it was, so a crash-looping
+		// server still backs off instead of being retried at the base rate.
+		if lived >= constants.StreamReconnectFlapThreshold {
+			backoff = constants.StreamReconnectBaseBackoff
+		}
+
+		if class == ClassUnavailable {
+			l.emit(Status{State: StateUnavailable, Err: err})
+			// Parked: no timer is armed at all. Only an external Probe or
+			// cancellation gets us out of here.
+			select {
+			case <-ctx.Done():
+				l.emit(Status{State: StateClosed, Err: ctx.Err()})
+				return
+			case <-l.probe:
+			}
+			continue
+		}
+
+		l.emit(Status{State: StateReconnecting, Err: err})
+		select {
+		case <-ctx.Done():
+			l.emit(Status{State: StateClosed, Err: ctx.Err()})
+			return
+		case <-l.probe:
+			// Retry now, but still let the backoff grow: a probe skips the
+			// wait, it does not declare the server healthy.
+		case <-after(backoff):
+		}
+		// Double, then clamp — deliberately not the forwarder's "double only
+		// while under the cap", which overshoots and settles at 8s. Here the
+		// steady-state re-probe rate is exactly StreamReconnectMaxBackoff.
+		backoff *= 2
+		if backoff > constants.StreamReconnectMaxBackoff {
+			backoff = constants.StreamReconnectMaxBackoff
+		}
+	}
+}
+
+// Run drives a one-shot reconnect loop for cfg. It is the convenience form of
+// NewLoop(cfg).Run(ctx) for consumers that never need to Probe.
+func Run(ctx context.Context, cfg Config) {
+	NewLoop(cfg).Run(ctx)
+}
+
+// attempt runs one connect-and-consume cycle, handing the attempt a markSynced
+// closure bound to this cycle's epoch. Bumping the epoch on return makes a late
+// markSynced from a straggling goroutine a no-op instead of a spurious
+// StateOK on top of the next attempt.
+func (l *Loop) attempt(ctx context.Context) error {
+	epoch := l.nextEpoch()
+	defer l.nextEpoch() // invalidates this cycle's markSynced closure
+	return l.cfg.Attempt(ctx, func() { l.markSynced(epoch) })
+}
+
+// nextEpoch bumps the attempt epoch and returns the new value. markSynced
+// compares the epoch its closure captured against the current one, so any bump
+// invalidates every outstanding closure.
+func (l *Loop) nextEpoch() uint64 {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.epoch++
+	return l.epoch
+}
+
+func (l *Loop) markSynced(epoch uint64) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.epoch != epoch {
+		return // the attempt that owned this callback has already ended
+	}
+	l.emitLocked(Status{State: StateOK})
+}
+
+func (l *Loop) emit(s Status) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.emitLocked(s)
+}
+
+// emitLocked delivers s under l.mu, which is what keeps OnStatus from ever
+// running concurrently, and drops consecutive duplicates plus anything that
+// follows the single StateClosed.
+func (l *Loop) emitLocked(s Status) {
+	if l.finished {
+		return
+	}
+	if l.hasLast && sameStatus(l.last, s) {
+		return
+	}
+	l.last = s
+	l.hasLast = true
+	if s.State == StateClosed {
+		l.finished = true
+	}
+	if l.cfg.OnStatus != nil {
+		l.cfg.OnStatus(s)
+	}
+}
+
+// sameStatus reports whether two statuses are indistinguishable for
+// duplicate-suppression purposes. Errors are compared by message rather than by
+// ==, because an arbitrary error's dynamic type need not be comparable and ==
+// on a non-comparable dynamic type panics at runtime.
+func sameStatus(a, b Status) bool {
+	if a.State != b.State {
+		return false
+	}
+	if (a.Err == nil) != (b.Err == nil) {
+		return false
+	}
+	return a.Err == nil || a.Err.Error() == b.Err.Error()
+}

--- a/internal/stream/loop_test.go
+++ b/internal/stream/loop_test.go
@@ -1,0 +1,679 @@
+package stream
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/charliek/prox/internal/constants"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Sentinel errors the scripted attempts below return; the tests' Classify maps
+// them onto the three Classifications.
+var (
+	errTransient = errors.New("transient: stream dropped")
+	errUnavail   = errors.New("unavailable: nothing is listening")
+	errTerminal  = errors.New("terminal: version skew")
+)
+
+// classifyBySentinel is the policy every test shares: the sentinels above map
+// onto their namesake Classification, anything else is transient.
+func classifyBySentinel(err error) Classification {
+	switch {
+	case errors.Is(err, errTerminal):
+		return ClassTerminal
+	case errors.Is(err, errUnavail):
+		return ClassUnavailable
+	default:
+		return ClassTransient
+	}
+}
+
+// fakeClock is the injected Now. Attempts advance it explicitly to script their
+// own lifetime, which is what drives the flap guard without wall-clock waits.
+type fakeClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func newClock() *fakeClock { return &fakeClock{t: time.Unix(1_000_000, 0)} }
+
+func (c *fakeClock) now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
+
+func (c *fakeClock) advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.t = c.t.Add(d)
+}
+
+// fakeTimer is the injected After: it records every backoff duration the loop
+// asks for. It fires instantly by default (so the loop never costs wall-clock
+// time); with block set, the returned channel never fires, which is how the
+// cancel-mid-backoff and probe-short-circuit tests pin those paths. armed
+// receives a signal per after() call, letting a test synchronize on "the loop
+// has reached the backoff wait" rather than racing the scheduler for it — a
+// cancel issued after that signal, with block set, can only be honored by the
+// backoff select's ctx branch.
+type fakeTimer struct {
+	mu    sync.Mutex
+	waits []time.Duration
+	block bool
+	armed chan struct{}
+}
+
+func (f *fakeTimer) after(d time.Duration) <-chan time.Time {
+	f.mu.Lock()
+	f.waits = append(f.waits, d)
+	block := f.block
+	f.mu.Unlock()
+
+	if f.armed != nil {
+		select {
+		case f.armed <- struct{}{}:
+		default:
+		}
+	}
+
+	ch := make(chan time.Time, 1)
+	if !block {
+		ch <- time.Time{}
+	}
+	return ch
+}
+
+func (f *fakeTimer) recorded() []time.Duration {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]time.Duration(nil), f.waits...)
+}
+
+// recorder collects the reported statuses.
+type recorder struct {
+	mu       sync.Mutex
+	statuses []Status
+}
+
+func (r *recorder) add(s Status) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.statuses = append(r.statuses, s)
+}
+
+func (r *recorder) all() []Status {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]Status(nil), r.statuses...)
+}
+
+func (r *recorder) states() []State {
+	all := r.all()
+	out := make([]State, 0, len(all))
+	for _, s := range all {
+		out = append(out, s.State)
+	}
+	return out
+}
+
+// harness bundles the scaffolding every loop test shares: a fake clock that
+// only moves when a test advances it, a timer that records each backoff, a
+// status recorder, and the Loop itself.
+type harness struct {
+	t     *testing.T
+	clk   *fakeClock
+	timer *fakeTimer
+	rec   *recorder
+	loop  *Loop
+
+	// attempt is the scripted connect-and-consume body; a test assigns it
+	// after newHarness returns. Routing through a field rather than passing
+	// the closure into newHarness means the closure can reach h.loop (to call
+	// Probe from inside an attempt) with no forward declaration.
+	attempt func(ctx context.Context, markSynced func()) error
+
+	// attempts counts calls to attempt, so scripts can branch on the attempt
+	// number (1-based: the first attempt sees h.attempts == 1). Written only
+	// from the goroutine running Run.
+	attempts int
+}
+
+// newHarness wires the shared Config — sentinel policy, status recorder, fake
+// clock, recording timer — around a Loop. Tests that need a different policy
+// (nil Classify, nil Attempt, nil OnStatus) build their Config directly.
+func newHarness(t *testing.T) *harness {
+	t.Helper()
+	h := &harness{
+		t:     t,
+		clk:   newClock(),
+		timer: &fakeTimer{armed: make(chan struct{}, 8)},
+		rec:   &recorder{},
+	}
+	h.loop = NewLoop(Config{
+		Attempt: func(ctx context.Context, markSynced func()) error {
+			h.attempts++
+			return h.attempt(ctx, markSynced)
+		},
+		Classify: classifyBySentinel,
+		OnStatus: h.rec.add,
+		Now:      h.clk.now,
+		After:    h.timer.after,
+	})
+	return h
+}
+
+// run drives the loop to completion, then pins the dedup invariant on every
+// harness test. Tests that run the loop in their own goroutine call
+// assertNoConsecutiveDuplicates directly once it has returned.
+func (h *harness) run(ctx context.Context) {
+	h.loop.Run(ctx)
+	h.assertNoConsecutiveDuplicates()
+}
+
+// waitForState blocks until the recorder has seen at least n statuses with
+// state s, failing the test after 2s. Polling is the only synchronization the
+// public API offers for "the loop has emitted X"; the interval is tiny and
+// the deadline generous, so this cannot flake under CI load without a real
+// hang.
+func (h *harness) waitForState(s State, n int) {
+	h.t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		count := 0
+		for _, st := range h.rec.states() {
+			if st == s {
+				count++
+			}
+		}
+		if count >= n {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	h.t.Fatalf("did not observe %d × %v within 2s (saw %v)", n, s, h.rec.states())
+}
+
+// assertNoConsecutiveDuplicates pins the OnStatus dedup invariant: the loop
+// never reports the same State back to back with the same error.
+func (h *harness) assertNoConsecutiveDuplicates() {
+	h.t.Helper()
+	statuses := h.rec.all()
+	for i := 1; i < len(statuses); i++ {
+		assert.Falsef(h.t, sameStatus(statuses[i-1], statuses[i]),
+			"consecutive duplicate status at index %d: %v", i, statuses[i].State)
+	}
+}
+
+// TestRun_BackoffDoublesAndCaps pins the reconnect schedule: the wait starts at
+// the base backoff and doubles per failed cycle until it clamps at the max
+// (500ms, 1s, 2s, 4s, 5s, 5s). The clock never advances, so every attempt is a
+// flap and none of them resets the backoff.
+func TestRun_BackoffDoublesAndCaps(t *testing.T) {
+	h := newHarness(t)
+	h.attempt = func(_ context.Context, _ func()) error {
+		if h.attempts > 6 {
+			return errTerminal
+		}
+		return errTransient
+	}
+	h.run(context.Background())
+
+	require.Equal(t, 7, h.attempts)
+	assert.Equal(t, []time.Duration{
+		500 * time.Millisecond,
+		time.Second,
+		2 * time.Second,
+		4 * time.Second,
+		5 * time.Second,
+		5 * time.Second,
+	}, h.timer.recorded())
+}
+
+// TestRun_FlapGuardControlsBackoffReset pins the flap guard borrowed from the
+// proxyd forwarder: an attempt that ends before the flap threshold leaves the
+// backoff growing, while one that survives the threshold resets it to base.
+func TestRun_FlapGuardControlsBackoffReset(t *testing.T) {
+	// Scripted attempt lifetimes: two instant flaps, one long-lived stream
+	// (>= the threshold, so it counts as a recovery), then another flap.
+	lifetimes := []time.Duration{0, 0, constants.StreamReconnectFlapThreshold, 0}
+
+	h := newHarness(t)
+	h.attempt = func(_ context.Context, _ func()) error {
+		if h.attempts > len(lifetimes) {
+			return errTerminal
+		}
+		h.clk.advance(lifetimes[h.attempts-1])
+		return errTransient
+	}
+	h.run(context.Background())
+
+	require.Equal(t, len(lifetimes)+1, h.attempts, "one terminal attempt follows the scripted lifetimes")
+	assert.Equal(t, []time.Duration{
+		500 * time.Millisecond, // flap: backoff stays at base, then doubles
+		time.Second,            // flap: no reset, the doubled wait applies
+		500 * time.Millisecond, // survived the threshold: reset to base
+		time.Second,            // flap again: doubling resumes
+	}, h.timer.recorded())
+}
+
+// TestRun_MarkSyncedTransitionsToOK pins Connecting -> OK on markSynced, and
+// Reconnecting -> Syncing on the retry.
+func TestRun_MarkSyncedTransitionsToOK(t *testing.T) {
+	h := newHarness(t)
+	h.attempt = func(_ context.Context, markSynced func()) error {
+		if h.attempts > 1 {
+			return errTerminal
+		}
+		markSynced()
+		return errTransient
+	}
+	h.run(context.Background())
+
+	assert.Equal(t, []State{
+		StateConnecting,
+		StateOK,
+		StateReconnecting,
+		StateSyncing,
+		StateClosed,
+	}, h.rec.states())
+}
+
+// TestRun_WithoutMarkSyncedStaysSyncing pins that an attempt which never
+// synchronizes never reports OK: the loop stays in Connecting/Syncing.
+func TestRun_WithoutMarkSyncedStaysSyncing(t *testing.T) {
+	h := newHarness(t)
+	h.attempt = func(_ context.Context, _ func()) error {
+		if h.attempts > 2 {
+			return errTerminal
+		}
+		return errTransient
+	}
+	h.run(context.Background())
+
+	assert.Equal(t, []State{
+		StateConnecting,
+		StateReconnecting,
+		StateSyncing,
+		StateReconnecting,
+		StateSyncing,
+		StateClosed,
+	}, h.rec.states())
+	assert.NotContains(t, h.rec.states(), StateOK)
+}
+
+// TestRun_MarkSyncedDeduplicates pins that repeated markSynced calls within one
+// attempt collapse into a single OK status.
+func TestRun_MarkSyncedDeduplicates(t *testing.T) {
+	h := newHarness(t)
+	h.attempt = func(_ context.Context, markSynced func()) error {
+		if h.attempts > 1 {
+			return errTerminal
+		}
+		for i := 0; i < 5; i++ {
+			markSynced()
+		}
+		return errTransient
+	}
+	h.run(context.Background())
+
+	// Exactly one OK, despite five markSynced calls.
+	assert.Equal(t, []State{
+		StateConnecting,
+		StateOK,
+		StateReconnecting,
+		StateSyncing,
+		StateClosed,
+	}, h.rec.states())
+}
+
+// TestRun_LateMarkSyncedIgnored pins the attempt-epoch guard: a markSynced
+// closure captured by one attempt is inert once that attempt has returned, so a
+// straggler cannot flip a later attempt's state to OK.
+func TestRun_LateMarkSyncedIgnored(t *testing.T) {
+	var stale func()
+
+	h := newHarness(t)
+	h.attempt = func(_ context.Context, markSynced func()) error {
+		if h.attempts > 1 {
+			stale() // belongs to the finished attempt: must be a no-op
+			return errTerminal
+		}
+		stale = markSynced // captured, deliberately not called yet
+		return errTransient
+	}
+	h.run(context.Background())
+
+	assert.NotContains(t, h.rec.states(), StateOK)
+}
+
+// TestRun_UnavailableParksThenProbeRetries pins that an Unavailable
+// classification arms no timer at all and that a Probe delivered while the loop
+// is running wakes exactly one retry.
+func TestRun_UnavailableParksThenProbeRetries(t *testing.T) {
+	h := newHarness(t)
+	h.attempt = func(_ context.Context, _ func()) error {
+		if h.attempts > 1 {
+			return errTerminal
+		}
+		// Two probes from inside the attempt coalesce into a single wake.
+		h.loop.Probe()
+		h.loop.Probe()
+		return errUnavail
+	}
+	h.run(context.Background())
+
+	require.Equal(t, 2, h.attempts)
+	assert.Empty(t, h.timer.recorded(), "a parked loop must not arm a backoff timer")
+	assert.Equal(t, []State{
+		StateConnecting,
+		StateUnavailable,
+		StateSyncing,
+		StateClosed,
+	}, h.rec.states())
+}
+
+// TestRun_UnavailableParksUntilProbeOrCancel pins the parking behaviour from the
+// outside: no retry happens on its own, a Probe releases exactly one, and
+// cancelling the context unparks the loop with a Closed status.
+func TestRun_UnavailableParksUntilProbeOrCancel(t *testing.T) {
+	entered := make(chan int, 8)
+
+	h := newHarness(t)
+	h.attempt = func(_ context.Context, _ func()) error {
+		entered <- h.attempts
+		return errUnavail
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h.loop.Run(ctx)
+	}()
+
+	require.Equal(t, 1, <-entered)
+	// Negative assertion window: this is not a backoff wait (the loop arms no
+	// timer while parked), just time for a wrong implementation to misbehave.
+	select {
+	case n := <-entered:
+		t.Fatalf("parked loop retried on its own (attempt %d)", n)
+	case <-time.After(50 * time.Millisecond):
+	}
+	assert.Empty(t, h.timer.recorded())
+
+	h.loop.Probe()
+	require.Equal(t, 2, <-entered)
+
+	// Cancel only after the SECOND Unavailable emission (the loop emits it
+	// right before re-parking; the intervening Syncing defeats dedup), so the
+	// loop is provably at-or-inside the parked select — an implementation
+	// that cannot cancel while parked hangs and fails the guard below (codex
+	// review: cancelling right after attempt 2 returned could be satisfied by
+	// the post-attempt ctx check instead).
+	h.waitForState(StateUnavailable, 2)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after the parked loop's context was cancelled")
+	}
+
+	statuses := h.rec.all()
+	require.NotEmpty(t, statuses)
+	last := statuses[len(statuses)-1]
+	assert.Equal(t, StateClosed, last.State)
+	assert.ErrorIs(t, last.Err, context.Canceled)
+	h.assertNoConsecutiveDuplicates()
+}
+
+// TestProbe_Coalesces pins the capacity-1 probe channel: repeated probes
+// collapse into a single pending wake.
+func TestProbe_Coalesces(t *testing.T) {
+	loop := NewLoop(Config{})
+	loop.Probe()
+	loop.Probe()
+	loop.Probe()
+	assert.Len(t, loop.probe, 1)
+}
+
+// TestRun_ProbeShortCircuitsBackoff pins that a probe delivered during a normal
+// (transient) backoff skips the remaining wait. The injected timer never fires,
+// so the loop can only proceed via the probe.
+func TestRun_ProbeShortCircuitsBackoff(t *testing.T) {
+	h := newHarness(t)
+	h.timer.block = true
+	h.attempt = func(_ context.Context, _ func()) error {
+		if h.attempts > 1 {
+			return errTerminal
+		}
+		h.loop.Probe()
+		return errTransient
+	}
+	h.run(context.Background())
+
+	require.Equal(t, 2, h.attempts)
+	assert.Equal(t, []time.Duration{500 * time.Millisecond}, h.timer.recorded(),
+		"the timer is still armed; the probe only wins the race against it")
+}
+
+// TestRun_TerminalClosesLoop pins that a terminal classification ends Run with a
+// Closed status carrying the error, without arming a backoff.
+func TestRun_TerminalClosesLoop(t *testing.T) {
+	h := newHarness(t)
+	h.attempt = func(_ context.Context, _ func()) error { return errTerminal }
+	h.run(context.Background())
+
+	require.Equal(t, 1, h.attempts)
+	assert.Empty(t, h.timer.recorded())
+	require.Equal(t, []State{StateConnecting, StateClosed}, h.rec.states())
+	assert.ErrorIs(t, h.rec.all()[1].Err, errTerminal)
+}
+
+// TestRun_ContextCancelDuringBackoff pins prompt shutdown while the loop is
+// waiting out a backoff: the injected timer never fires, so only cancellation
+// can end Run.
+func TestRun_ContextCancelDuringBackoff(t *testing.T) {
+	entered := make(chan struct{}, 4)
+
+	h := newHarness(t)
+	h.timer.block = true
+	h.attempt = func(_ context.Context, _ func()) error {
+		entered <- struct{}{}
+		return errTransient
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h.loop.Run(ctx)
+	}()
+
+	<-entered
+	// Cancel only once the loop has ARMED the backoff timer: with block set
+	// the timer never fires, so from here the backoff select's ctx branch is
+	// the only possible exit — an implementation missing that branch hangs
+	// and fails the 2s guard below (codex review: cancelling right after the
+	// attempt returned could be satisfied by the post-attempt ctx check,
+	// leaving the select branch unpinned).
+	<-h.timer.armed
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after cancellation mid-backoff")
+	}
+
+	statuses := h.rec.all()
+	require.NotEmpty(t, statuses)
+	last := statuses[len(statuses)-1]
+	assert.Equal(t, StateClosed, last.State)
+	assert.ErrorIs(t, last.Err, context.Canceled)
+	h.assertNoConsecutiveDuplicates()
+}
+
+// TestRun_CancelWithTimerAlreadyFired pins that cancellation observed around a
+// ready backoff timer never launches another attempt: the instant-fire timer
+// makes the select's timer branch permanently ready, and the cancel lands
+// before the loop leaves the attempt, so whichever check the loop takes next
+// (post-attempt or top-of-loop after a timer win) must end in Closed with no
+// second attempt.
+func TestRun_CancelWithTimerAlreadyFired(t *testing.T) {
+	h := newHarness(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	h.attempt = func(_ context.Context, _ func()) error {
+		cancel()
+		return errTransient
+	}
+	h.run(ctx)
+
+	require.Equal(t, 1, h.attempts, "no attempt may start after cancellation")
+	statuses := h.rec.all()
+	require.NotEmpty(t, statuses)
+	last := statuses[len(statuses)-1]
+	assert.Equal(t, StateClosed, last.State)
+	assert.ErrorIs(t, last.Err, context.Canceled)
+}
+
+// TestRun_CleanAttemptEndReconnects pins the clean-stream-end contract: an
+// attempt returning nil (server closed the stream without error, ctx still
+// live) is a transient end — the loop reports Reconnecting with a nil error
+// and retries, rather than treating the nil as terminal.
+func TestRun_CleanAttemptEndReconnects(t *testing.T) {
+	h := newHarness(t)
+	h.attempt = func(_ context.Context, _ func()) error {
+		if h.attempts == 1 {
+			return nil
+		}
+		return errTerminal
+	}
+	h.run(context.Background())
+
+	require.Equal(t, 2, h.attempts, "a clean end must be followed by a retry")
+	assert.Equal(t, []time.Duration{500 * time.Millisecond}, h.timer.recorded())
+
+	states := h.rec.states()
+	require.Contains(t, states, StateReconnecting)
+	for _, s := range h.rec.all() {
+		if s.State == StateReconnecting {
+			assert.NoError(t, s.Err, "clean end reports Reconnecting with nil error")
+		}
+	}
+}
+
+// TestRun_ContextCancelDuringAttempt pins prompt shutdown while an attempt is
+// in flight: the attempt honors ctx, and the loop closes without retrying.
+func TestRun_ContextCancelDuringAttempt(t *testing.T) {
+	entered := make(chan struct{}, 4)
+
+	h := newHarness(t)
+	h.attempt = func(actx context.Context, _ func()) error {
+		entered <- struct{}{}
+		<-actx.Done()
+		return actx.Err()
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h.loop.Run(ctx)
+	}()
+
+	<-entered
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after cancellation mid-attempt")
+	}
+
+	assert.Equal(t, 1, h.attempts)
+	assert.Empty(t, h.timer.recorded())
+	require.Equal(t, []State{StateConnecting, StateClosed}, h.rec.states())
+	assert.ErrorIs(t, h.rec.all()[1].Err, context.Canceled)
+}
+
+// TestRun_NilClassifyTreatsEverythingTransient pins the documented default
+// policy. It builds its own Config: the harness always wires
+// classifyBySentinel, which is exactly what this test must omit.
+func TestRun_NilClassifyTreatsEverythingTransient(t *testing.T) {
+	timer := &fakeTimer{}
+	rec := &recorder{}
+	attempts := 0
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	NewLoop(Config{
+		Attempt: func(_ context.Context, _ func()) error {
+			attempts++
+			if attempts >= 3 {
+				cancel() // the only way out when nothing is terminal
+			}
+			return errTerminal // would be terminal under classifyBySentinel
+		},
+		OnStatus: rec.add,
+		Now:      newClock().now,
+		After:    timer.after,
+	}).Run(ctx)
+
+	assert.Equal(t, 3, attempts)
+	assert.Equal(t, []time.Duration{500 * time.Millisecond, time.Second}, timer.recorded())
+	statuses := rec.all()
+	last := statuses[len(statuses)-1]
+	assert.Equal(t, StateClosed, last.State)
+	assert.ErrorIs(t, last.Err, context.Canceled)
+}
+
+// TestRun_NilAttemptClosesWithError pins that a misconfigured Loop reports a
+// terminal status instead of panicking in the consumer's goroutine.
+func TestRun_NilAttemptClosesWithError(t *testing.T) {
+	rec := &recorder{}
+	Run(context.Background(), Config{OnStatus: rec.add})
+
+	require.Equal(t, []State{StateClosed}, rec.states())
+	assert.ErrorIs(t, rec.all()[0].Err, errNoAttempt)
+}
+
+// TestRun_NilOnStatusIsSafe pins that a Loop without a status sink still runs.
+func TestRun_NilOnStatusIsSafe(t *testing.T) {
+	attempts := 0
+	Run(context.Background(), Config{
+		Attempt: func(_ context.Context, markSynced func()) error {
+			attempts++
+			markSynced()
+			return errTerminal
+		},
+		Classify: classifyBySentinel,
+		Now:      newClock().now,
+		After:    (&fakeTimer{}).after,
+	})
+	assert.Equal(t, 1, attempts)
+}
+
+// TestState_String keeps the rendered names stable for logs and status lines.
+func TestState_String(t *testing.T) {
+	assert.Equal(t, "connecting", StateConnecting.String())
+	assert.Equal(t, "syncing", StateSyncing.String())
+	assert.Equal(t, "ok", StateOK.String())
+	assert.Equal(t, "reconnecting", StateReconnecting.String())
+	assert.Equal(t, "unavailable", StateUnavailable.String())
+	assert.Equal(t, "closed", StateClosed.String())
+	assert.Equal(t, "unknown", State(99).String())
+}

--- a/internal/supervisor/change_bus_test.go
+++ b/internal/supervisor/change_bus_test.go
@@ -1,0 +1,572 @@
+package supervisor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/charliek/prox/internal/config"
+	"github.com/charliek/prox/internal/domain"
+	"github.com/charliek/prox/internal/logs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- helpers ----------------------------------------------------------------
+
+// converge drives EXACTLY the pattern the processes SSE handler will use: take a
+// snapshot via Processes(), and re-snapshot every time the dirty latch wakes,
+// until the snapshot satisfies want.
+//
+// Every convergence assertion in this file is written this way on purpose. The
+// latch coalesces by design, so the number of wakes for a given burst is not a
+// contract; what IS the contract is that the FINAL state is always observable to
+// a subscriber that keeps re-snapshotting. Snapshotting BEFORE blocking is also
+// what makes the loop lost-wake-free: the latch is level, so a change that
+// landed before we blocked either shows in the snapshot or has left the latch
+// set.
+func converge(t *testing.T, sup *Supervisor, ch <-chan struct{}, want func([]domain.ProcessInfo) bool) []domain.ProcessInfo {
+	t.Helper()
+	deadline := time.After(5 * time.Second)
+	for {
+		snap := sup.Processes()
+		if want(snap) {
+			return snap
+		}
+		select {
+		case _, ok := <-ch:
+			if !ok {
+				// The bus closed (supervisor stopped). Take one final snapshot before
+				// giving up: the close is the end of the stream, not a state change.
+				snap = sup.Processes()
+				if want(snap) {
+					return snap
+				}
+				t.Fatalf("change bus closed before the expected state was observable; last snapshot: %+v", snap)
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for the expected state; last snapshot: %+v", snap)
+		}
+	}
+}
+
+// stateIs builds a converge predicate matching one process's state.
+func stateIs(name string, want domain.ProcessState) func([]domain.ProcessInfo) bool {
+	return func(snap []domain.ProcessInfo) bool {
+		for _, p := range snap {
+			if p.Name == name {
+				return p.State == want
+			}
+		}
+		return false
+	}
+}
+
+// drain clears a pending latch so the next assertion is about the NEXT change.
+func drain(ch <-chan struct{}) {
+	select {
+	case <-ch:
+	default:
+	}
+}
+
+// requireWake blocks until the dirty latch is set. Used after a SYNCHRONOUS
+// transition (the supervisor call has already returned, so the notify has
+// already happened) or after triggering an asynchronous one, to pin that the
+// change actually reached the bus -- converge alone would be satisfied by a
+// snapshot taken without any wake at all.
+func requireWake(t *testing.T, ch <-chan struct{}) {
+	t.Helper()
+	select {
+	case _, ok := <-ch:
+		require.True(t, ok, "the change bus closed instead of waking")
+	case <-time.After(5 * time.Second):
+		t.Fatal("no wake arrived on the change bus")
+	}
+}
+
+// isClosed reports whether ch is closed, without blocking.
+func isClosed(t *testing.T, ch <-chan struct{}) bool {
+	t.Helper()
+	select {
+	case _, ok := <-ch:
+		return !ok
+	case <-time.After(2 * time.Second):
+		return false
+	}
+}
+
+// --- lifecycle --------------------------------------------------------------
+
+// Subscribe/Unsubscribe are symmetric: the subscriber count returns to its
+// baseline, the channel is closed on unsubscribe, and a repeated or unknown
+// Unsubscribe is a no-op.
+func TestChangeBus_SubscribeUnsubscribeCount(t *testing.T) {
+	sup := newStopSupervisor(t, map[string]*fakeProcess{}, "3s")
+	require.Equal(t, 0, sup.SubscriberCount(), "baseline")
+
+	id1, ch1 := sup.Subscribe()
+	id2, ch2 := sup.Subscribe()
+	require.NotEqual(t, id1, id2, "subscription ids must be unique")
+	require.Equal(t, 2, sup.SubscriberCount())
+
+	sup.Unsubscribe(id1)
+	assert.Equal(t, 1, sup.SubscriberCount())
+	assert.True(t, isClosed(t, ch1), "unsubscribe must close the subscriber channel")
+
+	// Idempotent: a repeated unsubscribe and an unknown id are both no-ops.
+	sup.Unsubscribe(id1)
+	sup.Unsubscribe("sup-does-not-exist")
+	assert.Equal(t, 1, sup.SubscriberCount())
+
+	sup.Unsubscribe(id2)
+	assert.Equal(t, 0, sup.SubscriberCount(), "count must return to baseline")
+	assert.True(t, isClosed(t, ch2))
+}
+
+// CloseEvents latches: every live subscriber is closed exactly once, the count
+// drops to zero, a second Close is a no-op, and a Subscribe AFTER the close
+// returns an already-closed channel (so a stream racing shutdown ends at once).
+func TestChangeBus_CloseLatchesAndIsIdempotent(t *testing.T) {
+	sup := newStopSupervisor(t, map[string]*fakeProcess{}, "3s")
+
+	_, ch1 := sup.Subscribe()
+	_, ch2 := sup.Subscribe()
+
+	sup.CloseEvents()
+	assert.Equal(t, 0, sup.SubscriberCount())
+	assert.True(t, isClosed(t, ch1))
+	assert.True(t, isClosed(t, ch2))
+
+	// Idempotent (and must not double-close a channel, which would panic).
+	sup.CloseEvents()
+	sup.CloseEvents()
+
+	id3, ch3 := sup.Subscribe()
+	assert.True(t, isClosed(t, ch3), "Subscribe after Close must return a closed channel")
+	assert.Equal(t, 0, sup.SubscriberCount(), "a post-close Subscribe must not be registered")
+	sup.Unsubscribe(id3) // no-op, must not panic
+
+	// A notify after the close is harmless.
+	sup.notifyChange()
+}
+
+// A goroutine blocked on its subscriber channel unblocks when the supervisor
+// stops: Supervisor.Stop latches the bus closed on every path, which is what
+// lets the (timeout-free) SSE route return before the API server is shut down.
+func TestChangeBus_StopUnblocksBlockedSubscriber(t *testing.T) {
+	sup := newStopSupervisor(t, map[string]*fakeProcess{
+		"alpha": newGracefulFake(9101),
+	}, "3s")
+
+	_, err := sup.Start(context.Background())
+	require.NoError(t, err)
+
+	// Drain the start-time wakes so the goroutine below really blocks.
+	_, ch := sup.Subscribe()
+
+	unblocked := make(chan bool, 1)
+	go func() {
+		for {
+			_, ok := <-ch
+			if !ok {
+				unblocked <- true
+				return
+			}
+		}
+	}()
+
+	require.NoError(t, sup.Stop(context.Background()))
+
+	select {
+	case <-unblocked:
+	case <-time.After(5 * time.Second):
+		t.Fatal("a subscriber blocked on the change bus was not released by Supervisor.Stop")
+	}
+}
+
+// Stop closes the bus even on its not-running early return: a shutdown must
+// always release stream subscribers, whether or not there was anything to stop.
+func TestChangeBus_StopClosesBusWhenNotRunning(t *testing.T) {
+	sup := newStopSupervisor(t, map[string]*fakeProcess{}, "3s")
+
+	_, ch := sup.Subscribe()
+	require.NoError(t, sup.Stop(context.Background()), "a not-running Stop returns nil")
+	assert.True(t, isClosed(t, ch), "the not-running Stop path must still close the bus")
+}
+
+// --- coalescing -------------------------------------------------------------
+
+// A burst of notifications never blocks the emitter and collapses into a single
+// pending wake (capacity-1 level latch), including when the subscriber is not
+// draining at all.
+func TestChangeBus_BurstNeverBlocksEmitterAndCoalesces(t *testing.T) {
+	sup := newStopSupervisor(t, map[string]*fakeProcess{}, "3s")
+	_, ch := sup.Subscribe()
+
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 10000; i++ {
+			sup.notifyChange()
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("notifyChange blocked on a subscriber that never drained")
+	}
+
+	assert.Equal(t, 1, len(ch), "a burst must coalesce into exactly one pending wake")
+	<-ch
+	assert.Equal(t, 0, len(ch), "the latch must be empty after a drain")
+}
+
+// N rapid REAL transitions: the subscriber wakes at least once and, after the
+// burst, its wake-driven snapshot converges on the final state -- the property
+// the SSE stream depends on (convergence, not event counts).
+func TestChangeBus_RapidTransitionsConvergeOnFinalState(t *testing.T) {
+	sup := newStopSupervisor(t, map[string]*fakeProcess{
+		"svc": newGracefulFake(9201),
+	}, "3s")
+
+	_, ch := sup.Subscribe()
+
+	_, err := sup.Start(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(func() { stopSup(t, sup) })
+
+	var wakes atomic.Int64
+	stopReader := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case _, ok := <-ch:
+				if !ok {
+					return
+				}
+				wakes.Add(1)
+				// Re-entrancy: snapshot from the wake handler, exactly as the SSE
+				// handler will.
+				_ = sup.Processes()
+			case <-stopReader:
+				return
+			}
+		}
+	}()
+
+	for i := 0; i < 5; i++ {
+		require.NoError(t, sup.StopProcess(context.Background(), "svc"))
+		require.NoError(t, sup.StartProcess(context.Background(), "svc"))
+	}
+	// Final transition: leave it stopped so the converged state is unambiguous.
+	require.NoError(t, sup.StopProcess(context.Background(), "svc"))
+
+	close(stopReader)
+	wg.Wait()
+	assert.GreaterOrEqual(t, wakes.Load(), int64(1), "a burst of transitions must wake the subscriber at least once")
+
+	// Drain whatever the latch holds and converge on the final state.
+	snap := converge(t, sup, ch, stateIs("svc", domain.ProcessStateStopped))
+	require.Equal(t, sup.Processes(), snap,
+		"a subscriber-driven snapshot must equal a direct Processes() read")
+}
+
+// --- convergence per transition type ----------------------------------------
+
+// start -> running, stop -> stopped, start again, and a restart-count bump are
+// each observable to a wake-driven subscriber.
+func TestChangeBus_ConvergesOnStartStopAndRestartCount(t *testing.T) {
+	sup := newStopSupervisor(t, map[string]*fakeProcess{
+		"svc": newGracefulFake(9301),
+	}, "3s")
+
+	_, ch := sup.Subscribe()
+
+	_, err := sup.Start(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(func() { stopSup(t, sup) })
+
+	converge(t, sup, ch, stateIs("svc", domain.ProcessStateRunning))
+
+	// Each of these calls commits its state before returning, so a wake MUST
+	// already be latched by the time the call returns.
+	drain(ch)
+	require.NoError(t, sup.StopProcess(context.Background(), "svc"))
+	requireWake(t, ch)
+	converge(t, sup, ch, stateIs("svc", domain.ProcessStateStopped))
+
+	drain(ch)
+	require.NoError(t, sup.StartProcess(context.Background(), "svc"))
+	requireWake(t, ch)
+	converge(t, sup, ch, stateIs("svc", domain.ProcessStateRunning))
+
+	drain(ch)
+	require.NoError(t, sup.RestartProcess(context.Background(), "svc"))
+	requireWake(t, ch)
+	snap := converge(t, sup, ch, func(snap []domain.ProcessInfo) bool {
+		for _, p := range snap {
+			if p.Name == "svc" {
+				return p.State == domain.ProcessStateRunning && p.RestartCount == 1
+			}
+		}
+		return false
+	})
+	require.Equal(t, sup.Processes(), snap)
+}
+
+// A natural (unexpected) leader exit commits crashed inside the monitor, with no
+// supervisor-level event of its own -- the path that was previously invisible to
+// subscribers.
+func TestChangeBus_ConvergesOnNaturalExit(t *testing.T) {
+	fake := newGracefulFake(9401)
+	sup := newStopSupervisor(t, map[string]*fakeProcess{"svc": fake}, "3s")
+
+	_, ch := sup.Subscribe()
+
+	_, err := sup.Start(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(func() { stopSup(t, sup) })
+
+	converge(t, sup, ch, stateIs("svc", domain.ProcessStateRunning))
+
+	// The leader exits on its own (and its group is gone): the monitor commits
+	// crashed for a plain process, rc=0 included. No supervisor-level event
+	// accompanies it, so the monitor's own notify is the only thing that can wake
+	// the bus here.
+	drain(ch)
+	fake.setAlive(false)
+	fake.exitLeader(nil)
+	requireWake(t, ch)
+
+	snap := converge(t, sup, ch, stateIs("svc", domain.ProcessStateCrashed))
+	require.Equal(t, sup.Processes(), snap)
+}
+
+// A health STATUS flip fires the injected transition callback -- once per change,
+// not once per check -- and fires it with h.mu released (the callback below reads
+// the checker's own state, which would deadlock if the lock were still held).
+func TestChangeBus_HealthTransitionFiresCallbackOnChangeOnly(t *testing.T) {
+	var calls atomic.Int64
+	var statuses sync.Map
+
+	cfg := domain.HealthConfig{
+		Cmd:         "false", // always fails
+		Interval:    20 * time.Millisecond,
+		Timeout:     time.Second,
+		Retries:     1,
+		StartPeriod: time.Millisecond,
+	}
+
+	var checker *HealthChecker
+	checker = NewHealthChecker("svc", cfg, func() {
+		calls.Add(1)
+		// Re-entrancy check: reading State() from the callback must not deadlock,
+		// which pins that the callback fires AFTER h.mu is released.
+		statuses.Store(string(checker.State().Status), true)
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	checker.Start(ctx)
+	t.Cleanup(checker.Stop)
+
+	require.Eventually(t, func() bool { return checker.Status() == domain.HealthStatusUnhealthy },
+		3*time.Second, 5*time.Millisecond, "the checker never went unhealthy")
+
+	// Let several more (identically failing) checks run: the status does not
+	// change, so no further callbacks may fire.
+	time.Sleep(200 * time.Millisecond)
+	assert.Equal(t, int64(1), calls.Load(),
+		"the transition callback must fire once per status CHANGE, not once per check")
+
+	_, ok := statuses.Load(string(domain.HealthStatusUnhealthy))
+	assert.True(t, ok, "the callback must observe the committed status")
+}
+
+// A health flip on a live process reaches the bus. The flip is TEST-triggered
+// (the check command tests for a file the test creates) rather than merely
+// time-triggered, so the wake can be required rather than raced against.
+func TestChangeBus_ConvergesOnHealthFlip(t *testing.T) {
+	logMgr := logs.NewManager(logs.ManagerConfig{BufferSize: 200})
+	t.Cleanup(func() { logMgr.Close() })
+
+	healthyMarker := filepath.Join(t.TempDir(), "healthy")
+
+	cfg := makeTestConfig(map[string]string{"svc": "sleep 30"})
+	proc := cfg.Processes["svc"]
+	proc.Healthcheck = &config.HealthcheckConfig{
+		Cmd:         "test -f " + healthyMarker,
+		Interval:    "20ms",
+		Timeout:     "2s",
+		Retries:     1,
+		StartPeriod: "1ms",
+	}
+	cfg.Processes["svc"] = proc
+
+	sup := New(cfg, logMgr, nil, DefaultSupervisorConfig())
+	_, ch := sup.Subscribe()
+
+	_, err := sup.Start(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(func() { stopSup(t, sup) })
+
+	healthIs := func(want domain.HealthStatus) func([]domain.ProcessInfo) bool {
+		return func(snap []domain.ProcessInfo) bool {
+			for _, p := range snap {
+				if p.Name == "svc" {
+					return p.Health == want
+				}
+			}
+			return false
+		}
+	}
+
+	// unknown -> unhealthy (the marker does not exist yet).
+	converge(t, sup, ch, healthIs(domain.HealthStatusUnhealthy))
+
+	// unhealthy -> healthy, triggered by the test.
+	drain(ch)
+	require.NoError(t, os.WriteFile(healthyMarker, []byte("ok"), 0o600))
+	requireWake(t, ch)
+
+	snap := converge(t, sup, ch, healthIs(domain.HealthStatusHealthy))
+	require.Equal(t, sup.Processes(), snap)
+}
+
+// A gated process's waiting -> running transition (WaitingOn is
+// ProcessInfo-visible) reaches the bus at both ends of the dependency gate.
+func TestChangeBus_ConvergesOnWaitingThenRunning(t *testing.T) {
+	prober := newCoordProber()
+	prober.set("db", "block")
+	sup, _, logMgr := gatedSupervisor(t,
+		map[string][]string{"web": {"db"}},
+		map[string]depSpec{"db": {timeout: 30 * time.Second}},
+		prober, nil)
+	t.Cleanup(func() { logMgr.Close() })
+
+	_, ch := sup.Subscribe()
+
+	_, err := sup.Start(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(func() { stopSup(t, sup) })
+
+	waiting := converge(t, sup, ch, stateIs("web", domain.ProcessStateWaiting))
+	for _, p := range waiting {
+		if p.Name == "web" {
+			assert.Equal(t, []string{"db"}, p.WaitingOn, "WaitingOn must be visible in the converged snapshot")
+		}
+	}
+
+	drain(ch)
+	prober.release("db")
+	requireWake(t, ch)
+	snap := converge(t, sup, ch, stateIs("web", domain.ProcessStateRunning))
+	require.Equal(t, sup.Processes(), snap)
+}
+
+// --- deadlock / re-entrancy -------------------------------------------------
+
+// The re-entrancy pattern the SSE handler will use: several subscribers block on
+// their latch and call Processes() (s.mu -> p.mu -> h.mu) straight from the wake
+// handler while lifecycle transitions run concurrently. Under -race this pins
+// both the lock discipline (no notify fires under a supervisor/process lock) and
+// the absence of data races on the bus itself.
+func TestChangeBus_SnapshotFromWakeHandlerUnderChurn(t *testing.T) {
+	sup := newStopSupervisor(t, map[string]*fakeProcess{
+		"a": newGracefulFake(9501),
+		"b": newGracefulFake(9502),
+	}, "3s")
+
+	const subscribers = 4
+	var wg sync.WaitGroup
+	for i := 0; i < subscribers; i++ {
+		_, ch := sup.Subscribe()
+		wg.Add(1)
+		go func(ch <-chan struct{}) {
+			defer wg.Done()
+			for {
+				_, ok := <-ch
+				if !ok {
+					// Final snapshot after end-of-stream, mirroring the handler's exit.
+					_ = sup.Processes()
+					return
+				}
+				_ = sup.Processes()
+			}
+		}(ch)
+	}
+
+	_, err := sup.Start(context.Background())
+	require.NoError(t, err)
+
+	var churn sync.WaitGroup
+	for _, name := range []string{"a", "b"} {
+		churn.Add(1)
+		go func(name string) {
+			defer churn.Done()
+			for i := 0; i < 5; i++ {
+				_ = sup.StopProcess(context.Background(), name)
+				_ = sup.StartProcess(context.Background(), name)
+			}
+		}(name)
+	}
+	churn.Wait()
+
+	// Stop closes the bus, which is what releases every subscriber goroutine.
+	_ = sup.Stop(context.Background())
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("wake-handler subscribers did not drain after the supervisor stopped (possible deadlock)")
+	}
+	assert.Equal(t, 0, sup.SubscriberCount())
+}
+
+// TestChangeBus_FilteredStartWakesForDormantTaskRegistration pins the codex C10
+// finding: the supervisor_start emit fires before process/task registration, so
+// a pre-start subscriber woken by it could snapshot an incomplete process set
+// and — when the filter schedules nothing further — never wake again. The
+// post-registration notify closes that window: a subscriber that keeps
+// re-snapshotting must observe the dormant task entry.
+func TestChangeBus_FilteredStartWakesForDormantTaskRegistration(t *testing.T) {
+	logMgr := logs.NewManager(logs.ManagerConfig{BufferSize: 100})
+	t.Cleanup(func() { logMgr.Close() })
+
+	cfg := &config.Config{
+		API:       config.APIConfig{Port: 5555, Host: "127.0.0.1"},
+		Processes: map[string]config.ProcessConfig{"web": {Cmd: "sleep 60"}},
+		Tasks:     map[string]config.TaskConfig{"migrate": {Cmd: "sleep 60"}},
+	}
+	sup := New(cfg, logMgr, nil, DefaultSupervisorConfig())
+
+	_, ch := sup.Subscribe()
+
+	// Filtered start naming only the process: the task is registered (dormant)
+	// but never scheduled, so registration is the LAST visible change.
+	_, err := sup.StartProcesses(context.Background(), []string{"web"})
+	require.NoError(t, err)
+	t.Cleanup(func() { stopSup(t, sup) })
+
+	snap := converge(t, sup, ch, func(snap []domain.ProcessInfo) bool {
+		var sawTask bool
+		for _, p := range snap {
+			if p.Name == "migrate" {
+				sawTask = true
+			}
+		}
+		return sawTask
+	})
+	require.Equal(t, sup.Processes(), snap)
+}

--- a/internal/supervisor/coordinator.go
+++ b/internal/supervisor/coordinator.go
@@ -157,6 +157,12 @@ func (s *Supervisor) scheduleGated(mp *ManagedProcess) error {
 	if err != nil {
 		return err
 	}
+	// Admission committed the waiting state (beginWaiting), which is
+	// ProcessInfo-visible via State and WaitingOn. Lock discipline: admitGated took
+	// and RELEASED s.mu (and p.mu inside it) before returning, so this fires with no
+	// lock held -- it deliberately is NOT inside admitGated, which notifies under
+	// s.mu.
+	s.notifyChange()
 	targets := mp.Config().DependsOn
 	go s.orchestrate(mp, targets, gen, procCtx, procCancel, supCtx, nil)
 	return nil
@@ -193,6 +199,10 @@ func (s *Supervisor) orchestrate(mp *ManagedProcess, targets []string, gen uint6
 	if len(blockedBy) > 0 {
 		if mp.markBlocked(blockedBy, gen) {
 			s.SystemLog("%s blocked: dependency not ready: %s", mp.Name(), strings.Join(blockedBy, ", "))
+			// waiting -> blocked, with BlockedOn now populated. Lock discipline:
+			// markBlocked released p.mu before returning and orchestrate holds no
+			// supervisor lock.
+			s.notifyChange()
 		}
 		return
 	}
@@ -215,7 +225,11 @@ func (s *Supervisor) orchestrate(mp *ManagedProcess, targets []string, gen uint6
 			// (finding 3). failWaitingLaunch retains p.current so Stop's crashed path
 			// reaps the group. It no-ops when the runner path already committed
 			// crashed, or when a superseding episode moved the process on.
-			mp.failWaitingLaunch(gen)
+			if mp.failWaitingLaunch(gen) {
+				// waiting -> crashed, committed AFTER the launch attempt's own notify.
+				// Lock discipline: failWaitingLaunch released p.mu before returning.
+				s.notifyChange()
+			}
 			s.logManager.Write(domain.LogEntry{
 				Timestamp: time.Now(),
 				Process:   mp.Name(),
@@ -420,6 +434,9 @@ func (s *Supervisor) startProcessGated(mp *ManagedProcess) error {
 	if err != nil {
 		return err
 	}
+	// Admission committed the waiting state (see scheduleGated's note). Lock
+	// discipline: admitGated released s.mu (and p.mu) before returning.
+	s.notifyChange()
 
 	// Admitted (the child is now waiting). Refresh the resolver + effective view
 	// from the reload, then re-resolve the previously-unready targets fresh.

--- a/internal/supervisor/coordinator_test.go
+++ b/internal/supervisor/coordinator_test.go
@@ -846,7 +846,7 @@ func TestCoordinator_RunningGatedRestartEmitsStarted(t *testing.T) {
 	waitState(t, sup, "web", domain.ProcessStateRunning)
 
 	// Subscribe AFTER the initial launch so we observe only the restart's event.
-	events := sup.Subscribe()
+	events := sup.subscribeEvents()
 	rctx, rcancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer rcancel()
 	require.NoError(t, sup.RestartProcess(rctx, "web"))

--- a/internal/supervisor/health.go
+++ b/internal/supervisor/health.go
@@ -32,17 +32,28 @@ type HealthChecker struct {
 	// ctx and cancel control the health check loop lifecycle
 	ctx    context.Context
 	cancel context.CancelFunc
+
+	// onTransition, when set, is invoked once per health STATUS change (plan 017
+	// C10) so the supervisor's change bus wakes on a health flip -- Health is
+	// ProcessInfo-visible. It carries no payload and is deliberately a bare
+	// callback rather than a supervisor back-reference: the checker knows nothing
+	// about the supervisor. It is fired with h.mu RELEASED (see runCheck), because
+	// a woken subscriber calls back into Processes() -> Info() -> State(), which
+	// takes h.mu. Set once at construction, so it is read lock-free.
+	onTransition func()
 }
 
-// NewHealthChecker creates a new health checker
-func NewHealthChecker(process string, config domain.HealthConfig) *HealthChecker {
+// NewHealthChecker creates a new health checker. onTransition may be nil; when
+// set it fires (lock-free) on each health status change -- see the field comment.
+func NewHealthChecker(process string, config domain.HealthConfig, onTransition func()) *HealthChecker {
 	// Apply defaults
 	config = config.WithDefaults()
 
 	return &HealthChecker{
-		config:  config,
-		process: process,
-		status:  domain.HealthStatusUnknown,
+		config:       config,
+		process:      process,
+		status:       domain.HealthStatusUnknown,
+		onTransition: onTransition,
 	}
 }
 
@@ -130,7 +141,9 @@ func (h *HealthChecker) runCheck(ctx context.Context) {
 	err := cmd.Run()
 
 	h.mu.Lock()
-	defer h.mu.Unlock()
+	// prev is sampled under the lock alongside the commit below so the transition
+	// test is exact; the callback itself fires after the unlock.
+	prev := h.status
 
 	h.lastCheck = time.Now()
 
@@ -159,5 +172,16 @@ func (h *HealthChecker) runCheck(ctx context.Context) {
 		// Health check passed
 		h.consecutiveFailures = 0
 		h.status = domain.HealthStatusHealthy
+	}
+	changed := h.status != prev
+	h.mu.Unlock()
+
+	// LOCK DISCIPLINE: h.mu is released above; the callback re-enters the
+	// supervisor (Processes -> Info -> State), which takes p.mu and h.mu. Fired
+	// only on a real status change, so a steady stream of passing checks does not
+	// wake subscribers on every tick (LastCheck/LastOutput churn deliberately does
+	// not notify).
+	if changed && h.onTransition != nil {
+		h.onTransition()
 	}
 }

--- a/internal/supervisor/health_test.go
+++ b/internal/supervisor/health_test.go
@@ -18,7 +18,7 @@ func TestHealthChecker_Healthy(t *testing.T) {
 		StartPeriod: 50 * time.Millisecond,
 	}
 
-	checker := NewHealthChecker("test", config)
+	checker := NewHealthChecker("test", config, nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -45,7 +45,7 @@ func TestHealthChecker_Unhealthy(t *testing.T) {
 		StartPeriod: 10 * time.Millisecond,
 	}
 
-	checker := NewHealthChecker("test", config)
+	checker := NewHealthChecker("test", config, nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -77,7 +77,7 @@ func TestHealthChecker_RecoveryAfterFailure(t *testing.T) {
 		StartPeriod: 10 * time.Millisecond,
 	}
 
-	checker := NewHealthChecker("test", config)
+	checker := NewHealthChecker("test", config, nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -101,7 +101,7 @@ func TestHealthChecker_StartPeriod(t *testing.T) {
 		StartPeriod: 200 * time.Millisecond,
 	}
 
-	checker := NewHealthChecker("test", config)
+	checker := NewHealthChecker("test", config, nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/supervisor/process.go
+++ b/internal/supervisor/process.go
@@ -226,6 +226,15 @@ type ManagedProcess struct {
 	// lock-free (like launchGate).
 	onLaunched func()
 
+	// onChange, when set, wakes the supervisor's process-change bus (plan 017 C10).
+	// It carries no payload -- a subscriber re-reads Processes() -- and is invoked
+	// ONLY with p.mu released (see notifyChange), because a woken subscriber calls
+	// straight back into Processes(), whose s.mu -> p.mu order would AB-BA against a
+	// notify fired under p.mu. supervisor.createManagedProcess/createManagedTask
+	// inject it; nil (direct construction in tests) means "no bus". Set once before
+	// publication, so it is read lock-free (like launchGate/onLaunched).
+	onChange func()
+
 	// stopBarrier is a test-only seam (nil in production). Stop invokes it,
 	// unlocked, at interleaving-sensitive points identified by phase:
 	//
@@ -304,6 +313,17 @@ func NewManagedProcess(config domain.ProcessConfig, env map[string]string, runne
 		state:          domain.ProcessStateStopped,
 		taskTimeout:    config.TaskTimeout,
 		taskHasTimeout: config.TaskHasTimeout,
+	}
+}
+
+// notifyChange wakes the supervisor's change bus for this process (plan 017 C10).
+//
+// LOCK DISCIPLINE: the caller MUST hold neither p.mu nor any supervisor lock --
+// every call site below documents which lock it has just released. A nil hook
+// (directly constructed test process) is a no-op.
+func (p *ManagedProcess) notifyChange() {
+	if p.onChange != nil {
+		p.onChange()
 	}
 }
 
@@ -604,6 +624,11 @@ func (p *ManagedProcess) bumpRestart() {
 	p.mu.Lock()
 	p.restartCount++
 	p.mu.Unlock()
+	// RestartCount is ProcessInfo-visible. Lock discipline: p.mu released above;
+	// the caller (executeTask) holds no process/supervisor lock either. The other
+	// bump (Restart) is bracketed by the stop half's and start half's own notifies,
+	// so it needs no site of its own.
+	p.notifyChange()
 }
 
 // startWithConfigGen is the shared launch wrapper: it runs the locked launch
@@ -615,6 +640,13 @@ func (p *ManagedProcess) startWithConfigGen(ctx context.Context, pending *pendin
 	if err == nil && p.onLaunched != nil {
 		p.onLaunched()
 	}
+	// Wake the change bus for every launch attempt. Lock discipline: p.mu is fully
+	// released by startWithConfigLocked before this runs (the same reason onLaunched
+	// is invoked here). Fired on the error path too, because a failed launch can
+	// still have committed a visible state (Crashed on an env-reload or runner
+	// failure); a refusal that changed nothing merely costs one spurious wake, which
+	// the level latch coalesces away.
+	p.notifyChange()
 	return err
 }
 
@@ -759,7 +791,10 @@ func (p *ManagedProcess) startWithConfigLocked(ctx context.Context, pending *pen
 
 	// Start health checker if configured
 	if p.config.Healthcheck != nil && p.config.Healthcheck.Cmd != "" {
-		p.healthChecker = NewHealthChecker(p.config.Name, *p.config.Healthcheck)
+		// The transition callback is stored here (under p.mu) but only ever FIRED
+		// from the checker's own goroutine with h.mu released, so wiring it inside
+		// this critical section is safe.
+		p.healthChecker = NewHealthChecker(p.config.Name, *p.config.Healthcheck, p.notifyChange)
 		p.healthChecker.Start(processCtx)
 	}
 
@@ -845,6 +880,13 @@ func (p *ManagedProcess) stopTask(ctx context.Context) error {
 // crashed for a task run-timeout). A surviving group always commits crashed
 // regardless; the error paths are unchanged.
 func (p *ManagedProcess) stop(ctx context.Context, cleanState domain.ProcessState) (retErr error) {
+	// Wake the change bus once this stop has settled, whichever of the many exits
+	// it takes (waiting->stopped, blocked->stopped, the early no-ops, and the final
+	// verdict commit). Registered as the FIRST defer so it runs LAST -- after the
+	// deferred episode backstop below, hence with p.mu released. Not every path
+	// changes state; a spurious wake just costs the subscriber one re-snapshot.
+	defer p.notifyChange()
+
 	p.mu.Lock()
 
 	switch p.state {
@@ -967,6 +1009,12 @@ func (p *ManagedProcess) stop(ctx context.Context, cleanState domain.ProcessStat
 	p.healthChecker = nil
 	barrier := p.stopBarrier
 	p.mu.Unlock()
+
+	// The Stopping transition is itself ProcessInfo-visible and can precede the
+	// terminal verdict by the whole stop budget, so surface it now rather than
+	// letting the stream jump straight from running to stopped. Lock discipline:
+	// p.mu released immediately above.
+	p.notifyChange()
 
 	defer func() { p.backstopStopEpisode(ep, inst, retErr) }()
 
@@ -1205,6 +1253,9 @@ func (p *ManagedProcess) monitor(inst *processInstance) {
 	exitCode := exitCodeFromWaitErr(err)
 
 	p.mu.Lock()
+	// prevState is sampled under the lock so the natural-exit commit below can be
+	// detected exactly (see the notify after the unlock).
+	prevState := p.state
 	// Generation guard: a stale monitor -- one whose instance has already been
 	// replaced by a newer Start -- must touch nothing shared and emit no
 	// (misleading) logs (drain-timeout notice or exit code) attributed to a run
@@ -1250,7 +1301,18 @@ func (p *ManagedProcess) monitor(inst *processInstance) {
 	}
 	// Deliberately do NOT null p.current: retaining it keeps the pgid reapable
 	// for a retry Stop.
+	stateChanged := p.state != prevState
 	p.mu.Unlock()
+
+	// Natural exit / task completion: this is the only path that commits
+	// completed or crashed without any supervisor-level emit, so it must wake the
+	// bus itself. Lock discipline: p.mu released immediately above; monitor holds
+	// nothing else. Gated on an actual transition so the far more common
+	// stop-driven exits (where Stop owns the verdict and its own notify) do not
+	// double-wake.
+	if stateChanged {
+		p.notifyChange()
+	}
 
 	inst.closeDone()
 }

--- a/internal/supervisor/stop_episode_test.go
+++ b/internal/supervisor/stop_episode_test.go
@@ -490,7 +490,7 @@ func TestStopEpisode_StopProcessNoStoppedEventOnSurvivor(t *testing.T) {
 	runner := newFakeRunner(func(call int) *fakeProcess { return newFastUnreapableFake(8000 + call) })
 	sup := New(cfg, logMgr, runner, DefaultSupervisorConfig())
 
-	events := sup.Subscribe()
+	events := sup.subscribeEvents()
 	_, err := sup.Start(context.Background())
 	require.NoError(t, err)
 

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"runtime"
 	"sort"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -96,8 +97,35 @@ type Supervisor struct {
 
 	// eventMu protects eventSubs from concurrent access
 	eventMu sync.RWMutex
-	// eventSubs holds channels for subscribers to supervisor events
+	// eventSubs holds channels for subscribers to supervisor events. This is the
+	// legacy, in-package typed-event fan-out (subscribeEvents/emit): drop-on-full,
+	// never closed, and consumed only by the supervisor's own tests. External
+	// consumers use the dirty-latch change bus below.
 	eventSubs []chan SupervisorEvent
+
+	// --- process-change bus (plan 017 C10) ---
+	//
+	// changeMu guards changeSubs and changeClosed. It is a LEAF lock: the only work
+	// done under it is map bookkeeping, non-blocking channel sends, and channel
+	// closes -- never a call back into supervisor/process/health code and never
+	// another lock acquisition. Because every send AND every close happens under
+	// this one mutex, a notify can never race a close into a closed channel (the
+	// logs/requests managers need the send outside their write lock because their
+	// sends carry payloads under an RWMutex; here the whole fan-out is O(subs)
+	// non-blocking sends, so a plain mutex is both simpler and safe).
+	changeMu sync.Mutex
+	// changeSubs holds the coalescing dirty-latch subscribers by id. Each channel
+	// has capacity 1 and is written with a non-blocking send, so it is a LEVEL
+	// latch ("something changed since you last looked"), not an edge queue: a burst
+	// of transitions can never lose its last event, because a subscriber that wakes
+	// re-snapshots the whole world via Processes(). Events therefore carry no
+	// payload at all.
+	changeSubs map[string]chan struct{}
+	// changeClosed latches at CloseEvents (which Stop always runs): every
+	// subscriber channel is closed once, and a later Subscribe returns an
+	// already-closed channel so a stream request racing shutdown ends immediately
+	// instead of blocking on a latch nothing will ever set.
+	changeClosed bool
 
 	// childrenMu serializes writes to the orphan-reaping ownership ledger
 	// (<supConfig.StateDir>/prox.children). Holding it across BOTH the s.mu
@@ -218,6 +246,7 @@ func New(cfg *config.Config, logManager *logs.Manager, runner ProcessRunner, sup
 		runner:     runner,
 		logManager: logManager,
 		state:      "stopped",
+		changeSubs: make(map[string]chan struct{}),
 	}
 	s.bootMarker = s.readBootMarker()
 	// Default resolver factory: build the real dependency resolver from config
@@ -347,6 +376,14 @@ func (s *Supervisor) startWithFilter(ctx context.Context, filter map[string]bool
 		s.mu.Unlock()
 	}
 
+	// Registration itself is a visible change: dormant task entries (and any
+	// filtered-out processes' absence) are part of Processes() output. The
+	// supervisor_start emit above fires BEFORE registration, so a subscriber
+	// woken by it can snapshot an incomplete process set and — if the filter
+	// then schedules nothing — never be woken again (codex C10 finding). One
+	// explicit notify after registration closes that window; no lock held.
+	s.notifyChange()
+
 	// Start all processes concurrently (tasks are skipped here; they are
 	// demand-driven or bare-up-driven -- see scheduleTaskDemands).
 	s.startProcessesConcurrently(&result)
@@ -417,6 +454,9 @@ func (s *Supervisor) createManagedProcess(name string, procConfig config.Process
 	// every managed process) means all launch paths persist and a future one
 	// cannot forget.
 	mp.onLaunched = s.persistChildren
+	// Wake the change bus on every process-level state commit (plan 017 C10).
+	// ManagedProcess invokes it only with p.mu released (see notifyChange there).
+	mp.onChange = s.notifyChange
 
 	return mp, nil
 }
@@ -557,6 +597,7 @@ func (s *Supervisor) createManagedTask(name string, taskConfig config.TaskConfig
 		return nil
 	}
 	mp.onLaunched = s.persistChildren
+	mp.onChange = s.notifyChange
 	return mp, nil
 }
 
@@ -893,6 +934,14 @@ func (s *Supervisor) RefuseLaunches() {
 // never a typed-nil *ProcessStopError -- when the stop is clean, and likewise nil
 // from the not-running early return (nothing to do) (#36, D3).
 func (s *Supervisor) Stop(ctx context.Context) error {
+	// Latch the change bus closed once this stop returns, on EVERY path including
+	// the not-running early return below (a shutdown must always release SSE
+	// subscribers, whether or not there was anything left to stop). Registered as
+	// the FIRST defer so it runs LAST: after the per-process stop goroutines, after
+	// the supervisor_stop emit, and with no lock held (the emit's own notify has
+	// already fired, so subscribers observe the final state and then end-of-stream).
+	defer s.CloseEvents()
+
 	s.mu.Lock()
 	if s.state != "running" {
 		s.mu.Unlock()
@@ -1322,8 +1371,15 @@ func (st SupervisorStatus) UptimeSeconds() int64 {
 	return int64(time.Since(st.StartedAt).Seconds())
 }
 
-// Subscribe creates a channel for receiving supervisor events
-func (s *Supervisor) Subscribe() <-chan SupervisorEvent {
+// subscribeEvents creates a channel for receiving typed supervisor events.
+//
+// This is the LEGACY in-package fan-out: unbounded subscriber list, drop-on-full
+// delivery, no unsubscribe and no close. It is consumed only by the supervisor's
+// own tests (which assert event TYPES per process); every external consumer uses
+// the payload-free change bus (Subscribe/Unsubscribe/CloseEvents) instead, which
+// every emit also feeds. It is deliberately left unexported and unchanged rather
+// than being grown into a second real bus.
+func (s *Supervisor) subscribeEvents() <-chan SupervisorEvent {
 	ch := make(chan SupervisorEvent, 100)
 
 	s.eventMu.Lock()
@@ -1333,16 +1389,117 @@ func (s *Supervisor) Subscribe() <-chan SupervisorEvent {
 	return ch
 }
 
-// emit sends an event to all subscribers
+// emit sends an event to all typed-event subscribers and wakes the change bus.
+//
+// Every emit is by construction a ProcessInfo-visible change, so routing all of
+// them through notifyChange keeps the two in lockstep without duplicating call
+// sites. Changes with no typed event (natural exit, health flips, waiting/blocked
+// transitions) call notifyChange directly.
 func (s *Supervisor) emit(event SupervisorEvent) {
 	s.eventMu.RLock()
-	defer s.eventMu.RUnlock()
-
 	for _, ch := range s.eventSubs {
 		select {
 		case ch <- event:
 		default:
 			// Channel full, skip
+		}
+	}
+	s.eventMu.RUnlock()
+
+	// Outside eventMu: notifyChange takes changeMu, and keeping the two critical
+	// sections disjoint means the bus never inherits the event list's lock.
+	s.notifyChange()
+}
+
+// changeSubIDCounter names change-bus subscriptions (mirrors the logs
+// subscription-id counter).
+var changeSubIDCounter atomic.Uint64
+
+// Subscribe registers a coalescing dirty-latch subscriber on the process-change
+// bus and returns its id (for Unsubscribe) and its wake channel.
+//
+// The channel carries NO payload: a wake means "some ProcessInfo-visible thing
+// changed; re-read Processes()". It has capacity 1 and is written with a
+// non-blocking send, so a burst of transitions collapses into a single pending
+// wake and the emitter is never blocked or slowed by a subscriber. Because the
+// latch is level rather than edge, the LAST change of a burst can never be lost:
+// either the latch is already set (the subscriber has not looked yet and will
+// see the final state when it does) or the send sets it.
+//
+// After CloseEvents the returned channel is already closed, so a stream handler
+// that races shutdown observes end-of-stream immediately instead of blocking on
+// a latch nothing will ever set (mirrors logs.SubscriptionManager.Subscribe).
+func (s *Supervisor) Subscribe() (string, <-chan struct{}) {
+	id := "sup-" + strconv.FormatUint(changeSubIDCounter.Add(1), 10)
+	ch := make(chan struct{}, 1)
+
+	s.changeMu.Lock()
+	defer s.changeMu.Unlock()
+	if s.changeClosed {
+		close(ch)
+		return id, ch
+	}
+	s.changeSubs[id] = ch
+	return id, ch
+}
+
+// Unsubscribe removes a change-bus subscriber and closes its channel. Idempotent:
+// an unknown id (already unsubscribed, or dropped by CloseEvents) is a no-op.
+func (s *Supervisor) Unsubscribe(id string) {
+	s.changeMu.Lock()
+	defer s.changeMu.Unlock()
+	ch, ok := s.changeSubs[id]
+	if !ok {
+		return
+	}
+	delete(s.changeSubs, id)
+	close(ch)
+}
+
+// SubscriberCount returns the number of live change-bus subscribers.
+func (s *Supervisor) SubscriberCount() int {
+	s.changeMu.Lock()
+	defer s.changeMu.Unlock()
+	return len(s.changeSubs)
+}
+
+// CloseEvents latches the change bus closed: every current subscriber channel is
+// closed (so a handler blocked on a wake returns), and every later Subscribe gets
+// an already-closed channel. Idempotent.
+//
+// Supervisor.Stop always runs this (see its deferred call), and up.go's shutdown
+// sequence runs Stop before the API server shutdown -- the same ordering the log
+// and request managers need, because the no-timeout SSE routes only end when
+// their data source closes (internal/api/server.go's route contract).
+func (s *Supervisor) CloseEvents() {
+	s.changeMu.Lock()
+	defer s.changeMu.Unlock()
+	if s.changeClosed {
+		return
+	}
+	s.changeClosed = true
+	for id, ch := range s.changeSubs {
+		delete(s.changeSubs, id)
+		close(ch)
+	}
+}
+
+// notifyChange sets every subscriber's dirty latch.
+//
+// LOCK DISCIPLINE: callers MUST hold no supervisor, process or health-checker
+// lock. notifyChange itself takes only changeMu (a leaf) and performs
+// non-blocking sends, so it never blocks and never re-enters supervisor code --
+// but keeping the callers lock-free is what makes the bus impossible to deadlock
+// against Processes(), which a woken subscriber calls straight back into.
+func (s *Supervisor) notifyChange() {
+	s.changeMu.Lock()
+	defer s.changeMu.Unlock()
+	for _, ch := range s.changeSubs {
+		select {
+		case ch <- struct{}{}:
+		default:
+			// Latch already set: the subscriber has not re-snapshotted yet, so it
+			// will observe this change (and everything after it) when it does.
 		}
 	}
 }

--- a/internal/supervisor/supervisor_stop_test.go
+++ b/internal/supervisor/supervisor_stop_test.go
@@ -165,7 +165,7 @@ func TestSupervisorStop_CleanEmitsStopped(t *testing.T) {
 		"beta":  newGracefulFake(5002),
 	}, "3s")
 
-	sub := sup.Subscribe()
+	sub := sup.subscribeEvents()
 	_, err := sup.Start(context.Background())
 	require.NoError(t, err)
 	require.NoError(t, sup.Stop(context.Background()))
@@ -184,7 +184,7 @@ func TestSupervisorStop_UnreapableEmitsCrashedNotStopped(t *testing.T) {
 		"bad":  newFastUnreapableFake(6002),
 	}, "3s")
 
-	sub := sup.Subscribe()
+	sub := sup.subscribeEvents()
 	_, err := sup.Start(context.Background())
 	require.NoError(t, err)
 
@@ -205,7 +205,7 @@ func TestSupervisorStop_StopProcessUnreapableEmitsCrashed(t *testing.T) {
 		"svc": newFastUnreapableFake(7001),
 	}, "5s")
 
-	sub := sup.Subscribe()
+	sub := sup.subscribeEvents()
 	_, err := sup.Start(context.Background())
 	require.NoError(t, err)
 
@@ -227,7 +227,7 @@ func TestSupervisorStop_CtxExpiredSecondaryNoEventStillReported(t *testing.T) {
 		"svc": newFastUnreapableFake(8001),
 	}, "5s")
 
-	sub := sup.Subscribe()
+	sub := sup.subscribeEvents()
 	_, err := sup.Start(context.Background())
 	require.NoError(t, err)
 

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -146,7 +146,7 @@ func TestSupervisor_Events(t *testing.T) {
 	})
 
 	sup := New(cfg, logMgr, nil, DefaultSupervisorConfig())
-	events := sup.Subscribe()
+	events := sup.subscribeEvents()
 
 	ctx := context.Background()
 	_, err := sup.Start(ctx)

--- a/internal/supervisor/tasks.go
+++ b/internal/supervisor/tasks.go
@@ -124,10 +124,12 @@ func (s *Supervisor) demandTask(ctx context.Context, name string) DepOutcome {
 		return DepOutcome{State: DepStateFailed, Err: fmt.Errorf("unknown task %q", name)}
 	}
 	node := s.taskNodes[name]
+	admitted := false
 	if node == nil {
 		// A plain (dependent-driven) demand joins or starts the once-per-lifetime
 		// run with no reload/rerun intent.
 		node = s.startTaskEpisodeLocked(name, mp, nil, false)
+		admitted = node != nil
 		if node == nil {
 			// beginWaiting refused admission: the task is unexpectedly active without a
 			// tracked node. Unreachable on the normal path (an active task always has a
@@ -139,6 +141,14 @@ func (s *Supervisor) demandTask(ctx context.Context, name string) DepOutcome {
 	}
 	done := node.done
 	s.taskMu.Unlock()
+
+	// A fresh episode moved the task terminal -> waiting (beginWaiting, inside
+	// startTaskEpisodeLocked). Lock discipline: taskMu released immediately above,
+	// and the notify is deliberately NOT inside startTaskEpisodeLocked, which runs
+	// under taskMu.
+	if admitted {
+		s.notifyChange()
+	}
 
 	select {
 	case <-done:
@@ -229,6 +239,9 @@ func (s *Supervisor) executeTask(mp *ManagedProcess, node *taskNode, runCtx, sup
 	} else if len(blockedBy) > 0 {
 		if mp.markBlocked(blockedBy, gen) {
 			s.SystemLog("task %s blocked: dependency not ready: %s", mp.Name(), strings.Join(blockedBy, ", "))
+			// waiting -> blocked (BlockedOn populated). Lock discipline: markBlocked
+			// released p.mu; executeTask holds no supervisor lock.
+			s.notifyChange()
 		}
 		return DepOutcome{State: DepStateFailed, Err: fmt.Errorf("task %q blocked: %s", mp.Name(), strings.Join(blockedBy, ", "))}
 	}
@@ -246,7 +259,11 @@ func (s *Supervisor) executeTask(mp *ManagedProcess, node *taskNode, runCtx, sup
 			// A genuine launch failure (e.g. a surviving previous group, or the
 			// runner failed): settle crashed (retaining current for reap) exactly as
 			// the gated path, and report a failure so dependents are blocked.
-			mp.failWaitingLaunch(gen)
+			if mp.failWaitingLaunch(gen) {
+				// waiting -> crashed after the launch attempt. Lock discipline:
+				// failWaitingLaunch released p.mu before returning.
+				s.notifyChange()
+			}
 			mp.logf(domain.StreamStderr, "task failed to start: %v", err)
 			return DepOutcome{State: DepStateFailed, Err: err}
 		}
@@ -359,6 +376,17 @@ func (s *Supervisor) demandTaskAsync(name string) bool {
 // retirement loop. Returns an already-active error only if admission is somehow
 // refused (unreachable on the normal path given rerunMu + the prior stop).
 func (s *Supervisor) rescheduleTask(mp *ManagedProcess, pending *pendingConfig, rerun bool) error {
+	// The fresh episode's admission moves the task terminal -> waiting. Lock
+	// discipline: this defer is registered BEFORE the taskMu unlock defer, so LIFO
+	// makes it run LAST -- with taskMu already released. (rerunMu, held by the
+	// caller, is not taken by notifyChange, which is a leaf.)
+	admitted := false
+	defer func() {
+		if admitted {
+			s.notifyChange()
+		}
+	}()
+
 	s.taskMu.Lock()
 	defer s.taskMu.Unlock()
 	if s.taskClosed {
@@ -373,6 +401,7 @@ func (s *Supervisor) rescheduleTask(mp *ManagedProcess, pending *pendingConfig, 
 		// beginWaiting refused: the process is unexpectedly active. Defensive only.
 		return domain.ErrProcessAlreadyRunning
 	}
+	admitted = true
 	return nil
 }
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -112,8 +112,8 @@ func forwardProxyRequests(ctx context.Context, p *tea.Program, ch <-chan proxy.R
 type TUIClient interface {
 	GetProcesses() (*api.ProcessListResponse, error)
 	RestartProcess(name string) error
-	StreamLogsChannel(params domain.LogParams) (<-chan api.LogEntryResponse, error)
-	StreamProxyRequestsChannel(params domain.ProxyRequestParams) (<-chan api.ProxyRequestResponse, error)
+	StreamLogsChannel(ctx context.Context, params domain.LogParams) (<-chan api.LogEntryResponse, error)
+	StreamProxyRequestsChannel(ctx context.Context, params domain.ProxyRequestParams) (<-chan api.ProxyRequestResponse, error)
 	GetProxyRequest(id string, includeBody bool) (*api.ProxyRequestDetailResponse, error)
 }
 
@@ -139,7 +139,7 @@ func RunClient(client TUIClient) error {
 // forwardClientLogs streams log entries from the API and sends them to the TUI program.
 // It exits when the context is cancelled or the channel is closed.
 func forwardClientLogs(ctx context.Context, p *tea.Program, client TUIClient) {
-	ch, err := client.StreamLogsChannel(domain.LogParams{})
+	ch, err := client.StreamLogsChannel(ctx, domain.LogParams{})
 	if err != nil {
 		// Send error as a system log entry so user sees feedback
 		p.Send(LogEntryMsg(domain.LogEntry{
@@ -192,7 +192,7 @@ func forwardClientLogs(ctx context.Context, p *tea.Program, client TUIClient) {
 // forwardClientProxyRequests streams proxy requests from the API and sends them to the TUI program.
 // It exits when the context is cancelled or the channel is closed.
 func forwardClientProxyRequests(ctx context.Context, p *tea.Program, client TUIClient) {
-	ch, err := client.StreamProxyRequestsChannel(domain.ProxyRequestParams{})
+	ch, err := client.StreamProxyRequestsChannel(ctx, domain.ProxyRequestParams{})
 	if err != nil {
 		// Proxy may not be enabled - this is not an error, just silently return
 		return

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -134,8 +134,10 @@ func reportLocalStreamClosed(ctx context.Context, send func(tea.Msg), id StreamI
 // one connect-and-consume attempt owned by an internal/stream.Loop, which needs
 // the terminal error to classify it. The channel forms remain on *cli.Client for
 // the --follow commands.
+// GetProcesses is deliberately absent: attach mode learns process state from
+// the processes stream alone (C12), so nothing here polls REST /processes. The
+// method stays on *cli.Client for the one-shot CLI commands.
 type TUIClient interface {
-	GetProcesses() (*api.ProcessListResponse, error)
 	RestartProcess(name string) error
 	// ConsumeLogs takes an onHandshake hook alongside onConnect: the logs sync
 	// (C9) must learn the server's log epoch before it can decide how to
@@ -143,6 +145,10 @@ type TUIClient interface {
 	// itself. A daemon that sends none never fires it.
 	ConsumeLogs(ctx context.Context, params domain.LogParams, onConnect func(), onHandshake func(api.HandshakeResponse), onEvent func(api.LogEntryResponse)) error
 	ConsumeProxyRequests(ctx context.Context, params domain.ProxyRequestParams, onConnect func(), onEvent func(api.ProxyRequestResponse)) error
+	// ConsumeProcesses carries a full process-list snapshot per event, so it
+	// needs neither params nor a handshake: there is nothing to filter and
+	// nothing to resume from.
+	ConsumeProcesses(ctx context.Context, onConnect func(), onEvent func(api.ProcessListResponse)) error
 	GetProxyRequest(id string, includeBody bool) (*api.ProxyRequestDetailResponse, error)
 
 	// GetProxyRequests and GetLogs fetch what the requests and logs streams
@@ -180,16 +186,38 @@ func runClientStreams(ctx context.Context, client TUIClient, send func(tea.Msg))
 	// attempt N stopped instead of re-fetching the world (C9).
 	logsSess := newLogsSyncSession()
 
-	loops := []*stream.Loop{
-		// Neither data stream is a pure stream consumer: each connect
-		// synchronizes against a REST fetch before reporting OK (C6, C9).
-		streamLoop(StreamLogs, send, classifyStreamError, func(ctx context.Context, markSynced func()) error {
-			return consumeLogsWithSync(ctx, client, logsSess, send, markSynced)
-		}),
-		streamLoop(StreamRequests, send, classifyRequestsStreamError, func(ctx context.Context, markSynced func()) error {
-			return consumeRequestsWithSync(ctx, client, send, markSynced)
-		}),
+	// Re-probing is SYMMETRIC (codex C12 finding): each loop's observer wakes
+	// every OTHER loop on a reconnect. The loops slice is filled before any
+	// Run starts, and OnStatus only fires from a Run goroutine, so the
+	// closures' reads are ordered after the write by goroutine creation.
+	var loops []*stream.Loop
+	probeOthers := func(self int) func(stream.Status) {
+		return reprobeOnReconnect(func() {
+			for i, l := range loops {
+				if i != self {
+					l.Probe()
+				}
+			}
+		})
 	}
+
+	// Neither data stream is a pure stream consumer: each connect
+	// synchronizes against a REST fetch before reporting OK (C6, C9).
+	logsLoop := streamLoop(StreamLogs, send, classifyStreamError, probeOthers(0), func(ctx context.Context, markSynced func()) error {
+		return consumeLogsWithSync(ctx, client, logsSess, send, markSynced)
+	})
+	requestsLoop := streamLoop(StreamRequests, send, classifyRequestsStreamError, probeOthers(1), func(ctx context.Context, markSynced func()) error {
+		return consumeRequestsWithSync(ctx, client, send, markSynced)
+	})
+	// The processes stream IS a pure consumer (snapshot-per-event); it also
+	// doubles as the run's daemon-liveness signal (see ClientModel).
+	processesLoop := streamLoop(StreamProcesses, send, classifyProcessesStreamError,
+		probeOthers(2),
+		func(ctx context.Context, markSynced func()) error {
+			return consumeProcesses(ctx, client, send, markSynced)
+		})
+
+	loops = []*stream.Loop{logsLoop, requestsLoop, processesLoop}
 
 	var wg sync.WaitGroup
 	wg.Add(len(loops))
@@ -206,19 +234,99 @@ func runClientStreams(ctx context.Context, client TUIClient, send func(tea.Msg))
 // connect-and-consume attempt, classify is the stream's reconnect policy, and
 // every transition reaches the models as a StreamStatusMsg for id.
 //
-// markSynced is handed to the attempt rather than called for it. Both of
-// today's attach streams call it from inside their sync protocol, after the
-// batch barrier, so an attempt that connects but cannot synchronize stays in
-// Syncing and can never flash OK or clear the outage warning (codex C5
-// finding).
-func streamLoop(id StreamID, send func(tea.Msg), classify func(error) stream.Classification, consume func(ctx context.Context, markSynced func()) error) *stream.Loop {
+// markSynced is handed to the attempt rather than called for it. The two
+// synchronizing attach streams call it from inside their sync protocol, after
+// the batch barrier, so an attempt that connects but cannot synchronize stays
+// in Syncing and can never flash OK or clear the outage warning (codex C5
+// finding). The processes stream has no such barrier — see consumeProcesses.
+//
+// observe (nilable) is an extra hook run on every transition, before the
+// message is sent. It exists for the one cross-loop behavior in attach mode:
+// the processes stream's reconnect re-probing the parked loops.
+func streamLoop(id StreamID, send func(tea.Msg), classify func(error) stream.Classification, observe func(stream.Status), consume func(ctx context.Context, markSynced func()) error) *stream.Loop {
 	return stream.NewLoop(stream.Config{
 		Attempt:  consume,
 		Classify: classify,
 		OnStatus: func(s stream.Status) {
+			if observe != nil {
+				observe(s)
+			}
 			send(StreamStatusMsg{Stream: id, Status: s})
 		},
 	})
+}
+
+// reprobeOnReconnect builds a stream's status observer: every OK transition
+// AFTER the first one is a RECONNECT, which is the best evidence attach mode
+// has that the daemon it lost was replaced — so it fires probe, which wakes
+// the OTHER loops. Any of them may be parked in StateUnavailable with no timer
+// of its own: a proxy-disabled requests stream, or the processes stream parked
+// on an old daemon's 404 — which is exactly why probing must be symmetric
+// rather than processes-only (codex C12 finding): the parked processes loop
+// can only be rescued by a sibling's reconnect.
+//
+// The other loops are probed unconditionally rather than only when parked:
+// Loop.Probe coalesces and never blocks, and a probe delivered to a loop that
+// is not parked at worst short-circuits one backoff wait — which, mid-daemon-
+// restart, is the desired behavior anyway.
+//
+// The bool needs no synchronization: Config.OnStatus is serialized by the
+// loop's own mutex and is never called concurrently.
+func reprobeOnReconnect(probe func()) func(stream.Status) {
+	sawOK := false
+	return func(s stream.Status) {
+		if s.State != stream.StateOK {
+			return
+		}
+		if !sawOK {
+			sawOK = true // the initial connect is not a reconnect
+			return
+		}
+		probe()
+	}
+}
+
+// consumeProcesses is the processes stream's single connect-and-consume
+// attempt. It is the one attach stream with no sync protocol: the endpoint
+// writes a full snapshot immediately after ": connected" and a full snapshot on
+// every later change (internal/api/sse.go), so there is no REST fetch to
+// reconcile against and no cursor to resume from — connect IS sync, and
+// markSynced rides onConnect.
+//
+// The consequence, accepted deliberately: OK can lead the first snapshot's
+// arrival by the microseconds it takes the server's initial write to land, a
+// window in which the status bar says healthy while the process list is still
+// the previous one (empty at startup). The alternative — deferring markSynced
+// to the first event — would leave the stream stuck in Syncing forever against
+// a daemon supervising nothing.
+func consumeProcesses(ctx context.Context, client TUIClient, send func(tea.Msg), markSynced func()) error {
+	return client.ConsumeProcesses(ctx, markSynced, func(resp api.ProcessListResponse) {
+		send(ProcessesMsg(streamedProcesses(resp)))
+	})
+}
+
+// streamedProcesses converts one full process-list snapshot to the domain
+// slice the models hold. It is the pure form of what attach mode's polling
+// fetchProcesses command used to do inline (C12 deleted the poll).
+//
+// ProcessState and the rest are cast directly from their status strings; an
+// unknown value from a newer daemon renders with default styling rather than
+// being rejected.
+func streamedProcesses(resp api.ProcessListResponse) []domain.ProcessInfo {
+	processes := make([]domain.ProcessInfo, len(resp.Processes))
+	for i, p := range resp.Processes {
+		processes[i] = domain.ProcessInfo{
+			Name:         p.Name,
+			State:        domain.ProcessState(p.Status),
+			PID:          p.PID,
+			RestartCount: p.Restarts,
+			Health:       domain.HealthStatus(p.Health),
+			Kind:         domain.ProcessKind(p.Kind),
+			WaitingOn:    p.WaitingOn,
+			BlockedOn:    p.BlockedOn,
+		}
+	}
+	return processes
 }
 
 // parseStreamTimestamp parses a server-supplied event timestamp. A malformed one

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -140,6 +140,12 @@ type TUIClient interface {
 	ConsumeLogs(ctx context.Context, params domain.LogParams, onConnect func(), onEvent func(api.LogEntryResponse)) error
 	ConsumeProxyRequests(ctx context.Context, params domain.ProxyRequestParams, onConnect func(), onEvent func(api.ProxyRequestResponse)) error
 	GetProxyRequest(id string, includeBody bool) (*api.ProxyRequestDetailResponse, error)
+
+	// GetProxyRequests fetches the ring snapshot the requests stream
+	// synchronizes against on every connect. It is the one ctx-taking
+	// non-stream method: the fetch is owned by a stream attempt and must be
+	// abandoned the moment that attempt ends.
+	GetProxyRequests(ctx context.Context, params domain.ProxyRequestParams) (*api.ProxyRequestsResponse, error)
 }
 
 // RunClient starts the TUI application in client mode (connected via API)
@@ -170,10 +176,11 @@ func runClientStreams(ctx context.Context, client TUIClient, send func(tea.Msg))
 				sendStreamedLogEntry(send, entry)
 			})
 		}),
-		streamLoop(StreamRequests, send, classifyRequestsStreamError, func(ctx context.Context, onConnect func()) error {
-			return client.ConsumeProxyRequests(ctx, domain.ProxyRequestParams{}, onConnect, func(req api.ProxyRequestResponse) {
-				sendStreamedProxyRequest(send, req)
-			})
+		// The requests stream is NOT a pure stream consumer: every connect
+		// synchronizes against a REST snapshot before reporting OK, so its
+		// markSynced lands inside the sync protocol rather than on connect.
+		streamLoop(StreamRequests, send, classifyRequestsStreamError, func(ctx context.Context, markSynced func()) error {
+			return consumeRequestsWithSync(ctx, client, send, markSynced)
 		}),
 	}
 
@@ -234,7 +241,15 @@ func sendStreamedLogEntry(send func(tea.Msg), entry api.LogEntryResponse) {
 
 // sendStreamedProxyRequest converts one streamed proxy request and delivers it.
 func sendStreamedProxyRequest(send func(tea.Msg), req api.ProxyRequestResponse) {
-	send(ProxyRequestMsg(proxy.RequestRecord{
+	send(ProxyRequestMsg(streamedProxyRequest(send, req)))
+}
+
+// streamedProxyRequest converts one wire proxy request to a record without
+// delivering it, so the sync protocol can buffer live events and convert
+// snapshot records (same wire type) through exactly the same mapping. send is
+// still needed: a malformed timestamp warns through the log pane.
+func streamedProxyRequest(send func(tea.Msg), req api.ProxyRequestResponse) proxy.RequestRecord {
+	return proxy.RequestRecord{
 		ID:         req.ID,
 		Timestamp:  parseStreamTimestamp(send, "proxy request", req.Timestamp),
 		Method:     req.Method,
@@ -244,5 +259,5 @@ func sendStreamedProxyRequest(send func(tea.Msg), req api.ProxyRequestResponse) 
 		Duration:   time.Duration(req.DurationMs) * time.Millisecond,
 		RemoteAddr: req.RemoteAddr,
 		InFlight:   req.InFlight,
-	}))
+	}
 }

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -137,15 +137,20 @@ func reportLocalStreamClosed(ctx context.Context, send func(tea.Msg), id StreamI
 type TUIClient interface {
 	GetProcesses() (*api.ProcessListResponse, error)
 	RestartProcess(name string) error
-	ConsumeLogs(ctx context.Context, params domain.LogParams, onConnect func(), onEvent func(api.LogEntryResponse)) error
+	// ConsumeLogs takes an onHandshake hook alongside onConnect: the logs sync
+	// (C9) must learn the server's log epoch before it can decide how to
+	// backfill, and that epoch rides a named handshake frame on the stream
+	// itself. A daemon that sends none never fires it.
+	ConsumeLogs(ctx context.Context, params domain.LogParams, onConnect func(), onHandshake func(api.HandshakeResponse), onEvent func(api.LogEntryResponse)) error
 	ConsumeProxyRequests(ctx context.Context, params domain.ProxyRequestParams, onConnect func(), onEvent func(api.ProxyRequestResponse)) error
 	GetProxyRequest(id string, includeBody bool) (*api.ProxyRequestDetailResponse, error)
 
-	// GetProxyRequests fetches the ring snapshot the requests stream
-	// synchronizes against on every connect. It is the one ctx-taking
-	// non-stream method: the fetch is owned by a stream attempt and must be
-	// abandoned the moment that attempt ends.
+	// GetProxyRequests and GetLogs fetch what the requests and logs streams
+	// synchronize against on every connect. They are the ctx-taking non-stream
+	// methods: each fetch is owned by a stream attempt and must be abandoned
+	// the moment that attempt ends.
 	GetProxyRequests(ctx context.Context, params domain.ProxyRequestParams) (*api.ProxyRequestsResponse, error)
+	GetLogs(ctx context.Context, params domain.LogParams) (*api.LogsResponse, error)
 }
 
 // RunClient starts the TUI application in client mode (connected via API)
@@ -170,15 +175,17 @@ func RunClient(client TUIClient) error {
 // loop's error is classified terminal. send is the program's message sink,
 // injected so the wiring is testable without a live *tea.Program.
 func runClientStreams(ctx context.Context, client TUIClient, send func(tea.Msg)) {
+	// One log-sync session for the whole attach run: it carries the cursor and
+	// epoch ACROSS reconnects, which is what lets attempt N+1 resume where
+	// attempt N stopped instead of re-fetching the world (C9).
+	logsSess := newLogsSyncSession()
+
 	loops := []*stream.Loop{
-		streamLoop(StreamLogs, send, classifyStreamError, func(ctx context.Context, onConnect func()) error {
-			return client.ConsumeLogs(ctx, domain.LogParams{}, onConnect, func(entry api.LogEntryResponse) {
-				sendStreamedLogEntry(send, entry)
-			})
+		// Neither data stream is a pure stream consumer: each connect
+		// synchronizes against a REST fetch before reporting OK (C6, C9).
+		streamLoop(StreamLogs, send, classifyStreamError, func(ctx context.Context, markSynced func()) error {
+			return consumeLogsWithSync(ctx, client, logsSess, send, markSynced)
 		}),
-		// The requests stream is NOT a pure stream consumer: every connect
-		// synchronizes against a REST snapshot before reporting OK, so its
-		// markSynced lands inside the sync protocol rather than on connect.
 		streamLoop(StreamRequests, send, classifyRequestsStreamError, func(ctx context.Context, markSynced func()) error {
 			return consumeRequestsWithSync(ctx, client, send, markSynced)
 		}),
@@ -199,17 +206,14 @@ func runClientStreams(ctx context.Context, client TUIClient, send func(tea.Msg))
 // connect-and-consume attempt, classify is the stream's reconnect policy, and
 // every transition reaches the models as a StreamStatusMsg for id.
 //
-// markSynced rides the client's onConnect hook, so it fires only once a
-// connection actually stands (headers + content type validated) — a
-// dead-on-arrival dial stays in Syncing and can never flash OK or clear the
-// outage warning (codex C5 finding). For these pure stream consumers connect
-// IS sync; the requests sync protocol later moves markSynced after its
-// snapshot barrier.
-func streamLoop(id StreamID, send func(tea.Msg), classify func(error) stream.Classification, consume func(ctx context.Context, onConnect func()) error) *stream.Loop {
+// markSynced is handed to the attempt rather than called for it. Both of
+// today's attach streams call it from inside their sync protocol, after the
+// batch barrier, so an attempt that connects but cannot synchronize stays in
+// Syncing and can never flash OK or clear the outage warning (codex C5
+// finding).
+func streamLoop(id StreamID, send func(tea.Msg), classify func(error) stream.Classification, consume func(ctx context.Context, markSynced func()) error) *stream.Loop {
 	return stream.NewLoop(stream.Config{
-		Attempt: func(ctx context.Context, markSynced func()) error {
-			return consume(ctx, markSynced)
-		},
+		Attempt:  consume,
 		Classify: classify,
 		OnStatus: func(s stream.Status) {
 			send(StreamStatusMsg{Stream: id, Status: s})
@@ -231,12 +235,25 @@ func parseStreamTimestamp(send func(tea.Msg), what, raw string) time.Time {
 
 // sendStreamedLogEntry converts one streamed log entry and delivers it.
 func sendStreamedLogEntry(send func(tea.Msg), entry api.LogEntryResponse) {
-	send(LogEntryMsg(domain.LogEntry{
+	send(LogEntryMsg(streamedLogEntry(send, entry)))
+}
+
+// streamedLogEntry converts one wire log entry without delivering it, so the
+// sync protocol can buffer live entries and convert backfill entries (same wire
+// type) through exactly the same mapping. send is still needed: a malformed
+// timestamp warns through the log pane.
+//
+// Seq is carried through: it is the server ingest sequence the sync protocol's
+// cursor arithmetic runs on, and is unrelated to the TUI-local DisplaySeq that
+// BaseModel stamps on arrival (D7).
+func streamedLogEntry(send func(tea.Msg), entry api.LogEntryResponse) domain.LogEntry {
+	return domain.LogEntry{
 		Timestamp: parseStreamTimestamp(send, "log", entry.Timestamp),
 		Process:   entry.Process,
 		Stream:    domain.Stream(entry.Stream),
 		Line:      entry.Line,
-	}))
+		Seq:       entry.Seq,
+	}
 }
 
 // sendStreamedProxyRequest converts one streamed proxy request and delivers it.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -10,6 +11,7 @@ import (
 	"github.com/charliek/prox/internal/domain"
 	"github.com/charliek/prox/internal/logs"
 	"github.com/charliek/prox/internal/proxy"
+	"github.com/charliek/prox/internal/stream"
 	"github.com/charliek/prox/internal/supervisor"
 )
 
@@ -40,17 +42,10 @@ func Run(sup *supervisor.Supervisor, logMgr *logs.Manager, reqMgr *proxy.Request
 	// Subscribe to logs before starting the forwarder
 	subID, ch, err := logMgr.Subscribe(domain.LogFilter{})
 	if err != nil {
-		// Send error as a system log entry so user sees feedback
-		// Don't cancel context here - proxy request forwarding should still work
-		p.Send(LogEntryMsg(domain.LogEntry{
-			Timestamp: time.Now(),
-			Process:   "system",
-			Stream:    domain.StreamStderr,
-			Line:      "Error subscribing to logs: " + err.Error(),
-		}))
+		// Don't cancel the context here - proxy request forwarding should still work.
+		p.Send(LogEntryMsg(systemLogEntry("Error subscribing to logs: " + err.Error())))
 	} else {
-		// Start a goroutine to forward log entries to the TUI
-		go forwardLogs(ctx, p, ch)
+		go forwardLogs(ctx, p.Send, ch)
 	}
 
 	// Subscribe to proxy requests if available
@@ -58,7 +53,7 @@ func Run(sup *supervisor.Supervisor, logMgr *logs.Manager, reqMgr *proxy.Request
 	if reqMgr != nil {
 		sub := reqMgr.Subscribe(proxy.RequestFilter{})
 		reqSubID = sub.ID
-		go forwardProxyRequests(ctx, p, sub.Ch)
+		go forwardProxyRequests(ctx, p.Send, sub.Ch)
 	}
 
 	_, runErr := p.Run()
@@ -75,45 +70,75 @@ func Run(sup *supervisor.Supervisor, logMgr *logs.Manager, reqMgr *proxy.Request
 	return runErr
 }
 
-// forwardLogs forwards log entries from the subscription channel to the TUI program.
-// It exits when the context is cancelled or the channel is closed.
-func forwardLogs(ctx context.Context, p *tea.Program, ch <-chan domain.LogEntry) {
+// systemLogEntry builds the synthetic "system" log line the TUI uses to show
+// itself a message in the log pane.
+func systemLogEntry(line string) domain.LogEntry {
+	return domain.LogEntry{
+		Timestamp: time.Now(),
+		Process:   "system",
+		Stream:    domain.StreamStderr,
+		Line:      line,
+	}
+}
+
+// forwardSubscription pumps a local-mode subscription channel into the TUI. It
+// exits when the context is cancelled or the channel is closed. toMsg wraps one
+// element as the message the models expect; closedLine is the system log line
+// recorded if the channel ends on its own.
+func forwardSubscription[T any](ctx context.Context, send func(tea.Msg), ch <-chan T, id StreamID, closedLine string, toMsg func(T) tea.Msg) {
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case entry, ok := <-ch:
+		case v, ok := <-ch:
 			if !ok {
+				reportLocalStreamClosed(ctx, send, id, closedLine)
 				return
 			}
-			p.Send(LogEntryMsg(entry))
+			send(toMsg(v))
 		}
 	}
 }
 
-// forwardProxyRequests forwards proxy requests from the subscription channel to the TUI program.
-// It exits when the context is cancelled or the channel is closed.
-func forwardProxyRequests(ctx context.Context, p *tea.Program, ch <-chan proxy.RequestRecord) {
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case req, ok := <-ch:
-			if !ok {
-				return
-			}
-			p.Send(ProxyRequestMsg(req))
-		}
+// forwardLogs forwards log entries from the subscription channel to the TUI.
+func forwardLogs(ctx context.Context, send func(tea.Msg), ch <-chan domain.LogEntry) {
+	forwardSubscription(ctx, send, ch, StreamLogs, "Log stream closed",
+		func(entry domain.LogEntry) tea.Msg { return LogEntryMsg(entry) })
+}
+
+// forwardProxyRequests forwards proxy requests from the subscription channel to
+// the TUI.
+func forwardProxyRequests(ctx context.Context, send func(tea.Msg), ch <-chan proxy.RequestRecord) {
+	forwardSubscription(ctx, send, ch, StreamRequests, "Proxy request stream closed",
+		func(req proxy.RequestRecord) tea.Msg { return ProxyRequestMsg(req) })
+}
+
+// reportLocalStreamClosed surfaces a local-mode subscription channel that ended
+// on its own. Local mode has no reconnect loop, so the feed is gone for the rest
+// of the session and the user has to be told: the status bar marks the stream
+// closed and one system log line records it. A close observed during shutdown
+// (ctx already cancelled, which the select can lose the race to) is expected and
+// stays silent.
+func reportLocalStreamClosed(ctx context.Context, send func(tea.Msg), id StreamID, line string) {
+	if ctx.Err() != nil {
+		return
 	}
+	send(StreamStatusMsg{Stream: id, Status: stream.Status{State: stream.StateClosed}})
+	send(LogEntryMsg(systemLogEntry(line)))
 }
 
 // TUIClient is the interface for TUI client mode API interactions.
 // It consolidates all API operations needed by the TUI client.
+//
+// The stream methods are attempt-shaped rather than channel-shaped: each call is
+// one connect-and-consume attempt owned by an internal/stream.Loop, which needs
+// the terminal error to classify it. The channel forms remain on *cli.Client for
+// the --follow commands.
 type TUIClient interface {
 	GetProcesses() (*api.ProcessListResponse, error)
 	RestartProcess(name string) error
-	StreamLogsChannel(ctx context.Context, params domain.LogParams) (<-chan api.LogEntryResponse, error)
-	StreamProxyRequestsChannel(ctx context.Context, params domain.ProxyRequestParams) (<-chan api.ProxyRequestResponse, error)
+	ConsumeLogs(ctx context.Context, params domain.LogParams, onConnect func(), onEvent func(api.LogEntryResponse)) error
+	ConsumeProxyRequests(ctx context.Context, params domain.ProxyRequestParams, onConnect func(), onEvent func(api.ProxyRequestResponse)) error
 	GetProxyRequest(id string, includeBody bool) (*api.ProxyRequestDetailResponse, error)
 }
 
@@ -124,113 +149,100 @@ func RunClient(client TUIClient) error {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	// Start goroutines to stream logs and proxy requests from the API
-	go forwardClientLogs(ctx, p, client)
-	go forwardClientProxyRequests(ctx, p, client)
+	go runClientStreams(ctx, client, p.Send)
 
 	_, err := p.Run()
 
-	// Cleanup: cancel context to stop the forwarder goroutines
+	// Cleanup: cancel context to stop the stream loops
 	cancel()
 
 	return err
 }
 
-// forwardClientLogs streams log entries from the API and sends them to the TUI program.
-// It exits when the context is cancelled or the channel is closed.
-func forwardClientLogs(ctx context.Context, p *tea.Program, client TUIClient) {
-	ch, err := client.StreamLogsChannel(ctx, domain.LogParams{})
-	if err != nil {
-		// Send error as a system log entry so user sees feedback
-		p.Send(LogEntryMsg(domain.LogEntry{
-			Timestamp: time.Now(),
-			Process:   "system",
-			Stream:    domain.StreamStderr,
-			Line:      "Error connecting to log stream: " + err.Error(),
-		}))
-		return
+// runClientStreams runs one reconnect loop per attach-mode stream and blocks
+// until every loop has ended, which happens when ctx is cancelled (on quit) or a
+// loop's error is classified terminal. send is the program's message sink,
+// injected so the wiring is testable without a live *tea.Program.
+func runClientStreams(ctx context.Context, client TUIClient, send func(tea.Msg)) {
+	loops := []*stream.Loop{
+		streamLoop(StreamLogs, send, classifyStreamError, func(ctx context.Context, onConnect func()) error {
+			return client.ConsumeLogs(ctx, domain.LogParams{}, onConnect, func(entry api.LogEntryResponse) {
+				sendStreamedLogEntry(send, entry)
+			})
+		}),
+		streamLoop(StreamRequests, send, classifyRequestsStreamError, func(ctx context.Context, onConnect func()) error {
+			return client.ConsumeProxyRequests(ctx, domain.ProxyRequestParams{}, onConnect, func(req api.ProxyRequestResponse) {
+				sendStreamedProxyRequest(send, req)
+			})
+		}),
 	}
 
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case entry, ok := <-ch:
-			if !ok {
-				// Channel closed - connection lost
-				p.Send(LogEntryMsg(domain.LogEntry{
-					Timestamp: time.Now(),
-					Process:   "system",
-					Stream:    domain.StreamStderr,
-					Line:      "Log stream connection closed",
-				}))
-				return
-			}
-			// Convert API response to LogEntry
-			ts, parseErr := time.Parse(time.RFC3339Nano, entry.Timestamp)
-			if parseErr != nil {
-				ts = time.Now() // Fallback for malformed timestamps
-				// Log warning so server-side timestamp bugs are visible
-				p.Send(LogEntryMsg(domain.LogEntry{
-					Timestamp: ts,
-					Process:   "system",
-					Stream:    domain.StreamStderr,
-					Line:      "Warning: failed to parse log timestamp: " + parseErr.Error(),
-				}))
-			}
-			logEntry := domain.LogEntry{
-				Timestamp: ts,
-				Process:   entry.Process,
-				Stream:    domain.Stream(entry.Stream),
-				Line:      entry.Line,
-			}
-			p.Send(LogEntryMsg(logEntry))
-		}
+	var wg sync.WaitGroup
+	wg.Add(len(loops))
+	for _, l := range loops {
+		go func() {
+			defer wg.Done()
+			l.Run(ctx)
+		}()
 	}
+	wg.Wait()
 }
 
-// forwardClientProxyRequests streams proxy requests from the API and sends them to the TUI program.
-// It exits when the context is cancelled or the channel is closed.
-func forwardClientProxyRequests(ctx context.Context, p *tea.Program, client TUIClient) {
-	ch, err := client.StreamProxyRequestsChannel(ctx, domain.ProxyRequestParams{})
-	if err != nil {
-		// Proxy may not be enabled - this is not an error, just silently return
-		return
-	}
+// streamLoop builds one attach-mode reconnect loop: consume is a single
+// connect-and-consume attempt, classify is the stream's reconnect policy, and
+// every transition reaches the models as a StreamStatusMsg for id.
+//
+// markSynced rides the client's onConnect hook, so it fires only once a
+// connection actually stands (headers + content type validated) — a
+// dead-on-arrival dial stays in Syncing and can never flash OK or clear the
+// outage warning (codex C5 finding). For these pure stream consumers connect
+// IS sync; the requests sync protocol later moves markSynced after its
+// snapshot barrier.
+func streamLoop(id StreamID, send func(tea.Msg), classify func(error) stream.Classification, consume func(ctx context.Context, onConnect func()) error) *stream.Loop {
+	return stream.NewLoop(stream.Config{
+		Attempt: func(ctx context.Context, markSynced func()) error {
+			return consume(ctx, markSynced)
+		},
+		Classify: classify,
+		OnStatus: func(s stream.Status) {
+			send(StreamStatusMsg{Stream: id, Status: s})
+		},
+	})
+}
 
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case req, ok := <-ch:
-			if !ok {
-				// Channel closed - connection lost
-				return
-			}
-			// Convert API response to RequestRecord
-			ts, parseErr := time.Parse(time.RFC3339Nano, req.Timestamp)
-			if parseErr != nil {
-				ts = time.Now() // Fallback for malformed timestamps
-				// Log warning so server-side timestamp bugs are visible
-				p.Send(LogEntryMsg(domain.LogEntry{
-					Timestamp: ts,
-					Process:   "system",
-					Stream:    domain.StreamStderr,
-					Line:      "Warning: failed to parse proxy request timestamp: " + parseErr.Error(),
-				}))
-			}
-			record := proxy.RequestRecord{
-				ID:         req.ID,
-				Timestamp:  ts,
-				Method:     req.Method,
-				URL:        req.URL,
-				Subdomain:  req.Subdomain,
-				StatusCode: req.StatusCode,
-				Duration:   time.Duration(req.DurationMs) * time.Millisecond,
-				RemoteAddr: req.RemoteAddr,
-				InFlight:   req.InFlight,
-			}
-			p.Send(ProxyRequestMsg(record))
-		}
+// parseStreamTimestamp parses a server-supplied event timestamp. A malformed one
+// falls back to now and emits a warning line naming what, so a server-side
+// timestamp bug stays visible instead of being papered over.
+func parseStreamTimestamp(send func(tea.Msg), what, raw string) time.Time {
+	ts, err := time.Parse(time.RFC3339Nano, raw)
+	if err != nil {
+		send(LogEntryMsg(systemLogEntry("Warning: failed to parse " + what + " timestamp: " + err.Error())))
+		return time.Now()
 	}
+	return ts
+}
+
+// sendStreamedLogEntry converts one streamed log entry and delivers it.
+func sendStreamedLogEntry(send func(tea.Msg), entry api.LogEntryResponse) {
+	send(LogEntryMsg(domain.LogEntry{
+		Timestamp: parseStreamTimestamp(send, "log", entry.Timestamp),
+		Process:   entry.Process,
+		Stream:    domain.Stream(entry.Stream),
+		Line:      entry.Line,
+	}))
+}
+
+// sendStreamedProxyRequest converts one streamed proxy request and delivers it.
+func sendStreamedProxyRequest(send func(tea.Msg), req api.ProxyRequestResponse) {
+	send(ProxyRequestMsg(proxy.RequestRecord{
+		ID:         req.ID,
+		Timestamp:  parseStreamTimestamp(send, "proxy request", req.Timestamp),
+		Method:     req.Method,
+		URL:        req.URL,
+		Subdomain:  req.Subdomain,
+		StatusCode: req.StatusCode,
+		Duration:   time.Duration(req.DurationMs) * time.Millisecond,
+		RemoteAddr: req.RemoteAddr,
+		InFlight:   req.InFlight,
+	}))
 }

--- a/internal/tui/base.go
+++ b/internal/tui/base.go
@@ -19,6 +19,7 @@ import (
 	"github.com/charliek/prox/internal/constants"
 	"github.com/charliek/prox/internal/domain"
 	"github.com/charliek/prox/internal/proxy"
+	"github.com/charliek/prox/internal/stream"
 )
 
 // maxLogEntries is the maximum number of log entries to keep in memory
@@ -117,6 +118,14 @@ type BaseModel struct {
 	// on leaving the detail view (esc).
 	detailRefreshFailed bool
 
+	// Per-stream health. streamHealth holds the last status reported for each
+	// stream; a stream with no entry has reported nothing and renders nothing.
+	// streamDropped latches a stream that has been seen reconnecting, so the
+	// Syncing that follows a drop keeps rendering as "reconnecting…" while a
+	// first-connect Syncing stays silent (see handleStreamStatus).
+	streamHealth  map[StreamID]stream.Status
+	streamDropped map[StreamID]bool
+
 	// Dimensions
 	width  int
 	height int
@@ -141,6 +150,8 @@ func newBaseModel(helpConfig HelpConfig) BaseModel {
 		mode:            ModeNormal,
 		viewMode:        ViewModeLogs,
 		filterProcesses: make(map[string]bool),
+		streamHealth:    make(map[StreamID]stream.Status),
+		streamDropped:   make(map[StreamID]bool),
 		followMode:      true,
 		logCursorIdx:    -1, // no-cursor sentinel (pairs with logCursorSeq 0)
 		helpConfig:      helpConfig,
@@ -1640,6 +1651,13 @@ func (b *BaseModel) statusBar(extraInfo string) string {
 		left = "String filter: " + b.textInput.View()
 	default:
 		left = b.statusLeftDefault(extraInfo, requests, entries)
+	}
+
+	// Per-stream health rides on the end of the left side in every mode: a
+	// degraded stream is worth showing even while a filter prompt is open, and
+	// it is orthogonal to the overall-connection text attach mode owns.
+	if segs := b.streamHealthSegments(); len(segs) > 0 {
+		left += " | " + strings.Join(segs, " | ")
 	}
 
 	// Right side: follow mode and count

--- a/internal/tui/base.go
+++ b/internal/tui/base.go
@@ -46,6 +46,13 @@ type BaseModel struct {
 	logEntries    []domain.LogEntry
 	proxyRequests []proxy.RequestRecord
 
+	// staleRequests holds the IDs of in-flight rows a requests-stream sync
+	// swept as prior-epoch: the server we synchronized against does not know
+	// them, so their completion can never arrive (see sweepPriorEpochInFlight).
+	// Rebuilt from the live list on every sync, and consulted only through
+	// requestIsStale.
+	staleRequests map[string]bool
+
 	// UI components
 	viewport  viewport.Model
 	textInput textinput.Model
@@ -146,6 +153,7 @@ func newBaseModel(helpConfig HelpConfig) BaseModel {
 		processes:       make([]domain.ProcessInfo, 0),
 		logEntries:      make([]domain.LogEntry, 0),
 		proxyRequests:   make([]proxy.RequestRecord, 0),
+		staleRequests:   make(map[string]bool),
 		textInput:       ti,
 		mode:            ModeNormal,
 		viewMode:        ViewModeLogs,
@@ -216,33 +224,61 @@ func (b *BaseModel) handleLogEntry(entry domain.LogEntry) {
 	}
 }
 
-// handleProxyRequest handles a new proxy request message. It upserts by ID:
-// a same-ID re-record (in-flight followed by its completion) replaces the
-// existing row in place rather than appending a duplicate, scanning from the
-// newest entry since that's where a live in-flight row lives. In-place
-// replacement keeps every other row's index stable, and the ID-anchored cursor
-// (resolveRequestCursor) rides along on its row regardless.
+// handleProxyRequest handles a new proxy request message: one monotonic merge
+// followed by one render.
 func (b *BaseModel) handleProxyRequest(req proxy.RequestRecord) {
-	replaced := false
+	b.mergeProxyRequest(req)
+	b.renderAfterProxyRequests()
+}
+
+// mergeProxyRequest applies one record to the list as a monotonic two-state
+// transition keyed by ID, mirroring proxy.Upsert's table:
+//
+//	absent                            → append (with the eviction trim)
+//	existing in-flight, incoming any  → replace in place
+//	existing final                    → no-op (final is terminal)
+//
+// The one deliberate difference from proxy.Upsert is the in-flight → in-flight
+// row: the ring no-ops it as a duplicate delivery, while the list takes the
+// newer copy. Both are correct (the two copies differ in nothing that matters),
+// and taking it keeps the display tracking the freshest server view.
+//
+// The terminal-final row is what makes replaying a snapshot alongside live
+// events safe in any interleaving (C6): a snapshot's stale in-flight copy can
+// never regress a completion that already arrived live, and a duplicate final
+// can never re-render one. In-place replacement keeps every other row's index
+// stable, and the ID-anchored cursor (resolveRequestCursor) rides along on its
+// row regardless. The scan runs newest-first, since that's where a live
+// in-flight row lives.
+//
+// Records with no ID (never produced by either proxy path) always append: they
+// have no identity to merge on.
+func (b *BaseModel) mergeProxyRequest(req proxy.RequestRecord) {
 	if req.ID != "" {
 		for i := len(b.proxyRequests) - 1; i >= 0; i-- {
-			if b.proxyRequests[i].ID == req.ID {
-				b.proxyRequests[i] = req
-				replaced = true
-				break
+			if b.proxyRequests[i].ID != req.ID {
+				continue
 			}
-		}
-	}
-	if !replaced {
-		b.proxyRequests = append(b.proxyRequests, req)
-		// Keep only last requests - create new slice to release memory from old requests
-		if len(b.proxyRequests) > maxProxyRequests {
-			newRequests := make([]proxy.RequestRecord, maxProxyRequests)
-			copy(newRequests, b.proxyRequests[len(b.proxyRequests)-maxProxyRequests:])
-			b.proxyRequests = newRequests
+			if b.proxyRequests[i].InFlight {
+				b.proxyRequests[i] = req
+			} // else: final is terminal
+			return
 		}
 	}
 
+	b.proxyRequests = append(b.proxyRequests, req)
+	// Keep only last requests - create new slice to release memory from old requests
+	if len(b.proxyRequests) > maxProxyRequests {
+		newRequests := make([]proxy.RequestRecord, maxProxyRequests)
+		copy(newRequests, b.proxyRequests[len(b.proxyRequests)-maxProxyRequests:])
+		b.proxyRequests = newRequests
+	}
+}
+
+// renderAfterProxyRequests is the shared render tail for request arrivals —
+// one live record or a whole sync batch. Batches deliberately share it so a
+// 1000-record replay costs exactly one render.
+func (b *BaseModel) renderAfterProxyRequests() {
 	// In the detail view an arrival updates only the list data: the viewport is
 	// showing the open detail, so re-rendering/scrolling it would yank the
 	// reader (today's GotoBottom wart). No follow change either. C4 layers the
@@ -272,6 +308,69 @@ func (b *BaseModel) handleProxyRequest(req proxy.RequestRecord) {
 	} else if b.followMode {
 		b.viewport.GotoBottom()
 	}
+}
+
+// handleRequestsSync applies one completed stream synchronization (C6): the
+// REST snapshot oldest-first, then the events buffered during the fetch in
+// arrival order, all through the monotonic merge — so any interleaving of
+// {snapshot copy, live copy, completion} converges on the final record with no
+// duplicate rows and no regressions.
+//
+// Everything renders ONCE at the end: a full 1000-record ring replay must not
+// re-render a thousand times. Cursor and follow semantics are unchanged because
+// they live in that single updateViewport — the cursor is ID-anchored, so a
+// user parked on a row keeps it, and follow mode re-pins to the newest row.
+func (b *BaseModel) handleRequestsSync(msg RequestsSyncMsg) {
+	seen := make(map[string]struct{}, len(msg.Snapshot)+len(msg.Buffered))
+	for _, req := range msg.Snapshot {
+		seen[req.ID] = struct{}{}
+		b.mergeProxyRequest(req)
+	}
+	for _, req := range msg.Buffered {
+		seen[req.ID] = struct{}{}
+		b.mergeProxyRequest(req)
+	}
+
+	b.sweepPriorEpochInFlight(seen)
+	b.renderAfterProxyRequests()
+}
+
+// sweepPriorEpochInFlight marks every still-in-flight row the sync did not
+// account for as stale. Such a row belongs to a dead epoch: the server we just
+// synchronized against has no record of it, so no completion event for it can
+// ever arrive and it would otherwise sit spinning "...ms" forever. seen holds
+// the IDs the sync batch carried (snapshot plus buffered live events), so a
+// request that legitimately started during the fetch is never swept.
+//
+// The mark is TUI-local: staleness on a proxy.RequestRecord is derived from its
+// age (StaleAt), and back-dating a record's Timestamp to force that would
+// corrupt the time column. The map is rebuilt from the live list on every sweep,
+// so it cannot grow past the list.
+func (b *BaseModel) sweepPriorEpochInFlight(seen map[string]struct{}) {
+	stale := make(map[string]bool)
+	for _, req := range b.proxyRequests {
+		if !req.InFlight || req.ID == "" {
+			continue
+		}
+		if _, ok := seen[req.ID]; ok {
+			continue
+		}
+		stale[req.ID] = true
+	}
+	b.staleRequests = stale
+}
+
+// requestIsStale reports whether a row renders as stale (D8, #53): either it
+// has been in-flight past constants.InFlightStaleAfter, or a sync batch swept
+// it as prior-epoch. Final records are never stale under either rule, which is
+// also why a swept row that later completes needs no explicit unmarking: the
+// in-flight gate below short-circuits before the map is consulted, and the next
+// sweep rebuilds the map from scratch anyway.
+func (b *BaseModel) requestIsStale(req proxy.RequestRecord) bool {
+	if !req.InFlight {
+		return false
+	}
+	return req.StaleAt(time.Now()) || b.staleRequests[req.ID]
 }
 
 // handleFilterKey handles keys in filter mode
@@ -1446,7 +1545,7 @@ func (b *BaseModel) formatProxyRequest(req proxy.RequestRecord) string {
 	durationMs := req.Duration.Milliseconds()
 	var duration string
 	switch {
-	case req.StaleAt(time.Now()):
+	case b.requestIsStale(req):
 		duration = "stale?"
 	case req.InFlight:
 		duration = "  ...ms"

--- a/internal/tui/base.go
+++ b/internal/tui/base.go
@@ -191,11 +191,21 @@ func (b *BaseModel) handleWindowSize(msg tea.WindowSizeMsg) {
 	}
 }
 
-// handleLogEntry handles a new log entry message
+// handleLogEntry handles a new log entry message: one append followed by one
+// render.
 func (b *BaseModel) handleLogEntry(entry domain.LogEntry) {
 	// Check if we're at/near bottom BEFORE adding new content
 	wasNearBottom := b.isNearBottom()
+	b.appendLogEntry(entry)
+	b.renderAfterLogEntries(wasNearBottom)
+}
 
+// appendLogEntry stamps one entry and appends it to the ring WITHOUT
+// rendering. Split out of handleLogEntry so a sync batch (C9) can apply a
+// thousand entries and render once; every arrival path — live entry, batch
+// entry, synthetic notice — goes through here, so the DisplaySeq stamping and
+// the eviction trim are identical for all of them.
+func (b *BaseModel) appendLogEntry(entry domain.LogEntry) {
 	// Stamp a session-local monotonic DisplaySeq so the logs search cursor can
 	// anchor to this line's identity across the front-eviction ring below. This
 	// overwrites nothing on the wire: the server's LogEntry.Seq is a separate
@@ -209,6 +219,14 @@ func (b *BaseModel) handleLogEntry(entry domain.LogEntry) {
 		copy(newEntries, b.logEntries[len(b.logEntries)-maxLogEntries:])
 		b.logEntries = newEntries
 	}
+}
+
+// renderAfterLogEntries is the shared render tail for log arrivals — one live
+// entry or a whole sync batch. wasNearBottom is the viewport's position
+// sampled BEFORE the entries were appended (its meaning is lost afterwards).
+// Batches deliberately share it so a 1000-entry replay costs exactly one
+// render, mirroring renderAfterProxyRequests.
+func (b *BaseModel) renderAfterLogEntries(wasNearBottom bool) {
 	b.updateViewport()
 
 	// If user was at bottom, re-enable follow mode and stay at bottom — UNLESS an
@@ -225,6 +243,34 @@ func (b *BaseModel) handleLogEntry(entry domain.LogEntry) {
 	} else if b.followMode {
 		b.viewport.GotoBottom()
 	}
+}
+
+// handleLogsSync applies one completed logs-stream synchronization (C9): the
+// optional notice line first, then the batch entries oldest-first, then ONE
+// render.
+//
+// The handler is deliberately dumb — append, don't merge. All the hard parts
+// (which entries to fetch, epoch changes, dropping entries this model has
+// already been shown) live in the sync layer, which excludes overlap by
+// cursor BEFORE delivery (logs_sync.go). Log lines have no identity to merge
+// on the way proxy requests do (the same line can legitimately repeat), so a
+// model-side dedupe is not available even in principle.
+//
+// Entries that predate an epoch change stay in the list as history: they are
+// what the previous daemon run printed, and the notice line marks the seam.
+func (b *BaseModel) handleLogsSync(msg LogsSyncMsg) {
+	if msg.Notice == "" && len(msg.Entries) == 0 {
+		return // nothing changed: a caught-up reconnect must not force a render
+	}
+
+	wasNearBottom := b.isNearBottom()
+	if msg.Notice != "" {
+		b.appendLogEntry(systemLogEntry(msg.Notice))
+	}
+	for _, entry := range msg.Entries {
+		b.appendLogEntry(entry)
+	}
+	b.renderAfterLogEntries(wasNearBottom)
 }
 
 // handleProxyRequest handles a new proxy request message: one monotonic merge

--- a/internal/tui/base.go
+++ b/internal/tui/base.go
@@ -81,15 +81,16 @@ type BaseModel struct {
 	logSearchQuery string
 
 	// logSeq is a session-local monotonic counter stamped onto each ingested
-	// LogEntry.Seq. The logs cursor is anchored by Seq, not index, so it rides
-	// the 1000-entry front-eviction ring without drifting (a bare index would
-	// shift when old entries are dropped — see LogEntry.Seq) (D7).
+	// LogEntry.DisplaySeq. The logs cursor is anchored by DisplaySeq, not index,
+	// so it rides the 1000-entry front-eviction ring without drifting (a bare
+	// index would shift when old entries are dropped — see LogEntry.DisplaySeq).
+	// This is unrelated to LogEntry.Seq, the server ingest sequence (D7).
 	logSeq int64
 
-	// Logs-view search cursor (Seq-anchored). logCursorSeq names the line the
-	// cursor sits on; logCursorIdx is its index in the filtered list. Both are
+	// Logs-view search cursor (DisplaySeq-anchored). logCursorSeq names the line
+	// the cursor sits on; logCursorIdx is its index in the filtered list. Both are
 	// mutated ONLY through setLogCursor so they can never disagree. logCursorSeq
-	// 0 is the explicit no-cursor sentinel (ingested Seqs are always >= 1), and
+	// 0 is the explicit no-cursor sentinel (stamped DisplaySeqs are always >= 1), and
 	// logCursorIdx -1 pairs with it. Unlike the requests cursor, this one exists
 	// only while a `/`-search is active and is not scroll-coupled: j/k keep
 	// scrolling the viewport, and resolveLogCursor only re-derives the marker
@@ -195,10 +196,12 @@ func (b *BaseModel) handleLogEntry(entry domain.LogEntry) {
 	// Check if we're at/near bottom BEFORE adding new content
 	wasNearBottom := b.isNearBottom()
 
-	// Stamp a session-local monotonic Seq so the logs search cursor can anchor
-	// to this line's identity across the front-eviction ring below (D7).
+	// Stamp a session-local monotonic DisplaySeq so the logs search cursor can
+	// anchor to this line's identity across the front-eviction ring below. This
+	// overwrites nothing on the wire: the server's LogEntry.Seq is a separate
+	// field and is left untouched (D7).
 	b.logSeq++
-	entry.Seq = b.logSeq
+	entry.DisplaySeq = b.logSeq
 	b.logEntries = append(b.logEntries, entry)
 	// Keep only last entries - create new slice to release memory from old entries
 	if len(b.logEntries) > maxLogEntries {
@@ -843,7 +846,7 @@ func (b *BaseModel) seekLogSearchMatch(dir int) {
 
 // logSearchOriginIdx returns the index in entries from which a seek should
 // begin. With a cursor already anchored (logCursorSeq set), it re-resolves that
-// Seq to its current index — surviving the eviction ring — and clamps the
+// DisplaySeq to its current index — surviving the eviction ring — and clamps the
 // last-known index when the anchored line has been evicted. On the FIRST search
 // (no cursor yet), it seeds from what the user is looking at: the newest row
 // under follow, else the top visible row derived from the viewport offset, so
@@ -852,7 +855,7 @@ func (b *BaseModel) logSearchOriginIdx(entries []domain.LogEntry) int {
 	n := len(entries)
 	if b.logCursorSeq != 0 {
 		for i, e := range entries {
-			if e.Seq == b.logCursorSeq {
+			if e.DisplaySeq == b.logCursorSeq {
 				return i
 			}
 		}
@@ -901,14 +904,14 @@ func (b *BaseModel) setLogCursor(entries []domain.LogEntry, idx int) {
 	}
 	idx = clampIndex(idx, len(entries))
 	b.logCursorIdx = idx
-	b.logCursorSeq = entries[idx].Seq
+	b.logCursorSeq = entries[idx].DisplaySeq
 }
 
 // resolveLogCursor re-anchors the logs search cursor against the current
 // filtered list at render time (called from updateViewport only while a search
 // is active), so the row marker stays on the searched-to line as entries stream
 // in and the eviction ring shifts indices. Mirrors resolveRequestCursor but
-// anchors by Seq (logs have no ID) and NEVER scrolls — the logs viewport scroll
+// anchors by DisplaySeq (logs have no ID) and NEVER scrolls — the logs viewport scroll
 // stays owned by j/k, follow, and the one-shot ensureLogCursorVisible.
 //
 // Unlike the requests cursor (which always exists), the logs cursor is
@@ -932,7 +935,7 @@ func (b *BaseModel) resolveLogCursor(entries []domain.LogEntry) {
 		return
 	}
 	for i, e := range entries {
-		if e.Seq == b.logCursorSeq {
+		if e.DisplaySeq == b.logCursorSeq {
 			b.setLogCursor(entries, i)
 			return
 		}

--- a/internal/tui/client.go
+++ b/internal/tui/client.go
@@ -1,12 +1,14 @@
 package tui
 
 import (
+	"errors"
+
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/charliek/prox/internal/api"
-	"github.com/charliek/prox/internal/constants"
 	"github.com/charliek/prox/internal/domain"
 	"github.com/charliek/prox/internal/proxy"
+	"github.com/charliek/prox/internal/stream"
 )
 
 // ClientModel is the bubbletea model for TUI client mode (connected via API)
@@ -16,8 +18,12 @@ type ClientModel struct {
 	// Dependencies
 	client TUIClient
 
-	// Connection state
-	connectionError error // Last API connection error, nil if connected
+	// connectionError is the attach session's global connection state, DERIVED
+	// (C12) from the processes stream's health rather than reported by any
+	// failing call: nothing polls any more, so there is no request left to fail
+	// and produce it. noteProcessesStreamHealth owns every write; nil means
+	// connected.
+	connectionError error
 
 	// detailFetchSeq counts every fetchRequestDetail call (Enter and D16's
 	// background live-refresh alike); each call's closure captures its own
@@ -41,46 +47,55 @@ func NewClientModel(client TUIClient) ClientModel {
 	}
 }
 
-// Init initializes the model
+// Init has nothing to do. Attach mode has no periodic work left: every feed —
+// logs, requests and, since C12, processes — is pushed by a stream loop that
+// RunClient starts alongside the program, and the processes stream's
+// snapshot-on-connect delivers the initial process list without anyone asking
+// for it. The method stays because tea.Model requires it.
 func (m ClientModel) Init() tea.Cmd {
-	return tea.Batch(
-		m.fetchProcesses(),
-		tickCmd(constants.TUILocalTickInterval),
-	)
+	return nil
 }
 
-// fetchProcesses returns a command to fetch processes from the API
-func (m ClientModel) fetchProcesses() tea.Cmd {
-	return func() tea.Msg {
-		resp, err := m.client.GetProcesses()
-		if err != nil {
-			return ClientErrorMsg{Err: err}
-		}
+// errProcessesStreamLost is the connection error shown when the processes
+// stream dropped without an error of its own (the daemon closed the stream
+// cleanly, e.g. a shutdown mid-attach).
+var errProcessesStreamLost = errors.New("connection to the prox daemon was lost")
 
-		// Convert API response to domain ProcessInfo
-		// Note: ProcessState is cast directly from the status string.
-		// Known valid states: starting, running, stopping, stopped, failed.
-		// Unknown states will result in default styling in the TUI.
-		processes := make([]domain.ProcessInfo, len(resp.Processes))
-		for i, p := range resp.Processes {
-			processes[i] = domain.ProcessInfo{
-				Name:         p.Name,
-				State:        domain.ProcessState(p.Status),
-				PID:          p.PID,
-				RestartCount: p.Restarts,
-				Health:       domain.HealthStatus(p.Health),
-				Kind:         domain.ProcessKind(p.Kind),
-				WaitingOn:    p.WaitingOn,
-				BlockedOn:    p.BlockedOn,
-			}
-		}
-		return ProcessesMsg(processes)
+// errProcessesStreamUnsupported is the version-skew case: the loop parks on a
+// 404 (classifyProcessesStreamError), which means the daemon predates the
+// processes stream and no reconnect can help until it is replaced.
+var errProcessesStreamUnsupported = errors.New("the prox daemon is too old to push process state; restart it on this prox version")
+
+// noteProcessesStreamHealth derives connectionError from the processes stream's
+// health. That stream is attach mode's liveness signal — it is the one feed
+// whose absence means the whole view is stale, and the only one that exists on
+// every daemon regardless of configuration (the requests feed is off whenever
+// the proxy is) — so its state, and only its state, drives the status line's
+// "Connection error (retrying...)".
+//
+// Reconnecting and Closed are outages; Unavailable is the old-daemon park.
+// Only OK clears the error: the loop emits Syncing before every retry DIALS,
+// so clearing on Syncing/Connecting would flip the banner back to "Connected"
+// for the whole life of a dial that may hang for its full 30s header timeout
+// against a blackholed daemon (codex C12 finding). During startup neither
+// state sets nor clears anything — connectionError is nil until the first
+// degradation.
+func (m *ClientModel) noteProcessesStreamHealth(msg StreamStatusMsg) {
+	if msg.Stream != StreamProcesses {
+		return
 	}
-}
-
-// ClientErrorMsg is sent when an API error occurs
-type ClientErrorMsg struct {
-	Err error
+	switch msg.Status.State {
+	case stream.StateReconnecting, stream.StateClosed:
+		if msg.Status.Err != nil {
+			m.connectionError = msg.Status.Err
+		} else {
+			m.connectionError = errProcessesStreamLost
+		}
+	case stream.StateUnavailable:
+		m.connectionError = errProcessesStreamUnsupported
+	case stream.StateOK:
+		m.connectionError = nil
+	}
 }
 
 // Update handles messages
@@ -140,22 +155,20 @@ func (m ClientModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case StreamStatusMsg:
 		m.handleStreamStatus(msg)
+		m.noteProcessesStreamHealth(msg)
 
 	case ProcessesMsg:
+		// One full snapshot off the processes stream (C12). connectionError is
+		// deliberately NOT touched here: it is derived from stream health
+		// alone, and the OK transition that precedes the first snapshot has
+		// already cleared it.
 		m.processes = []domain.ProcessInfo(msg)
-		m.connectionError = nil // Clear error on successful fetch
 		// Update filter map with any new processes
 		for _, p := range m.processes {
 			if _, ok := m.filterProcesses[p.Name]; !ok {
 				m.filterProcesses[p.Name] = true
 			}
 		}
-
-	case ClientErrorMsg:
-		// Note: No automatic reconnection is attempted. If daemon stops,
-		// user must quit (q) and re-run 'prox attach'. This is intentional
-		// to avoid masking daemon failures.
-		m.connectionError = msg.Err
 
 	case RestartResultMsg:
 		m.lastRestartProcess = msg.Process
@@ -203,11 +216,6 @@ func (m ClientModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			m.updateViewport()
 		}
-
-	case TickMsg:
-		// Refresh processes periodically
-		cmds = append(cmds, m.fetchProcesses())
-		cmds = append(cmds, tickCmd(constants.TUILocalTickInterval))
 	}
 
 	// Handle viewport updates
@@ -355,7 +363,19 @@ func (m ClientModel) View() string {
 		return m.helpView()
 	default:
 		statusInfo := "Connected via API"
-		if m.connectionError != nil {
+		if errors.Is(m.connectionError, errProcessesStreamUnsupported) {
+			// The old-daemon park is not an outage and never self-heals by
+			// waiting, so "retrying..." would be a lie — render the actionable
+			// hint instead.
+			statusInfo = truncateError(m.connectionError, maxErrorDisplayLen)
+		} else if m.connectionError != nil && m.streamHealth[StreamProcesses].State == stream.StateClosed {
+			// Terminal: the loop is gone (auth failure classified terminal, or
+			// quit teardown) and no retry will ever happen — promising one
+			// would be a lie too (codex C12 finding).
+			statusInfo = "Connection lost: " + truncateError(m.connectionError, maxErrorDisplayLen)
+		} else if m.connectionError != nil {
+			// One wording for every transient degraded processes-stream state:
+			// the per-stream detail lives in the status bar's health segments.
 			statusInfo = "Connection error (retrying...)"
 		} else if m.lastRestartProcess != "" {
 			if m.lastRestartError != nil {

--- a/internal/tui/client.go
+++ b/internal/tui/client.go
@@ -112,6 +112,27 @@ func (m ClientModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, m.fetchRequestDetail(record.ID, m.detailFetchSeq))
 		}
 
+	case RequestsSyncMsg:
+		// One batch, one render (C6). Attach mode only: local mode reads the
+		// request ring directly and has nothing to synchronize against.
+		m.handleRequestsSync(msg)
+		// D16 also applies to a completion that arrives via the sync batch
+		// instead of a live event: an open detail still showing an in-flight
+		// snapshot must refetch once its row went final. Guarded on the
+		// detail's own in-flight state (unlike the live path, which fires at
+		// most once per ID by upsert monotonicity) so routine reconnect syncs
+		// don't refetch an already-final detail on every re-sync.
+		if m.viewMode == ViewModeRequestDetail && m.selectedRequestID != "" &&
+			(m.requestDetail == nil || m.requestDetail.InFlight) {
+			for _, r := range m.proxyRequests {
+				if r.ID == m.selectedRequestID && !r.InFlight {
+					m.detailFetchSeq++
+					cmds = append(cmds, m.fetchRequestDetail(r.ID, m.detailFetchSeq))
+					break
+				}
+			}
+		}
+
 	case StreamStatusMsg:
 		m.handleStreamStatus(msg)
 

--- a/internal/tui/client.go
+++ b/internal/tui/client.go
@@ -99,6 +99,11 @@ func (m ClientModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case LogEntryMsg:
 		m.handleLogEntry(domain.LogEntry(msg))
 
+	case LogsSyncMsg:
+		// One batch, one render (C9). Attach mode only: local mode reads the
+		// log manager's ring directly and has nothing to synchronize against.
+		m.handleLogsSync(msg)
+
 	case ProxyRequestMsg:
 		record := proxy.RequestRecord(msg)
 		m.handleProxyRequest(record)

--- a/internal/tui/client.go
+++ b/internal/tui/client.go
@@ -4,6 +4,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/charliek/prox/internal/api"
+	"github.com/charliek/prox/internal/constants"
 	"github.com/charliek/prox/internal/domain"
 	"github.com/charliek/prox/internal/proxy"
 )
@@ -44,7 +45,7 @@ func NewClientModel(client TUIClient) ClientModel {
 func (m ClientModel) Init() tea.Cmd {
 	return tea.Batch(
 		m.fetchProcesses(),
-		tickCmd(),
+		tickCmd(constants.TUILocalTickInterval),
 	)
 }
 
@@ -177,7 +178,7 @@ func (m ClientModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case TickMsg:
 		// Refresh processes periodically
 		cmds = append(cmds, m.fetchProcesses())
-		cmds = append(cmds, tickCmd())
+		cmds = append(cmds, tickCmd(constants.TUILocalTickInterval))
 	}
 
 	// Handle viewport updates

--- a/internal/tui/client.go
+++ b/internal/tui/client.go
@@ -112,6 +112,9 @@ func (m ClientModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, m.fetchRequestDetail(record.ID, m.detailFetchSeq))
 		}
 
+	case StreamStatusMsg:
+		m.handleStreamStatus(msg)
+
 	case ProcessesMsg:
 		m.processes = []domain.ProcessInfo(msg)
 		m.connectionError = nil // Clear error on successful fetch

--- a/internal/tui/client_model_test.go
+++ b/internal/tui/client_model_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"sync"
@@ -32,13 +33,13 @@ func (s *stubTUIClient) GetProcesses() (*api.ProcessListResponse, error) {
 
 func (s *stubTUIClient) RestartProcess(string) error { return nil }
 
-func (s *stubTUIClient) StreamLogsChannel(domain.LogParams) (<-chan api.LogEntryResponse, error) {
+func (s *stubTUIClient) StreamLogsChannel(context.Context, domain.LogParams) (<-chan api.LogEntryResponse, error) {
 	ch := make(chan api.LogEntryResponse)
 	close(ch)
 	return ch, nil
 }
 
-func (s *stubTUIClient) StreamProxyRequestsChannel(domain.ProxyRequestParams) (<-chan api.ProxyRequestResponse, error) {
+func (s *stubTUIClient) StreamProxyRequestsChannel(context.Context, domain.ProxyRequestParams) (<-chan api.ProxyRequestResponse, error) {
 	ch := make(chan api.ProxyRequestResponse)
 	close(ch)
 	return ch, nil

--- a/internal/tui/client_model_test.go
+++ b/internal/tui/client_model_test.go
@@ -36,6 +36,14 @@ type stubTUIClient struct {
 	// connection, skip it to model a dead-on-arrival dial.
 	consumeLogs     func(ctx context.Context, onConnect func(), onEvent func(api.LogEntryResponse)) error
 	consumeRequests func(ctx context.Context, onConnect func(), onEvent func(api.ProxyRequestResponse)) error
+
+	// snapshot is the requests-sync REST payload (newest-first, as the real
+	// endpoint returns). nil means an empty snapshot. snapshotErr, when set,
+	// fails every fetch; snapshotCalls counts them.
+	snapshot     []api.ProxyRequestResponse
+	snapshotErr  error
+	snapshotCall func(n int) // optional per-call hook; n is the 1-based call count
+	snapshotN    int         // number of GetProxyRequests calls made
 }
 
 func (s *stubTUIClient) GetProcesses() (*api.ProcessListResponse, error) {
@@ -75,6 +83,32 @@ func (s *stubTUIClient) GetProxyRequest(id string, _ bool) (*api.ProxyRequestDet
 	return &api.ProxyRequestDetailResponse{
 		ProxyRequestResponse: api.ProxyRequestResponse{ID: id},
 	}, nil
+}
+
+func (s *stubTUIClient) GetProxyRequests(ctx context.Context, _ domain.ProxyRequestParams) (*api.ProxyRequestsResponse, error) {
+	s.mu.Lock()
+	s.snapshotN++
+	n := s.snapshotN
+	hook, err, records := s.snapshotCall, s.snapshotErr, s.snapshot
+	s.mu.Unlock()
+
+	if hook != nil {
+		hook(n)
+	}
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &api.ProxyRequestsResponse{Requests: records}, nil
+}
+
+// snapshotCalls returns how many times GetProxyRequests has been called.
+func (s *stubTUIClient) snapshotCalls() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.snapshotN
 }
 
 // lastRequestedID returns the most recent GetProxyRequest id, or "".

--- a/internal/tui/client_model_test.go
+++ b/internal/tui/client_model_test.go
@@ -20,11 +20,22 @@ import (
 // responses, so ClientModel Enter/detail flows can be exercised without a live
 // daemon. Shared C2 deliverable — C4 reuses it for the attach-mode
 // detail-refresh tests.
+// The Consume* stubs block until ctx is cancelled by default — a quiet,
+// never-ending stream. Returning immediately would spin a reconnect loop, so a
+// test that wants scripted events or a specific failure sets the matching hook
+// instead.
 type stubTUIClient struct {
 	mu           sync.Mutex
 	requestedIDs []string // every GetProxyRequest id, in call order
 	detailResp   *api.ProxyRequestDetailResponse
 	detailErr    error
+
+	// Optional per-stream attempt behavior; nil means "connect successfully,
+	// then block until cancelled" (onConnect fires, no events). A scripted
+	// hook owns the onConnect call: invoke it to model an established
+	// connection, skip it to model a dead-on-arrival dial.
+	consumeLogs     func(ctx context.Context, onConnect func(), onEvent func(api.LogEntryResponse)) error
+	consumeRequests func(ctx context.Context, onConnect func(), onEvent func(api.ProxyRequestResponse)) error
 }
 
 func (s *stubTUIClient) GetProcesses() (*api.ProcessListResponse, error) {
@@ -33,16 +44,22 @@ func (s *stubTUIClient) GetProcesses() (*api.ProcessListResponse, error) {
 
 func (s *stubTUIClient) RestartProcess(string) error { return nil }
 
-func (s *stubTUIClient) StreamLogsChannel(context.Context, domain.LogParams) (<-chan api.LogEntryResponse, error) {
-	ch := make(chan api.LogEntryResponse)
-	close(ch)
-	return ch, nil
+func (s *stubTUIClient) ConsumeLogs(ctx context.Context, _ domain.LogParams, onConnect func(), onEvent func(api.LogEntryResponse)) error {
+	if s.consumeLogs != nil {
+		return s.consumeLogs(ctx, onConnect, onEvent)
+	}
+	onConnect()
+	<-ctx.Done()
+	return ctx.Err()
 }
 
-func (s *stubTUIClient) StreamProxyRequestsChannel(context.Context, domain.ProxyRequestParams) (<-chan api.ProxyRequestResponse, error) {
-	ch := make(chan api.ProxyRequestResponse)
-	close(ch)
-	return ch, nil
+func (s *stubTUIClient) ConsumeProxyRequests(ctx context.Context, _ domain.ProxyRequestParams, onConnect func(), onEvent func(api.ProxyRequestResponse)) error {
+	if s.consumeRequests != nil {
+		return s.consumeRequests(ctx, onConnect, onEvent)
+	}
+	onConnect()
+	<-ctx.Done()
+	return ctx.Err()
 }
 
 func (s *stubTUIClient) GetProxyRequest(id string, _ bool) (*api.ProxyRequestDetailResponse, error) {

--- a/internal/tui/client_model_test.go
+++ b/internal/tui/client_model_test.go
@@ -31,10 +31,12 @@ type stubTUIClient struct {
 	detailErr    error
 
 	// Optional per-stream attempt behavior; nil means "connect successfully,
-	// then block until cancelled" (onConnect fires, no events). A scripted
-	// hook owns the onConnect call: invoke it to model an established
-	// connection, skip it to model a dead-on-arrival dial.
-	consumeLogs     func(ctx context.Context, onConnect func(), onEvent func(api.LogEntryResponse)) error
+	// announce the default log epoch, then block until cancelled" (onConnect
+	// and — for logs — onHandshake fire, no events). A scripted hook owns both
+	// calls: invoke onConnect to model an established connection, skip it to
+	// model a dead-on-arrival dial; invoke onHandshake to model a C8+ daemon,
+	// skip it to model an old one that sends no handshake.
+	consumeLogs     func(ctx context.Context, onConnect func(), onHandshake func(api.HandshakeResponse), onEvent func(api.LogEntryResponse)) error
 	consumeRequests func(ctx context.Context, onConnect func(), onEvent func(api.ProxyRequestResponse)) error
 
 	// snapshot is the requests-sync REST payload (newest-first, as the real
@@ -44,7 +46,18 @@ type stubTUIClient struct {
 	snapshotErr  error
 	snapshotCall func(n int) // optional per-call hook; n is the 1-based call count
 	snapshotN    int         // number of GetProxyRequests calls made
+
+	// logsResponder backs the C9 logs-sync backfill (GetLogs): it owns the
+	// response for each call, so a test can serve a different payload per
+	// attempt (n is the 1-based call count). nil means an empty response.
+	// logsParams records every call's params, in order.
+	logsResponder func(n int, params domain.LogParams) (*api.LogsResponse, error)
+	logsParams    []domain.LogParams
 }
+
+// stubLogEpoch is the stream_id the default ConsumeLogs stub announces. Tests
+// that script their own handshake pick their own.
+const stubLogEpoch = "epoch-stub"
 
 func (s *stubTUIClient) GetProcesses() (*api.ProcessListResponse, error) {
 	return &api.ProcessListResponse{}, nil
@@ -52,13 +65,39 @@ func (s *stubTUIClient) GetProcesses() (*api.ProcessListResponse, error) {
 
 func (s *stubTUIClient) RestartProcess(string) error { return nil }
 
-func (s *stubTUIClient) ConsumeLogs(ctx context.Context, _ domain.LogParams, onConnect func(), onEvent func(api.LogEntryResponse)) error {
+func (s *stubTUIClient) ConsumeLogs(ctx context.Context, _ domain.LogParams, onConnect func(), onHandshake func(api.HandshakeResponse), onEvent func(api.LogEntryResponse)) error {
 	if s.consumeLogs != nil {
-		return s.consumeLogs(ctx, onConnect, onEvent)
+		return s.consumeLogs(ctx, onConnect, onHandshake, onEvent)
 	}
 	onConnect()
+	onHandshake(api.HandshakeResponse{StreamID: stubLogEpoch})
 	<-ctx.Done()
 	return ctx.Err()
+}
+
+// GetLogs serves the logs-sync backfill. Params are recorded so tests can pin
+// the full-fetch vs since_seq-resume decision.
+func (s *stubTUIClient) GetLogs(ctx context.Context, params domain.LogParams) (*api.LogsResponse, error) {
+	s.mu.Lock()
+	s.logsParams = append(s.logsParams, params)
+	n := len(s.logsParams)
+	responder := s.logsResponder
+	s.mu.Unlock()
+
+	if responder != nil {
+		return responder(n, params)
+	}
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	return &api.LogsResponse{}, nil
+}
+
+// logsCalls returns the params of every GetLogs call, in order.
+func (s *stubTUIClient) logsCalls() []domain.LogParams {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]domain.LogParams(nil), s.logsParams...)
 }
 
 func (s *stubTUIClient) ConsumeProxyRequests(ctx context.Context, _ domain.ProxyRequestParams, onConnect func(), onEvent func(api.ProxyRequestResponse)) error {

--- a/internal/tui/client_model_test.go
+++ b/internal/tui/client_model_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/assert"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/charliek/prox/internal/api"
 	"github.com/charliek/prox/internal/domain"
+	"github.com/charliek/prox/internal/stream"
 )
 
 // stubTUIClient is a test double for the TUIClient interface (app.go). It
@@ -36,8 +38,18 @@ type stubTUIClient struct {
 	// calls: invoke onConnect to model an established connection, skip it to
 	// model a dead-on-arrival dial; invoke onHandshake to model a C8+ daemon,
 	// skip it to model an old one that sends no handshake.
-	consumeLogs     func(ctx context.Context, onConnect func(), onHandshake func(api.HandshakeResponse), onEvent func(api.LogEntryResponse)) error
-	consumeRequests func(ctx context.Context, onConnect func(), onEvent func(api.ProxyRequestResponse)) error
+	consumeLogs      func(ctx context.Context, onConnect func(), onHandshake func(api.HandshakeResponse), onEvent func(api.LogEntryResponse)) error
+	consumeRequests  func(ctx context.Context, onConnect func(), onEvent func(api.ProxyRequestResponse)) error
+	consumeProcesses func(ctx context.Context, onConnect func(), onEvent func(api.ProcessListResponse)) error
+
+	// processesN counts ConsumeProcesses attempts, so a test can watch the
+	// processes loop reconnect. getProcessesN counts REST GetProcesses calls,
+	// which C12 expects to stay at zero for the whole attach session: the
+	// method is no longer on TUIClient at all, and this counter is the
+	// runtime half of that proof.
+	processesN    int
+	requestsN     int
+	getProcessesN int
 
 	// snapshot is the requests-sync REST payload (newest-first, as the real
 	// endpoint returns). nil means an empty snapshot. snapshotErr, when set,
@@ -59,8 +71,46 @@ type stubTUIClient struct {
 // that script their own handshake pick their own.
 const stubLogEpoch = "epoch-stub"
 
+// GetProcesses is deliberately kept on the stub even though C12 removed it from
+// the TUIClient interface: it is the tripwire for a poll creeping back in. If
+// some future code path reaches for REST process state, this counter catches it
+// (see TestClientModel_NeverPollsProcesses).
 func (s *stubTUIClient) GetProcesses() (*api.ProcessListResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.getProcessesN++
 	return &api.ProcessListResponse{}, nil
+}
+
+// getProcessesCalls returns how many times the REST process poll was called.
+func (s *stubTUIClient) getProcessesCalls() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.getProcessesN
+}
+
+// ConsumeProcesses stands in for the processes stream. The default is a
+// connected, silent stream: onConnect fires (which is the whole sync barrier
+// for this stream) and nothing is ever delivered.
+func (s *stubTUIClient) ConsumeProcesses(ctx context.Context, onConnect func(), onEvent func(api.ProcessListResponse)) error {
+	s.mu.Lock()
+	s.processesN++
+	hook := s.consumeProcesses
+	s.mu.Unlock()
+
+	if hook != nil {
+		return hook(ctx, onConnect, onEvent)
+	}
+	onConnect()
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+// processesCalls returns how many ConsumeProcesses attempts have been made.
+func (s *stubTUIClient) processesCalls() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.processesN
 }
 
 func (s *stubTUIClient) RestartProcess(string) error { return nil }
@@ -101,12 +151,25 @@ func (s *stubTUIClient) logsCalls() []domain.LogParams {
 }
 
 func (s *stubTUIClient) ConsumeProxyRequests(ctx context.Context, _ domain.ProxyRequestParams, onConnect func(), onEvent func(api.ProxyRequestResponse)) error {
-	if s.consumeRequests != nil {
-		return s.consumeRequests(ctx, onConnect, onEvent)
+	s.mu.Lock()
+	s.requestsN++
+	hook := s.consumeRequests
+	s.mu.Unlock()
+
+	if hook != nil {
+		return hook(ctx, onConnect, onEvent)
 	}
 	onConnect()
 	<-ctx.Done()
 	return ctx.Err()
+}
+
+// requestsCalls returns how many ConsumeProxyRequests attempts have been made —
+// the observable that proves a parked requests loop was re-probed.
+func (s *stubTUIClient) requestsCalls() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.requestsN
 }
 
 func (s *stubTUIClient) GetProxyRequest(id string, _ bool) (*api.ProxyRequestDetailResponse, error) {
@@ -173,6 +236,163 @@ func newClientRequestsModel(stub *stubTUIClient, n, viewportHeight int) ClientMo
 func clientUpdate(m ClientModel, msg tea.Msg) ClientModel {
 	nm, _ := m.Update(msg)
 	return nm.(ClientModel)
+}
+
+// --- C12: the poll is gone; process state arrives on a stream ---
+
+// TestClientModel_NeverPollsProcesses is the panel-mandated no-poll proof.
+// Init must return no command at all, and no message the model can receive —
+// including the TickMsg the deleted poll used to ride — may produce a REST
+// process fetch. The compile-level half of the proof is that
+// ClientModel.fetchProcesses and TUIClient.GetProcesses no longer exist;
+// this is the runtime half.
+func TestClientModel_NeverPollsProcesses(t *testing.T) {
+	stub := &stubTUIClient{}
+	m := NewClientModel(stub)
+
+	require.Nil(t, m.Init(), "attach mode has no periodic work left")
+
+	// A synthetic tick must be inert (the case was deleted, not repurposed).
+	_, cmd := m.Update(TickMsg(time.Now()))
+	if cmd != nil {
+		// tea.Batch of nothing can still be non-nil; running it must at least
+		// never produce a fetch.
+		cmd()
+	}
+
+	assert.Zero(t, stub.getProcessesCalls(), "nothing in attach mode may poll REST /processes")
+}
+
+// TestClientModel_ProcessesMsgUpdatesListAndFilterMap pins that a snapshot
+// delivered by the stream lands exactly as the poll's result did: the process
+// list is replaced wholesale and every new name is registered (defaulting to
+// visible) in the filter map, while an existing name's filter choice is left
+// alone.
+func TestClientModel_ProcessesMsgUpdatesListAndFilterMap(t *testing.T) {
+	m := NewClientModel(&stubTUIClient{})
+	m.filterProcesses["web"] = false // the user hid this one earlier
+
+	m = clientUpdate(m, ProcessesMsg([]domain.ProcessInfo{
+		{Name: "web", State: domain.ProcessState("running"), PID: 10},
+		{Name: "api", State: domain.ProcessState("starting")},
+	}))
+
+	require.Len(t, m.processes, 2)
+	assert.Equal(t, "web", m.processes[0].Name)
+	assert.Equal(t, 10, m.processes[0].PID)
+	assert.False(t, m.filterProcesses["web"], "an existing filter choice survives a snapshot")
+	assert.True(t, m.filterProcesses["api"], "a newly seen process defaults to visible")
+
+	// A later snapshot replaces the list wholesale (processes can disappear).
+	m = clientUpdate(m, ProcessesMsg([]domain.ProcessInfo{{Name: "api"}}))
+	require.Len(t, m.processes, 1)
+	assert.Equal(t, "api", m.processes[0].Name)
+}
+
+// TestClientModel_ConnectionErrorDerivedFromProcessesStream pins C12's derived
+// connectionError: the processes stream's health, and nothing else, drives the
+// status line's connection notice.
+func TestClientModel_ConnectionErrorDerivedFromProcessesStream(t *testing.T) {
+	m := readyClientModel()
+
+	// A drop reports the outage, carrying the loop's own error.
+	m = clientUpdate(m, StreamStatusMsg{
+		Stream: StreamProcesses,
+		Status: stream.Status{State: stream.StateReconnecting, Err: errors.New("connection refused")},
+	})
+	require.Error(t, m.connectionError)
+	assert.EqualError(t, m.connectionError, "connection refused")
+	assert.Contains(t, m.View(), "Connection error (retrying...)")
+	assert.NotContains(t, m.View(), "processes:", "the processes stream never renders its own segment")
+
+	// Recovery clears it.
+	m = clientUpdate(m, statusMsg(StreamProcesses, stream.StateOK))
+	assert.NoError(t, m.connectionError)
+	assert.NotContains(t, m.View(), "Connection error")
+}
+
+// TestClientModel_ConnectionErrorCleanDropHasGenericError covers the drop with
+// no error of its own (the daemon closed the stream cleanly): the notice still
+// has to say something.
+func TestClientModel_ConnectionErrorCleanDropHasGenericError(t *testing.T) {
+	m := clientUpdate(readyClientModel(), statusMsg(StreamProcesses, stream.StateReconnecting))
+
+	require.Error(t, m.connectionError)
+	assert.Equal(t, errProcessesStreamLost, m.connectionError)
+	assert.Contains(t, m.View(), "Connection error (retrying...)")
+}
+
+// TestClientModel_ConnectionErrorClosedStream pins the terminal case: a loop
+// that ended (auth failure, cancellation) is still an outage, not a clean state.
+func TestClientModel_ConnectionErrorClosedStream(t *testing.T) {
+	m := clientUpdate(readyClientModel(), StreamStatusMsg{
+		Stream: StreamProcesses,
+		Status: stream.Status{State: stream.StateClosed, Err: errors.New("api error 401")},
+	})
+
+	assert.EqualError(t, m.connectionError, "api error 401")
+	// Terminal means no retry will ever happen — the rendering must not
+	// promise one (codex C12 finding).
+	assert.Contains(t, m.View(), "Connection lost: api error 401")
+	assert.NotContains(t, m.View(), "retrying")
+}
+
+// TestClientModel_ConnectionErrorLatchedThroughRetrySyncing pins the outage
+// latch (codex C12 finding): the loop emits Syncing before every retry DIALS,
+// and a dial against a blackholed daemon can hang for its full header timeout
+// — the banner must keep reporting the outage until an attempt actually
+// reaches OK.
+func TestClientModel_ConnectionErrorLatchedThroughRetrySyncing(t *testing.T) {
+	m := clientUpdate(readyClientModel(), statusMsg(StreamProcesses, stream.StateReconnecting))
+	require.Error(t, m.connectionError)
+
+	m = clientUpdate(m, statusMsg(StreamProcesses, stream.StateSyncing))
+	assert.Error(t, m.connectionError, "a retry's pre-dial Syncing must not clear the outage")
+	assert.Contains(t, m.View(), "Connection error (retrying...)")
+
+	m = clientUpdate(m, statusMsg(StreamProcesses, stream.StateOK))
+	assert.NoError(t, m.connectionError, "only OK clears the outage")
+	assert.Contains(t, m.View(), "Connected via API")
+}
+
+// TestClientModel_ConnectionErrorOldDaemon pins the version-skew rendering: a
+// parked (404) processes stream reports the old daemon by name rather than
+// leaving the UI silently frozen on an empty process list.
+func TestClientModel_ConnectionErrorOldDaemon(t *testing.T) {
+	m := clientUpdate(readyClientModel(), statusMsg(StreamProcesses, stream.StateUnavailable))
+
+	require.Error(t, m.connectionError)
+	assert.Equal(t, errProcessesStreamUnsupported, m.connectionError)
+	assert.Contains(t, m.connectionError.Error(), "too old")
+	// The park never self-heals by waiting, so the actionable hint renders
+	// instead of the transient "retrying..." wording.
+	assert.Contains(t, m.View(), "too old")
+	assert.NotContains(t, m.View(), "Connection error (retrying...)")
+}
+
+// TestClientModel_ConnectionErrorIgnoresOtherStreams pins that the derivation
+// is processes-only: a dead logs or requests stream degrades its own status-bar
+// segment and must not claim the whole connection is down.
+func TestClientModel_ConnectionErrorIgnoresOtherStreams(t *testing.T) {
+	m := readyClientModel()
+	m = clientUpdate(m, statusMsg(StreamLogs, stream.StateReconnecting))
+	m = clientUpdate(m, statusMsg(StreamRequests, stream.StateUnavailable))
+
+	assert.NoError(t, m.connectionError)
+	view := m.View()
+	assert.NotContains(t, view, "Connection error")
+	assert.Contains(t, view, "⚠ logs: reconnecting…")
+}
+
+// TestClientModel_StartupIsQuiet pins that a fresh attach session shows no
+// connection error before any stream has reported anything.
+func TestClientModel_StartupIsQuiet(t *testing.T) {
+	m := readyClientModel()
+	assert.NoError(t, m.connectionError)
+	assert.NotContains(t, m.View(), "Connection error")
+
+	m = clientUpdate(m, statusMsg(StreamProcesses, stream.StateConnecting))
+	assert.NoError(t, m.connectionError)
 }
 
 // TestClientModel_EnterOpensCursorRow verifies the attach-mode Enter path opens

--- a/internal/tui/logs_sync.go
+++ b/internal/tui/logs_sync.go
@@ -1,0 +1,485 @@
+package tui
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/charliek/prox/internal/api"
+	"github.com/charliek/prox/internal/constants"
+	"github.com/charliek/prox/internal/domain"
+)
+
+// LogsSyncMsg is one completed logs-stream synchronization: the entries fetched
+// over REST plus every live entry that arrived while the fetch was running, in
+// one oldest-first batch, and an optional one-line notice describing a
+// discontinuity the user needs to know about (a restarted daemon, or entries
+// the server's ring evicted before we could resume). The models append the
+// notice then the entries and re-render ONCE, so a full 1000-line backfill
+// costs one render rather than a thousand.
+//
+// Exactly one of these is delivered per successful stream attempt, immediately
+// before the loop is marked synchronized (StateOK). An attempt with nothing to
+// report still delivers one (empty), which the model handler no-ops.
+type LogsSyncMsg struct {
+	Entries []domain.LogEntry
+	Notice  string
+}
+
+// errLogsSyncOverflow ends an attempt whose live-entry buffer filled before the
+// backfill landed. Distinct on purpose: the loop reconnects and re-syncs from
+// the cursor, which is the only way to recover the entries the buffer could not
+// hold. Nothing is silently lost — the resume asks the server for exactly them.
+var errLogsSyncOverflow = errors.New("logs sync: live entry buffer overflowed before the backfill landed")
+
+// errLogsSyncGap ends an attempt that observed a hole in the server's ingest
+// sequence — an entry whose Seq jumped past lastSeq+1, which means the daemon
+// dropped events into our subscriber channel (logs.Manager drops for a slow
+// subscriber rather than blocking ingest).
+//
+// PINNED SHAPE: abort the attempt and let the loop reconnect and re-sync,
+// rather than splicing an inline since_seq fetch into a live stream. The
+// reconnect re-runs the same protocol, whose resume fetch asks for everything
+// after our cursor and therefore recovers exactly the dropped entries (as long
+// as the server's ring still holds them; if it does not, the rolled-buffer
+// notice reports the loss honestly). Gap events are rare and a reconnect is
+// cheap, so the simpler control flow wins over a second code path that would
+// have to interleave a fetch with a live stream all over again.
+var errLogsSyncGap = errors.New("logs sync: server-side sequence gap; reconnecting to re-sync")
+
+// errLogsSyncEpochChanged ends an attempt whose REST backfill answered from a
+// different manager lifetime than the SSE handshake announced (daemon replaced
+// between the two). The batch cannot be labeled with either epoch safely;
+// reconnecting yields a fresh handshake and a consistent backfill.
+var errLogsSyncEpochChanged = errors.New("logs sync: backfill epoch differs from handshake epoch; reconnecting to re-sync")
+
+// logsBackfillFetchAttempts is how many consecutive backfill fetch failures an
+// otherwise-live attempt tolerates before it is aborted and recycled. Same
+// reasoning as requestsSnapshotFetchAttempts: retrying in place is right for a
+// blip, but an endlessly failing fetch would pin the stream in Syncing forever.
+const logsBackfillFetchAttempts = 3
+
+// logsHandshakeWait bounds how long a connected attempt waits for the server's
+// handshake frame before concluding it is talking to a pre-C8 daemon that never
+// sends one. The real handshake is written immediately after ": connected" and
+// before any log entry (internal/api/sse.go), so on a current daemon this wait
+// is a round trip; the budget only ever elapses against an old one.
+//
+// It is a var solely so tests need not spend it. Production never changes it.
+var logsHandshakeWait = 2 * time.Second
+
+// logsRestartNotice marks the seam where a NEW daemon epoch's backfill was
+// spliced onto entries printed by the previous run, which stay on screen as
+// history.
+const logsRestartNotice = "log stream restarted; earlier entries are from the previous run"
+
+// logsLostNotice reports entries the server's ring evicted between our cursor
+// and the oldest entry it could still hand back.
+func logsLostNotice(lost uint64) string {
+	return fmt.Sprintf("log stream reconnected; %d earlier entries were lost", lost)
+}
+
+// UNFILTERED INVARIANT (pinned): every seq comparison in this file — the
+// resume cursor, the rolled-buffer lost count, the live-gap detection — is
+// only sound on an UNFILTERED subscription, where "the next entry I should see
+// has Seq == lastSeq+1" holds. The attach TUI subscribes with an empty
+// domain.LogParams and filters client-side (BaseModel.filteredEntries), so it
+// qualifies. A future filtered subscription would see legitimate holes in the
+// sequence for every entry the server filtered out, and would report phantom
+// gaps and phantom losses on every reconnect: such a stream MUST NOT reuse this
+// machinery without first replacing seq arithmetic with something filter-aware.
+
+// logsSyncSession is the CROSS-ATTEMPT half of the protocol: how far the attach
+// session has consumed (lastSeq) and which server epoch that cursor belongs to
+// (streamID). Both zero means "never synced". One session is created per attach
+// run and shared by every attempt of the logs loop, which is what lets attempt
+// N+1 resume where attempt N left off instead of re-fetching the world.
+//
+// Attempts are sequential (one stream.Loop, one attempt at a time), but within
+// an attempt the SSE reader goroutine and the fetch goroutine both touch it, so
+// it carries its own mutex. Lock order is always logsSyncState.mu →
+// logsSyncSession.mu; nothing here calls back into the state.
+type logsSyncSession struct {
+	mu       sync.Mutex
+	lastSeq  uint64
+	streamID string
+}
+
+func newLogsSyncSession() *logsSyncSession {
+	return &logsSyncSession{}
+}
+
+// cursor reads the session's resume point.
+func (s *logsSyncSession) cursor() (lastSeq uint64, streamID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastSeq, s.streamID
+}
+
+// adopt records the epoch a completed sync synchronized against and the seq it
+// consumed up to. It is an assignment, not a merge: after an epoch change the
+// new epoch's sequence is unrelated to the old one and may well be lower.
+func (s *logsSyncSession) adopt(streamID string, lastSeq uint64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.streamID = streamID
+	s.lastSeq = lastSeq
+}
+
+// advance carries the cursor forward for a live entry delivered post-sync.
+func (s *logsSyncSession) advance(seq uint64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if seq > s.lastSeq {
+		s.lastSeq = seq
+	}
+}
+
+// consumeLogsWithSync is the logs stream's single connect-and-consume attempt.
+// It mirrors consumeRequestsWithSync (C6) deliberately — the two are meant to
+// read as one protocol with two payloads — and differs in exactly three ways:
+//
+//   - The fetch cannot be issued at connect time. It needs the server's epoch
+//     first, which arrives as the handshake frame, so the fetch goroutine
+//     starts at connect but blocks on the handshake before choosing between a
+//     full backfill and a since_seq resume.
+//   - Log lines have no ID, so overlap is excluded by cursor before delivery
+//     rather than merged by identity in the model.
+//   - A hole in the ingest sequence is itself an event (errLogsSyncGap).
+//
+// The barrier discipline is identical: onConnect starts but does not complete
+// the sync, live entries are buffered meanwhile, and the one LogsSyncMsg,
+// markSynced, and the flip to passthrough all happen under one mutex so no live
+// entry can slip out either side of the batch.
+func consumeLogsWithSync(ctx context.Context, client TUIClient, sess *logsSyncSession, send func(tea.Msg), markSynced func()) error {
+	attemptCtx, fetch := newSyncFetch(ctx)
+	defer fetch.join()
+
+	st := &logsSyncState{
+		buffering:   true,
+		abort:       fetch.abort,
+		send:        send,
+		sess:        sess,
+		handshakeCh: make(chan string, 1),
+	}
+
+	// The subscription is deliberately unfiltered — see the invariant above.
+	err := client.ConsumeLogs(attemptCtx, domain.LogParams{},
+		func() {
+			fetch.start(func() error {
+				return syncLogsBackfill(attemptCtx, client, st, markSynced)
+			})
+		},
+		st.noteHandshake,
+		st.observe)
+
+	// Join before reading the fetch's error: the deferred backstop runs only
+	// after the return value has been computed.
+	fetch.join()
+	return fetch.attemptError(ctx, st.abortErr(), err)
+}
+
+// syncLogsBackfill waits for the epoch, fetches the right backfill for it, and
+// completes the sync. It runs on its own goroutine, concurrently with the SSE
+// read loop (which is busy reading; buffering would deadlock if the fetch ran
+// on it).
+//
+// The fetch decision, once the epoch is known:
+//
+//	never synced, or a DIFFERENT epoch → full fetch of the last maxLogEntries
+//	                                     lines; an epoch CHANGE (as opposed to
+//	                                     a first sync) also carries the restart
+//	                                     notice.
+//	same epoch, cursor > 0             → resume: everything after the cursor.
+//	                                     oldest_seq > cursor+1 means the ring
+//	                                     rolled past us: deliver what came back
+//	                                     plus the lost-count notice.
+//	same epoch, cursor 0               → full fetch, no notice. We hold nothing
+//	                                     from this epoch, so everything in the
+//	                                     buffer is new and there is nothing to
+//	                                     have lost. (Reachable: a first sync
+//	                                     against an empty buffer adopts the
+//	                                     epoch with cursor 0.)
+//
+// A failure while the stream is still live is retried in place at the stream
+// package's base backoff rather than tearing the connection down — the entries
+// we are buffering are exactly what the reconnect would have to re-fetch
+// anyway. After logsBackfillFetchAttempts consecutive failures it gives up and
+// returns the error, which aborts the attempt so the loop's own backoff and
+// status reporting take over. The loop stays in Syncing (never OK) throughout.
+//
+// A ctx cancellation returns nil: the attempt is already ending for a reason
+// the caller knows better than we do, and reporting a bare cancellation here
+// would mask the stream's real error.
+func syncLogsBackfill(ctx context.Context, client TUIClient, st *logsSyncState, markSynced func()) error {
+	streamID, ok := st.awaitHandshake(ctx)
+	if !ok {
+		if ctx.Err() != nil {
+			return nil
+		}
+		// Pre-C8 daemon: no handshake, and its entries carry no Seq either, so
+		// there is no epoch to compare and no cursor to resume from. Complete
+		// the sync with an empty batch — which still delivers whatever was
+		// buffered during the wait, in order — and let the rest of the attempt
+		// run as the pure passthrough consumer it was before C9. The loop
+		// therefore reports OK one handshake budget after connect instead of at
+		// connect; that delay is bounded by logsHandshakeWait and only ever
+		// paid against an old daemon.
+		st.complete(logsBatch{}, markSynced)
+		return nil
+	}
+
+	lastSeq, storedID := st.sess.cursor()
+	resume := storedID == streamID && lastSeq > 0
+
+	// Lines is always set: the server defaults an absent `lines` to
+	// constants.DefaultLogLimit (100), far below what the TUI holds. On the
+	// resume path the cap keeps the OLDEST entries after the cursor (see
+	// logs.Manager.QueryFromSeq), so a resume that hits it stops short of the
+	// live stream; the resulting seam is caught as a gap and recovered by the
+	// next attempt's resume rather than being silently swallowed.
+	params := domain.LogParams{Lines: maxLogEntries}
+	if resume {
+		params.SinceSeq = lastSeq
+	}
+
+	var lastErr error
+	for i := 0; i < logsBackfillFetchAttempts; i++ {
+		if i > 0 {
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-time.After(constants.StreamReconnectBaseBackoff):
+			}
+		}
+
+		resp, err := client.GetLogs(ctx, params)
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			lastErr = err
+			continue
+		}
+
+		// Epoch-consistency guard (codex C9 finding): the REST backfill must
+		// belong to the SAME epoch the SSE handshake announced. If the daemon
+		// restarted between the handshake and this fetch, the response carries
+		// the new manager's stream_id — labeling that data with the handshake
+		// epoch would splice two epochs into one batch and adopt a cursor from
+		// the wrong sequence space. Abort the attempt instead: the reconnect
+		// gets a fresh handshake and a consistent backfill.
+		if resp.StreamID != "" && resp.StreamID != streamID {
+			return fmt.Errorf("logs sync: backfill epoch %q does not match handshake epoch %q: %w",
+				resp.StreamID, streamID, errLogsSyncEpochChanged)
+		}
+
+		batch := logsBatch{streamID: streamID}
+		for _, e := range resp.Logs {
+			batch.entries = append(batch.entries, streamedLogEntry(st.send, e))
+		}
+		switch {
+		case resume:
+			batch.cursor = lastSeq
+			if resp.OldestSeq > lastSeq+1 {
+				batch.notice = logsLostNotice(resp.OldestSeq - lastSeq - 1)
+			}
+		case storedID != "" && storedID != streamID:
+			batch.notice = logsRestartNotice
+		}
+
+		st.complete(batch, markSynced)
+		return nil
+	}
+	if ctx.Err() != nil {
+		return nil
+	}
+	return fmt.Errorf("logs sync: backfill fetch failed %d times: %w", logsBackfillFetchAttempts, lastErr)
+}
+
+// logsSyncState is the PER-ATTEMPT handoff between the SSE reader goroutine
+// (which produces the handshake and live entries) and the fetch goroutine
+// (which ends the buffering phase). Everything is guarded by mu: complete's
+// "deliver the batch, adopt the cursor, mark synced, flip to passthrough" must
+// be atomic with respect to observe, or a live entry could slip out either side
+// of the batch or be measured against a cursor that is mid-update.
+type logsSyncState struct {
+	mu        sync.Mutex
+	buffering bool
+	buf       []domain.LogEntry
+	overflow  bool
+	gap       bool
+
+	// handshakeCh carries the epoch from the reader goroutine to the fetch
+	// goroutine. Buffered (cap 1) and written at most once, so the handshake
+	// may arrive before OR after the fetch goroutine starts waiting: early, it
+	// sits in the buffer; late, the waiter is already parked on it.
+	handshakeCh   chan string
+	handshakeOnce sync.Once
+
+	// abort cancels the attempt context (syncFetch.abort). Called once, outside
+	// mu, when the buffer overflows or a sequence gap is seen.
+	abort func()
+
+	send func(tea.Msg)
+	sess *logsSyncSession
+}
+
+// logsBatch is what a completed backfill hands to logsSyncState.complete: the
+// fetched entries (oldest-first), the epoch they came from, the seq the fetch
+// resumed FROM (0 for a full fetch, which seeds the same overlap/gap arithmetic
+// observe applies to live entries), and the discontinuity notice, if any. The
+// zero value is the pre-C8 daemon's "nothing to backfill against".
+type logsBatch struct {
+	entries  []domain.LogEntry
+	notice   string
+	streamID string
+	cursor   uint64
+}
+
+// noteHandshake latches the FIRST handshake of the attempt. A server that sends
+// more than one is harmless: the epoch cannot change without a new connection,
+// and re-triggering the fetch decision mid-attempt would be meaningless work.
+func (st *logsSyncState) noteHandshake(hs api.HandshakeResponse) {
+	st.handshakeOnce.Do(func() { st.handshakeCh <- hs.StreamID })
+}
+
+// awaitHandshake blocks for the epoch. ok is false when the attempt ended or
+// the budget elapsed without one (a pre-C8 daemon).
+func (st *logsSyncState) awaitHandshake(ctx context.Context) (string, bool) {
+	timer := time.NewTimer(logsHandshakeWait)
+	defer timer.Stop()
+
+	select {
+	case streamID := <-st.handshakeCh:
+		return streamID, true
+	case <-timer.C:
+		return "", false
+	case <-ctx.Done():
+		return "", false
+	}
+}
+
+// observe handles one live entry: buffered while the backfill is outstanding,
+// cursor-checked and delivered directly once the sync has completed.
+func (st *logsSyncState) observe(entry api.LogEntryResponse) {
+	st.mu.Lock()
+
+	if st.buffering {
+		if st.overflow || st.gap {
+			// The attempt is already being torn down; nothing gained by keeping
+			// entries for a batch that will never be delivered.
+			st.mu.Unlock()
+			return
+		}
+		// The buffer is sized to the TUI's own log ring: more entries than that
+		// arriving during one fetch would evict each other on arrival anyway,
+		// and the resume fetch re-reads them from the server.
+		if len(st.buf) >= maxLogEntries {
+			st.overflow = true
+			st.mu.Unlock()
+			st.abort()
+			return
+		}
+		st.buf = append(st.buf, streamedLogEntry(st.send, entry))
+		st.mu.Unlock()
+		return
+	}
+
+	// Passthrough. Entries with Seq 0 come from a pre-C8 daemon (or never
+	// passed through logs.Manager.Write) and carry no cursor information, so
+	// they are always delivered and never move the cursor.
+	if entry.Seq > 0 {
+		lastSeq, _ := st.sess.cursor()
+		switch {
+		case entry.Seq <= lastSeq:
+			// Already applied by the sync batch: the fetch and the live stream
+			// overlap by construction.
+			st.mu.Unlock()
+			return
+		case lastSeq > 0 && entry.Seq > lastSeq+1:
+			st.gap = true
+			st.mu.Unlock()
+			st.abort()
+			return
+		}
+		st.sess.advance(entry.Seq)
+	}
+	st.mu.Unlock()
+
+	sendStreamedLogEntry(st.send, entry)
+}
+
+// complete delivers the sync batch and switches to passthrough. A no-op once
+// the attempt has overflowed or seen a gap (the batch is moot) or the sync
+// already completed (a client that called onConnect twice).
+func (st *logsSyncState) complete(batch logsBatch, markSynced func()) {
+	st.mu.Lock()
+
+	if !st.buffering || st.overflow || st.gap {
+		st.mu.Unlock()
+		return
+	}
+
+	entries := batch.entries
+	cursor := batch.cursor
+	for _, e := range entries {
+		if e.Seq > cursor {
+			cursor = e.Seq
+		}
+	}
+
+	// Splice the buffered live entries onto the batch, dropping the overlap the
+	// fetch already covered. A hole here is the same server-side drop observe
+	// watches for, and is handled the same way: abort, reconnect, and let the
+	// next attempt's resume re-fetch the missing entries.
+	for _, e := range st.buf {
+		if e.Seq == 0 {
+			entries = append(entries, e)
+			continue
+		}
+		if cursor > 0 {
+			if e.Seq <= cursor {
+				continue
+			}
+			if e.Seq > cursor+1 {
+				st.gap = true
+				st.mu.Unlock()
+				st.abort()
+				return
+			}
+		}
+		entries = append(entries, e)
+		cursor = e.Seq
+	}
+
+	st.buf = nil
+	st.buffering = false
+	// Adopt BEFORE the flip is observable: the next live entry is measured
+	// against this cursor.
+	st.sess.adopt(batch.streamID, cursor)
+
+	st.send(LogsSyncMsg{Entries: entries, Notice: batch.notice})
+	// Only NOW is the stream synchronized: the models hold the backfill plus
+	// everything that arrived during the fetch.
+	markSynced()
+	st.mu.Unlock()
+}
+
+// abortErr reports the sync-protocol reason this attempt must be recycled, or
+// nil if it ended for a reason of the stream's own.
+func (st *logsSyncState) abortErr() error {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	switch {
+	case st.overflow:
+		return errLogsSyncOverflow
+	case st.gap:
+		return errLogsSyncGap
+	}
+	return nil
+}

--- a/internal/tui/logs_sync_test.go
+++ b/internal/tui/logs_sync_test.go
@@ -1,0 +1,565 @@
+package tui
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/charliek/prox/internal/api"
+	"github.com/charliek/prox/internal/domain"
+	"github.com/charliek/prox/internal/stream"
+)
+
+// --- helpers ---
+
+// wireLog builds one wire-format log entry as the REST backfill and the SSE
+// stream both deliver it. seq 0 models a pre-C8 daemon's entry.
+func wireLog(seq uint64, line string) api.LogEntryResponse {
+	return api.LogEntryResponse{
+		Timestamp: time.Unix(0, 0).UTC().Format(time.RFC3339Nano),
+		Process:   "web",
+		Stream:    "stdout",
+		Line:      line,
+		Seq:       seq,
+	}
+}
+
+// backfill builds a LogsResponse carrying entries from seq lo through hi
+// (inclusive, oldest-first), with the buffer bounds a server would report for a
+// ring holding oldestSeq..hi.
+func backfill(oldestSeq, lo, hi uint64) *api.LogsResponse {
+	resp := &api.LogsResponse{OldestSeq: oldestSeq, LatestSeq: hi}
+	for seq := lo; seq <= hi; seq++ {
+		resp.Logs = append(resp.Logs, wireLog(seq, fmt.Sprintf("line-%d", seq)))
+	}
+	resp.FilteredCount = len(resp.Logs)
+	resp.TotalCount = len(resp.Logs)
+	return resp
+}
+
+// logLines lists a batch's lines in order, for ordering/duplication assertions.
+func logLines(entries []domain.LogEntry) []string {
+	lines := make([]string, 0, len(entries))
+	for _, e := range entries {
+		lines = append(lines, e.Line)
+	}
+	return lines
+}
+
+// shortenLogsHandshakeWait shrinks the pre-C8 handshake budget for the duration
+// of one test, so an old-server case costs milliseconds instead of seconds.
+func shortenLogsHandshakeWait(t *testing.T, d time.Duration) {
+	t.Helper()
+	prev := logsHandshakeWait
+	logsHandshakeWait = d
+	t.Cleanup(func() { logsHandshakeWait = prev })
+}
+
+// newLogsSyncHarness drives consumeLogsWithSync attempts against ONE attach
+// session, so a test can run several attempts against the cursor the previous
+// one adopted — which is the whole point of the reconnect cases. See
+// syncHarness (stream_health_test.go) for the machinery.
+func newLogsSyncHarness(sess *logsSyncSession) *syncHarness {
+	return newSyncHarness(func(ctx context.Context, client TUIClient, send func(tea.Msg), markSynced func()) error {
+		return consumeLogsWithSync(ctx, client, sess, send, markSynced)
+	})
+}
+
+// quietStream is the common script: connect, announce streamID, then hold the
+// stream open until the attempt ends. Live entries are the interesting part of
+// the other tests, so the ones that only care about the backfill use this.
+func quietStream(streamID string) func(context.Context, func(), func(api.HandshakeResponse), func(api.LogEntryResponse)) error {
+	return func(ctx context.Context, onConnect func(), onHandshake func(api.HandshakeResponse), _ func(api.LogEntryResponse)) error {
+		onConnect()
+		onHandshake(api.HandshakeResponse{StreamID: streamID})
+		<-ctx.Done()
+		return ctx.Err()
+	}
+}
+
+// syncOnce runs one attempt against a quiet stream and returns its batch. The
+// attempt is cancelled (and joined) before returning, so the session cursor it
+// adopted is stable for the caller.
+func syncOnce(t *testing.T, sess *logsSyncSession, client *stubTUIClient) LogsSyncMsg {
+	t.Helper()
+	h := newLogsSyncHarness(sess)
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := h.runInBackground(ctx, client)
+	msg := awaitSync[LogsSyncMsg](t, h)
+	cancel()
+	<-errCh
+	return msg
+}
+
+// --- attempt-level sync protocol ---
+
+// TestConsumeLogsWithSync_DeliversBatchThenMarksSynced pins the barrier on a
+// FIRST sync: the backfill is fetched in full (no cursor to resume from),
+// entries seen before it lands are BUFFERED into the one LogsSyncMsg rather
+// than delivered loose, an entry the backfill already covered is dropped rather
+// than duplicated, markSynced fires only after that message, and later entries
+// pass straight through.
+func TestConsumeLogsWithSync_DeliversBatchThenMarksSynced(t *testing.T) {
+	sess := newLogsSyncSession()
+	h := newLogsSyncHarness(sess)
+	buffered := make(chan struct{})
+	client := &stubTUIClient{}
+	client.logsResponder = func(int, domain.LogParams) (*api.LogsResponse, error) {
+		// The fetch may only return once the live entries have been buffered.
+		<-buffered
+		return backfill(1, 1, 3), nil
+	}
+	client.consumeLogs = func(ctx context.Context, onConnect func(), onHandshake func(api.HandshakeResponse), onEvent func(api.LogEntryResponse)) error {
+		onConnect()
+		onHandshake(api.HandshakeResponse{StreamID: "epoch-1"})
+		onEvent(wireLog(3, "line-3")) // overlaps the backfill: must not duplicate
+		onEvent(wireLog(4, "line-4")) // buffered: the fetch is held above
+		close(buffered)
+		// Once the sync barrier is crossed, a further entry must arrive as a
+		// plain LogEntryMsg rather than being buffered.
+		select {
+		case <-h.syncedCh:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+		onEvent(wireLog(5, "line-5"))
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := h.runInBackground(ctx, client)
+
+	syncMsg := awaitSync[LogsSyncMsg](t, h)
+	assert.Equal(t, []string{"line-1", "line-2", "line-3", "line-4"}, logLines(syncMsg.Entries),
+		"backfill oldest-first, then the buffered entries, with the overlap dropped")
+	assert.Empty(t, syncMsg.Notice, "a first sync reports no discontinuity")
+
+	// Wait for the passthrough entry before tearing the attempt down.
+	h.collector.await(t, func(m tea.Msg) bool { return logMsgCarriesLine(m, "line-5") })
+	cancel()
+	<-errCh
+
+	assert.Equal(t, int32(1), h.syncedN.Load(), "markSynced fires exactly once, after the batch")
+	assert.Equal(t, []domain.LogParams{{Lines: maxLogEntries}}, client.logsCalls(),
+		"a first sync is a full fetch of the TUI's own buffer size, with no cursor")
+
+	msgs := h.collector.all()
+	require.NotEmpty(t, msgs)
+	_, first := msgs[0].(LogsSyncMsg)
+	assert.True(t, first, "no loose LogEntryMsg before the sync batch; got %T", msgs[0])
+
+	var passthrough []string
+	for _, msg := range msgs[1:] {
+		if entry, ok := msg.(LogEntryMsg); ok {
+			passthrough = append(passthrough, domain.LogEntry(entry).Line)
+		}
+	}
+	assert.Equal(t, []string{"line-5"}, passthrough, "post-sync entries pass straight through")
+
+	lastSeq, streamID := sess.cursor()
+	assert.Equal(t, uint64(5), lastSeq, "the cursor tracks the newest delivered entry")
+	assert.Equal(t, "epoch-1", streamID)
+}
+
+// TestConsumeLogsWithSync_ReconnectResumesFromCursor pins the reconnect case
+// the whole protocol exists for: the same epoch, a gap that still fits in the
+// server's ring. The second attempt asks for exactly what it missed and gets
+// exactly that — no duplicates of what it already holds, and no notice, because
+// nothing was lost.
+func TestConsumeLogsWithSync_ReconnectResumesFromCursor(t *testing.T) {
+	sess := newLogsSyncSession()
+	client := &stubTUIClient{consumeLogs: quietStream("epoch-1")}
+	client.logsResponder = func(n int, params domain.LogParams) (*api.LogsResponse, error) {
+		if n == 1 {
+			return backfill(1, 1, 3), nil
+		}
+		return backfill(1, params.SinceSeq+1, 5), nil
+	}
+
+	first := syncOnce(t, sess, client)
+	require.Equal(t, []string{"line-1", "line-2", "line-3"}, logLines(first.Entries))
+
+	second := syncOnce(t, sess, client)
+
+	assert.Equal(t, []string{"line-4", "line-5"}, logLines(second.Entries),
+		"exactly the entries missed while disconnected")
+	assert.Empty(t, second.Notice, "a gap the ring still covers is not a loss")
+	assert.Equal(t, []domain.LogParams{
+		{Lines: maxLogEntries},
+		{Lines: maxLogEntries, SinceSeq: 3},
+	}, client.logsCalls(), "the second fetch resumes from the cursor")
+
+	lastSeq, _ := sess.cursor()
+	assert.Equal(t, uint64(5), lastSeq)
+}
+
+// TestConsumeLogsWithSync_RolledBufferReportsLostCount pins the honest-loss
+// case: the server's ring rolled past our cursor while we were away, so the
+// entries in between are gone for good and the batch carries a notice saying
+// how many.
+func TestConsumeLogsWithSync_RolledBufferReportsLostCount(t *testing.T) {
+	sess := newLogsSyncSession()
+	client := &stubTUIClient{consumeLogs: quietStream("epoch-1")}
+	client.logsResponder = func(n int, _ domain.LogParams) (*api.LogsResponse, error) {
+		if n == 1 {
+			return backfill(1, 1, 3), nil
+		}
+		// The ring now starts at 8: entries 4..7 were evicted.
+		return backfill(8, 8, 9), nil
+	}
+
+	syncOnce(t, sess, client)
+	second := syncOnce(t, sess, client)
+
+	assert.Equal(t, []string{"line-8", "line-9"}, logLines(second.Entries))
+	assert.Equal(t, logsLostNotice(4), second.Notice, "oldest_seq 8 - cursor 3 - 1 = 4 lost entries")
+}
+
+// TestConsumeLogsWithSync_EpochChangeRefetchesWithNotice pins the daemon-restart
+// case: a different stream_id means every seq we hold belongs to a dead epoch,
+// so the cursor is abandoned, the backfill is a full fetch, and the batch is
+// prefixed with the restart notice that marks the seam.
+func TestConsumeLogsWithSync_EpochChangeRefetchesWithNotice(t *testing.T) {
+	sess := newLogsSyncSession()
+	client := &stubTUIClient{consumeLogs: quietStream("epoch-1")}
+	client.logsResponder = func(n int, _ domain.LogParams) (*api.LogsResponse, error) {
+		if n == 1 {
+			return backfill(1, 1, 3), nil
+		}
+		// The new daemon's sequence starts over, numerically BEHIND the cursor
+		// we were holding.
+		return backfill(1, 1, 2), nil
+	}
+
+	syncOnce(t, sess, client)
+	client.consumeLogs = quietStream("epoch-2")
+	second := syncOnce(t, sess, client)
+
+	assert.Equal(t, []string{"line-1", "line-2"}, logLines(second.Entries))
+	assert.Equal(t, logsRestartNotice, second.Notice)
+	assert.Equal(t, []domain.LogParams{
+		{Lines: maxLogEntries},
+		{Lines: maxLogEntries},
+	}, client.logsCalls(), "an epoch change must not resume from the dead epoch's cursor")
+
+	lastSeq, streamID := sess.cursor()
+	assert.Equal(t, uint64(2), lastSeq, "the cursor is replaced by the new epoch's, not merged")
+	assert.Equal(t, "epoch-2", streamID)
+}
+
+// TestConsumeLogsWithSync_OldServerStaysLiveOnly pins the compatibility path: a
+// pre-C8 daemon sends no handshake, so there is no epoch to compare and no
+// cursor to resume from. The attempt fetches nothing, delivers what it saw, and
+// reports OK — exactly the pre-C9 behavior — without inventing a sync state.
+func TestConsumeLogsWithSync_OldServerStaysLiveOnly(t *testing.T) {
+	shortenLogsHandshakeWait(t, 50*time.Millisecond)
+
+	sess := newLogsSyncSession()
+	h := newLogsSyncHarness(sess)
+	client := &stubTUIClient{
+		// onHandshake deliberately never called.
+		consumeLogs: func(ctx context.Context, onConnect func(), _ func(api.HandshakeResponse), onEvent func(api.LogEntryResponse)) error {
+			onConnect()
+			onEvent(wireLog(0, "old-line")) // pre-C8 entries carry no seq
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := h.runInBackground(ctx, client)
+	h.collector.await(t, func(m tea.Msg) bool { return logMsgCarriesLine(m, "old-line") })
+	cancel()
+	<-errCh
+
+	assert.Empty(t, client.logsCalls(), "no cursor, no epoch, nothing to backfill against")
+	assert.Equal(t, int32(1), h.syncedN.Load(), "the loop still reports OK")
+
+	lastSeq, streamID := sess.cursor()
+	assert.Zero(t, lastSeq, "no phantom cursor from an old server")
+	assert.Empty(t, streamID, "no phantom epoch from an old server")
+}
+
+// TestConsumeLogsWithSync_LiveGapAbortsAndNextAttemptRecovers pins the
+// discontinuity rule: an entry whose seq jumps past lastSeq+1 means the daemon
+// dropped events into our subscription, so the attempt aborts with the distinct
+// gap error (PINNED: abort-and-resync, not an inline splice) and the reconnect
+// re-fetches exactly the missing entries from the cursor.
+func TestConsumeLogsWithSync_LiveGapAbortsAndNextAttemptRecovers(t *testing.T) {
+	sess := newLogsSyncSession()
+	h := newLogsSyncHarness(sess)
+	client := &stubTUIClient{}
+	client.logsResponder = func(n int, params domain.LogParams) (*api.LogsResponse, error) {
+		if n == 1 {
+			return backfill(1, 1, 3), nil
+		}
+		return backfill(1, params.SinceSeq+1, 6), nil
+	}
+	client.consumeLogs = func(ctx context.Context, onConnect func(), onHandshake func(api.HandshakeResponse), onEvent func(api.LogEntryResponse)) error {
+		onConnect()
+		onHandshake(api.HandshakeResponse{StreamID: "epoch-1"})
+		select {
+		case <-h.syncedCh:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+		onEvent(wireLog(6, "line-6")) // 4 and 5 never arrived
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	err := h.run(context.Background(), client)
+
+	require.ErrorIs(t, err, errLogsSyncGap)
+	assert.Equal(t, stream.ClassTransient, classifyStreamError(err),
+		"the loop must reconnect and re-sync on a sequence gap")
+	for _, msg := range h.collector.all() {
+		if entry, ok := msg.(LogEntryMsg); ok {
+			assert.NotEqual(t, "line-6", domain.LogEntry(entry).Line,
+				"the entry that exposed the gap is not delivered out of order")
+		}
+	}
+	lastSeq, _ := sess.cursor()
+	require.Equal(t, uint64(3), lastSeq, "the cursor stays where the batch left it")
+
+	// The reconnect recovers everything after the cursor, gap included.
+	client.consumeLogs = quietStream("epoch-1")
+	second := syncOnce(t, sess, client)
+	assert.Equal(t, []string{"line-4", "line-5", "line-6"}, logLines(second.Entries))
+	assert.Empty(t, second.Notice)
+}
+
+// TestConsumeLogsWithSync_BufferOverflowAbortsAttempt pins the
+// nothing-silently-lost rule (mirroring the requests stream): a live buffer
+// that fills before the backfill lands ends the attempt with a distinct,
+// retryable error rather than dropping entries, and the next attempt re-syncs
+// cleanly from the cursor.
+func TestConsumeLogsWithSync_BufferOverflowAbortsAttempt(t *testing.T) {
+	sess := newLogsSyncSession()
+	h := newLogsSyncHarness(sess)
+	overflowed := make(chan struct{})
+	client := &stubTUIClient{}
+	client.logsResponder = func(int, domain.LogParams) (*api.LogsResponse, error) {
+		// Hold the backfill until the buffer has overflowed.
+		<-overflowed
+		return backfill(1, 1, 1), nil
+	}
+	client.consumeLogs = func(ctx context.Context, onConnect func(), onHandshake func(api.HandshakeResponse), onEvent func(api.LogEntryResponse)) error {
+		onConnect()
+		onHandshake(api.HandshakeResponse{StreamID: "epoch-1"})
+		for i := 1; i <= maxLogEntries+1; i++ {
+			onEvent(wireLog(uint64(i), fmt.Sprintf("line-%d", i)))
+		}
+		close(overflowed)
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	err := h.run(context.Background(), client)
+
+	require.ErrorIs(t, err, errLogsSyncOverflow)
+	assert.Zero(t, h.syncedN.Load(), "an overflowed attempt never reports OK")
+	assert.Equal(t, stream.ClassTransient, classifyStreamError(err),
+		"the loop must reconnect and re-sync on overflow")
+	for _, msg := range h.collector.all() {
+		_, isSync := msg.(LogsSyncMsg)
+		assert.False(t, isSync, "an overflowed attempt delivers no batch")
+	}
+	lastSeq, streamID := sess.cursor()
+	assert.Zero(t, lastSeq, "an aborted attempt adopts nothing")
+	assert.Empty(t, streamID)
+
+	// A re-attempt against a healthy stream syncs normally.
+	client.consumeLogs = quietStream("epoch-1")
+	client.logsResponder = func(int, domain.LogParams) (*api.LogsResponse, error) {
+		return backfill(1, 1, 2), nil
+	}
+	retry := syncOnce(t, newLogsSyncSession(), client)
+	assert.Equal(t, []string{"line-1", "line-2"}, logLines(retry.Entries))
+}
+
+// TestConsumeLogsWithSync_BackfillFetchRetriesThenRecycles pins the
+// fetch-failure policy, mirroring the requests stream: retry in place while the
+// stream is live (staying unsynced the whole time), then abort the attempt
+// after logsBackfillFetchAttempts so the loop's own backoff takes over.
+func TestConsumeLogsWithSync_BackfillFetchRetriesThenRecycles(t *testing.T) {
+	h := newLogsSyncHarness(newLogsSyncSession())
+	client := &stubTUIClient{consumeLogs: quietStream("epoch-1")}
+	client.logsResponder = func(int, domain.LogParams) (*api.LogsResponse, error) {
+		return nil, errors.New("backfill boom")
+	}
+
+	err := h.run(context.Background(), client)
+
+	assert.Len(t, client.logsCalls(), logsBackfillFetchAttempts, "retries in place")
+	assert.Zero(t, h.syncedN.Load(), "stays unsynced (Syncing) for the whole retry window")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "backfill boom")
+	assert.ErrorContains(t, err, "backfill fetch failed")
+	assert.Equal(t, stream.ClassTransient, classifyStreamError(err))
+}
+
+// TestConsumeLogsWithSync_DeadDialNeverSyncs pins that an attempt that never
+// connects never fetches and never reports OK.
+func TestConsumeLogsWithSync_DeadDialNeverSyncs(t *testing.T) {
+	h := newLogsSyncHarness(newLogsSyncSession())
+	client := &stubTUIClient{
+		consumeLogs: func(context.Context, func(), func(api.HandshakeResponse), func(api.LogEntryResponse)) error {
+			return errors.New("connection refused")
+		},
+	}
+
+	assert.EqualError(t, h.run(context.Background(), client), "connection refused")
+	assert.Empty(t, client.logsCalls(), "no backfill without a connection")
+	assert.Zero(t, h.syncedN.Load())
+}
+
+// --- model application (Update-driven) ---
+
+// TestLogsSync_BatchAppendsNoticeThenEntries pins the model half: the notice
+// renders as a system line ahead of the batch, the batch keeps its oldest-first
+// order, entries already on screen from a previous epoch are kept as history,
+// and every applied line gets a DisplaySeq so the search cursor can anchor to
+// it.
+func TestLogsSync_BatchAppendsNoticeThenEntries(t *testing.T) {
+	m := NewClientModel(&stubTUIClient{})
+	m, _ = clientUpdateModel(m, tea.WindowSizeMsg{Width: 120, Height: 20})
+	m = clientUpdate(m, LogEntryMsg(domain.LogEntry{Process: "web", Line: "before"}))
+
+	m = clientUpdate(m, LogsSyncMsg{
+		Notice: logsRestartNotice,
+		Entries: []domain.LogEntry{
+			{Process: "web", Line: "new-1", Seq: 1},
+			{Process: "web", Line: "new-2", Seq: 2},
+		},
+	})
+
+	require.Len(t, m.logEntries, 4)
+	assert.Equal(t, []string{"before", logsRestartNotice, "new-1", "new-2"}, logLines(m.logEntries),
+		"prior entries stay as history; the notice marks the seam ahead of the batch")
+	assert.Equal(t, "system", m.logEntries[1].Process, "the notice renders as a system log line")
+
+	for i, e := range m.logEntries {
+		assert.Equal(t, int64(i+1), e.DisplaySeq, "every applied line is stamped, batch lines included")
+	}
+	assert.Contains(t, m.View(), "new-2", "the batch rendered")
+}
+
+// TestLogsSync_EmptyBatchIsNoOp pins that a caught-up reconnect — the common
+// case on a quiet stream — changes nothing at all.
+func TestLogsSync_EmptyBatchIsNoOp(t *testing.T) {
+	m := NewClientModel(&stubTUIClient{})
+	m, _ = clientUpdateModel(m, tea.WindowSizeMsg{Width: 120, Height: 20})
+	m = clientUpdate(m, LogEntryMsg(domain.LogEntry{Process: "web", Line: "only"}))
+	seqBefore := m.logSeq
+
+	m = clientUpdate(m, LogsSyncMsg{})
+
+	assert.Equal(t, []string{"only"}, logLines(m.logEntries))
+	assert.Equal(t, seqBefore, m.logSeq, "an empty batch stamps nothing")
+}
+
+// TestLogsSync_BatchDoesNotRegisterProcesses pins the filter-map division of
+// labor: batch entries flow through exactly the same append path as live ones,
+// and neither registers a process in filterProcesses — that map is owned by the
+// process list (ProcessesMsg). A batch must not smuggle in filter state a live
+// entry would not have created.
+func TestLogsSync_BatchDoesNotRegisterProcesses(t *testing.T) {
+	m := NewClientModel(&stubTUIClient{})
+	m, _ = clientUpdateModel(m, tea.WindowSizeMsg{Width: 120, Height: 20})
+
+	m = clientUpdate(m, LogsSyncMsg{Entries: []domain.LogEntry{{Process: "batch-only", Line: "x"}}})
+	m = clientUpdate(m, LogEntryMsg(domain.LogEntry{Process: "live-only", Line: "y"}))
+
+	assert.Empty(t, m.filterProcesses, "log arrivals never register processes, by either path")
+	assert.Equal(t, []string{"x", "y"}, logLines(m.filteredEntries()),
+		"and both remain visible under the empty filter map")
+}
+
+// clientUpdateModel is clientUpdate keeping the returned command, for the
+// window-size seeding above.
+func clientUpdateModel(m ClientModel, msg tea.Msg) (ClientModel, tea.Cmd) {
+	nm, cmd := m.Update(msg)
+	return nm.(ClientModel), cmd
+}
+
+// --- loop-level wiring ---
+
+// TestRunClientStreams_LogsOKOnlyAfterSync pins the protocol at the loop level,
+// mirroring the requests case: the logs stream reports OK only once the
+// backfill has been applied, never between connect and sync completion.
+func TestRunClientStreams_LogsOKOnlyAfterSync(t *testing.T) {
+	collector := newMsgCollector()
+	release := make(chan struct{})
+	client := &stubTUIClient{consumeLogs: quietStream("epoch-1")}
+	client.logsResponder = func(int, domain.LogParams) (*api.LogsResponse, error) {
+		<-release
+		return backfill(1, 1, 2), nil
+	}
+
+	startClientStreams(t, client, collector.send)
+
+	// Before the backfill lands the logs loop must not be OK.
+	time.Sleep(50 * time.Millisecond)
+	for _, msg := range collector.all() {
+		if s, ok := msg.(StreamStatusMsg); ok && s.Stream == StreamLogs {
+			assert.NotEqual(t, stream.StateOK, s.Status.State, "OK before the backfill applied")
+		}
+	}
+
+	close(release)
+	collector.await(t, func(m tea.Msg) bool {
+		s, ok := m.(StreamStatusMsg)
+		return ok && s.Stream == StreamLogs && s.Status.State == stream.StateOK
+	})
+
+	// ...and the batch reached the models before that OK.
+	var syncIdx, okIdx = -1, -1
+	for i, msg := range collector.all() {
+		switch v := msg.(type) {
+		case LogsSyncMsg:
+			if syncIdx < 0 {
+				syncIdx = i
+			}
+		case StreamStatusMsg:
+			if v.Stream == StreamLogs && v.Status.State == stream.StateOK && okIdx < 0 {
+				okIdx = i
+			}
+		}
+	}
+	require.GreaterOrEqual(t, syncIdx, 0, "the sync batch must be delivered")
+	require.GreaterOrEqual(t, okIdx, 0)
+	assert.Less(t, syncIdx, okIdx, "the batch is delivered before the loop reports OK")
+}
+
+// TestConsumeLogsWithSync_BackfillEpochMismatchAborts pins the epoch-consistency
+// guard (codex C9 review): a REST backfill answered by a DIFFERENT manager
+// lifetime than the SSE handshake announced (daemon replaced between the two)
+// must abort the attempt rather than label the new epoch's data — and cursor —
+// with the old epoch.
+func TestConsumeLogsWithSync_BackfillEpochMismatchAborts(t *testing.T) {
+	sess := newLogsSyncSession()
+	client := &stubTUIClient{consumeLogs: quietStream("epoch-1")}
+	client.logsResponder = func(int, domain.LogParams) (*api.LogsResponse, error) {
+		resp := backfill(1, 1, 3)
+		resp.StreamID = "epoch-2" // restarted daemon answered the fetch
+		return resp, nil
+	}
+
+	h := newLogsSyncHarness(sess)
+	errCh := h.runInBackground(context.Background(), client)
+
+	err := <-errCh
+	require.ErrorIs(t, err, errLogsSyncEpochChanged)
+
+	lastSeq, streamID := sess.cursor()
+	assert.Zero(t, lastSeq, "no cursor may be adopted from a mixed-epoch fetch")
+	assert.Empty(t, streamID)
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -40,9 +40,6 @@ type Model struct {
 	// Dependencies
 	supervisor *supervisor.Supervisor
 	logManager *logs.Manager
-
-	// Subscription ID for log tracking
-	subID string
 }
 
 // NewModel creates a new TUI model
@@ -71,10 +68,15 @@ func NewModel(sup *supervisor.Supervisor, logMgr *logs.Manager) Model {
 	}
 }
 
-// Init initializes the model
+// Init initializes the model.
+//
+// It does NOT subscribe to logs itself (plan 017 C13 deleted the second,
+// leaked subscription this used to open via subscribeToLogs): the REAL local
+// log subscription is the one app.go's Run makes before starting the
+// forwarder, and its entries reach the model as LogEntryMsg regardless of
+// what Init returns.
 func (m Model) Init() tea.Cmd {
 	return tea.Batch(
-		subscribeToLogs(m.logManager),
 		refreshProcesses(),
 		tickCmd(constants.TUILocalTickInterval),
 	)
@@ -173,20 +175,6 @@ func restartResultClearCmd() tea.Cmd {
 		return RestartResultClearMsg{}
 	})
 }
-
-// subscribeToLogs starts log subscription (returns subscription ID for tracking)
-// Note: Actual log forwarding is handled by forwardLogs in app.go
-func subscribeToLogs(logMgr *logs.Manager) tea.Cmd {
-	return func() tea.Msg {
-		id, _, err := logMgr.Subscribe(domain.LogFilter{})
-		if err != nil {
-			return nil
-		}
-		return subIDMsg(id)
-	}
-}
-
-type subIDMsg string
 
 // refreshProcesses returns a command to refresh process list
 func refreshProcesses() tea.Cmd {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -196,10 +196,11 @@ func refreshProcesses() tea.Cmd {
 }
 
 // tickCmd returns a command that ticks after d, driving the periodic
-// process-list refresh. The interval is a parameter because the two modes
-// pay different costs per tick: local mode reads the in-process supervisor,
-// attach mode does an HTTP round trip (until the processes stream replaces
-// it entirely).
+// process-list refresh. LOCAL MODE ONLY since C12: attach mode's tick was
+// deleted when the processes stream took over, so the only remaining caller
+// reads the in-process supervisor, which costs nothing. The interval stays a
+// parameter rather than being inlined so the cadence remains one named
+// constant away from the call.
 func tickCmd(d time.Duration) tea.Cmd {
 	return tea.Tick(d, func(t time.Time) tea.Msg {
 		return TickMsg(t)

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -9,6 +9,7 @@ import (
 	"github.com/charliek/prox/internal/domain"
 	"github.com/charliek/prox/internal/logs"
 	"github.com/charliek/prox/internal/proxy"
+	"github.com/charliek/prox/internal/stream"
 	"github.com/charliek/prox/internal/supervisor"
 )
 
@@ -56,6 +57,12 @@ func NewModel(sup *supervisor.Supervisor, logMgr *logs.Manager) Model {
 		base.filterProcesses[p.Name] = true
 	}
 	base.processes = sup.Processes()
+
+	// Local mode reads in-process subscriptions: every stream is healthy from
+	// the start and only ever changes if a subscription channel closes under it.
+	for _, id := range allStreams {
+		base.streamHealth[id] = stream.Status{State: stream.StateOK}
+	}
 
 	return Model{
 		BaseModel:  base,

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -5,6 +5,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/charliek/prox/internal/constants"
 	"github.com/charliek/prox/internal/domain"
 	"github.com/charliek/prox/internal/logs"
 	"github.com/charliek/prox/internal/proxy"
@@ -68,7 +69,7 @@ func (m Model) Init() tea.Cmd {
 	return tea.Batch(
 		subscribeToLogs(m.logManager),
 		refreshProcesses(),
-		tickCmd(),
+		tickCmd(constants.TUILocalTickInterval),
 	)
 }
 
@@ -187,9 +188,13 @@ func refreshProcesses() tea.Cmd {
 	}
 }
 
-// tickCmd returns a command that ticks periodically
-func tickCmd() tea.Cmd {
-	return tea.Tick(500*time.Millisecond, func(t time.Time) tea.Msg {
+// tickCmd returns a command that ticks after d, driving the periodic
+// process-list refresh. The interval is a parameter because the two modes
+// pay different costs per tick: local mode reads the in-process supervisor,
+// attach mode does an HTTP round trip (until the processes stream replaces
+// it entirely).
+func tickCmd(d time.Duration) tea.Cmd {
+	return tea.Tick(d, func(t time.Time) tea.Msg {
 		return TickMsg(t)
 	})
 }

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -310,7 +310,8 @@ func TestModel_ProxyRequestMsg(t *testing.T) {
 	model := newTestModel()
 	model.ready = true
 
-	// Send a proxy request through Update()
+	// Send a proxy request through Update() — in-flight, as the live stream
+	// publishes it at response-header time.
 	req := proxy.RequestRecord{
 		ID:         "req-1",
 		Timestamp:  time.Now(),
@@ -318,8 +319,8 @@ func TestModel_ProxyRequestMsg(t *testing.T) {
 		Method:     "POST",
 		URL:        "/api/users",
 		StatusCode: 201,
-		Duration:   50 * time.Millisecond,
 		RemoteAddr: "192.168.1.1:54321",
+		InFlight:   true,
 	}
 
 	newModel, _ := model.Update(ProxyRequestMsg(req))
@@ -331,7 +332,6 @@ func TestModel_ProxyRequestMsg(t *testing.T) {
 	assert.Equal(t, "POST", m.proxyRequests[0].Method)
 	assert.Equal(t, "/api/users", m.proxyRequests[0].URL)
 	assert.Equal(t, 201, m.proxyRequests[0].StatusCode)
-	assert.Equal(t, 50*time.Millisecond, m.proxyRequests[0].Duration)
 
 	// Verify request is accessible via filteredProxyRequests
 	filtered := m.filteredProxyRequests()
@@ -362,11 +362,12 @@ func TestModel_ProxyRequestMsg(t *testing.T) {
 	assert.Len(t, filtered, 1)
 	assert.Equal(t, "/api/users", filtered[0].URL)
 
-	// A same-ID re-record (e.g. an in-flight row's completion event) updates
-	// the row in place rather than appending a duplicate.
+	// A same-ID re-record (the in-flight row's completion event) updates the
+	// row in place rather than appending a duplicate.
 	req1Updated := req
 	req1Updated.StatusCode = 204
 	req1Updated.Duration = 99 * time.Millisecond
+	req1Updated.InFlight = false
 
 	newModel, _ = m.Update(ProxyRequestMsg(req1Updated))
 	m = newModel.(Model)
@@ -374,6 +375,18 @@ func TestModel_ProxyRequestMsg(t *testing.T) {
 	assert.Len(t, m.proxyRequests, 2, "same-ID update must not duplicate the row")
 	assert.Equal(t, 204, m.proxyRequests[0].StatusCode)
 	assert.Equal(t, 99*time.Millisecond, m.proxyRequests[0].Duration)
+
+	// Final is terminal (C6): neither a duplicate final nor a late in-flight
+	// copy of the same ID may regress the completed row.
+	regress := req1Updated
+	regress.StatusCode = 500
+	regress.InFlight = true
+	newModel, _ = m.Update(ProxyRequestMsg(regress))
+	m = newModel.(Model)
+
+	assert.Len(t, m.proxyRequests, 2)
+	assert.Equal(t, 204, m.proxyRequests[0].StatusCode, "a stale in-flight copy must not regress a final row")
+	assert.False(t, m.proxyRequests[0].InFlight)
 }
 
 // TestModel_ProxyRequestMsg_SelectionStable pins the cursor invariant (D11):
@@ -382,6 +395,11 @@ func TestModel_ProxyRequestMsg(t *testing.T) {
 // opens.
 func TestModel_ProxyRequestMsg_SelectionStable(t *testing.T) {
 	m := newRequestsModel(3, 20)
+	// The rows start in-flight: an in-place update is only ever a completion
+	// arriving for a live row (final rows are terminal — C6).
+	for i := range m.proxyRequests {
+		m.proxyRequests[i].InFlight = true
+	}
 	m = updateModel(m, keyRune('g')) // cursor row 0, follow off
 	m = updateModel(m, keyRune('j')) // cursor row 1 (req-001), not the last row
 	assert.Equal(t, "req-001", m.cursorID)

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1449,7 +1449,7 @@ func TestLogsSearch_EvictionAnchorSurvives(t *testing.T) {
 		feed(fmt.Sprintf("flood %d", i))
 	}
 	for _, e := range m.logEntries {
-		require.NotEqual(t, needleSeq, e.Seq, "NEEDLE has been evicted")
+		require.NotEqual(t, needleSeq, e.DisplaySeq, "NEEDLE has been evicted")
 	}
 	assert.GreaterOrEqual(t, m.logCursorIdx, 0, "the evicted cursor clamps in range")
 	assert.Less(t, m.logCursorIdx, len(m.logEntries), "the evicted cursor clamps in range")

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -34,6 +34,35 @@ func TestNewModel(t *testing.T) {
 	assert.Empty(t, model.logEntries)
 }
 
+// TestModel_Init_DoesNotSubscribeToLogs proves the panel finding fixed by
+// plan 017 C13: local mode used to open a SECOND, leaked log subscription
+// from Model.Init (via the now-deleted subscribeToLogs/subIDMsg), on top of
+// the real one app.go's Run makes before starting the forwarder. It executes
+// every command Init returns — exactly as the bubbletea runtime would — and
+// asserts the log manager's subscriber count never moves, using
+// logs.Manager.Stats().Subscribers as the smallest available accessor.
+func TestModel_Init_DoesNotSubscribeToLogs(t *testing.T) {
+	logMgr := logs.NewManager(logs.DefaultManagerConfig())
+	sup := supervisor.New(nil, logMgr, nil, supervisor.DefaultSupervisorConfig())
+	model := NewModel(sup, logMgr)
+
+	before := logMgr.Stats().Subscribers
+
+	cmd := model.Init()
+	require.NotNil(t, cmd)
+	msg := cmd()
+	batch, ok := msg.(tea.BatchMsg)
+	require.True(t, ok, "expected Init to return a tea.Batch, got %T", msg)
+	for _, sub := range batch {
+		if sub != nil {
+			sub() // runs refreshProcesses and tickCmd; neither subscribes
+		}
+	}
+
+	after := logMgr.Stats().Subscribers
+	assert.Equal(t, before, after, "Model.Init must not open its own log subscription — the real one belongs to app.go Run")
+}
+
 func TestModel_HandleKey_Quit(t *testing.T) {
 	model := newTestModel()
 

--- a/internal/tui/requests_sync.go
+++ b/internal/tui/requests_sync.go
@@ -1,0 +1,255 @@
+package tui
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/charliek/prox/internal/api"
+	"github.com/charliek/prox/internal/constants"
+	"github.com/charliek/prox/internal/domain"
+	"github.com/charliek/prox/internal/proxy"
+)
+
+// RequestsSyncMsg is one completed requests-stream synchronization: the ring
+// snapshot fetched over REST (oldest-first) plus every live event that arrived
+// while the fetch was running (in arrival order). The models apply Snapshot
+// then Buffered through the monotonic merge and re-render ONCE, so a
+// full-ring replay costs one render rather than a thousand.
+//
+// Exactly one of these is delivered per successful stream attempt, immediately
+// before the loop is marked synchronized (StateOK).
+type RequestsSyncMsg struct {
+	Snapshot []proxy.RequestRecord
+	Buffered []proxy.RequestRecord
+}
+
+// errRequestsSyncOverflow ends an attempt whose live-event buffer filled before
+// the snapshot landed. It is deliberately a distinct error: the loop reconnects
+// and re-syncs from a fresh snapshot, which is the only way to recover the
+// events the buffer could not hold. Nothing is silently lost.
+var errRequestsSyncOverflow = errors.New("requests sync: live event buffer overflowed before the snapshot landed")
+
+// requestsSnapshotFetchAttempts is how many consecutive snapshot fetch failures
+// an otherwise-live stream attempt tolerates before the attempt is aborted and
+// recycled. Retrying in place (at the stream package's base backoff) is right
+// for a blip — the SSE connection is fine and tearing it down would lose the
+// live events we are already buffering — but an endlessly failing fetch would
+// otherwise pin the stream in Syncing forever, so the attempt eventually
+// recycles and the loop's own backoff takes over.
+const requestsSnapshotFetchAttempts = 3
+
+// consumeRequestsWithSync is the requests stream's single connect-and-consume
+// attempt (the logs stream stays a pure stream consumer; C9 owns log sync).
+//
+// The protocol, mirroring the forwarder's proven backfillSnapshot shape:
+//
+//  1. Connect. onConnect fires on the SSE reader goroutine and starts — but
+//     does NOT complete — the sync: markSynced is deliberately not called yet,
+//     so the loop stays in Syncing and the status bar keeps saying so.
+//  2. Live events arriving from here on are BUFFERED, not delivered.
+//  3. Concurrently (a goroutine — the reader goroutine is busy reading, and
+//     buffering would deadlock if the fetch ran on it), fetch the full ring
+//     over REST.
+//  4. On success, deliver one RequestsSyncMsg carrying the snapshot and the
+//     buffer, mark the loop synchronized (StateOK), and flip live events back
+//     to direct delivery. All three happen under one mutex, so the reader
+//     goroutine cannot interleave an event between the batch and the flip.
+//
+// The fetch goroutine is tied to a per-attempt context and waited for before
+// returning, so it never outlives its attempt — which is what makes calling
+// markSynced from it safe despite stream.Config.Attempt's "call it from the
+// attempt itself" rule: the rule exists to stop a STRAGGLING goroutine from
+// flipping a later attempt's state, and this one cannot straggle (the loop's
+// epoch guard is the second line of defense).
+func consumeRequestsWithSync(ctx context.Context, client TUIClient, send func(tea.Msg), markSynced func()) error {
+	attemptCtx, cancel := context.WithCancel(ctx)
+
+	st := &requestsSyncState{buffering: true, abort: cancel}
+	fetchDone := make(chan struct{})
+	var fetchStarted atomic.Bool
+	var fetchErr error
+
+	// join ends the fetch goroutine and waits for it, so it can never outlive
+	// its attempt. Idempotent (cancel is; a closed channel stays receivable),
+	// so it is safe both as the deferred backstop and as the explicit join
+	// below that makes fetchErr readable.
+	join := func() {
+		cancel()
+		if fetchStarted.Load() {
+			<-fetchDone
+		}
+	}
+	defer join()
+
+	err := client.ConsumeProxyRequests(attemptCtx, domain.ProxyRequestParams{},
+		func() {
+			// One sync per attempt: a client that called onConnect twice would
+			// otherwise start a second fetch goroutine and double-close
+			// fetchDone.
+			if !fetchStarted.CompareAndSwap(false, true) {
+				return
+			}
+			go func() {
+				defer close(fetchDone)
+				fetchErr = syncRequestsSnapshot(attemptCtx, client, send, st, markSynced)
+				if fetchErr != nil {
+					// Give up on this attempt: the loop reconnects and the
+					// next attempt re-syncs from scratch.
+					cancel()
+				}
+			}()
+		},
+		func(req api.ProxyRequestResponse) {
+			st.observe(send, req)
+		})
+
+	// Join before reading fetchErr: the deferred backstop runs only after the
+	// return value has been computed.
+	join()
+
+	// Prefer the sync-protocol cause. Aborting a sync cancels the attempt
+	// context, which makes ConsumeProxyRequests report a generic cancellation
+	// that would otherwise hide why the attempt is recycling. A cancellation
+	// of the PARENT context (the TUI quitting) is not ours to reinterpret —
+	// the loop ends on it regardless.
+	if ctx.Err() == nil {
+		if st.overflowed() {
+			return errRequestsSyncOverflow
+		}
+		if fetchErr != nil {
+			return fetchErr
+		}
+	}
+	return err
+}
+
+// syncRequestsSnapshot fetches the ring snapshot and completes the sync. It
+// runs on its own goroutine, concurrently with the SSE read loop.
+//
+// A failure while the stream is still live is retried in place at the stream
+// package's base backoff rather than tearing the connection down — the events
+// we are buffering are exactly what the reconnect would have to re-fetch
+// anyway. After requestsSnapshotFetchAttempts consecutive failures it gives up
+// and returns the error, which aborts the attempt so the loop's own backoff
+// and status reporting take over. The loop stays in Syncing (never OK) for the
+// whole retry window.
+//
+// A ctx cancellation returns nil: the attempt is already ending for a reason
+// the caller knows better than we do, and reporting a bare cancellation here
+// would mask the stream's real error.
+func syncRequestsSnapshot(ctx context.Context, client TUIClient, send func(tea.Msg), st *requestsSyncState, markSynced func()) error {
+	var lastErr error
+	for i := 0; i < requestsSnapshotFetchAttempts; i++ {
+		if i > 0 {
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-time.After(constants.StreamReconnectBaseBackoff):
+			}
+		}
+
+		resp, err := client.GetProxyRequests(ctx, domain.ProxyRequestParams{Limit: constants.MaxProxyRequests})
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			lastErr = err
+			continue
+		}
+
+		st.complete(send, snapshotRecords(send, resp.Requests), markSynced)
+		return nil
+	}
+	if ctx.Err() != nil {
+		return nil
+	}
+	return fmt.Errorf("requests sync: snapshot fetch failed %d times: %w", requestsSnapshotFetchAttempts, lastErr)
+}
+
+// snapshotRecords converts a REST snapshot to records in APPLY order. The
+// endpoint returns newest-first; the merge wants oldest-first so the list ends
+// up in the same order the live stream would have produced.
+func snapshotRecords(send func(tea.Msg), requests []api.ProxyRequestResponse) []proxy.RequestRecord {
+	records := make([]proxy.RequestRecord, 0, len(requests))
+	for i := len(requests) - 1; i >= 0; i-- {
+		records = append(records, streamedProxyRequest(send, requests[i]))
+	}
+	return records
+}
+
+// requestsSyncState is the handoff between the SSE reader goroutine (which
+// produces live events) and the snapshot fetch goroutine (which ends the
+// buffering phase). Everything is guarded by mu: complete's "deliver the batch,
+// mark synced, flip to passthrough" must be atomic with respect to observe, or
+// a live event could slip out either side of the batch.
+type requestsSyncState struct {
+	mu        sync.Mutex
+	buffering bool
+	buf       []proxy.RequestRecord
+	overflow  bool
+
+	// abort cancels the attempt context. Called (once, outside mu) when the
+	// buffer overflows, since a buffering onEvent has no other way to end the
+	// attempt.
+	abort func()
+}
+
+// observe handles one live event: buffered while the snapshot is outstanding,
+// delivered directly once the sync has completed.
+func (st *requestsSyncState) observe(send func(tea.Msg), req api.ProxyRequestResponse) {
+	st.mu.Lock()
+
+	if !st.buffering {
+		st.mu.Unlock()
+		sendStreamedProxyRequest(send, req)
+		return
+	}
+	if st.overflow {
+		// The attempt is already being torn down; nothing gained by keeping
+		// events for a batch that will never be delivered.
+		st.mu.Unlock()
+		return
+	}
+	if len(st.buf) >= constants.MaxProxyRequests {
+		st.overflow = true
+		st.mu.Unlock()
+		st.abort()
+		return
+	}
+
+	st.buf = append(st.buf, streamedProxyRequest(send, req))
+	st.mu.Unlock()
+}
+
+// complete delivers the sync batch and switches to passthrough. A no-op once
+// the attempt has overflowed (the batch is moot) or the sync already completed
+// (a client that called onConnect twice).
+func (st *requestsSyncState) complete(send func(tea.Msg), snapshot []proxy.RequestRecord, markSynced func()) {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+
+	if !st.buffering || st.overflow {
+		return
+	}
+
+	buffered := st.buf
+	st.buf = nil
+	st.buffering = false
+
+	send(RequestsSyncMsg{Snapshot: snapshot, Buffered: buffered})
+	// Only NOW is the stream synchronized: the models hold the full ring plus
+	// everything that arrived during the fetch.
+	markSynced()
+}
+
+func (st *requestsSyncState) overflowed() bool {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	return st.overflow
+}

--- a/internal/tui/requests_sync.go
+++ b/internal/tui/requests_sync.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -45,7 +44,8 @@ var errRequestsSyncOverflow = errors.New("requests sync: live event buffer overf
 const requestsSnapshotFetchAttempts = 3
 
 // consumeRequestsWithSync is the requests stream's single connect-and-consume
-// attempt (the logs stream stays a pure stream consumer; C9 owns log sync).
+// attempt. The logs stream runs the same protocol over its own payload
+// (consumeLogsWithSync); the two are meant to read as one.
 //
 // The protocol, mirroring the forwarder's proven backfillSnapshot shape:
 //
@@ -53,80 +53,30 @@ const requestsSnapshotFetchAttempts = 3
 //     does NOT complete — the sync: markSynced is deliberately not called yet,
 //     so the loop stays in Syncing and the status bar keeps saying so.
 //  2. Live events arriving from here on are BUFFERED, not delivered.
-//  3. Concurrently (a goroutine — the reader goroutine is busy reading, and
-//     buffering would deadlock if the fetch ran on it), fetch the full ring
+//  3. Concurrently, on the fetch goroutine (see syncFetch), fetch the full ring
 //     over REST.
 //  4. On success, deliver one RequestsSyncMsg carrying the snapshot and the
 //     buffer, mark the loop synchronized (StateOK), and flip live events back
 //     to direct delivery. All three happen under one mutex, so the reader
 //     goroutine cannot interleave an event between the batch and the flip.
-//
-// The fetch goroutine is tied to a per-attempt context and waited for before
-// returning, so it never outlives its attempt — which is what makes calling
-// markSynced from it safe despite stream.Config.Attempt's "call it from the
-// attempt itself" rule: the rule exists to stop a STRAGGLING goroutine from
-// flipping a later attempt's state, and this one cannot straggle (the loop's
-// epoch guard is the second line of defense).
 func consumeRequestsWithSync(ctx context.Context, client TUIClient, send func(tea.Msg), markSynced func()) error {
-	attemptCtx, cancel := context.WithCancel(ctx)
+	attemptCtx, fetch := newSyncFetch(ctx)
+	defer fetch.join()
 
-	st := &requestsSyncState{buffering: true, abort: cancel}
-	fetchDone := make(chan struct{})
-	var fetchStarted atomic.Bool
-	var fetchErr error
-
-	// join ends the fetch goroutine and waits for it, so it can never outlive
-	// its attempt. Idempotent (cancel is; a closed channel stays receivable),
-	// so it is safe both as the deferred backstop and as the explicit join
-	// below that makes fetchErr readable.
-	join := func() {
-		cancel()
-		if fetchStarted.Load() {
-			<-fetchDone
-		}
-	}
-	defer join()
+	st := &requestsSyncState{buffering: true, abort: fetch.abort, send: send}
 
 	err := client.ConsumeProxyRequests(attemptCtx, domain.ProxyRequestParams{},
 		func() {
-			// One sync per attempt: a client that called onConnect twice would
-			// otherwise start a second fetch goroutine and double-close
-			// fetchDone.
-			if !fetchStarted.CompareAndSwap(false, true) {
-				return
-			}
-			go func() {
-				defer close(fetchDone)
-				fetchErr = syncRequestsSnapshot(attemptCtx, client, send, st, markSynced)
-				if fetchErr != nil {
-					// Give up on this attempt: the loop reconnects and the
-					// next attempt re-syncs from scratch.
-					cancel()
-				}
-			}()
+			fetch.start(func() error {
+				return syncRequestsSnapshot(attemptCtx, client, st, markSynced)
+			})
 		},
-		func(req api.ProxyRequestResponse) {
-			st.observe(send, req)
-		})
+		st.observe)
 
-	// Join before reading fetchErr: the deferred backstop runs only after the
-	// return value has been computed.
-	join()
-
-	// Prefer the sync-protocol cause. Aborting a sync cancels the attempt
-	// context, which makes ConsumeProxyRequests report a generic cancellation
-	// that would otherwise hide why the attempt is recycling. A cancellation
-	// of the PARENT context (the TUI quitting) is not ours to reinterpret —
-	// the loop ends on it regardless.
-	if ctx.Err() == nil {
-		if st.overflowed() {
-			return errRequestsSyncOverflow
-		}
-		if fetchErr != nil {
-			return fetchErr
-		}
-	}
-	return err
+	// Join before reading the fetch's error: the deferred backstop runs only
+	// after the return value has been computed.
+	fetch.join()
+	return fetch.attemptError(ctx, st.abortErr(), err)
 }
 
 // syncRequestsSnapshot fetches the ring snapshot and completes the sync. It
@@ -143,7 +93,7 @@ func consumeRequestsWithSync(ctx context.Context, client TUIClient, send func(te
 // A ctx cancellation returns nil: the attempt is already ending for a reason
 // the caller knows better than we do, and reporting a bare cancellation here
 // would mask the stream's real error.
-func syncRequestsSnapshot(ctx context.Context, client TUIClient, send func(tea.Msg), st *requestsSyncState, markSynced func()) error {
+func syncRequestsSnapshot(ctx context.Context, client TUIClient, st *requestsSyncState, markSynced func()) error {
 	var lastErr error
 	for i := 0; i < requestsSnapshotFetchAttempts; i++ {
 		if i > 0 {
@@ -163,7 +113,7 @@ func syncRequestsSnapshot(ctx context.Context, client TUIClient, send func(tea.M
 			continue
 		}
 
-		st.complete(send, snapshotRecords(send, resp.Requests), markSynced)
+		st.complete(snapshotRecords(st.send, resp.Requests), markSynced)
 		return nil
 	}
 	if ctx.Err() != nil {
@@ -194,20 +144,21 @@ type requestsSyncState struct {
 	buf       []proxy.RequestRecord
 	overflow  bool
 
-	// abort cancels the attempt context. Called (once, outside mu) when the
-	// buffer overflows, since a buffering onEvent has no other way to end the
-	// attempt.
+	// abort cancels the attempt context (syncFetch.abort). Called once, outside
+	// mu, when the buffer overflows.
 	abort func()
+
+	send func(tea.Msg)
 }
 
 // observe handles one live event: buffered while the snapshot is outstanding,
 // delivered directly once the sync has completed.
-func (st *requestsSyncState) observe(send func(tea.Msg), req api.ProxyRequestResponse) {
+func (st *requestsSyncState) observe(req api.ProxyRequestResponse) {
 	st.mu.Lock()
 
 	if !st.buffering {
 		st.mu.Unlock()
-		sendStreamedProxyRequest(send, req)
+		sendStreamedProxyRequest(st.send, req)
 		return
 	}
 	if st.overflow {
@@ -223,14 +174,14 @@ func (st *requestsSyncState) observe(send func(tea.Msg), req api.ProxyRequestRes
 		return
 	}
 
-	st.buf = append(st.buf, streamedProxyRequest(send, req))
+	st.buf = append(st.buf, streamedProxyRequest(st.send, req))
 	st.mu.Unlock()
 }
 
 // complete delivers the sync batch and switches to passthrough. A no-op once
 // the attempt has overflowed (the batch is moot) or the sync already completed
 // (a client that called onConnect twice).
-func (st *requestsSyncState) complete(send func(tea.Msg), snapshot []proxy.RequestRecord, markSynced func()) {
+func (st *requestsSyncState) complete(snapshot []proxy.RequestRecord, markSynced func()) {
 	st.mu.Lock()
 	defer st.mu.Unlock()
 
@@ -242,14 +193,19 @@ func (st *requestsSyncState) complete(send func(tea.Msg), snapshot []proxy.Reque
 	st.buf = nil
 	st.buffering = false
 
-	send(RequestsSyncMsg{Snapshot: snapshot, Buffered: buffered})
+	st.send(RequestsSyncMsg{Snapshot: snapshot, Buffered: buffered})
 	// Only NOW is the stream synchronized: the models hold the full ring plus
 	// everything that arrived during the fetch.
 	markSynced()
 }
 
-func (st *requestsSyncState) overflowed() bool {
+// abortErr reports the sync-protocol reason this attempt must be recycled, or
+// nil if it ended for a reason of the stream's own.
+func (st *requestsSyncState) abortErr() error {
 	st.mu.Lock()
 	defer st.mu.Unlock()
-	return st.overflow
+	if st.overflow {
+		return errRequestsSyncOverflow
+	}
+	return nil
 }

--- a/internal/tui/requests_sync_test.go
+++ b/internal/tui/requests_sync_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -261,41 +259,10 @@ func TestRequestsSync_SweptRowUnmarkedByLateCompletion(t *testing.T) {
 
 // --- attempt-level sync protocol ---
 
-// syncHarness runs consumeRequestsWithSync attempts: it collects the messages
-// the attempt delivers, counts markSynced calls, and publishes syncedCh so a
-// scripted stream can wait for the sync barrier before streaming more events.
-type syncHarness struct {
-	collector *msgCollector
-	syncedCh  chan struct{}
-	syncedN   atomic.Int32
-	once      sync.Once
-}
-
-func newSyncHarness() *syncHarness {
-	return &syncHarness{collector: newMsgCollector(), syncedCh: make(chan struct{})}
-}
-
-func (h *syncHarness) markSynced() {
-	h.syncedN.Add(1)
-	h.once.Do(func() { close(h.syncedCh) })
-}
-
-func (h *syncHarness) run(ctx context.Context, client TUIClient) error {
-	return consumeRequestsWithSync(ctx, client, h.collector.send, h.markSynced)
-}
-
-// runInBackground starts one attempt and returns a channel carrying its error.
-func (h *syncHarness) runInBackground(ctx context.Context, client TUIClient) <-chan error {
-	errCh := make(chan error, 1)
-	go func() { errCh <- h.run(ctx, client) }()
-	return errCh
-}
-
-// awaitSync blocks until the attempt delivers its RequestsSyncMsg.
-func (h *syncHarness) awaitSync(t *testing.T) RequestsSyncMsg {
-	t.Helper()
-	msg := h.collector.await(t, func(m tea.Msg) bool { _, ok := m.(RequestsSyncMsg); return ok })
-	return msg.(RequestsSyncMsg)
+// newRequestsSyncHarness drives consumeRequestsWithSync attempts. See
+// syncHarness (stream_health_test.go) for the machinery.
+func newRequestsSyncHarness() *syncHarness {
+	return newSyncHarness(consumeRequestsWithSync)
 }
 
 // TestConsumeRequestsWithSync_DeliversBatchThenMarksSynced pins the barrier:
@@ -303,7 +270,7 @@ func (h *syncHarness) awaitSync(t *testing.T) RequestsSyncMsg {
 // RequestsSyncMsg (never delivered loose), markSynced fires only after that
 // message, and later events pass straight through.
 func TestConsumeRequestsWithSync_DeliversBatchThenMarksSynced(t *testing.T) {
-	h := newSyncHarness()
+	h := newRequestsSyncHarness()
 	buffered := make(chan struct{})
 	client := &stubTUIClient{
 		snapshot: []api.ProxyRequestResponse{wireRequest("snap-1", 200, false)},
@@ -329,7 +296,7 @@ func TestConsumeRequestsWithSync_DeliversBatchThenMarksSynced(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	errCh := h.runInBackground(ctx, client)
 
-	syncMsg := h.awaitSync(t)
+	syncMsg := awaitSync[RequestsSyncMsg](t, h)
 	assert.Equal(t, []string{"snap-1"}, wireIDs(syncMsg.Snapshot))
 	assert.Equal(t, []string{"live-1"}, wireIDs(syncMsg.Buffered))
 
@@ -362,7 +329,7 @@ func TestConsumeRequestsWithSync_DeliversBatchThenMarksSynced(t *testing.T) {
 // ends the attempt with a distinct, retryable error rather than dropping
 // events, and the next attempt re-syncs cleanly.
 func TestConsumeRequestsWithSync_BufferOverflowAbortsAttempt(t *testing.T) {
-	h := newSyncHarness()
+	h := newRequestsSyncHarness()
 	overflowed := make(chan struct{})
 	client := &stubTUIClient{}
 	client.consumeRequests = func(ctx context.Context, onConnect func(), onEvent func(api.ProxyRequestResponse)) error {
@@ -389,11 +356,11 @@ func TestConsumeRequestsWithSync_BufferOverflowAbortsAttempt(t *testing.T) {
 	}
 
 	// A re-attempt against a healthy stream syncs normally.
-	retryH := newSyncHarness()
+	retryH := newRequestsSyncHarness()
 	retry := &stubTUIClient{snapshot: []api.ProxyRequestResponse{wireRequest("snap-1", 200, false)}}
 	ctx, cancel := context.WithCancel(context.Background())
 	errCh := retryH.runInBackground(ctx, retry)
-	assert.Equal(t, []string{"snap-1"}, wireIDs(retryH.awaitSync(t).Snapshot))
+	assert.Equal(t, []string{"snap-1"}, wireIDs(awaitSync[RequestsSyncMsg](t, retryH).Snapshot))
 	cancel()
 	<-errCh
 	assert.Equal(t, int32(1), retryH.syncedN.Load())
@@ -413,7 +380,7 @@ func TestConsumeRequestsWithSync_SnapshotFetchRetriesThenRecycles(t *testing.T) 
 		},
 	}
 
-	h := newSyncHarness()
+	h := newRequestsSyncHarness()
 	err := h.run(context.Background(), client)
 
 	assert.Equal(t, requestsSnapshotFetchAttempts, client.snapshotCalls(), "retries in place")
@@ -435,7 +402,7 @@ func TestConsumeRequestsWithSync_StreamErrorSurvivesTheSync(t *testing.T) {
 		},
 	}
 
-	h := newSyncHarness()
+	h := newRequestsSyncHarness()
 	assert.EqualError(t, h.run(context.Background(), client), "connection reset")
 }
 
@@ -448,7 +415,7 @@ func TestConsumeRequestsWithSync_DeadDialNeverSyncs(t *testing.T) {
 		},
 	}
 
-	h := newSyncHarness()
+	h := newRequestsSyncHarness()
 	assert.EqualError(t, h.run(context.Background(), client), "connection refused")
 	assert.Equal(t, 0, client.snapshotCalls(), "no snapshot fetch without a connection")
 	assert.Zero(t, h.syncedN.Load())

--- a/internal/tui/requests_sync_test.go
+++ b/internal/tui/requests_sync_test.go
@@ -1,0 +1,564 @@
+package tui
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/charliek/prox/internal/api"
+	"github.com/charliek/prox/internal/constants"
+	"github.com/charliek/prox/internal/proxy"
+	"github.com/charliek/prox/internal/stream"
+)
+
+// --- helpers ---
+
+// wireRequest builds one wire-format record as the REST snapshot and the SSE
+// stream both deliver it.
+func wireRequest(id string, status int, inFlight bool) api.ProxyRequestResponse {
+	return api.ProxyRequestResponse{
+		ID:         id,
+		Timestamp:  time.Unix(0, 0).Format(time.RFC3339Nano),
+		Method:     "GET",
+		URL:        "/" + id,
+		StatusCode: status,
+		InFlight:   inFlight,
+	}
+}
+
+// syncRecord builds one already-converted record, for seeding a model's list
+// and for building RequestsSyncMsg payloads directly.
+func syncRecord(id string, status int, inFlight bool) proxy.RequestRecord {
+	return proxy.RequestRecord{
+		ID:         id,
+		Timestamp:  time.Now(),
+		Method:     "GET",
+		URL:        "/" + id,
+		StatusCode: status,
+		InFlight:   inFlight,
+	}
+}
+
+// requestIDs lists the model's rows in order, for duplicate/ordering assertions.
+func requestIDs(m ClientModel) []string {
+	ids := make([]string, 0, len(m.proxyRequests))
+	for _, req := range m.proxyRequests {
+		ids = append(ids, req.ID)
+	}
+	return ids
+}
+
+// findRequest returns the row with the given ID.
+func findRequest(t *testing.T, m ClientModel, id string) proxy.RequestRecord {
+	t.Helper()
+	for _, req := range m.proxyRequests {
+		if req.ID == id {
+			return req
+		}
+	}
+	t.Fatalf("no row with id %q; have %v", id, requestIDs(m))
+	return proxy.RequestRecord{}
+}
+
+// syncModel builds an attach-mode model in the requests view with no rows.
+func syncModel() ClientModel {
+	return newClientRequestsModel(&stubTUIClient{}, 0, 10)
+}
+
+// --- merge / interleaving permutations (Update-driven) ---
+
+// TestRequestsSync_SnapshotInFlightCannotRegressLiveFinal covers the ordering
+// that snapshot replay makes unavoidable: the completion arrived live before
+// the sync, and the snapshot (taken earlier, server-side) still shows the
+// request in flight. Final is terminal, so the row must not regress.
+func TestRequestsSync_SnapshotInFlightCannotRegressLiveFinal(t *testing.T) {
+	m := syncModel()
+	m = clientUpdate(m, ProxyRequestMsg(syncRecord("req-1", 200, false)))
+
+	m = clientUpdate(m, RequestsSyncMsg{
+		Snapshot: []proxy.RequestRecord{syncRecord("req-1", 0, true)},
+	})
+
+	assert.Equal(t, []string{"req-1"}, requestIDs(m), "no duplicate row")
+	row := findRequest(t, m, "req-1")
+	assert.False(t, row.InFlight, "a snapshot's stale in-flight copy must not regress a final row")
+	assert.Equal(t, 200, row.StatusCode)
+}
+
+// TestRequestsSync_BufferedFinalWinsOverSnapshotInFlight covers the same race
+// the other way round: the completion arrived DURING the fetch, so it rides in
+// Buffered and is applied after the snapshot's in-flight copy.
+func TestRequestsSync_BufferedFinalWinsOverSnapshotInFlight(t *testing.T) {
+	m := syncModel()
+
+	m = clientUpdate(m, RequestsSyncMsg{
+		Snapshot: []proxy.RequestRecord{syncRecord("req-1", 0, true)},
+		Buffered: []proxy.RequestRecord{syncRecord("req-1", 204, false)},
+	})
+
+	assert.Equal(t, []string{"req-1"}, requestIDs(m))
+	row := findRequest(t, m, "req-1")
+	assert.False(t, row.InFlight)
+	assert.Equal(t, 204, row.StatusCode)
+}
+
+// TestRequestsSync_SnapshotFinalSurvivesBufferedInFlight is the inverse: a
+// duplicate in-flight event buffered behind a snapshot that already has the
+// completion cannot un-finish it.
+func TestRequestsSync_SnapshotFinalSurvivesBufferedInFlight(t *testing.T) {
+	m := syncModel()
+
+	m = clientUpdate(m, RequestsSyncMsg{
+		Snapshot: []proxy.RequestRecord{syncRecord("req-1", 200, false)},
+		Buffered: []proxy.RequestRecord{syncRecord("req-1", 0, true)},
+	})
+
+	row := findRequest(t, m, "req-1")
+	assert.False(t, row.InFlight, "final is terminal")
+	assert.Equal(t, 200, row.StatusCode)
+}
+
+// TestRequestsSync_LiveArrivalDuringSyncAppearsOnce pins that a request that
+// started during the fetch — present only in the buffer — lands exactly once.
+func TestRequestsSync_LiveArrivalDuringSyncAppearsOnce(t *testing.T) {
+	m := syncModel()
+
+	m = clientUpdate(m, RequestsSyncMsg{
+		Snapshot: []proxy.RequestRecord{syncRecord("old-1", 200, false)},
+		Buffered: []proxy.RequestRecord{syncRecord("new-1", 0, true), syncRecord("new-1", 201, false)},
+	})
+
+	assert.Equal(t, []string{"old-1", "new-1"}, requestIDs(m))
+	assert.Equal(t, 201, findRequest(t, m, "new-1").StatusCode)
+}
+
+// TestRequestsSync_DuplicateIDsAcrossSnapshotAndBufferDoNotDuplicate pins the
+// no-duplicates property over a batch where every buffered event also appears
+// in the snapshot (the common case: the fetch raced the same events).
+func TestRequestsSync_DuplicateIDsAcrossSnapshotAndBufferDoNotDuplicate(t *testing.T) {
+	m := syncModel()
+
+	m = clientUpdate(m, RequestsSyncMsg{
+		Snapshot: []proxy.RequestRecord{
+			syncRecord("req-1", 200, false),
+			syncRecord("req-2", 0, true),
+			syncRecord("req-3", 0, true),
+		},
+		Buffered: []proxy.RequestRecord{
+			syncRecord("req-2", 0, true),
+			syncRecord("req-3", 500, false),
+			syncRecord("req-1", 200, false),
+		},
+	})
+
+	assert.Equal(t, []string{"req-1", "req-2", "req-3"}, requestIDs(m))
+	assert.True(t, findRequest(t, m, "req-2").InFlight, "still in flight")
+	assert.Equal(t, 500, findRequest(t, m, "req-3").StatusCode, "completion applied")
+}
+
+// TestRequestsSync_SnapshotAppliesOldestFirst pins the replay order: the list
+// must end up in the same order the live stream would have produced.
+func TestRequestsSync_SnapshotAppliesOldestFirst(t *testing.T) {
+	send := func(tea.Msg) {}
+	// The REST endpoint returns newest-first.
+	records := snapshotRecords(send, []api.ProxyRequestResponse{
+		wireRequest("req-3", 200, false),
+		wireRequest("req-2", 200, false),
+		wireRequest("req-1", 200, false),
+	})
+
+	m := clientUpdate(syncModel(), RequestsSyncMsg{Snapshot: records})
+	assert.Equal(t, []string{"req-1", "req-2", "req-3"}, requestIDs(m))
+}
+
+// TestRequestsSync_BatchRendersOnce is deliberately absent as an instrumented
+// assertion: BaseModel exposes no render counter and adding one purely for the
+// test would put test-only state on the production model. The property is
+// structural instead — handleRequestsSync has exactly ONE call to
+// renderAfterProxyRequests, after the whole batch is merged — and the tests
+// above pin that the batch's end state matches record-by-record application.
+
+// --- cursor / follow semantics across a batch ---
+
+// TestRequestsSync_CursorSurvivesBatch pins that a user parked on a row keeps
+// it across a sync batch: the cursor is ID-anchored, so rows arriving before
+// and after it cannot drag it.
+func TestRequestsSync_CursorSurvivesBatch(t *testing.T) {
+	m := newClientRequestsModel(&stubTUIClient{}, 5, 10)
+	m = clientUpdate(m, keyRune('g')) // cursor row 0, follow off
+	m = clientUpdate(m, keyRune('j')) // cursor row 1 (req-001)
+	require.Equal(t, "req-001", m.cursorID)
+	require.False(t, m.followMode)
+
+	m = clientUpdate(m, RequestsSyncMsg{
+		Snapshot: []proxy.RequestRecord{syncRecord("snap-1", 200, false)},
+		Buffered: []proxy.RequestRecord{syncRecord("live-1", 200, false)},
+	})
+
+	assert.Equal(t, "req-001", m.cursorID, "the ID-anchored cursor survives the batch")
+	assert.Equal(t, 1, m.cursorIdx, "and keeps its index: the batch only appended")
+	assert.False(t, m.followMode, "a sync batch never re-engages follow")
+}
+
+// TestRequestsSync_FollowPinsToNewestAfterBatch pins the other half: with
+// follow engaged, the cursor lands on the newest row of the merged list.
+func TestRequestsSync_FollowPinsToNewestAfterBatch(t *testing.T) {
+	m := newClientRequestsModel(&stubTUIClient{}, 3, 10)
+	require.True(t, m.followMode)
+
+	m = clientUpdate(m, RequestsSyncMsg{
+		Snapshot: []proxy.RequestRecord{syncRecord("snap-1", 200, false)},
+		Buffered: []proxy.RequestRecord{syncRecord("live-1", 200, false)},
+	})
+
+	assert.Equal(t, "live-1", m.cursorID, "follow pins to the newest row")
+	assert.Equal(t, len(m.proxyRequests)-1, m.cursorIdx)
+}
+
+// --- prior-epoch sweep ---
+
+// TestRequestsSync_PriorEpochInFlightSweptStale pins that an in-flight row the
+// synchronized server has never heard of is marked stale immediately: its
+// daemon is gone, so no completion can ever arrive and the row would otherwise
+// spin "...ms" forever.
+func TestRequestsSync_PriorEpochInFlightSweptStale(t *testing.T) {
+	m := syncModel()
+	m = clientUpdate(m, ProxyRequestMsg(syncRecord("orphan", 0, true)))
+	m = clientUpdate(m, ProxyRequestMsg(syncRecord("done", 200, false)))
+	require.False(t, m.requestIsStale(findRequest(t, m, "orphan")), "not stale before the sync")
+
+	m = clientUpdate(m, RequestsSyncMsg{
+		Snapshot: []proxy.RequestRecord{syncRecord("known", 0, true)},
+		Buffered: []proxy.RequestRecord{syncRecord("fresh", 0, true)},
+	})
+
+	assert.True(t, m.requestIsStale(findRequest(t, m, "orphan")), "swept: absent from the snapshot")
+	assert.False(t, m.requestIsStale(findRequest(t, m, "known")), "in the snapshot")
+	assert.False(t, m.requestIsStale(findRequest(t, m, "fresh")), "started during the fetch")
+	assert.False(t, m.requestIsStale(findRequest(t, m, "done")), "final rows are never stale")
+	assert.Contains(t, m.View(), "stale?", "the sweep is visible in the requests list")
+}
+
+// TestRequestsSync_SweptRowUnmarkedByLateCompletion pins the mark is not
+// permanent: a completion that does arrive clears it.
+func TestRequestsSync_SweptRowUnmarkedByLateCompletion(t *testing.T) {
+	m := syncModel()
+	m = clientUpdate(m, ProxyRequestMsg(syncRecord("orphan", 0, true)))
+	m = clientUpdate(m, RequestsSyncMsg{})
+	require.True(t, m.requestIsStale(findRequest(t, m, "orphan")))
+
+	m = clientUpdate(m, ProxyRequestMsg(syncRecord("orphan", 200, false)))
+	assert.False(t, m.requestIsStale(findRequest(t, m, "orphan")))
+}
+
+// --- attempt-level sync protocol ---
+
+// syncHarness runs consumeRequestsWithSync attempts: it collects the messages
+// the attempt delivers, counts markSynced calls, and publishes syncedCh so a
+// scripted stream can wait for the sync barrier before streaming more events.
+type syncHarness struct {
+	collector *msgCollector
+	syncedCh  chan struct{}
+	syncedN   atomic.Int32
+	once      sync.Once
+}
+
+func newSyncHarness() *syncHarness {
+	return &syncHarness{collector: newMsgCollector(), syncedCh: make(chan struct{})}
+}
+
+func (h *syncHarness) markSynced() {
+	h.syncedN.Add(1)
+	h.once.Do(func() { close(h.syncedCh) })
+}
+
+func (h *syncHarness) run(ctx context.Context, client TUIClient) error {
+	return consumeRequestsWithSync(ctx, client, h.collector.send, h.markSynced)
+}
+
+// runInBackground starts one attempt and returns a channel carrying its error.
+func (h *syncHarness) runInBackground(ctx context.Context, client TUIClient) <-chan error {
+	errCh := make(chan error, 1)
+	go func() { errCh <- h.run(ctx, client) }()
+	return errCh
+}
+
+// awaitSync blocks until the attempt delivers its RequestsSyncMsg.
+func (h *syncHarness) awaitSync(t *testing.T) RequestsSyncMsg {
+	t.Helper()
+	msg := h.collector.await(t, func(m tea.Msg) bool { _, ok := m.(RequestsSyncMsg); return ok })
+	return msg.(RequestsSyncMsg)
+}
+
+// TestConsumeRequestsWithSync_DeliversBatchThenMarksSynced pins the barrier:
+// events seen before the snapshot land are BUFFERED into the one
+// RequestsSyncMsg (never delivered loose), markSynced fires only after that
+// message, and later events pass straight through.
+func TestConsumeRequestsWithSync_DeliversBatchThenMarksSynced(t *testing.T) {
+	h := newSyncHarness()
+	buffered := make(chan struct{})
+	client := &stubTUIClient{
+		snapshot: []api.ProxyRequestResponse{wireRequest("snap-1", 200, false)},
+	}
+	client.consumeRequests = func(ctx context.Context, onConnect func(), onEvent func(api.ProxyRequestResponse)) error {
+		onConnect()
+		onEvent(wireRequest("live-1", 0, true)) // buffered: the fetch is held below
+		close(buffered)
+		// Once the sync barrier is crossed, a further event must arrive as a
+		// plain ProxyRequestMsg rather than being buffered.
+		select {
+		case <-h.syncedCh:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+		onEvent(wireRequest("live-2", 200, false))
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	// The fetch may only return once the first live event has been buffered.
+	client.snapshotCall = func(int) { <-buffered }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := h.runInBackground(ctx, client)
+
+	syncMsg := h.awaitSync(t)
+	assert.Equal(t, []string{"snap-1"}, wireIDs(syncMsg.Snapshot))
+	assert.Equal(t, []string{"live-1"}, wireIDs(syncMsg.Buffered))
+
+	// Wait for the passthrough event before tearing the attempt down.
+	h.collector.await(t, func(m tea.Msg) bool {
+		req, ok := m.(ProxyRequestMsg)
+		return ok && req.ID == "live-2"
+	})
+	cancel()
+	<-errCh
+
+	assert.Equal(t, int32(1), h.syncedN.Load(), "markSynced fires exactly once, after the batch")
+
+	msgs := h.collector.all()
+	require.NotEmpty(t, msgs)
+	_, first := msgs[0].(RequestsSyncMsg)
+	assert.True(t, first, "no loose ProxyRequestMsg before the sync batch; got %T", msgs[0])
+
+	var passthrough []string
+	for _, msg := range msgs[1:] {
+		if req, ok := msg.(ProxyRequestMsg); ok {
+			passthrough = append(passthrough, req.ID)
+		}
+	}
+	assert.Equal(t, []string{"live-2"}, passthrough, "post-sync events pass straight through")
+}
+
+// TestConsumeRequestsWithSync_BufferOverflowAbortsAttempt pins the
+// nothing-silently-lost rule: a buffer that fills before the snapshot lands
+// ends the attempt with a distinct, retryable error rather than dropping
+// events, and the next attempt re-syncs cleanly.
+func TestConsumeRequestsWithSync_BufferOverflowAbortsAttempt(t *testing.T) {
+	h := newSyncHarness()
+	overflowed := make(chan struct{})
+	client := &stubTUIClient{}
+	client.consumeRequests = func(ctx context.Context, onConnect func(), onEvent func(api.ProxyRequestResponse)) error {
+		onConnect()
+		for i := 0; i <= constants.MaxProxyRequests; i++ {
+			onEvent(wireRequest(fmt.Sprintf("req-%04d", i), 200, false))
+		}
+		close(overflowed)
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	// Hold the snapshot until the buffer has overflowed.
+	client.snapshotCall = func(int) { <-overflowed }
+
+	err := h.run(context.Background(), client)
+
+	require.ErrorIs(t, err, errRequestsSyncOverflow)
+	assert.Zero(t, h.syncedN.Load(), "an overflowed attempt never reports OK")
+	assert.Equal(t, stream.ClassTransient, classifyRequestsStreamError(err),
+		"the loop must reconnect and re-sync on overflow")
+	for _, msg := range h.collector.all() {
+		_, isSync := msg.(RequestsSyncMsg)
+		assert.False(t, isSync, "an overflowed attempt delivers no batch")
+	}
+
+	// A re-attempt against a healthy stream syncs normally.
+	retryH := newSyncHarness()
+	retry := &stubTUIClient{snapshot: []api.ProxyRequestResponse{wireRequest("snap-1", 200, false)}}
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := retryH.runInBackground(ctx, retry)
+	assert.Equal(t, []string{"snap-1"}, wireIDs(retryH.awaitSync(t).Snapshot))
+	cancel()
+	<-errCh
+	assert.Equal(t, int32(1), retryH.syncedN.Load())
+}
+
+// TestConsumeRequestsWithSync_SnapshotFetchRetriesThenRecycles pins the
+// fetch-failure policy: retry in place while the stream is live (staying
+// unsynced the whole time), then abort the attempt after
+// requestsSnapshotFetchAttempts so the loop's own backoff takes over.
+func TestConsumeRequestsWithSync_SnapshotFetchRetriesThenRecycles(t *testing.T) {
+	client := &stubTUIClient{
+		snapshotErr: errors.New("snapshot boom"),
+		consumeRequests: func(ctx context.Context, onConnect func(), onEvent func(api.ProxyRequestResponse)) error {
+			onConnect()
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	}
+
+	h := newSyncHarness()
+	err := h.run(context.Background(), client)
+
+	assert.Equal(t, requestsSnapshotFetchAttempts, client.snapshotCalls(), "retries in place")
+	assert.Zero(t, h.syncedN.Load(), "stays unsynced (Syncing) for the whole retry window")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "snapshot boom")
+	assert.ErrorContains(t, err, "snapshot fetch failed")
+	assert.Equal(t, stream.ClassTransient, classifyRequestsStreamError(err))
+}
+
+// TestConsumeRequestsWithSync_StreamErrorSurvivesTheSync pins that a stream
+// that simply dies reports ITS error, not a cancellation manufactured by the
+// sync teardown.
+func TestConsumeRequestsWithSync_StreamErrorSurvivesTheSync(t *testing.T) {
+	client := &stubTUIClient{
+		consumeRequests: func(ctx context.Context, onConnect func(), onEvent func(api.ProxyRequestResponse)) error {
+			onConnect()
+			return errors.New("connection reset")
+		},
+	}
+
+	h := newSyncHarness()
+	assert.EqualError(t, h.run(context.Background(), client), "connection reset")
+}
+
+// TestConsumeRequestsWithSync_DeadDialNeverSyncs pins that an attempt that
+// never connects never fetches and never reports OK.
+func TestConsumeRequestsWithSync_DeadDialNeverSyncs(t *testing.T) {
+	client := &stubTUIClient{
+		consumeRequests: func(context.Context, func(), func(api.ProxyRequestResponse)) error {
+			return errors.New("connection refused")
+		},
+	}
+
+	h := newSyncHarness()
+	assert.EqualError(t, h.run(context.Background(), client), "connection refused")
+	assert.Equal(t, 0, client.snapshotCalls(), "no snapshot fetch without a connection")
+	assert.Zero(t, h.syncedN.Load())
+}
+
+// --- loop-level wiring ---
+
+// TestRunClientStreams_RequestsOKOnlyAfterSync pins the whole point of the
+// protocol at the loop level: the requests stream reports OK only once the
+// snapshot has been applied, never between connect and sync completion.
+func TestRunClientStreams_RequestsOKOnlyAfterSync(t *testing.T) {
+	collector := newMsgCollector()
+	release := make(chan struct{})
+	client := &stubTUIClient{
+		snapshot: []api.ProxyRequestResponse{wireRequest("snap-1", 200, false)},
+		consumeRequests: func(ctx context.Context, onConnect func(), onEvent func(api.ProxyRequestResponse)) error {
+			onConnect()
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	}
+	client.snapshotCall = func(int) { <-release }
+
+	startClientStreams(t, client, collector.send)
+
+	// Before the snapshot lands the requests loop must not be OK.
+	time.Sleep(50 * time.Millisecond)
+	for _, msg := range collector.all() {
+		if s, ok := msg.(StreamStatusMsg); ok && s.Stream == StreamRequests {
+			assert.NotEqual(t, stream.StateOK, s.Status.State, "OK before the snapshot applied")
+		}
+	}
+
+	close(release)
+	collector.await(t, func(m tea.Msg) bool {
+		s, ok := m.(StreamStatusMsg)
+		return ok && s.Stream == StreamRequests && s.Status.State == stream.StateOK
+	})
+
+	// ...and the batch reached the models before that OK.
+	var syncIdx, okIdx = -1, -1
+	for i, msg := range collector.all() {
+		switch v := msg.(type) {
+		case RequestsSyncMsg:
+			if syncIdx < 0 {
+				syncIdx = i
+			}
+		case StreamStatusMsg:
+			if v.Stream == StreamRequests && v.Status.State == stream.StateOK && okIdx < 0 {
+				okIdx = i
+			}
+		}
+	}
+	require.GreaterOrEqual(t, syncIdx, 0, "the sync batch must be delivered")
+	require.GreaterOrEqual(t, okIdx, 0)
+	assert.Less(t, syncIdx, okIdx, "the batch is delivered before the loop reports OK")
+}
+
+// --- small helpers used above ---
+
+func wireIDs(records []proxy.RequestRecord) []string {
+	ids := make([]string, 0, len(records))
+	for _, r := range records {
+		ids = append(ids, r.ID)
+	}
+	return ids
+}
+
+// TestRequestsSync_CompletionViaSyncRefreshesOpenDetail pins D16 for the sync
+// path (cursor C6 review): a detail view open on an in-flight request whose
+// completion arrives inside a sync batch — not as a live event — must refetch,
+// exactly as the live-completion path does.
+func TestRequestsSync_CompletionViaSyncRefreshesOpenDetail(t *testing.T) {
+	stub := &stubTUIClient{}
+	m := newClientRequestsModel(stub, 0, 10)
+	m = clientUpdate(m, ProxyRequestMsg(syncRecord("req-1", 0, true)))
+	m.viewMode = ViewModeRequestDetail
+	m.selectedRequestID = "req-1"
+	m.requestDetail = inFlightDetailFor("req-1")
+	seqBefore := m.detailFetchSeq
+
+	nm, cmd := m.Update(RequestsSyncMsg{
+		Snapshot: []proxy.RequestRecord{syncRecord("req-1", 200, false)},
+	})
+	m = nm.(ClientModel)
+
+	require.NotNil(t, cmd, "sync-borne completion must trigger a detail refetch")
+	assert.Equal(t, seqBefore+1, m.detailFetchSeq)
+	// Executing the command performs the fetch against the selected row.
+	cmd()
+	assert.Equal(t, "req-1", stub.lastRequestedID())
+}
+
+// TestRequestsSync_FinalDetailNotRefetchedOnResync pins the guard the sync path
+// adds over the live path: a detail already showing a final response is not
+// refetched by every routine reconnect re-sync that includes its row.
+func TestRequestsSync_FinalDetailNotRefetchedOnResync(t *testing.T) {
+	stub := &stubTUIClient{}
+	m := newClientRequestsModel(stub, 0, 10)
+	m = clientUpdate(m, ProxyRequestMsg(syncRecord("req-1", 200, false)))
+	m.viewMode = ViewModeRequestDetail
+	m.selectedRequestID = "req-1"
+	m.requestDetail = finalDetailFor("req-1")
+	seqBefore := m.detailFetchSeq
+
+	nm, cmd := m.Update(RequestsSyncMsg{
+		Snapshot: []proxy.RequestRecord{syncRecord("req-1", 200, false)},
+	})
+	m = nm.(ClientModel)
+
+	assert.Nil(t, cmd, "an already-final detail must not refetch on re-sync")
+	assert.Equal(t, seqBefore, m.detailFetchSeq)
+}

--- a/internal/tui/stream_health.go
+++ b/internal/tui/stream_health.go
@@ -1,0 +1,138 @@
+package tui
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/charliek/prox/internal/domain"
+	"github.com/charliek/prox/internal/stream"
+)
+
+// StreamID names one of the TUI's data streams. Attach mode runs each of them
+// on its own internal/stream.Loop and reports the loop's health per stream;
+// local mode has no loops but reports the same identities so the status bar is
+// rendered by one shared path.
+type StreamID int
+
+const (
+	StreamLogs StreamID = iota
+	StreamRequests
+	// StreamProcesses is defined now and unused until the processes stream
+	// replaces attach mode's polling tick.
+	StreamProcesses
+)
+
+// String is the name rendered in the status bar.
+func (s StreamID) String() string {
+	switch s {
+	case StreamLogs:
+		return "logs"
+	case StreamRequests:
+		return "requests"
+	case StreamProcesses:
+		return "processes"
+	default:
+		return "unknown"
+	}
+}
+
+// allStreams fixes the status-bar segment order. Iterating this rather than the
+// health map keeps the bar from reshuffling between renders.
+var allStreams = []StreamID{StreamLogs, StreamRequests, StreamProcesses}
+
+// StreamStatusMsg carries one stream.Loop state transition into the models.
+// Both Update loops route it through BaseModel.handleStreamStatus.
+type StreamStatusMsg struct {
+	Stream StreamID
+	Status stream.Status
+}
+
+// APIStatusError is the structural view of a daemon error response that the
+// stream reconnect policies discriminate on. *cli.APIError implements it;
+// internal/cli imports internal/tui, so the concrete type cannot be named here.
+type APIStatusError interface {
+	// StatusCode is the HTTP status of the failed response.
+	StatusCode() int
+	// ErrorCode is the machine-readable code from the JSON error body, empty
+	// when the body carried none.
+	ErrorCode() string
+}
+
+// classifyStreamError is the shared attach-mode reconnect policy: an
+// authentication or authorization failure will not fix itself by retrying, so
+// it ends the loop; everything else (dial failures, hangups, 5xx) is transient.
+func classifyStreamError(err error) stream.Classification {
+	var apiErr APIStatusError
+	if errors.As(err, &apiErr) {
+		switch apiErr.StatusCode() {
+		case http.StatusUnauthorized, http.StatusForbidden:
+			return stream.ClassTerminal
+		}
+	}
+	return stream.ClassTransient
+}
+
+// classifyRequestsStreamError extends the shared policy with the one condition
+// unique to the requests stream: the daemon runs fine with the proxy disabled,
+// so a 503 PROXY_NOT_ENABLED is a standing "no such feed" rather than an
+// outage. The loop parks instead of retrying on a timer, and the status bar
+// renders it passively.
+func classifyRequestsStreamError(err error) stream.Classification {
+	var apiErr APIStatusError
+	if errors.As(err, &apiErr) &&
+		apiErr.StatusCode() == http.StatusServiceUnavailable &&
+		apiErr.ErrorCode() == domain.ErrCodeProxyNotEnabled {
+		return stream.ClassUnavailable
+	}
+	return classifyStreamError(err)
+}
+
+// handleStreamStatus records a stream's new health. Both maps are allocated by
+// newBaseModel.
+//
+// streamDropped latches on StateReconnecting so the Syncing that follows a drop
+// keeps rendering "reconnecting…": the loop's Reconnecting → Syncing → OK
+// sequence would otherwise flicker through a third wording on every retry. It
+// clears on any state that is neither Reconnecting nor Syncing, which leaves
+// the startup Connecting → Syncing → OK path silent.
+func (b *BaseModel) handleStreamStatus(msg StreamStatusMsg) {
+	b.streamHealth[msg.Stream] = msg.Status
+
+	switch msg.Status.State {
+	case stream.StateReconnecting:
+		b.streamDropped[msg.Stream] = true
+	case stream.StateSyncing:
+		// Keep the latch: this is either the post-drop retry (stay loud) or a
+		// first sync that never set it (stay silent).
+	default:
+		delete(b.streamDropped, msg.Stream)
+	}
+}
+
+// streamHealthSegments renders the status-bar segments for every stream that is
+// not healthy, in allStreams order. A healthy, still-connecting or
+// never-reported stream contributes nothing: startup must not be noisy.
+//
+// StateUnavailable is deliberately passive ("requests: n/a", no warning sign) —
+// it means the feed does not exist here, not that something broke.
+func (b *BaseModel) streamHealthSegments() []string {
+	var segs []string
+	for _, id := range allStreams {
+		st, ok := b.streamHealth[id]
+		if !ok {
+			continue
+		}
+		switch {
+		// A post-drop Syncing keeps the reconnecting wording (see the latch in
+		// handleStreamStatus); a first-connect Syncing stays silent.
+		case st.State == stream.StateReconnecting,
+			st.State == stream.StateSyncing && b.streamDropped[id]:
+			segs = append(segs, "⚠ "+id.String()+": reconnecting…")
+		case st.State == stream.StateUnavailable:
+			segs = append(segs, id.String()+": n/a")
+		case st.State == stream.StateClosed:
+			segs = append(segs, "⚠ "+id.String()+": disconnected")
+		}
+	}
+	return segs
+}

--- a/internal/tui/stream_health.go
+++ b/internal/tui/stream_health.go
@@ -17,8 +17,9 @@ type StreamID int
 const (
 	StreamLogs StreamID = iota
 	StreamRequests
-	// StreamProcesses is defined now and unused until the processes stream
-	// replaces attach mode's polling tick.
+	// StreamProcesses is attach mode's process-state feed, which replaced the
+	// polling tick in C12. Its health is reported like the others' but rendered
+	// differently — see streamHealthSegments.
 	StreamProcesses
 )
 
@@ -87,6 +88,21 @@ func classifyRequestsStreamError(err error) stream.Classification {
 	return classifyStreamError(err)
 }
 
+// classifyProcessesStreamError extends the shared policy with the one condition
+// unique to the processes stream: version skew. A daemon predating plan 017 has
+// no /api/v1/processes/stream at all and answers 404, which no amount of
+// retrying fixes — only replacing the daemon does. The loop parks
+// (ClassUnavailable) rather than hammering a route that does not exist, and the
+// attach model renders the parked state as a standing connection error naming
+// the old daemon (see ClientModel.noteProcessesStreamHealth).
+func classifyProcessesStreamError(err error) stream.Classification {
+	var apiErr APIStatusError
+	if errors.As(err, &apiErr) && apiErr.StatusCode() == http.StatusNotFound {
+		return stream.ClassUnavailable
+	}
+	return classifyStreamError(err)
+}
+
 // handleStreamStatus records a stream's new health. Both maps are allocated by
 // newBaseModel.
 //
@@ -115,9 +131,20 @@ func (b *BaseModel) handleStreamStatus(msg StreamStatusMsg) {
 //
 // StateUnavailable is deliberately passive ("requests: n/a", no warning sign) —
 // it means the feed does not exist here, not that something broke.
+//
+// StreamProcesses contributes NO segment, ever (C12). It is attach mode's
+// global-liveness signal rather than one feed among three: losing it means the
+// daemon is gone, which the status line already reports as "Connection error
+// (retrying...)" via ClientModel.connectionError, derived from exactly this
+// stream's health. A segment here would report the same outage twice, in two
+// wordings. Local mode never degrades it at all (newBaseModel starts every
+// stream OK and nothing moves the processes entry off it).
 func (b *BaseModel) streamHealthSegments() []string {
 	var segs []string
 	for _, id := range allStreams {
+		if id == StreamProcesses {
+			continue
+		}
 		st, ok := b.streamHealth[id]
 		if !ok {
 			continue

--- a/internal/tui/stream_health_test.go
+++ b/internal/tui/stream_health_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -238,6 +239,47 @@ func (c *msgCollector) await(t *testing.T, match func(tea.Msg) bool) tea.Msg {
 	}
 }
 
+// syncHarness runs one attach stream's connect-and-consume sync attempts: it
+// collects the messages an attempt delivers, counts markSynced calls, and
+// publishes syncedCh so a scripted stream can wait for the sync barrier before
+// streaming more events. attempt is the protocol under test, so the same
+// harness drives both consumeRequestsWithSync and consumeLogsWithSync.
+type syncHarness struct {
+	collector *msgCollector
+	syncedCh  chan struct{}
+	syncedN   atomic.Int32
+	once      sync.Once
+	attempt   func(ctx context.Context, client TUIClient, send func(tea.Msg), markSynced func()) error
+}
+
+func newSyncHarness(attempt func(context.Context, TUIClient, func(tea.Msg), func()) error) *syncHarness {
+	return &syncHarness{collector: newMsgCollector(), syncedCh: make(chan struct{}), attempt: attempt}
+}
+
+func (h *syncHarness) markSynced() {
+	h.syncedN.Add(1)
+	h.once.Do(func() { close(h.syncedCh) })
+}
+
+func (h *syncHarness) run(ctx context.Context, client TUIClient) error {
+	return h.attempt(ctx, client, h.collector.send, h.markSynced)
+}
+
+// runInBackground starts one attempt and returns a channel carrying its error.
+func (h *syncHarness) runInBackground(ctx context.Context, client TUIClient) <-chan error {
+	errCh := make(chan error, 1)
+	go func() { errCh <- h.run(ctx, client) }()
+	return errCh
+}
+
+// awaitSync blocks until the attempt delivers its sync batch, of whichever
+// message type the stream under test carries.
+func awaitSync[T tea.Msg](t *testing.T, h *syncHarness) T {
+	t.Helper()
+	msg := h.collector.await(t, func(m tea.Msg) bool { _, ok := m.(T); return ok })
+	return msg.(T)
+}
+
 // TestForwardLogs_ChannelCloseReportsClosed pins the W7 hardening: a local
 // subscription that dies on its own marks the stream closed and says so once.
 func TestForwardLogs_ChannelCloseReportsClosed(t *testing.T) {
@@ -340,18 +382,25 @@ func startClientStreams(t *testing.T, client TUIClient, send func(tea.Msg)) {
 }
 
 // TestRunClientStreams_ForwardsEventsAndStatus pins the wiring end to end: a
-// streamed entry reaches the model as a LogEntryMsg and the loop's own
-// transitions arrive as StreamStatusMsg for the right stream.
+// streamed entry reaches the model and the loop's own transitions arrive as
+// StreamStatusMsg for the right stream.
+//
+// Which message carries the entry is timing-dependent since C9: an entry that
+// races the backfill fetch is buffered into the LogsSyncMsg, and one that
+// arrives after the sync barrier passes through as a LogEntryMsg. Both are
+// correct deliveries, so the assertion accepts either.
 func TestRunClientStreams_ForwardsEventsAndStatus(t *testing.T) {
 	collector := newMsgCollector()
 	client := &stubTUIClient{
-		consumeLogs: func(ctx context.Context, onConnect func(), onEvent func(api.LogEntryResponse)) error {
+		consumeLogs: func(ctx context.Context, onConnect func(), onHandshake func(api.HandshakeResponse), onEvent func(api.LogEntryResponse)) error {
 			onConnect()
+			onHandshake(api.HandshakeResponse{StreamID: stubLogEpoch})
 			onEvent(api.LogEntryResponse{
 				Timestamp: time.Now().Format(time.RFC3339Nano),
 				Process:   "web",
 				Stream:    "stdout",
 				Line:      "streamed",
+				Seq:       1,
 			})
 			<-ctx.Done()
 			return ctx.Err()
@@ -360,17 +409,29 @@ func TestRunClientStreams_ForwardsEventsAndStatus(t *testing.T) {
 
 	startClientStreams(t, client, collector.send)
 
-	msg := collector.await(t, func(m tea.Msg) bool { _, ok := m.(LogEntryMsg); return ok })
-	assert.Equal(t, "streamed", domain.LogEntry(msg.(LogEntryMsg)).Line)
+	collector.await(t, func(m tea.Msg) bool { return logMsgCarriesLine(m, "streamed") })
 
-	// markSynced rides onConnect: OK is reported once the connection stands.
-	var sawLogsOK bool
-	for _, m := range collector.all() {
-		if s, ok := m.(StreamStatusMsg); ok && s.Stream == StreamLogs && s.Status.State == stream.StateOK {
-			sawLogsOK = true
+	// markSynced now rides the sync barrier: OK follows the backfill.
+	collector.await(t, func(m tea.Msg) bool {
+		s, ok := m.(StreamStatusMsg)
+		return ok && s.Stream == StreamLogs && s.Status.State == stream.StateOK
+	})
+}
+
+// logMsgCarriesLine reports whether msg delivers a log line with the given
+// text, through either attach-mode path (live entry or sync batch).
+func logMsgCarriesLine(msg tea.Msg, line string) bool {
+	switch v := msg.(type) {
+	case LogEntryMsg:
+		return domain.LogEntry(v).Line == line
+	case LogsSyncMsg:
+		for _, e := range v.Entries {
+			if e.Line == line {
+				return true
+			}
 		}
 	}
-	assert.True(t, sawLogsOK, "logs loop reports OK once the connection is established")
+	return false
 }
 
 // TestRunClientStreams_AttemptErrorReportsReconnecting pins that an attempt
@@ -379,7 +440,7 @@ func TestRunClientStreams_AttemptErrorReportsReconnecting(t *testing.T) {
 	collector := newMsgCollector()
 	client := &stubTUIClient{
 		// onConnect deliberately not called: a dead-on-arrival dial.
-		consumeLogs: func(context.Context, func(), func(api.LogEntryResponse)) error {
+		consumeLogs: func(context.Context, func(), func(api.HandshakeResponse), func(api.LogEntryResponse)) error {
 			return errors.New("connection refused")
 		},
 	}

--- a/internal/tui/stream_health_test.go
+++ b/internal/tui/stream_health_test.go
@@ -1,0 +1,467 @@
+package tui
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/charliek/prox/internal/api"
+	"github.com/charliek/prox/internal/domain"
+	"github.com/charliek/prox/internal/proxy"
+	"github.com/charliek/prox/internal/stream"
+)
+
+// fakeAPIError implements APIStatusError, standing in for *cli.APIError, which
+// internal/tui cannot import (internal/cli imports internal/tui).
+type fakeAPIError struct {
+	status int
+	code   string
+}
+
+func (e *fakeAPIError) Error() string     { return fmt.Sprintf("api error %d", e.status) }
+func (e *fakeAPIError) StatusCode() int   { return e.status }
+func (e *fakeAPIError) ErrorCode() string { return e.code }
+
+// readyClientModel builds a ClientModel wide enough that the status bar renders
+// without wrapping the health segments.
+func readyClientModel() ClientModel {
+	m := NewClientModel(&stubTUIClient{})
+	nm, _ := m.Update(tea.WindowSizeMsg{Width: 200, Height: 20})
+	return nm.(ClientModel)
+}
+
+func statusMsg(id StreamID, state stream.State) StreamStatusMsg {
+	return StreamStatusMsg{Stream: id, Status: stream.Status{State: state}}
+}
+
+// TestStreamStatus_ReconnectingRendersWarning pins that a reconnecting logs
+// stream both updates the health map and reaches the rendered status bar.
+func TestStreamStatus_ReconnectingRendersWarning(t *testing.T) {
+	m := clientUpdate(readyClientModel(), statusMsg(StreamLogs, stream.StateReconnecting))
+
+	assert.Equal(t, stream.StateReconnecting, m.streamHealth[StreamLogs].State)
+	assert.Contains(t, m.View(), "⚠ logs: reconnecting…")
+	assert.NotContains(t, m.View(), "requests:")
+}
+
+// TestStreamStatus_RequestsUnavailableIsPassive pins the one non-warning
+// degraded rendering: the proxy simply is not enabled.
+func TestStreamStatus_RequestsUnavailableIsPassive(t *testing.T) {
+	m := clientUpdate(readyClientModel(), statusMsg(StreamRequests, stream.StateUnavailable))
+
+	view := m.View()
+	assert.Contains(t, view, "requests: n/a")
+	assert.NotContains(t, view, "⚠")
+}
+
+// TestStreamStatus_OKRendersNothing pins that a healthy stream contributes no
+// status-bar segment, including after it recovers from a drop.
+func TestStreamStatus_OKRendersNothing(t *testing.T) {
+	m := clientUpdate(readyClientModel(), statusMsg(StreamLogs, stream.StateOK))
+	assert.NotContains(t, m.View(), "logs:")
+
+	m = clientUpdate(m, statusMsg(StreamLogs, stream.StateReconnecting))
+	require.Contains(t, m.View(), "⚠ logs: reconnecting…")
+
+	m = clientUpdate(m, statusMsg(StreamLogs, stream.StateOK))
+	assert.NotContains(t, m.View(), "logs:")
+	assert.False(t, m.streamDropped[StreamLogs], "recovery clears the drop latch")
+}
+
+// TestStreamStatus_InitialConnectAndSyncSilent pins that startup is quiet:
+// nothing has dropped yet, so neither Connecting nor the first Syncing renders.
+func TestStreamStatus_InitialConnectAndSyncSilent(t *testing.T) {
+	m := clientUpdate(readyClientModel(), statusMsg(StreamLogs, stream.StateConnecting))
+	assert.NotContains(t, m.View(), "logs:")
+
+	m = clientUpdate(m, statusMsg(StreamLogs, stream.StateSyncing))
+	assert.NotContains(t, m.View(), "logs:")
+}
+
+// TestStreamStatus_PostDropSyncingRendersReconnecting pins the latch: the
+// Syncing the loop emits on each retry keeps the "reconnecting…" wording rather
+// than flickering through a third phrase.
+func TestStreamStatus_PostDropSyncingRendersReconnecting(t *testing.T) {
+	m := clientUpdate(readyClientModel(), statusMsg(StreamLogs, stream.StateConnecting))
+	m = clientUpdate(m, statusMsg(StreamLogs, stream.StateReconnecting))
+	m = clientUpdate(m, statusMsg(StreamLogs, stream.StateSyncing))
+
+	assert.Contains(t, m.View(), "⚠ logs: reconnecting…")
+}
+
+// TestStreamStatus_ClosedRendersDisconnected covers the local-mode terminal
+// state: the feed is gone for the session, so it stays on the bar.
+func TestStreamStatus_ClosedRendersDisconnected(t *testing.T) {
+	m := clientUpdate(readyClientModel(), statusMsg(StreamRequests, stream.StateClosed))
+	assert.Contains(t, m.View(), "⚠ requests: disconnected")
+}
+
+// TestStreamStatus_SegmentOrderIsFixed pins that two degraded streams render in
+// allStreams order rather than map order.
+func TestStreamStatus_SegmentOrderIsFixed(t *testing.T) {
+	m := clientUpdate(readyClientModel(), statusMsg(StreamRequests, stream.StateUnavailable))
+	m = clientUpdate(m, statusMsg(StreamLogs, stream.StateReconnecting))
+
+	view := m.View()
+	assert.Less(t, strings.Index(view, "logs:"), strings.Index(view, "requests:"))
+}
+
+// TestLocalModel_StreamsStartHealthy pins the local-mode initialization: every
+// stream is OK up front, so the bar is clean until a subscription dies.
+func TestLocalModel_StreamsStartHealthy(t *testing.T) {
+	m := newTestModel()
+	for _, id := range allStreams {
+		assert.Equal(t, stream.StateOK, m.streamHealth[id].State, "stream %s", id)
+	}
+	assert.Empty(t, m.streamHealthSegments())
+}
+
+// TestLocalModel_HandlesStreamStatusMsg pins that the local Update loop routes
+// the message too — both models share the rendering path.
+func TestLocalModel_HandlesStreamStatusMsg(t *testing.T) {
+	m := updateModel(newTestModel(), tea.WindowSizeMsg{Width: 200, Height: 20})
+	m = updateModel(m, statusMsg(StreamLogs, stream.StateClosed))
+
+	assert.Equal(t, stream.StateClosed, m.streamHealth[StreamLogs].State)
+	assert.Contains(t, m.View(), "⚠ logs: disconnected")
+}
+
+// --- classifier ---
+
+// TestClassifyStreamError covers the shared policy: auth failures are terminal,
+// everything else is worth retrying. The wrapped case proves errors.As traversal.
+func TestClassifyStreamError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want stream.Classification
+	}{
+		{"unauthorized", &fakeAPIError{status: http.StatusUnauthorized}, stream.ClassTerminal},
+		{"forbidden", &fakeAPIError{status: http.StatusForbidden}, stream.ClassTerminal},
+		{"wrapped unauthorized", fmt.Errorf("stream: %w", &fakeAPIError{status: http.StatusUnauthorized}), stream.ClassTerminal},
+		{"server error", &fakeAPIError{status: http.StatusInternalServerError}, stream.ClassTransient},
+		{"network error", errors.New("dial tcp: connection refused"), stream.ClassTransient},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, classifyStreamError(tt.err))
+		})
+	}
+}
+
+// TestClassifyRequestsStreamError pins the requests-only addition: a 503
+// carrying PROXY_NOT_ENABLED parks the loop; a bare 503 (daemon starting up)
+// does not.
+func TestClassifyRequestsStreamError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want stream.Classification
+	}{
+		{
+			"proxy not enabled",
+			&fakeAPIError{status: http.StatusServiceUnavailable, code: domain.ErrCodeProxyNotEnabled},
+			stream.ClassUnavailable,
+		},
+		{
+			"503 without the code",
+			&fakeAPIError{status: http.StatusServiceUnavailable},
+			stream.ClassTransient,
+		},
+		{
+			"code on another status",
+			&fakeAPIError{status: http.StatusInternalServerError, code: domain.ErrCodeProxyNotEnabled},
+			stream.ClassTransient,
+		},
+		{"unauthorized", &fakeAPIError{status: http.StatusUnauthorized}, stream.ClassTerminal},
+		{"network error", errors.New("dial tcp: connection refused"), stream.ClassTransient},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, classifyRequestsStreamError(tt.err))
+		})
+	}
+}
+
+// --- local-mode forwarders ---
+
+// msgCollector is a thread-safe stand-in for (*tea.Program).Send.
+type msgCollector struct {
+	mu   sync.Mutex
+	msgs []tea.Msg
+	ch   chan tea.Msg
+}
+
+func newMsgCollector() *msgCollector {
+	return &msgCollector{ch: make(chan tea.Msg, 64)}
+}
+
+func (c *msgCollector) send(msg tea.Msg) {
+	c.mu.Lock()
+	c.msgs = append(c.msgs, msg)
+	c.mu.Unlock()
+	select {
+	case c.ch <- msg:
+	default:
+	}
+}
+
+func (c *msgCollector) all() []tea.Msg {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]tea.Msg(nil), c.msgs...)
+}
+
+// await blocks until a message satisfying match arrives or the deadline passes.
+func (c *msgCollector) await(t *testing.T, match func(tea.Msg) bool) tea.Msg {
+	t.Helper()
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case msg := <-c.ch:
+			if match(msg) {
+				return msg
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for message; got %v", c.all())
+			return nil
+		}
+	}
+}
+
+// TestForwardLogs_ChannelCloseReportsClosed pins the W7 hardening: a local
+// subscription that dies on its own marks the stream closed and says so once.
+func TestForwardLogs_ChannelCloseReportsClosed(t *testing.T) {
+	collector := newMsgCollector()
+	ch := make(chan domain.LogEntry)
+	close(ch)
+
+	forwardLogs(context.Background(), collector.send, ch)
+
+	msgs := collector.all()
+	require.Len(t, msgs, 2)
+	assert.Equal(t, StreamStatusMsg{Stream: StreamLogs, Status: stream.Status{State: stream.StateClosed}}, msgs[0])
+	entry, ok := msgs[1].(LogEntryMsg)
+	require.True(t, ok)
+	assert.Equal(t, "system", entry.Process)
+	assert.Contains(t, entry.Line, "Log stream closed")
+}
+
+// TestForwardLogs_CancelledCloseIsSilent pins the other half: a close during
+// shutdown is expected and must not spam the log pane or the status bar.
+func TestForwardLogs_CancelledCloseIsSilent(t *testing.T) {
+	collector := newMsgCollector()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	ch := make(chan domain.LogEntry)
+	close(ch)
+
+	forwardLogs(ctx, collector.send, ch)
+
+	assert.Empty(t, collector.all())
+}
+
+// TestForwardProxyRequests_ChannelCloseReportsClosed mirrors the logs case for
+// the requests subscription.
+func TestForwardProxyRequests_ChannelCloseReportsClosed(t *testing.T) {
+	collector := newMsgCollector()
+	ch := make(chan proxy.RequestRecord)
+	close(ch)
+
+	forwardProxyRequests(context.Background(), collector.send, ch)
+
+	msgs := collector.all()
+	require.Len(t, msgs, 2)
+	assert.Equal(t, StreamStatusMsg{Stream: StreamRequests, Status: stream.Status{State: stream.StateClosed}}, msgs[0])
+	entry, ok := msgs[1].(LogEntryMsg)
+	require.True(t, ok)
+	assert.Contains(t, entry.Line, "Proxy request stream closed")
+}
+
+// TestForwardProxyRequests_CancelledCloseIsSilent pins the shutdown path.
+func TestForwardProxyRequests_CancelledCloseIsSilent(t *testing.T) {
+	collector := newMsgCollector()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	ch := make(chan proxy.RequestRecord)
+	close(ch)
+
+	forwardProxyRequests(ctx, collector.send, ch)
+
+	assert.Empty(t, collector.all())
+}
+
+// TestForwardLogs_DeliversEntries keeps the happy path covered after the send
+// injection.
+func TestForwardLogs_DeliversEntries(t *testing.T) {
+	collector := newMsgCollector()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch := make(chan domain.LogEntry, 1)
+	ch <- domain.LogEntry{Process: "web", Line: "hello"}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		forwardLogs(ctx, collector.send, ch)
+	}()
+
+	msg := collector.await(t, func(m tea.Msg) bool { _, ok := m.(LogEntryMsg); return ok })
+	assert.Equal(t, "hello", domain.LogEntry(msg.(LogEntryMsg)).Line)
+	cancel()
+	<-done
+}
+
+// --- attach-mode loop wiring ---
+
+// startClientStreams runs runClientStreams in the background, cancelling it and
+// waiting for both loops to exit when the test ends.
+func startClientStreams(t *testing.T, client TUIClient, send func(tea.Msg)) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		runClientStreams(ctx, client, send)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		<-done
+	})
+}
+
+// TestRunClientStreams_ForwardsEventsAndStatus pins the wiring end to end: a
+// streamed entry reaches the model as a LogEntryMsg and the loop's own
+// transitions arrive as StreamStatusMsg for the right stream.
+func TestRunClientStreams_ForwardsEventsAndStatus(t *testing.T) {
+	collector := newMsgCollector()
+	client := &stubTUIClient{
+		consumeLogs: func(ctx context.Context, onConnect func(), onEvent func(api.LogEntryResponse)) error {
+			onConnect()
+			onEvent(api.LogEntryResponse{
+				Timestamp: time.Now().Format(time.RFC3339Nano),
+				Process:   "web",
+				Stream:    "stdout",
+				Line:      "streamed",
+			})
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	}
+
+	startClientStreams(t, client, collector.send)
+
+	msg := collector.await(t, func(m tea.Msg) bool { _, ok := m.(LogEntryMsg); return ok })
+	assert.Equal(t, "streamed", domain.LogEntry(msg.(LogEntryMsg)).Line)
+
+	// markSynced rides onConnect: OK is reported once the connection stands.
+	var sawLogsOK bool
+	for _, m := range collector.all() {
+		if s, ok := m.(StreamStatusMsg); ok && s.Stream == StreamLogs && s.Status.State == stream.StateOK {
+			sawLogsOK = true
+		}
+	}
+	assert.True(t, sawLogsOK, "logs loop reports OK once the connection is established")
+}
+
+// TestRunClientStreams_AttemptErrorReportsReconnecting pins that an attempt
+// failure surfaces as a status message instead of silently killing the feed.
+func TestRunClientStreams_AttemptErrorReportsReconnecting(t *testing.T) {
+	collector := newMsgCollector()
+	client := &stubTUIClient{
+		// onConnect deliberately not called: a dead-on-arrival dial.
+		consumeLogs: func(context.Context, func(), func(api.LogEntryResponse)) error {
+			return errors.New("connection refused")
+		},
+	}
+
+	startClientStreams(t, client, collector.send)
+
+	msg := collector.await(t, func(m tea.Msg) bool {
+		s, ok := m.(StreamStatusMsg)
+		return ok && s.Stream == StreamLogs && s.Status.State == stream.StateReconnecting
+	})
+	assert.EqualError(t, msg.(StreamStatusMsg).Status.Err, "connection refused")
+
+	// A dial that never establishes a connection must never report OK: OK
+	// clears the outage warning, so a spurious one would flash the UI healthy
+	// mid-outage on every retry (codex C5 finding).
+	for _, m := range collector.all() {
+		if s, ok := m.(StreamStatusMsg); ok && s.Stream == StreamLogs {
+			assert.NotEqual(t, stream.StateOK, s.Status.State,
+				"failed dial must not emit OK")
+		}
+	}
+}
+
+// TestRunClientStreams_ProxyNotEnabledParks pins the classifier reaching the
+// requests loop: the proxy being off is reported as unavailable, not as an
+// endless reconnect.
+func TestRunClientStreams_ProxyNotEnabledParks(t *testing.T) {
+	collector := newMsgCollector()
+	client := &stubTUIClient{
+		consumeRequests: func(context.Context, func(), func(api.ProxyRequestResponse)) error {
+			return &fakeAPIError{status: http.StatusServiceUnavailable, code: domain.ErrCodeProxyNotEnabled}
+		},
+	}
+
+	startClientStreams(t, client, collector.send)
+
+	collector.await(t, func(m tea.Msg) bool {
+		s, ok := m.(StreamStatusMsg)
+		return ok && s.Stream == StreamRequests && s.Status.State == stream.StateUnavailable
+	})
+}
+
+// TestSendStreamedLogEntry_BadTimestampWarns pins the conversion factored out of
+// the old forwarder: a malformed timestamp still delivers the entry, preceded by
+// a system warning.
+func TestSendStreamedLogEntry_BadTimestampWarns(t *testing.T) {
+	collector := newMsgCollector()
+	sendStreamedLogEntry(collector.send, api.LogEntryResponse{
+		Timestamp: "not-a-timestamp",
+		Process:   "web",
+		Stream:    "stdout",
+		Line:      "hello",
+	})
+
+	msgs := collector.all()
+	require.Len(t, msgs, 2)
+	assert.Contains(t, domain.LogEntry(msgs[0].(LogEntryMsg)).Line, "failed to parse log timestamp")
+	entry := domain.LogEntry(msgs[1].(LogEntryMsg))
+	assert.Equal(t, "hello", entry.Line)
+	assert.False(t, entry.Timestamp.IsZero(), "malformed timestamps fall back to now")
+}
+
+// TestSendStreamedProxyRequest_Converts pins the requests conversion, including
+// the millisecond-to-Duration mapping.
+func TestSendStreamedProxyRequest_Converts(t *testing.T) {
+	collector := newMsgCollector()
+	ts := time.Now().UTC().Truncate(time.Millisecond)
+	sendStreamedProxyRequest(collector.send, api.ProxyRequestResponse{
+		ID:         "req-1",
+		Timestamp:  ts.Format(time.RFC3339Nano),
+		Method:     "GET",
+		URL:        "/x",
+		StatusCode: 200,
+		DurationMs: 25,
+		InFlight:   true,
+	})
+
+	msgs := collector.all()
+	require.Len(t, msgs, 1)
+	record := proxy.RequestRecord(msgs[0].(ProxyRequestMsg))
+	assert.Equal(t, "req-1", record.ID)
+	assert.True(t, ts.Equal(record.Timestamp))
+	assert.Equal(t, 25*time.Millisecond, record.Duration)
+	assert.True(t, record.InFlight)
+}

--- a/internal/tui/stream_health_test.go
+++ b/internal/tui/stream_health_test.go
@@ -483,6 +483,158 @@ func TestRunClientStreams_ProxyNotEnabledParks(t *testing.T) {
 	})
 }
 
+// --- C12: the processes stream ---
+
+// TestRunClientStreams_ProcessesSnapshotsReachTheModel pins the third loop end
+// to end: a full snapshot pushed on the processes stream arrives as the same
+// ProcessesMsg the deleted poll produced, converted field for field.
+func TestRunClientStreams_ProcessesSnapshotsReachTheModel(t *testing.T) {
+	collector := newMsgCollector()
+	client := &stubTUIClient{
+		consumeProcesses: func(ctx context.Context, onConnect func(), onEvent func(api.ProcessListResponse)) error {
+			onConnect()
+			onEvent(api.ProcessListResponse{Processes: []api.ProcessResponse{{
+				Name:      "web",
+				Status:    "running",
+				PID:       4242,
+				Restarts:  2,
+				Health:    "healthy",
+				Kind:      "process",
+				WaitingOn: []string{"db"},
+			}}})
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	}
+
+	startClientStreams(t, client, collector.send)
+
+	msg := collector.await(t, func(m tea.Msg) bool { _, ok := m.(ProcessesMsg); return ok })
+	processes := []domain.ProcessInfo(msg.(ProcessesMsg))
+	require.Len(t, processes, 1)
+	assert.Equal(t, "web", processes[0].Name)
+	assert.Equal(t, domain.ProcessState("running"), processes[0].State)
+	assert.Equal(t, 4242, processes[0].PID)
+	assert.Equal(t, 2, processes[0].RestartCount)
+	assert.Equal(t, domain.HealthStatus("healthy"), processes[0].Health)
+	assert.Equal(t, domain.ProcessKind("process"), processes[0].Kind)
+	assert.Equal(t, []string{"db"}, processes[0].WaitingOn)
+
+	// Connect IS sync for this stream: OK follows onConnect with no barrier, so
+	// it has already been delivered by the time the snapshot lands. Scanned
+	// from the full log rather than awaited, since the await above may have
+	// consumed it (the loop emits each status exactly once).
+	require.Eventually(t, func() bool {
+		for _, m := range collector.all() {
+			if s, ok := m.(StreamStatusMsg); ok && s.Stream == StreamProcesses && s.Status.State == stream.StateOK {
+				return true
+			}
+		}
+		return false
+	}, 5*time.Second, 10*time.Millisecond, "connect is sync for the processes stream")
+}
+
+// TestRunClientStreams_ProcessesReconnectReprobesParkedLoops pins W2's
+// re-probe: the requests loop parks (proxy disabled) with no timer of its own,
+// so only an external nudge can ever retry it. The processes stream
+// reconnecting is that nudge — it is the evidence attach mode has that the
+// daemon it lost came back, possibly with the proxy now enabled.
+//
+// The observable is a SECOND ConsumeProxyRequests attempt: the parked loop
+// would otherwise never make one.
+func TestRunClientStreams_ProcessesReconnectReprobesParkedLoops(t *testing.T) {
+	collector := newMsgCollector()
+
+	// The processes stream connects, then drops once; the loop's backoff
+	// reconnects it, and THAT second OK is the re-probe trigger.
+	var attempts atomic.Int32
+	client := &stubTUIClient{
+		consumeRequests: func(context.Context, func(), func(api.ProxyRequestResponse)) error {
+			return &fakeAPIError{status: http.StatusServiceUnavailable, code: domain.ErrCodeProxyNotEnabled}
+		},
+		consumeProcesses: func(ctx context.Context, onConnect func(), _ func(api.ProcessListResponse)) error {
+			onConnect()
+			if attempts.Add(1) == 1 {
+				return errors.New("daemon went away")
+			}
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	}
+
+	startClientStreams(t, client, collector.send)
+
+	// The requests loop parks first...
+	collector.await(t, func(m tea.Msg) bool {
+		s, ok := m.(StreamStatusMsg)
+		return ok && s.Stream == StreamRequests && s.Status.State == stream.StateUnavailable
+	})
+	require.Equal(t, 1, client.requestsCalls(), "a parked loop makes no further attempts on its own")
+
+	// ...and is woken by the processes stream's reconnect.
+	require.Eventually(t, func() bool { return client.requestsCalls() >= 2 },
+		5*time.Second, 10*time.Millisecond,
+		"the processes stream's reconnect must re-probe the parked requests loop")
+	assert.GreaterOrEqual(t, int(attempts.Load()), 2)
+}
+
+// TestRunClientStreams_ProcessesNotFoundParks pins the version-skew classifier
+// reaching the processes loop: an old daemon with no such endpoint answers 404,
+// and the loop parks rather than reconnecting against a route that will never
+// exist.
+func TestRunClientStreams_ProcessesNotFoundParks(t *testing.T) {
+	collector := newMsgCollector()
+	client := &stubTUIClient{
+		consumeProcesses: func(context.Context, func(), func(api.ProcessListResponse)) error {
+			return &fakeAPIError{status: http.StatusNotFound}
+		},
+	}
+
+	startClientStreams(t, client, collector.send)
+
+	collector.await(t, func(m tea.Msg) bool {
+		s, ok := m.(StreamStatusMsg)
+		return ok && s.Stream == StreamProcesses && s.Status.State == stream.StateUnavailable
+	})
+}
+
+// TestClassifyProcessesStreamError pins the processes-only addition: a 404 is
+// version skew (park), auth is still terminal, everything else still retries.
+func TestClassifyProcessesStreamError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want stream.Classification
+	}{
+		{"not found (old daemon)", &fakeAPIError{status: http.StatusNotFound}, stream.ClassUnavailable},
+		{"wrapped not found", fmt.Errorf("stream: %w", &fakeAPIError{status: http.StatusNotFound}), stream.ClassUnavailable},
+		{"unauthorized", &fakeAPIError{status: http.StatusUnauthorized}, stream.ClassTerminal},
+		{"forbidden", &fakeAPIError{status: http.StatusForbidden}, stream.ClassTerminal},
+		{"server error", &fakeAPIError{status: http.StatusInternalServerError}, stream.ClassTransient},
+		{"network error", errors.New("dial tcp: connection refused"), stream.ClassTransient},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, classifyProcessesStreamError(tt.err))
+		})
+	}
+}
+
+// TestStreamHealthSegments_ProcessesNeverRenders pins the matrix completion:
+// however degraded the processes stream gets, it contributes no segment — the
+// global connection notice reports it instead, and reporting it twice in two
+// wordings would be worse than either alone.
+func TestStreamHealthSegments_ProcessesNeverRenders(t *testing.T) {
+	for _, state := range []stream.State{
+		stream.StateReconnecting, stream.StateSyncing, stream.StateUnavailable, stream.StateClosed,
+	} {
+		m := clientUpdate(readyClientModel(), statusMsg(StreamProcesses, stream.StateReconnecting))
+		m = clientUpdate(m, statusMsg(StreamProcesses, state))
+		assert.Empty(t, m.streamHealthSegments(), "state %s", state)
+		assert.NotContains(t, m.View(), "processes:", "state %s", state)
+	}
+}
+
 // TestSendStreamedLogEntry_BadTimestampWarns pins the conversion factored out of
 // the old forwarder: a malformed timestamp still delivers the entry, preceded by
 // a system warning.
@@ -525,4 +677,62 @@ func TestSendStreamedProxyRequest_Converts(t *testing.T) {
 	assert.True(t, ts.Equal(record.Timestamp))
 	assert.Equal(t, 25*time.Millisecond, record.Duration)
 	assert.True(t, record.InFlight)
+}
+
+// TestRunClientStreams_LogsReconnectRescuesParkedProcessesLoop pins the
+// SYMMETRY of the re-probe (codex C12 finding): the processes loop itself can
+// park (old daemon, 404), and the only production nudge that can ever rescue
+// it is a SIBLING stream's reconnect — the logs stream dropping and coming
+// back is exactly what a daemon upgrade under a live attach looks like.
+func TestRunClientStreams_LogsReconnectRescuesParkedProcessesLoop(t *testing.T) {
+	collector := newMsgCollector()
+
+	// The re-probe fires on a stream's SECOND OK, and the logs stream only
+	// reaches OK once its sync completes (handshake + fetch), so attempt 1
+	// must fully sync before it fails: the hook hands over the handshake,
+	// waits until the loop has reported OK, then returns an error.
+	logsOK := func() int {
+		n := 0
+		for _, m := range collector.all() {
+			if s, ok := m.(StreamStatusMsg); ok && s.Stream == StreamLogs && s.Status.State == stream.StateOK {
+				n++
+			}
+		}
+		return n
+	}
+	var logAttempts atomic.Int32
+	client := &stubTUIClient{
+		consumeProcesses: func(context.Context, func(), func(api.ProcessListResponse)) error {
+			return &fakeAPIError{status: http.StatusNotFound}
+		},
+		consumeLogs: func(ctx context.Context, onConnect func(), onHandshake func(api.HandshakeResponse), _ func(api.LogEntryResponse)) error {
+			onConnect()
+			onHandshake(api.HandshakeResponse{StreamID: "epoch-1"})
+			if logAttempts.Add(1) == 1 {
+				// Fail only after the sync landed OK #1, so the reconnect's
+				// OK #2 is unambiguously a reconnect.
+				deadline := time.Now().Add(5 * time.Second)
+				for logsOK() < 1 && time.Now().Before(deadline) {
+					time.Sleep(2 * time.Millisecond)
+				}
+				return errors.New("daemon went away")
+			}
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	}
+
+	startClientStreams(t, client, collector.send)
+
+	// The processes loop parks on the 404...
+	collector.await(t, func(m tea.Msg) bool {
+		s, ok := m.(StreamStatusMsg)
+		return ok && s.Stream == StreamProcesses && s.Status.State == stream.StateUnavailable
+	})
+	require.Equal(t, 1, client.processesCalls(), "a parked loop makes no further attempts on its own")
+
+	// ...and is woken by the logs stream's reconnect (its second OK).
+	require.Eventually(t, func() bool { return client.processesCalls() >= 2 },
+		5*time.Second, 10*time.Millisecond,
+		"a sibling stream's reconnect must re-probe the parked processes loop")
 }

--- a/internal/tui/sync_attempt.go
+++ b/internal/tui/sync_attempt.go
@@ -1,0 +1,88 @@
+package tui
+
+import (
+	"context"
+	"sync/atomic"
+)
+
+// syncFetch is the machinery both attach-stream sync protocols share: the
+// once-per-attempt REST fetch (the requests snapshot, the logs backfill) that a
+// connect-and-consume attempt runs alongside its SSE read loop, plus the
+// teardown that keeps it inside its attempt.
+//
+// It must run on its own goroutine: the reader goroutine is busy reading, and
+// the live events the protocol buffers meanwhile would deadlock if the fetch
+// ran on it. It must be joined before the attempt returns, which is what makes
+// calling markSynced from it safe despite stream.Config.Attempt's "call it from
+// the attempt itself" rule: that rule exists to stop a STRAGGLING goroutine
+// from flipping a LATER attempt's state, and a fetch that cannot straggle
+// cannot break it (the loop's epoch guard is the second line of defense).
+type syncFetch struct {
+	cancel  context.CancelFunc
+	done    chan struct{}
+	started atomic.Bool
+
+	// err is written by the fetch goroutine and read only after join.
+	err error
+}
+
+// newSyncFetch derives the per-attempt context the fetch and the stream both
+// run under; cancelling it ends both. The caller must `defer f.join()`
+// immediately, which is what cancels it.
+func newSyncFetch(ctx context.Context) (context.Context, *syncFetch) {
+	attemptCtx, cancel := context.WithCancel(ctx)
+	return attemptCtx, &syncFetch{cancel: cancel, done: make(chan struct{})}
+}
+
+// start is the body of an attempt's onConnect hook: it runs the fetch once, on
+// its own goroutine. A failure aborts the attempt so the loop reconnects and
+// the next attempt re-syncs. A second call is a no-op — a client that fired
+// onConnect twice would otherwise start a second goroutine and double-close
+// done.
+func (f *syncFetch) start(run func() error) {
+	if !f.started.CompareAndSwap(false, true) {
+		return
+	}
+	go func() {
+		defer close(f.done)
+		f.err = run()
+		if f.err != nil {
+			f.abort()
+		}
+	}()
+}
+
+// abort cancels the attempt context. It is how a buffering onEvent hook — which
+// has no other way to end an attempt — reports that this attempt cannot
+// complete, and how the fetch gives up on its own.
+func (f *syncFetch) abort() { f.cancel() }
+
+// join ends the fetch goroutine and waits for it, so it can never outlive its
+// attempt, and makes err readable. Idempotent (cancel is; a closed channel
+// stays receivable), so it is safe both as the deferred backstop and as the
+// explicit join that must precede reading err.
+func (f *syncFetch) join() {
+	f.cancel()
+	if f.started.Load() {
+		<-f.done
+	}
+}
+
+// attemptError picks which of an attempt's three possible causes to report,
+// once it has been joined. The sync-protocol cause (abortErr, then the fetch's
+// own failure) wins: aborting a sync cancels the attempt context, which makes
+// the stream consumer report a generic cancellation that would otherwise hide
+// why the attempt is recycling. A cancellation of the PARENT context (the TUI
+// quitting) is not ours to reinterpret — the loop ends on it regardless, so
+// streamErr is reported as-is.
+func (f *syncFetch) attemptError(ctx context.Context, abortErr, streamErr error) error {
+	if ctx.Err() == nil {
+		if abortErr != nil {
+			return abortErr
+		}
+		if f.err != nil {
+			return f.err
+		}
+	}
+	return streamErr
+}

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -54,7 +54,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case TickMsg:
 		m.processes = m.supervisor.Processes()
-		cmds = append(cmds, tickCmd())
+		cmds = append(cmds, tickCmd(constants.TUILocalTickInterval))
 
 	case subIDMsg:
 		m.subID = string(msg)

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -49,6 +49,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.clampViewportToContent()
 		}
 
+	case StreamStatusMsg:
+		m.handleStreamStatus(msg)
+
 	case ProcessesMsg:
 		m.processes = m.supervisor.Processes()
 

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -59,9 +59,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.processes = m.supervisor.Processes()
 		cmds = append(cmds, tickCmd(constants.TUILocalTickInterval))
 
-	case subIDMsg:
-		m.subID = string(msg)
-
 	case RestartResultMsg:
 		m.lastRestartProcess = msg.Process
 		m.lastRestartError = msg.Err

--- a/test/integration/push_data_plane_test.go
+++ b/test/integration/push_data_plane_test.go
@@ -1,0 +1,481 @@
+package integration
+
+// Plan 017 C14: end-to-end coverage for the SSE data plane against the real
+// binary -- heartbeats keeping idle streams alive, /processes/stream
+// snapshots, /logs/stream's handshake+seq cursor contract, the no-access-log
+// invariant for the control plane, and a clean shutdown while streams are
+// connected. These complement the unit-level SSE tests in
+// internal/api/sse_test.go (which drive handlers directly with injectable
+// timings) by proving the same behavior holds through the real HTTP
+// listener, real router/middleware chain, and the real (uninjectable,
+// constants.SSEHeartbeatInterval-driven) production timings.
+//
+// Deliberately NOT covered here: an SSE client following a process or log
+// stream ACROSS a daemon restart. Live (manual) verification covers that
+// end-to-end, and command-level reconnect behavior (StreamID change
+// detection, cursor resume) is covered by unit tests -- see
+// internal/api/sse_test.go and internal/cli/client_test.go.
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/charliek/prox/internal/constants"
+)
+
+// sseFrame is one parsed SSE frame: a named "event: X" data line (event set)
+// or a bare "data:" line belonging to no named event (event == "").
+type sseFrame struct {
+	event string
+	data  string
+}
+
+// sseClient connects to a real SSE endpoint and drains it continuously in the
+// background, counting ": ping" heartbeat comments and collecting every
+// event/data frame it sees. Tests can idle for a while (sleeping, doing other
+// HTTP calls, etc.) and then inspect what arrived without babysitting a
+// synchronous scan loop themselves.
+type sseClient struct {
+	resp *http.Response
+
+	mu     sync.Mutex
+	pings  int
+	frames []sseFrame
+}
+
+// dialSSE connects to url and, on a 200 text/event-stream response, starts
+// draining it in the background. It returns an error rather than failing the
+// test directly so callers that must tolerate a non-200 (e.g. a
+// proxy-requests stream on a config with no proxy configured) can decide what
+// to do with it.
+func dialSSE(url string) (*sseClient, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		return nil, fmt.Errorf("GET %s: status %d: %s", url, resp.StatusCode, body)
+	}
+
+	c := &sseClient{resp: resp}
+	go c.run()
+	return c, nil
+}
+
+// run scans the response body line by line until it closes (client Close, or
+// the server tearing the stream down), classifying each line into a ping
+// count or a collected frame.
+func (c *sseClient) run() {
+	scanner := bufio.NewScanner(c.resp.Body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	var pendingEvent string
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch {
+		case line == ": ping":
+			c.mu.Lock()
+			c.pings++
+			c.mu.Unlock()
+		case strings.HasPrefix(line, "event: "):
+			pendingEvent = strings.TrimPrefix(line, "event: ")
+		case strings.HasPrefix(line, "data: "):
+			c.mu.Lock()
+			c.frames = append(c.frames, sseFrame{event: pendingEvent, data: strings.TrimPrefix(line, "data: ")})
+			c.mu.Unlock()
+			pendingEvent = ""
+		}
+	}
+}
+
+// Close disconnects the stream, ending the background scan.
+func (c *sseClient) Close() {
+	c.resp.Body.Close()
+}
+
+// PingCount reports how many ": ping" heartbeat comments have arrived so far.
+func (c *sseClient) PingCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.pings
+}
+
+// Frames returns a snapshot copy of every frame collected so far.
+func (c *sseClient) Frames() []sseFrame {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]sseFrame, len(c.frames))
+	copy(out, c.frames)
+	return out
+}
+
+// waitForFrameCountAtLeast polls c until it has collected at least n frames
+// matching event, or fails the test after timeout.
+func waitForFrameCountAtLeast(t *testing.T, c *sseClient, event string, n int, timeout time.Duration) []sseFrame {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		var matched []sseFrame
+		for _, f := range c.Frames() {
+			if f.event == event {
+				matched = append(matched, f)
+			}
+		}
+		if len(matched) >= n {
+			return matched
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("did not observe %d frame(s) for event %q within %v; got: %+v", n, event, timeout, c.Frames())
+	return nil
+}
+
+// quietConfig renders a config with a single process that prints one
+// distinctive marker on launch and then sleeps quietly (no periodic output),
+// so a freshly-connected SSE client sees no log traffic at all until
+// something (a restart) triggers a new line.
+func quietConfig(port int) string {
+	return fmt.Sprintf(`api:
+  port: %d
+  host: 127.0.0.1
+
+processes:
+  quiet:
+    cmd: 'echo "QUIET_START"; sleep 3600'
+`, port)
+}
+
+// TestAPI_SSEHeartbeatsKeepIdleStreamsAlive (plan 017 C14): idles two SSE
+// connections (logs, processes) well past 2x the real heartbeat interval and
+// asserts each received at least 2 ": ping" comments, then proves the logs
+// stream is still fully functional afterward by restarting the process and
+// observing a fresh data event. This idles ~35s, so it's guarded by
+// skipShort like the other slow integration tests.
+//
+// The requests stream needs a proxy-enabled config; this fixture has none
+// (building a dedicated proxy fixture is out of scope for this commit -- the
+// requests-stream heartbeat path is unit-covered in internal/api/sse_test.go),
+// so this test only confirms it correctly 503s here rather than holding it
+// open.
+func TestAPI_SSEHeartbeatsKeepIdleStreamsAlive(t *testing.T) {
+	skipShort(t)
+
+	binary := buildBinary(t)
+	const port = 15565
+	addr := fmt.Sprintf("http://127.0.0.1:%d", port)
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "prox.yaml")
+	requireNoError(t, os.WriteFile(cfgPath, []byte(quietConfig(port)), 0644), "writing quiet config")
+
+	cmd := startProx(t, binary, "up", "-c", cfgPath)
+	defer killProx(cmd)
+
+	waitForAPI(t, addr, 10*time.Second)
+	waitForLogContains(t, addr, "quiet", "QUIET_START", 5*time.Second)
+
+	logsClient, err := dialSSE(addr + "/api/v1/logs/stream")
+	requireNoError(t, err, "connecting to logs stream")
+	defer logsClient.Close()
+
+	processesClient, err := dialSSE(addr + "/api/v1/processes/stream")
+	requireNoError(t, err, "connecting to processes stream")
+	defer processesClient.Close()
+
+	// Confirm the requests stream correctly refuses without a proxy config,
+	// rather than holding it open (see doc comment above).
+	if resp, rerr := http.Get(addr + "/api/v1/proxy/requests/stream"); rerr == nil {
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusServiceUnavailable {
+			t.Errorf("expected requests stream to 503 without a proxy config, got %d", resp.StatusCode)
+		}
+	} else {
+		t.Errorf("GET requests stream: %v", rerr)
+	}
+
+	// Idle well past 2x the real heartbeat interval. Both streams have
+	// nothing else to send (the quiet process is asleep, and no process
+	// state is changing), so pings are the only thing keeping them alive.
+	idleFor := 2*constants.SSEHeartbeatInterval + 5*time.Second
+	time.Sleep(idleFor)
+
+	if got := logsClient.PingCount(); got < 2 {
+		t.Errorf("logs stream: expected >=2 pings after idling %v, got %d", idleFor, got)
+	}
+	if got := processesClient.PingCount(); got < 2 {
+		t.Errorf("processes stream: expected >=2 pings after idling %v, got %d", idleFor, got)
+	}
+
+	// Now prove the logs stream still works: restarting the quiet process
+	// makes it print a fresh QUIET_START line, which must arrive as a new
+	// (unnamed-event) data frame.
+	before := len(logsClient.Frames())
+	status, errResp := restartProcess(t, addr, "quiet")
+	if status != http.StatusOK {
+		t.Fatalf("restart failed: status=%d code=%s error=%s", status, errResp.Code, errResp.Error)
+	}
+	waitForFrameCountAtLeast(t, logsClient, "", before+1, 10*time.Second)
+}
+
+// TestAPI_ProcessesStreamServesSnapshots (plan 017 C14): connects to
+// /api/v1/processes/stream against the real binary and asserts the
+// ": connected" preamble is followed by an initial snapshot listing the
+// configured processes, then stops one process via the API and asserts a
+// later snapshot converges on the stopped state (debounce coalesces bursts,
+// it doesn't guarantee any particular snapshot count, so this scans forward
+// with a deadline rather than asserting on the Nth event).
+func TestAPI_ProcessesStreamServesSnapshots(t *testing.T) {
+	skipShort(t)
+
+	binary := buildBinary(t)
+	cmd := startProx(t, binary, "up", "-c", configPath("integration"))
+	defer killProx(cmd)
+
+	waitForAPI(t, testAPIAddr, 10*time.Second)
+	waitForProcessState(t, testAPIAddr, "long", "running", 5*time.Second)
+
+	client, err := dialSSE(testAPIAddr + "/api/v1/processes/stream")
+	requireNoError(t, err, "connecting to processes stream")
+	defer client.Close()
+
+	frames := waitForFrameCountAtLeast(t, client, "", 1, 5*time.Second)
+
+	var initial ProcessListResponse
+	requireNoError(t, json.Unmarshal([]byte(frames[0].data), &initial), "decoding initial snapshot")
+	names := make(map[string]bool, len(initial.Processes))
+	for _, p := range initial.Processes {
+		names[p.Name] = true
+	}
+	for _, want := range []string{"long", "echo"} {
+		if !names[want] {
+			t.Errorf("initial snapshot missing configured process %q: %+v", want, initial.Processes)
+		}
+	}
+
+	status, errResp := stopProcess(t, testAPIAddr, "long")
+	if status != http.StatusOK {
+		t.Fatalf("stop failed: status=%d code=%s error=%s", status, errResp.Code, errResp.Error)
+	}
+
+	// Scan forward through whatever snapshots arrive until one shows "long"
+	// stopped, or fail after a deadline. Debounce means the stop may be
+	// coalesced with other changes into a single later snapshot rather than
+	// producing one snapshot per transition.
+	deadline := time.Now().Add(10 * time.Second)
+	converged := false
+	var lastSeen string
+	for time.Now().Before(deadline) && !converged {
+		for _, f := range client.Frames() {
+			var snap ProcessListResponse
+			if json.Unmarshal([]byte(f.data), &snap) != nil {
+				continue
+			}
+			for _, p := range snap.Processes {
+				if p.Name == "long" {
+					lastSeen = p.Status
+					if p.Status == "stopped" {
+						converged = true
+					}
+				}
+			}
+		}
+		if !converged {
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+	if !converged {
+		t.Fatalf("no processes/stream snapshot showed 'long' stopped within deadline; last seen status: %q", lastSeen)
+	}
+}
+
+// TestAPI_LogsStreamHandshakeAndCursor (plan 017 C14): connects to
+// /api/v1/logs/stream and asserts the "event: handshake" frame arrives right
+// after ": connected" carrying a non-empty stream_id, and that subsequent
+// plain data events carry strictly-increasing non-zero seq numbers. It then
+// fetches GET /api/v1/logs?since_seq=<mid> and asserts only strictly-newer
+// entries come back, tagged with the same stream_id the SSE handshake
+// reported.
+func TestAPI_LogsStreamHandshakeAndCursor(t *testing.T) {
+	skipShort(t)
+
+	binary := buildBinary(t)
+	cmd := startProx(t, binary, "up", "-c", configPath("integration"))
+	defer killProx(cmd)
+
+	waitForAPI(t, testAPIAddr, 10*time.Second)
+
+	client, err := dialSSE(testAPIAddr + "/api/v1/logs/stream")
+	requireNoError(t, err, "connecting to logs stream")
+	defer client.Close()
+
+	handshakeFrames := waitForFrameCountAtLeast(t, client, "handshake", 1, 5*time.Second)
+	var handshake struct {
+		StreamID string `json:"stream_id"`
+	}
+	requireNoError(t, json.Unmarshal([]byte(handshakeFrames[0].data), &handshake), "decoding handshake")
+	if handshake.StreamID == "" {
+		t.Fatal("handshake carried an empty stream_id")
+	}
+
+	// The "long" and "echo" processes both produce steady output, so a
+	// handful of plain data events should arrive quickly.
+	dataFrames := waitForFrameCountAtLeast(t, client, "", 5, 10*time.Second)
+
+	var seqs []uint64
+	for _, f := range dataFrames {
+		var entry struct {
+			Seq uint64 `json:"seq"`
+		}
+		requireNoError(t, json.Unmarshal([]byte(f.data), &entry), "decoding log data frame")
+		seqs = append(seqs, entry.Seq)
+	}
+	for i, s := range seqs {
+		if s == 0 {
+			t.Errorf("data frame %d carried a zero seq", i)
+		}
+		if i > 0 && s <= seqs[i-1] {
+			t.Errorf("seq not strictly increasing at frame %d: %d -> %d", i, seqs[i-1], s)
+		}
+	}
+
+	// Pick a cursor in the middle of what we've seen so far and confirm the
+	// REST endpoint returns only strictly-newer entries, tagged with the same
+	// stream_id.
+	mid := seqs[len(seqs)/2]
+
+	resp, err := http.Get(fmt.Sprintf("%s/api/v1/logs?since_seq=%d", testAPIAddr, mid))
+	requireNoError(t, err, "GET /api/v1/logs?since_seq")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var page struct {
+		Logs []struct {
+			Seq uint64 `json:"seq"`
+		} `json:"logs"`
+		StreamID string `json:"stream_id"`
+	}
+	requireNoError(t, json.NewDecoder(resp.Body).Decode(&page), "decoding logs page")
+
+	if page.StreamID != handshake.StreamID {
+		t.Errorf("logs page stream_id %q does not match SSE handshake stream_id %q", page.StreamID, handshake.StreamID)
+	}
+	if len(page.Logs) == 0 {
+		t.Fatal("expected at least one log entry newer than the mid cursor")
+	}
+	for _, e := range page.Logs {
+		if e.Seq <= mid {
+			t.Errorf("since_seq=%d returned an entry with seq %d (not strictly newer)", mid, e.Seq)
+		}
+	}
+}
+
+// TestUpForeground_NoControlPlaneAccessLogs (plan 017 C14): the router
+// deliberately runs with no chi access-log middleware (see the doc comment on
+// NewServer in internal/api/server.go) so control-plane traffic never drowns
+// out `prox up`'s own process-log output on stdout/stderr. This test drives
+// several real API GETs against a foreground daemon and asserts the captured
+// combined output never grows a chi-style access-log line for them, while
+// still containing genuine process log lines.
+func TestUpForeground_NoControlPlaneAccessLogs(t *testing.T) {
+	skipShort(t)
+
+	binary := buildBinary(t)
+	prox := startProxWithOutput(t, binary, "up", "-c", configPath("integration"))
+	defer killProx(prox.cmd)
+
+	waitForAPI(t, testAPIAddr, 10*time.Second)
+	waitForOutputContains(t, prox, "Still running...", 5*time.Second)
+
+	for _, path := range []string{"/api/v1/status", "/api/v1/processes", "/api/v1/logs"} {
+		resp, err := http.Get(testAPIAddr + path)
+		requireNoError(t, err, "GET "+path)
+		resp.Body.Close()
+	}
+
+	// Give any (undesired) access-log write a moment to land before asserting
+	// its absence.
+	time.Sleep(500 * time.Millisecond)
+
+	output := prox.Output()
+
+	// chi's DefaultLogFormatter renders a request line as
+	// `"GET http://host/path HTTP/1.1" from 127.0.0.1:port - 200 ...`; match
+	// on the distinctive `"GET http` fragment so this fails loudly if that
+	// middleware is ever reintroduced.
+	if strings.Contains(output, `"GET http`) {
+		t.Errorf("captured output contains a chi-style access-log line, but the control plane must not log requests:\n%s", output)
+	}
+
+	// The real process logs must still be present -- this isn't a test of an
+	// empty/broken output stream.
+	if !strings.Contains(output, "Still running...") {
+		t.Errorf("expected genuine process log output to still be present:\n%s", output)
+	}
+}
+
+// TestAPI_ShutdownPromptWithStreamsConnected (plan 017 C14): opens logs and
+// processes SSE connections and holds them open, then requests a full,
+// waited shutdown (POST /api/v1/shutdown?wait=true, the same idiom
+// TestStopCommand_WaitsForCleanExit and friends use) and asserts the
+// foreground process still exits within the existing suite's shutdown
+// budget. This pins the supervisor change-bus close -> SSE teardown ->
+// prompt HTTP shutdown chain: connected SSE clients must never wedge
+// shutdown.
+func TestAPI_ShutdownPromptWithStreamsConnected(t *testing.T) {
+	skipShort(t)
+
+	binary := buildBinary(t)
+	cmd := startProx(t, binary, "up", "-c", configPath("integration"))
+	// Safety net: harmless no-op once waitCmdExit below has already reaped
+	// the process (Kill on an exited process and a second Wait both just
+	// return discarded errors -- see waitCmdExit's doc comment) but catches
+	// any earlier t.Fatal in this test before shutdown is even triggered.
+	defer killProx(cmd)
+
+	waitForAPI(t, testAPIAddr, 10*time.Second)
+	waitForProcessState(t, testAPIAddr, "long", "running", 5*time.Second)
+
+	logsClient, err := dialSSE(testAPIAddr + "/api/v1/logs/stream")
+	requireNoError(t, err, "connecting to logs stream")
+	defer logsClient.Close()
+
+	processesClient, err := dialSSE(testAPIAddr + "/api/v1/processes/stream")
+	requireNoError(t, err, "connecting to processes stream")
+	defer processesClient.Close()
+
+	// Both streams must have completed their handshake/initial snapshot
+	// before we trigger shutdown, so this actually exercises live, connected
+	// clients rather than ones still mid-connect.
+	waitForFrameCountAtLeast(t, logsClient, "handshake", 1, 5*time.Second)
+	waitForFrameCountAtLeast(t, processesClient, "", 1, 5*time.Second)
+
+	req, err := http.NewRequest(http.MethodPost, testAPIAddr+"/api/v1/shutdown?wait=true", nil)
+	requireNoError(t, err, "building shutdown request")
+
+	start := time.Now()
+	resp, err := http.DefaultClient.Do(req)
+	requireNoError(t, err, "POST /api/v1/shutdown?wait=true")
+	resp.Body.Close()
+	t.Logf("waited shutdown responded after %v (status %d)", time.Since(start), resp.StatusCode)
+
+	// Reuse the existing suite's shutdown budget (TestFullStop_NoOrphanedGrandchild
+	// uses the same 20s ceiling for a full-instance stop) rather than inventing a
+	// tighter one.
+	if err := waitCmdExit(t, cmd, 20*time.Second); err != nil {
+		t.Errorf("foreground prox up should exit cleanly with SSE clients connected, got %v", err)
+	}
+}


### PR DESCRIPTION
Plan 017: every attach-mode data feed (logs, requests, process state) now flows through one uniform pattern — **SSE + heartbeat + reconnect-with-backoff + snapshot synchronization + monotonic merge + visible stream health** — and no steady-state polling remains.

## Why

Reported live against v0.2.4: the attach TUI's requests view showed nothing despite the daemon holding 100 captured records. Root cause: the client SSE reader enforced a 60s idle deadline **assuming server heartbeats that no endpoint ever sent** — any quiet minute silently killed the stream, and no consumer reconnected. Compounding it: the attach TUI polled `/api/v1/processes` every 500ms and chi's access logger printed every one of those requests into the `prox up` terminal.

## What changed (per workstream)

- **W1 — Server heartbeats** (`e84d193`): all SSE endpoints tick `: ping` every 15s; every SSE write goes through `http.ResponseController` with a per-frame deadline and a checked Flush error. chi's `middleware.Logger` removed — it drowned `prox up` output AND its wrapped writer masked exactly the flush errors this needed (its errorless `Flush` wins over `Unwrap` in `ResponseController`).
- **W2 — Reconnect machinery** (`0ee7bcc`, `288e387`, `199c5e1`, `9cc2738`): typed `APIError` + context-aware SSE client; new leaf package `internal/stream` (backoff 500ms→5s, flap guard, probe-able parked state, injectable clock); attach TUI streams and CLI `--follow` both reconnect with per-outage stderr/status-bar notices. Ctrl-C stays clean; initial-connect fail-fast UX unchanged.
- **W3 — Requests sync** (`0010efc`): every connect buffers live events, fetches the full ring, applies oldest-first, then drains — so a fresh attach shows history and reconnect gaps self-repair. The TUI merge is now monotonic (final is terminal; a stale in-flight snapshot can never regress a completed row). Subscriber-channel overflow now closes the SSE subscriber (visible reconnect + re-sync) instead of silently dropping events.
- **W4 — Log sequencing** (`42fdd44`, `e5d7878`, `d2cd3fb`): log entries gain a server ingest `seq` (assignment serialized with ring-append and broadcast) and a per-manager `stream_id` epoch; `GET /logs` gains `since_seq` + cursor metadata; the stream announces its epoch in a handshake frame. The attach TUI resumes logs gap-free within buffer capacity, reports lost counts when the buffer rolled, and marks daemon restarts with one notice line. (The old TUI-local `Seq` field is renamed `DisplaySeq` — it was a different concept sharing the name.)
- **W5 — Process push** (`1e058d7`, `22dc6d4`, `ca80bb6`): the supervisor event bus gains full lifecycle (Unsubscribe + latched Close, wired before HTTP shutdown) and cap-1 dirty-latch subscribers, with emission on every ProcessInfo-visible change (health, waiting/blocked, restarts, natural exits) fired outside all locks with no payloads — snapshot-on-wake by contract. New `GET /api/v1/processes/stream` serves full snapshots (100ms trailing-edge debounce with a starvation cap). The attach TUI consumes it and **the 500ms poll is deleted**; connection liveness derives from this stream, and re-probing is symmetric so any stream's reconnect rescues a parked sibling. REST `/api/v1/processes` is unchanged for scripts/agents.
- **W7 — Health surfacing + hygiene**: per-stream status in the shared status bar (`⚠ logs: reconnecting…`, passive `requests: n/a`, actionable old-daemon hint); local mode surfaces unexpected subscription closes and sheds a leaked write-only log subscription that also spammed drop-noise once full.

## Verification

- 14 gated commits, each through `make lint && make test && make test-race && make build` green.
- Every commit externally reviewed (codex; cursor as fallback once). ~15 real findings fixed along the way — highlights: chi wrapper masking SSE flush errors; markSynced-before-dial flashing healthy mid-outage; an epoch-mismatch hole between the logs handshake and its REST backfill; the supervisor-start emit racing task registration; debounce starvation under flapping; a parked processes loop with no rescue path; two Ctrl-C paths exiting dirty.
- New integration suite (`c56cbcc`): idle survival past 2 heartbeat intervals against the real binary (the original bug, held green), processes-stream snapshots, logs handshake+cursor, zero access-log foreground output, prompt shutdown with held SSE connections.
- Live pass on a scratch project with the branch binary: 95s-idle repro PASS; 15s heartbeat cadence on all three streams; daemon restart under a live attach showed the outage, reconnected, re-synced requests, and printed the epoch notice; `logs --follow` rode a daemon restart with exactly one disconnect/reconnect notice pair; fail-fast preserved.

## Compatibility / impact

- **0.2.x breakage window (deliberate, per plan)**: `LogEntryResponse`/`LogsResponse` gain fields (additive); `/api/v1/logs/stream` emits a named handshake frame old clients ignore (a parser guard prevents phantom rows); new `/processes/stream` endpoint; new clients against an old daemon park with an explicit "daemon too old" hint. The daemon's exact-version-match discipline applies at the next release as usual — restart the shared daemon and projects after installing.
- No new dependencies. No secrets/privacy impact. The full test suite grew ~45s (one 35s idle-survival test, `-short`-guarded).
- Accepted risks (dispositioned in the plan): requests-stream heartbeat is unit-covered only at the binary level; the 404-park path wasn't exercised against a real 0.2.4 daemon; the proxyd forwarder hop keeps its deliberate no-deadline design (unix-socket EOF suffices), noted as future work.

Plan 018 (TUI unification — local mode becomes an API client; richer TUI toward default-interface) is seeded to follow.

<details>
<summary>Plan 017 (full text, panel-reviewed)</summary>

    # Plan 017 — Unified push data plane: SSE heartbeats, reconnect, backfill everywhere, polls eliminated
    
    - **Status**: implemented (14 commits) and live-verified — see § Verified
    - **Date**: 2026-07-28
    - **Repo**: prox (single repo, one PR)
    - **Branch**: `feature/plan-017-push-data-plane`
    - **Panel corrections** (Codex + GLM 5.2 + CodeRabbit, all findings verified
      against the code before adoption): (1) `domain.LogEntry.Seq` already exists
      as TUI-session-local — renamed to `DisplaySeq`, transport seq is new §W4;
      (2) `streamLoop` moved to a new leaf package `internal/stream` —
      `internal/cli` imports `internal/tui`, so the original placement was an
      import cycle; (3) supervisor event bus gains Unsubscribe + latched Close —
      without them every processes-stream connection leaks a channel and a
      connected client blocks API shutdown; (4) log seq assignment serialized
      with ring-append + broadcast (concurrent writers would otherwise reorder);
      (5) log cursor is `(stream_id, seq)` — seq regression alone cannot detect a
      daemon restart that out-runs the old watermark; (6) requests backfill is
      now a synchronization protocol (buffer-then-apply, monotonic merge, `ok`
      only after sync) — the TUI's blind replace-by-ID could regress final→
      in-flight and interleave stale order; (7) 503/proxy-disabled
      discrimination pinned to a typed `APIError`; (8) heartbeat flush errors
      observed via `http.NewResponseController`; (9) CLI `--follow` keeps
      fail-fast initial-connect UX, reconnects only after first success; (10)
      `unavailable` re-probes on daemon-restart evidence instead of latching
      forever; (11) log retention truth is 1000 (`DefaultLogBufferSize`), not
      `MaxLogLines`; (12) acceptance criteria tightened (detection vs recovery
      time, counting-based no-poll proof, shutdown promptness, leak checks);
      (13) C-commits resequenced/split (log work was too large for one commit).
    
    ## Scope direction (user-pinned)
    
    Features are considered complete; the goal is internal-pattern cleanup toward
    a strong TUI that can eventually become the default interface. Large changes
    are acceptable if well tested. **Backwards incompatibility on types and
    endpoints is acceptable** — deliberate 0.2.x breakage window ahead of a
    shareable next minor release. User chose the bigger change set. TUI
    unification (collapsing local mode into an API-client-only TUI) is deferred
    to plan 018 (seed: `018-tui-unification-seed.md`) so this provider-side
    rewrite lands and is trusted before the consumer-side rewrite begins.
    
    ## 1. Problem / motivation
    
    Reported live on 2026-07-28 against v0.2.4 (slauth project, shared daemon):
    
    1. **The attach TUI's requests view shows nothing** despite the daemon having
       captured records. Root cause: the client SSE reader has a 60s rolling idle
       timeout that assumes server heartbeats; no SSE endpoint sends any. Any 60s
       idle window kills the stream; no consumer reconnects; the requests-stream
       death is invisible.
    2. **The attach TUI polls `GET /api/v1/processes` every 500ms**, and chi's
       `middleware.Logger` prints every control-plane request into the `prox up`
       terminal, drowning process logs.
    3. **General data-plane fragility**: stream deaths silent or near-silent, no
       stream-health indicator, no requests backfill, logs cannot resume gap-free
       (no IDs/cursor), process state is poll-only, and local mode leaks a
       vestigial log subscription that also spams "dropped message" lines once
       its undrained channel fills (`internal/logs/subscription.go:82`).
    
    End state: **all three data types — logs, requests, process state — flow
    through one uniform pattern: SSE + heartbeat + reconnect with backoff +
    snapshot synchronization + monotonic merge + visible stream health. No
    steady-state polling remains in attach mode.**
    
    ## 2. Current state (verified this session)
    
    Verified by direct reading plus live experiments against a running v0.2.4
    daemon + slauth project (SSE curl subscribe → proxied request → in-flight and
    final events observed; REST returns 100 records while the attach TUI shows
    none). Panel-cited facts re-verified in-repo before adoption.
    
    - **No heartbeats anywhere.** `StreamLogs` (`internal/api/sse.go:54`) and
      `StreamProxyRequests` (`internal/api/handlers.go:634`) write `": connected"`
      once, then only data events; no ticker branch. Same for the daemon's
      `handleStreamRequests` (`internal/proxyd/server.go:826-846`). Note
      `http.Flusher.Flush()` returns no error — write-failure detection needs
      `http.NewResponseController` (server `WriteTimeout` is deliberately 0 for
      SSE, `internal/api/server.go:266`).
    - **Client 60s idle timeout with a false assumption.**
      `sseReadTimeout = 60s` (`internal/cli/client.go:24`); comment claims "SSE
      servers send heartbeats". `deadlineReader` (`client.go:28-41`) re-arms
      `SetReadDeadline` per read. `streamSSE` (`client.go:351-415`) closes the
      channel on any read error — never surfaced, indistinguishable from clean
      EOF. Stream requests are built without a context (`client.go:427`); non-200
      bodies are flattened to strings (`client.go:250-269` `httpStatusError`),
      so callers cannot discriminate error codes without string matching.
    - **No consumer reconnects.** `forwardClientLogs`
      (`internal/tui/app.go:141-190`): one synthetic line, permanent exit.
      `forwardClientProxyRequests` (`app.go:194-236`): silent return; connect
      errors conflate "proxy not enabled" with genuine failures (`app.go:196-199`).
      `prox logs --follow` (`internal/cli/commands.go:381-395`) and
      `prox requests --follow` (`commands.go:759-773`) exit 0 silently on close
      (both fail fast with a helpful error on *initial* connect failure — that
      UX is worth preserving).
    - **Misleading status on daemon restart**: the 500ms poll self-heals
      (`internal/tui/client.go:114-128`) so the status bar shows "Connected via
      API" while both SSE streams are dead forever.
    - **Subscriptions are forward-only and lossy.** `RequestManager.Subscribe`
      (`internal/proxy/requests.go:446-463`); logs Subscribe
      (`internal/logs/subscription.go:119-137`). Both drop silently on a full
      100-slot channel (`requests.go:503-527`, `subscription.go:82`) and keep the
      stream open — an undetectable, never-repaired gap for SSE consumers today.
    - **REST backfill exists for requests, not logs.** `GET /api/v1/proxy/requests`
      → `RecentPage` (`internal/api/handlers.go:429-466`,
      `internal/proxy/requests.go:346-401`): newest-first, limit ≤
      `constants.MaxProxyRequests = 1000`, ring-cursor `before_id`, 410-Gone on
      stale cursor. `GET /api/v1/logs` (`handlers.go:219-246`): last-N only.
    - **`domain.LogEntry.Seq` already exists** (`internal/domain/log.go:24-31`):
      `int64`, `json:"-"`, documented TUI-session-local, stamped unconditionally
      by `BaseModel.handleLogEntry` (`internal/tui/base.go:181-182`), anchors the
      logs `/`-search cursor (`base.go:745,794,825`; tested
      `model_test.go:1434`). Any server-side sequencing must not collide with it.
    - **Log retention is 1000 entries** (`internal/cli/up.go:311-312`,
      `constants.DefaultLogBufferSize = 1000`); `MaxLogLines = 10000` is only an
      API request cap. `Manager.Write` (`internal/logs/manager.go:43`) is called
      concurrently by per-process scanner goroutines with no manager-level
      serialization across assignment/ring/broadcast.
    - **Request IDs are unordered** (truncated SHA-256,
      `internal/proxy/requests.go:79-95`); ring position is the only order —
      snapshot backfill, not since-ID queries. `Upsert` (`requests.go:281-344`)
      is monotonic (final is terminal); the TUI's `handleProxyRequest`
      (`internal/tui/base.go:214-264`) is **not** — it blindly replaces same-ID
      rows, so a stale in-flight snapshot record could overwrite a final live
      record. It also calls `updateViewport()` per record (O(n) scan + full
      re-render each).
    - **The proxyd forwarder is the resilience template**: reconnect loop
      (`internal/proxyd/forwarder.go:133-221`), backoff 500ms→5s, flap guard
      (`forwarder.go:52,163-173`), heal gating (`constants.go:89-93`), full-ring
      backfill on every (re)connect replayed oldest-first through `Upsert`
      (`forwarder.go:270-283,332-371`), `ForwarderStatusSink`
      (`forwarder.go:25-38`), injectable clock (`forwarder.go:94-112`) with
      fake-clock tests (`forwarder_heal_test.go:19-26`). It sets no read
      deadline — safe for a unix socket (peer death ⇒ EOF), a rationale that
      does NOT transfer to the TCP TUI hop (half-open connections are real
      there; hence heartbeats + deadlines).
    - **Supervisor event bus exists, unused, incomplete, unclosable**:
      `Subscribe()` (`internal/supervisor/supervisor.go:1326-1331`) appends
      forever — **no Unsubscribe, no Close**; `emit` (`supervisor.go:1336-1348`)
      is non-blocking drop-on-full. Events cover start/stop/crash paths only.
      `HealthChecker` (`internal/supervisor/health.go`) owns health state under
      its own `mu` with **no supervisor back-reference or callback** — it
      physically cannot emit today. `WaitingOn`/`BlockedOn` are derived in
      `ManagedProcess.Info()` (`process.go:384-393`) — no transition call site
      exists. The shutdown contract for no-timeout SSE routes relies on data
      sources closing subscriber channels (`internal/api/server.go:177-182`;
      logs latch-close at `subscription.go:168-185`, requests at
      `requests.go:446-459`; `up.go` shutdown ordering `up.go:729-`); the
      supervisor bus has no equivalent — a connected processes-stream client
      would pin `http.Server.Shutdown`.
    - **Import structure**: `internal/cli` imports `internal/tui`
      (`commands.go:17`, `up.go:27`) — shared stream machinery cannot live in
      `internal/cli` if `internal/tui` consumes it.
    - **Control-plane noise**: `r.Use(middleware.Logger)`
      (`internal/api/server.go:54`) → chi default → `log.New(os.Stdout, ...)`,
      interleaved with `printLogs` (`internal/cli/up.go:1106-1117`). No quiet
      mechanism; `--verbose` only tunes the standalone proxy's slog level.
    - **Tick usage**: shared 500ms `tea.Tick` (`internal/tui/model.go:190-195`);
      sole purpose is process refresh (local: in-memory `update.go:55-57`;
      attach: HTTP GET per tick `client.go:177-180`). No other consumer.
    - **TUI cursor/backfill groundwork**: requests cursor is ID-anchored
      (`base.go:882-933`), follow mode re-pins to newest, empty→non-empty tested
      (`model_test.go:905-928`), detail-view arrivals guarded (`base.go:235-241`),
      attach detail fetches seq-guarded (`client.go:139-175`).
    - **Local-mode warts**: leaked write-only log subscription
      (`model.go:67-73,171-179`, `update.go:59-60`) whose undrained channel spams
      drop-noise via the global `log` package once full; local forwarders
      (`app.go:80-108`) exit silently on channel close.
    - **Test landscape**: attach-mode streaming stubbed to **closed channels**
      (`client_model_test.go:35-45`) — under a reconnect loop that idiom means
      "reconnect forever", so the stub must change with C5. Templates:
      `internal/api/sse_test.go`, `server_test.go:463-527`,
      `test/integration/api_test.go:176+`, forwarder fake-clock tests. Bubble
      Tea (pinned v1.x) documents `Program.Send` after termination as a no-op —
      the real quit-time risk is uncanceled HTTP work, not sends.
    
    ## 3. Design decisions (PINNED)
    
    ### W1 — Server-side SSE heartbeats (project API)
    
    All project-API SSE handlers (logs, requests, and W5's processes stream)
    gain a ticker branch writing `": ping\n\n"` every
    `constants.SSEHeartbeatInterval = 15 * time.Second`.
    
    - **Flush/write failure is observable**: writes go through
      `http.NewResponseController(w)`; each write (data or heartbeat) sets a
      write deadline `now + constants.SSEWriteTimeout` (10s) and checks both
      write and `Flush()` errors; any failure tears down the handler. This is
      what actually detects half-open TCP clients — plain `fmt.Fprintf` +
      errorless `flusher.Flush()` does not.
    - **Interval is a handler-config field** (struct field with default, set by
      tests), NOT a mutable package var (racy under parallel tests) — matching
      the `forwarderConfig` idiom.
    - `sseReadTimeout` moves to `constants.SSEReadTimeout = 60s`; documented
      invariant `SSEReadTimeout > 3×SSEHeartbeatInterval`; false client comment
      fixed.
    - Backward compatible: `:`-comments already skipped by all clients.
    - Rejected: dropping the client read deadline (forwarder style) — TCP hop,
      half-open connections are real; heartbeat + deadline is the SSE contract.
    
    ### W2 — `internal/stream`: one reconnect runner, typed errors, real contexts
    
    **Package placement (corrected)**: new leaf package **`internal/stream`**
    (imported by both `internal/cli` and `internal/tui`; `cli` already imports
    `tui`, so the runner cannot live in `cli`).
    
    - **Typed errors first**: `internal/cli` gains
      `APIError{Status int; Code string; Message string}` returned by non-200
      paths (replacing string-flattening at `client.go:250-269` for programmatic
      callers). Stream methods become context-aware
      (`StreamLogsChannel(ctx, ...)` etc.); the SSE response validates
      `Content-Type: text/event-stream`; the reader surfaces its terminal error
      instead of only closing the channel (attempt-style API:
      `consume(ctx, onEvent) error`). Cancelling ctx tears down the connection
      immediately (no 60s zombie reader).
    - **`stream.Loop`**: reconnects an attempt function forever until ctx ends —
      backoff `StreamReconnectBaseBackoff = 500ms` doubling to
      `StreamReconnectMaxBackoff = 5s`, flap guard
      `StreamReconnectFlapThreshold = 1s` (named to avoid implying the
      forwarder's local `streamFlapThreshold` uses it); injectable `now`/`after`;
      status callback with the state machine below.
    - **Retry classification (explicit)**: network error / timeout / EOF /
      generic 5xx / malformed SSE ⇒ transient (retry). 401/403 ⇒ terminal
      (surface, stop). Requests-stream 503/`ErrCodeProxyNotEnabled` ⇒
      `unavailable`. Processes-stream 404 (old server) ⇒ `unavailable`.
      Discrimination is by typed `APIError` fields — never string matching.
      (Amended at C13: the TUI's `unavailable` classifications map to TERMINAL
      for the CLI `--follow` commands — a one-shot command has no status bar to
      park behind, so it exits non-zero with the error instead.)
    - **`unavailable` is latched-with-re-probe, not terminal**: any
      processes-stream reconnect transition (evidence the daemon restarted)
      triggers one re-probe of `unavailable` streams — so enabling the proxy in
      `prox.yaml` and restarting `prox up` under a live attach recovers without
      restarting attach.
    - **State machine (shared by all streams)**:
      `connecting → syncing → ok → reconnecting → (syncing → ok)* | unavailable | closed`.
      `ok` requires HTTP 200 **and** successful snapshot synchronization (W3/W4);
      a failed snapshot fetch with a live SSE connection stays `syncing` and
      retries the snapshot (bounded backoff) without dropping the stream.
    - **No self-heal port** (deliberate): the TUI cannot re-ensure a separate
      `prox up` process the way the forwarder heals the daemon; it only waits
      and retries. Stated here so the omission isn't "fixed" later.
    - **CLI `--follow` semantics (corrected)**: initial connect failure keeps
      today's fail-fast error and non-zero exit (`commands.go:381-386,759-764`
      UX preserved); the reconnect loop engages only after the first successful
      connect. Signal-derived context (Ctrl-C cancels cleanly, exit 0 mid-follow
      as today). Status transitions (not every attempt) print to stderr; stdout
      stays machine-clean. No CLI backfill.
    
    ### W3 — Requests synchronization protocol (attach TUI)
    
    Not "backfill" but a sync barrier, mirroring the forwarder but adapted to
    the TUI's single-threaded model:
    
    1. On stream connect (HTTP 200): state `syncing`. Live SSE records are
       **buffered client-side, not delivered**.
    2. Fetch `GET /api/v1/proxy/requests?limit=constants.MaxProxyRequests`.
    3. Deliver one `RequestsSyncMsg{Snapshot []Record, Buffered []Record}`:
       apply snapshot oldest-first, then drain buffered live records, then state
       `ok`.
    4. Failure of the snapshot fetch: stay `syncing`, retry with backoff; the
       live buffer caps at `MaxProxyRequests` (overflow ⇒ drop the stream
       attempt and reconnect — sync restarts, nothing is silently lost).
    
    - **Monotonic TUI merge (new invariant in `handleProxyRequest` or a sibling
      merge func)**: absent ⇒ append; in-flight ⇒ final replace-in-place;
      final ⇒ anything is a no-op. This mirrors `Upsert`'s table
      (`requests.go:281-344`) and closes the stale-snapshot-overwrites-final
      hole. **Batch application renders once** (single `updateViewport()` after
      the batch, not per record — 1000-record replays were O(n²) with 1000
      re-renders).
    - **Server-side subscriber overflow closes the stream** (requests + logs SSE
      subscriptions): instead of silent drop-and-continue
      (`requests.go:503-527`, `subscription.go:82`), an overflowing SSE
      subscriber's channel is latch-closed; the handler ends the stream; the
      client reconnects and re-syncs. Converts an undetectable gap into a
      self-healing reconnect. (Amended at C6: the latch-close is manager-wide,
      so the local TUI's direct subscription also closes on overflow — surfaced
      as a visible disconnect by W7's close reporting. Chosen over the
      originally-planned local drop-and-continue: visible death beats silent
      loss, and same-process delivery rarely backs up.)
    - **Prior-epoch hygiene**: request history from before a daemon restart
      remains visible (it is real history); on each completed sync, any
      still-in-flight row absent from the new snapshot is marked stale
      immediately (it can never finalize — its daemon died) rather than waiting
      out `InFlightStaleAfter` (5m).
    - `TUIClient` gains `GetProxyRequests(ctx, limit)` (exists on `*cli.Client`,
      not on the interface).
    
    ### W4 — Log sequencing: rename + epoch + serialized ingest
    
    - **Field collision resolved by rename**: existing TUI-local
      `domain.LogEntry.Seq` → **`DisplaySeq int64 json:"-"`** (doc comment and
      `handleLogEntry`/search-cursor/test references updated). New
      **`Seq uint64 json:"seq"`** is the server transport sequence, assigned by
      `logs.Manager`. The old comment's claim "the wire has no Seq field"
      becomes false and is rewritten.
    - **Serialized ingest**: seq assignment, ring append, and subscriber
      broadcast happen in one critical section (or a single ingest goroutine) in
      ingest order — a bare atomic would let seq 2 enter the ring before seq 1
      under concurrent per-process writers. Race-detector test with concurrent
      writers asserts strictly increasing ring/SSE order.
    - **Epoch token**: `logs.Manager` gets a random `stream_id` (generated at
      construction). The cursor is `(stream_id, seq)`. Seq regression alone
      cannot detect a restart that out-runs the old watermark.
    - **API**: `LogEntryResponse` gains `seq`; `GET /api/v1/logs` gains
      `since_seq` and returns cursor metadata `{stream_id, oldest_seq,
      latest_seq}`; `/logs/stream` announces `stream_id` in its handshake (first
      event) and carries `seq` per event.
    - **Client sync (initial AND reconnect — both backfill)**: initial connect
      fetches the last `DefaultLogBufferSize` (1000 — the true retention; NOT
      `MaxLogLines`) then streams. Reconnect with matching `stream_id`: fetch
      `since_seq=<last seen>`; if `oldest_seq > lastSeen+1` the buffer rolled —
      splice what's available plus one synthetic notice with the lost count
      (`oldest_seq − lastSeen − 1`). Mismatched `stream_id` (daemon restarted):
      full last-N fetch + one synthetic notice. Live-stream seq discontinuity
      while the TCP stream stays open (server-side drop) triggers an inline
      `since_seq` catch-up fetch.
    - **Filtered-stream invariant (pinned)**: seq-gap math is only valid on an
      unfiltered subscription; the TUI attaches unfiltered (`app.go:142`).
      Documented in code so a future filtered-stream feature doesn't silently
      break gap detection.
    - Retention stays 1000 — log lines can be large; do not raise to match
      `MaxLogLines`.
    
    ### W5 — Process state becomes push: `/api/v1/processes/stream`
    
    - **Bus lifecycle first (corrected)**: `Supervisor.Subscribe` is redesigned
      to return an ID (or cancel func) with **`Unsubscribe`**, plus a **latched
      `Close`** on supervisor stop that closes all subscriber channels —
      mirroring the logs/requests manager pattern — and `up.go`'s shutdown
      sequence closes it before HTTP shutdown (same ordering as logMgr/reqMgr,
      `up.go:729-`). Connections arriving after the stop transition get an
      immediately-closed subscription. Without this, every reconnect leaks a
      channel and a connected client pins `http.Server.Shutdown`.
    - **Coalescing dirty-flag, not an event channel**: the SSE handler only
      needs a wake-up (it re-snapshots via `Processes()`), so each subscriber is
      a cap-1 latch (set-if-empty) — a burst can never lose its last event, which
      makes "snapshot-per-event self-heals" actually true (drop-tail on a cap-100
      event channel would not). Debounce ~100ms trailing-edge: the last change
      always yields a snapshot; C8's test asserts exactly that.
    - **Emission coverage is new wiring, not new call sites**: `HealthChecker`
      has no supervisor reference — it gets a transition callback injected at
      construction, invoked **after releasing `h.mu`** (sample old/new under
      lock, fire outside). Dependency-gate transitions (`WaitingOn`/`BlockedOn`)
      fire at `beginWaiting`/`blockedBy` mutation sites, outside process locks.
      Restart-count bumps ride the existing crash/stop emits. Natural process
      exit / task completion paths in `ManagedProcess.monitor` are verified
      covered (added if not). **Events carry no `Info` payload** — handlers
      snapshot independently; this removes the ABBA deadlock class
      (`HealthChecker.mu` vs supervisor locks via `Processes()→Info()→State()`)
      by construction. Tests assert *endpoint convergence* (final snapshot
      matches final state), not brittle exact event counts.
    - **Subscribe-before-snapshot**: the handler subscribes first, then sends
      the initial snapshot — no transition can fall between them.
    - **Endpoint**: `GET /api/v1/processes/stream`, SSE, no-timeout route group,
      heartbeat per W1, auth like siblings. Every event is a full
      `ProcessListResponse` snapshot (pinned: snapshots, not deltas — poll
      semantics with push timing; trivial merge; ~255B payloads). The
      REST-handler conversion (`handlers.go:143`) is factored and shared so REST
      and SSE cannot drift.
    - **TUI adoption**: third `stream.Loop`; snapshots become `ProcessesMsg`;
      attach tick/poll machinery deleted; global liveness derives from the
      processes stream ("Connection error (retrying...)" ⇔ processes stream not
      `ok`). **Accepted trade, stated**: a hung-open connection is detected in
      ≤`SSEReadTimeout` (60s) vs ~1s under the old 500ms poll; a killed daemon
      is still detected immediately (EOF).
    - **Status rendering matrix (pinned)**: processes stream degraded ⇒ global
      "Connection error (retrying…)" banner state; logs/requests degraded while
      processes is `ok` ⇒ per-stream `⚠ logs: reconnecting…` /
      `⚠ requests: syncing…` segments; `unavailable` renders a passive note
      (e.g. `requests: n/a`), not a warning.
    - **REST `GET /api/v1/processes` untouched** — agents keep polling
      semantics. Local mode keeps its in-memory 500ms tick (plan 018 decides its
      fate).
    
    ### W6 — Quiet control plane
    
    Remove `middleware.Logger` (`server.go:54`) unconditionally, no replacement.
    `middleware.RequestID`/`RealIP` stay (harmless, cheap, useful to any future
    debug logging; removal is not worth the churn). Errors remain visible via
    `middleware.Recoverer` + handler logs.
    
    ### W7 — Stream-health surfacing + local-mode hardening
    
    - `BaseModel` gains per-stream health for `logs`/`requests`/`processes`
      using the W2 state machine, updated via `StreamStatusMsg`; local mode
      initializes all to `ok`.
    - Rendering per the W5 matrix through the shared
      `statusBar`/`statusLeftDefault` path (`base.go:1569,1609-1675`).
    - Local mode: unexpected channel close ⇒ `StreamStatusMsg{closed}` + one
      synthetic system line (ctx-cancelled shutdown stays silent).
    - Delete the leaked local log subscription (`subscribeToLogs`, `subIDMsg`,
      `Model.subID`) — also removes a live noise source (undrained channel ⇒
      "dropped message" spam through the global `log` once full).
    
    ## 4. Deviations / non-goals
    
    - **TUI unification → plan 018** (seed exists). This plan leaves everything
      the TUI needs served by the API.
    - **Daemon↔project hop untouched** (`proxyd` server + forwarder): immune to
      idle-death by design (unix socket EOF); proven reconnect/heal/backfill.
      Hung-open-socket case → future work.
    - **Forwarder not migrated** to `internal/stream`/shared constants.
    - **CLI `--follow`: reconnect after first success only; no backfill; initial
      fail-fast and exit codes unchanged.**
    - **No release** in this plan.
    
    ## 5. Work breakdown (gated commits)
    
    Gate per commit: `make lint && make test && make test-race && make build`.
    
    - **C1 (sonnet) — Server SSE heartbeats + write-error observability + quiet
      control plane.** ResponseController writes with `SSEWriteTimeout`
      deadlines; heartbeat ticker via handler-config interval field; constants
      `SSEHeartbeatInterval`/`SSEWriteTimeout`/`SSEReadTimeout`; client comment
      fix. **W6's `middleware.Logger` removal moved into this commit** (C1
      review finding): chi's wrapped writer implements an errorless `Flush`,
      which `http.ResponseController` prefers over `Unwrap`, so with the logger
      installed SSE flush errors were unobservable — the removal is a
      correctness dependency of this commit, not just noise reduction. Tests:
      idle heartbeat cadence (short interval via config, wall-clock-bounded
      assertion), teardown on write failure/disconnect, read-timeout invariant.
    - **C2 (sonnet) — Tick parameterization.** `tickCmd(d)`;
      `TUILocalTickInterval = 500ms` (logger removal moved to C1).
    - **C3 (opus) — Typed errors + context-aware client streams.** `APIError`;
      ctx on stream/snapshot methods; Content-Type validation; attempt-style
      consume returning terminal error; preserve the one-dial `conn`-capture
      invariant the read deadline depends on (`client.go:352-364`). Tests:
      error typing (401/403/404/503/proxy-disabled/malformed SSE/wrong
      content-type), ctx cancel mid-read.
    - **C4 (opus) — `internal/stream.Loop`.** Backoff/flap/state machine/retry
      classification/re-probe hook; injectable clock. Fake-clock tests:
      reconnect, backoff progression, flap guard, terminal vs transient vs
      unavailable, ctx cancel in every phase (connecting/backoff/reading).
    - **C5 (opus) — Attach TUI on stream.Loop (logs+requests) + health UI.**
      `StreamStatusMsg`; `BaseModel` health fields + status matrix rendering;
      proxy-disabled ⇒ `unavailable`; **test-stub rework** (blocked-channel or
      no-reconnect seam — the closed-channel stub idiom would spin forever under
      the loop). Tests: status transitions, rendering, stub migration of the
      existing suite.
    - **C6 (opus) — Requests sync protocol.** Buffer-then-apply barrier;
      `RequestsSyncMsg`; monotonic merge (final terminal); single-render batch;
      server-side SSE-subscriber overflow ⇒ latch-close (requests + logs);
      prior-epoch in-flight stale sweep; `TUIClient.GetProxyRequests(ctx,limit)`.
      Tests: interleaving permutations (live-final before snapshot-in-flight;
      live-new during sync; snapshot-final vs buffered in-flight; buffer
      overflow ⇒ resync; snapshot fetch failure ⇒ stays syncing then recovers),
      cursor/follow preservation.
    - **C7 (opus) — Log seq foundation.** `Seq`→`DisplaySeq` rename (+ doc
      comment, search-cursor and test refs); transport `Seq uint64`; serialized
      ingest (assignment+ring+broadcast); `stream_id` epoch. Tests: concurrent
      writers strictly-increasing order (race detector), epoch stability.
    - **C8 (sonnet) — Logs cursor API.** `since_seq`; cursor metadata
      `{stream_id, oldest_seq, latest_seq}` on `GET /logs`; stream handshake
      event + per-event seq. Tests: filtering, boundary/overflow params,
      metadata correctness.
    - **C9 (opus) — Client/TUI log sync.** Initial last-1000 backfill; reconnect
      `since_seq` splice with lost-count notice; epoch-mismatch fallback;
      live-gap catch-up on seq discontinuity; unfiltered-only invariant
      documented. Tests: gap-fits-buffer, buffer-rolled lost-count,
      epoch-mismatch (empty/shorter/numerically-ahead new buffers),
      discontinuity catch-up.
    - **C10 (opus) — Supervisor bus lifecycle + emission wiring.** *Highest-risk
      commit; full-intensity review.* Unsubscribe + latched Close + shutdown
      ordering in `up.go`; cap-1 dirty-latch subscribers; HealthChecker callback
      (fired outside `h.mu`); dependency-gate + restart-count coverage; natural
      exit/task-completion coverage verified; no `Info` payloads. Tests:
      endpoint-convergence per transition type, shutdown promptness with a
      connected subscriber, subscriber count returns to baseline after
      disconnect, no emit under held locks (race detector).
    - **C11 (sonnet) — `/api/v1/processes/stream`.** Subscribe-then-snapshot;
      trailing-edge debounce; heartbeat; shared REST/SSE conversion; auth.
      Tests: connect snapshot, convergence after burst, debounce trailing-edge
      guarantee, heartbeat.
    - **C12 (opus) — TUI processes adoption; poll deleted.** Third loop;
      liveness re-derivation; status matrix final wiring; `unavailable` re-probe
      on processes reconnect; attach tick/fetch machinery removed. Tests:
      snapshot updates, liveness transitions, **no-poll proof via stub
      call-counting** (not log absence), old-server-404 ⇒ unavailable.
    - **C13 (sonnet) — CLI follow + local-mode cleanup.** Follow commands on the
      loop (fail-fast initial, reconnect after first success, signal ctx, stderr
      transitions); delete leaked subscription; local close surfacing. Tests:
      httptest reconnect-after-success, initial-failure exit code preserved,
      local close handling.
    - **C14 — Integration pass.** `test/integration`: idle survival ≥ read
      timeout; daemon-restart reconnect+re-sync for all three streams
      (deterministic self-exiting fixture, not killing arbitrary PIDs); API
      shutdown promptness with all three streams connected; goroutine/subscription
      leak check after client disconnect; no-access-log check.
    
    ## 6. File map (indicative)
    
    - `internal/stream/` (new) — `loop.go`, state machine, tests
    - `internal/constants/constants.go` — SSE/stream/tick constants
    - `internal/api/sse.go`, `handlers.go` — ResponseController writes,
      heartbeats, seq/cursor metadata, processes-stream handler, shared
      conversion
    - `internal/api/server.go` — logger removal; new route
    - `internal/api/responses.go` — seq, cursor metadata, snapshot event
    - `internal/domain/log.go` — `DisplaySeq` rename + transport `Seq`
    - `internal/logs/` — serialized ingest, `stream_id`, since-seq query,
      SSE-subscriber overflow latch-close
    - `internal/proxy/requests.go` — SSE-subscriber overflow latch-close
    - `internal/supervisor/` — bus lifecycle, dirty-latch, emission wiring
      (supervisor.go, health.go, process.go), shutdown ordering (via up.go)
    - `internal/cli/client.go` — APIError, ctx streams, Content-Type check
    - `internal/cli/commands.go` — follow commands
    - `internal/cli/up.go` — shutdown ordering; logger removal fallout
    - `internal/tui/` — app.go (loops, status msgs), base.go (health fields,
      monotonic merge, batch apply, status matrix), client.go (sync msgs, poll
      deletion, liveness), model.go/update.go (tick param, subID deletion)
    - tests alongside all of the above + `test/integration/`
    
    ## 7. Acceptance criteria
    
    1. (W1) Over an idle window spanning ≥3 heartbeat intervals, neither data
       nor heartbeat silence ever reaches `SSEReadTimeout` on any of the three
       streams (observed cadence within scheduling tolerance of
       `SSEHeartbeatInterval`); the invariant
       `SSEReadTimeout > 3×SSEHeartbeatInterval` is asserted in a test.
    2. (W2) With attach live: killing the daemon is detected ≤1s (EOF); a
       restored API is reconnected within `StreamReconnectMaxBackoff` of
       availability; a hung-open connection is detected ≤`SSEReadTimeout`.
       Status bar reflects `reconnecting…` during the outage and only returns to
       healthy after re-sync (`ok`), not on TCP connect.
    3. (W3) Fresh attach shows existing requests (≤1000) in canonical order;
       after a reconnect gap: no duplicates, no final→in-flight regression, gap
       records present; client-buffer overflow during sync triggers a clean
       re-sync rather than silent loss.
    4. (W4) Log continuity is `(stream_id, seq)`-based: gap-fits-buffer splices
       exactly; buffer-rolled and epoch-mismatch cases produce exactly one
       synthetic notice (with lost count when computable) — including the
       epoch-advanced-beyond-old-watermark case; a live seq discontinuity
       triggers catch-up without user-visible loss.
    5. (W5) With attach open, zero steady-state polling (proven by client
       call-counting in tests, not log absence); process crash/health/dependency
       transitions appear via push with endpoint convergence; REST `/processes`
       unchanged; API shutdown completes promptly with all three streams
       connected; supervisor subscriber count returns to baseline after client
       disconnect.
    6. (W6) `prox up` foreground output contains zero control-plane access-log
       lines during an attach session (verified live; automated coverage via the
       no-poll counting tests + absence of the middleware).
    7. (W7) No stream death is silent in either mode; per-stream vs global
       degradation renders per the status matrix; `prox logs --follow` fails
       fast with non-zero exit on initial connect failure, and across a
       mid-follow daemon restart prints stderr notices and resumes.
    8. On TUI quit: no streamLoop goroutines, HTTP bodies/transports, or API
       subscriptions remain (leak-checked test). Gate (incl. race detector)
       green on every commit.
    
    ## 8. Verification plan (beyond automated tests)
    
    Live end-to-end pass on this machine (artifacts →
    `~/.claude/plans/prox/017-tui-data-plane-hardening/`):
    
    1. Branch binary; `prox up` on a scratch project; `prox attach` in tmux.
    2. Original-bug repro: idle ≥90s, then drive one proxied request → appears
       in the TUI requests view. `tmux capture-pane` before/after.
    3. `curl -N` all three streams ≥45s; capture heartbeat timestamps.
    4. Restart the daemon mid-attach; capture `reconnecting…`, then re-synced
       state: requests history + stale-swept in-flight rows, log gap notice,
       fresh process snapshot.
    5. Crash a managed process (deterministic fixture) with attach open →
       state flips via push; verify no /processes REST calls via a temporary
       counting client build or `lsof` connection accounting (the access log no
       longer exists to check — by design).
    6. Capture `prox up` foreground output during an attach session → no
       access-log lines.
    7. `prox logs --follow`: against stopped daemon (fail-fast, non-zero);
       across a daemon restart (stderr notices + resume).
    
    ## 9. Risks / open items / future work
    
    - **C10 (supervisor) remains the highest-risk commit** — but the risk is now
      structural wiring (callbacks fired outside locks, latched close, shutdown
      ordering), with the deadlock class removed by the no-payload rule.
    - **Sync-protocol complexity** (W3/W4) is the price of correctness the
      panel demanded; the interleaving test matrix in C6/C9 is the guard.
    - **Version skew mid-plan**: incremental commits C1–C13 tested against a
      same-build daemon; a dev running an old daemon + new client mid-plan sees
      the documented skew behavior (processes stream 404 ⇒ `unavailable`) — not
      a bug. Post-release, the daemon's exact-version-match discipline applies.
    - **Perf note**: monotonic merge keeps the linear ID scan; if profiling ever
      shows reconnect-churn jank, add an ID→index map (explicitly deferred).
    - **Future work (018+)**: TUI unification (seed:
      `018-tui-unification-seed.md`), forwarder heartbeat/read-deadline
      symmetry + migration onto `internal/stream`, structured debug access log,
      log persistence, richer TUI toward default-interface goal.
    
    ## § Verified (2026-07-29)
    
    Automated coverage: 14 gated commits, each through `make lint && make test &&
    make test-race && make build` green; every codex/cursor review finding fixed
    or dispositioned in its commit message; C14 added five end-to-end integration
    tests (idle survival ≥2 heartbeat intervals against the real binary,
    processes-stream snapshots, logs handshake+cursor, no-access-log foreground,
    prompt shutdown with held SSE connections).
    
    Live pass beyond the tests (branch binary, scratch project with isolated
    $HOME — standalone proxy, the user's live 0.2.4 shared daemon untouched;
    artifacts in `017-tui-data-plane-hardening/`):
    
    1. **Original-bug repro — PASS** (`attach_after_request.txt`): attach TUI
       requests view survived 95s of idle (past the old 60s death) and showed a
       proxied request sent afterwards. Backfill also verified: two pre-attach
       requests visible at attach start (`attach_initial.txt`).
    2. **Heartbeats — PASS** (`hb_*.txt`): all three streams, exactly 15s
       cadence (3 pings per 50s capture each).
    3. **Daemon restart under live attach — PASS** (`attach_daemon_down.txt`,
       `attach_reconnected.txt`, `attach_logs_view.txt`): outage rendered as
       global "Connection error (retrying...)" + per-stream "⚠ logs/requests:
       reconnecting…" with request history retained; after restart the banner
       cleared, requests re-synced (history + gap rows), and the logs view
       carried old-epoch history plus the "log stream restarted; earlier entries
       are from the previous run" notice.
    4. **Crash propagation — PASS**: killed the managed process; state reached
       the API/TUI with no polling in existence (C12 removed it; integration
       test pins the snapshot-on-change path).
    5. **Quiet control plane — PASS** (`up_output.log`): zero access-log lines
       across the whole session including API traffic.
    6. **`logs --follow` across restart — PASS** (`follow_stderr.log`): exactly
       "prox: stream disconnected, reconnecting..." then "prox: stream
       reconnected" on stderr, entries on stdout; fail-fast against an absent
       daemon preserved (same error text, exit 1).
    
    Known-unexercised paths (honest limits): the requests SSE stream's heartbeat
    at the binary level (unit-covered only — no proxy-enabled quiet fixture);
    attach against a genuinely old (0.2.4) daemon for the 404-park path
    (classifier unit-covered; version-skew park not exercised live); TUI-visible
    crash rendering verified via API state + push architecture rather than a
    color-capable pane capture.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QYoxAbd8V8ZsAiAYd7v8Fk


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live process-status streaming with snapshots, heartbeats, and automatic updates.
  * Added log stream handshakes, sequence numbers, cursor-based resumption, and buffer-bound metadata.
  * Improved CLI follow mode with automatic reconnects, cancellation support, and clearer terminal errors.
  * Added resilient TUI synchronization for logs, proxy requests, and process streams.
  * Added stream health indicators and connection status messaging in the TUI.

* **Bug Fixes**
  * Improved SSE disconnect handling, shutdown behavior, and subscriber cleanup.
  * Prevented lost, duplicated, or stale streamed records during reconnects and synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->