### PR TITLE
fix(supervisor): deflake the restarting change-bus tests

### DIFF
--- a/internal/supervisor/change_bus_test.go
+++ b/internal/supervisor/change_bus_test.go
@@ -506,16 +506,21 @@ func TestChangeBus_SnapshotFromWakeHandlerUnderChurn(t *testing.T) {
 		churn.Add(1)
 		go func(name string) {
 			defer churn.Done()
+			// assert, not require: FailNow off the test goroutine is
+			// unsupported, and it would abandon this name's remaining
+			// iterations — losing the churn the rest of the test needs.
 			for i := 0; i < 5; i++ {
-				require.NoError(t, sup.StopProcess(context.Background(), name))
-				require.NoError(t, sup.StartProcess(context.Background(), name))
+				assert.NoErrorf(t, sup.StopProcess(context.Background(), name), "%s stop #%d", name, i)
+				assert.NoErrorf(t, sup.StartProcess(context.Background(), name), "%s start #%d", name, i)
 			}
 		}(name)
 	}
 	churn.Wait()
 
 	// Stop closes the bus, which is what releases every subscriber goroutine.
-	_ = sup.Stop(context.Background())
+	// With graceful fakes a clean stop is the expected outcome; an error here
+	// would mean a surviving group, which this test should notice.
+	require.NoError(t, sup.Stop(context.Background()))
 
 	done := make(chan struct{})
 	go func() { wg.Wait(); close(done) }()

--- a/internal/supervisor/change_bus_test.go
+++ b/internal/supervisor/change_bus_test.go
@@ -231,9 +231,7 @@ func TestChangeBus_BurstNeverBlocksEmitterAndCoalesces(t *testing.T) {
 // burst, its wake-driven snapshot converges on the final state -- the property
 // the SSE stream depends on (convergence, not event counts).
 func TestChangeBus_RapidTransitionsConvergeOnFinalState(t *testing.T) {
-	sup := newStopSupervisor(t, map[string]*fakeProcess{
-		"svc": newGracefulFake(9201),
-	}, "3s")
+	sup := newRestartSupervisor(t, map[string]int{"svc": 9201}, "3s")
 
 	_, ch := sup.Subscribe()
 
@@ -285,9 +283,7 @@ func TestChangeBus_RapidTransitionsConvergeOnFinalState(t *testing.T) {
 // start -> running, stop -> stopped, start again, and a restart-count bump are
 // each observable to a wake-driven subscriber.
 func TestChangeBus_ConvergesOnStartStopAndRestartCount(t *testing.T) {
-	sup := newStopSupervisor(t, map[string]*fakeProcess{
-		"svc": newGracefulFake(9301),
-	}, "3s")
+	sup := newRestartSupervisor(t, map[string]int{"svc": 9301}, "3s")
 
 	_, ch := sup.Subscribe()
 
@@ -481,10 +477,7 @@ func TestChangeBus_ConvergesOnWaitingThenRunning(t *testing.T) {
 // both the lock discipline (no notify fires under a supervisor/process lock) and
 // the absence of data races on the bus itself.
 func TestChangeBus_SnapshotFromWakeHandlerUnderChurn(t *testing.T) {
-	sup := newStopSupervisor(t, map[string]*fakeProcess{
-		"a": newGracefulFake(9501),
-		"b": newGracefulFake(9502),
-	}, "3s")
+	sup := newRestartSupervisor(t, map[string]int{"a": 9501, "b": 9601}, "3s")
 
 	const subscribers = 4
 	var wg sync.WaitGroup
@@ -514,8 +507,8 @@ func TestChangeBus_SnapshotFromWakeHandlerUnderChurn(t *testing.T) {
 		go func(name string) {
 			defer churn.Done()
 			for i := 0; i < 5; i++ {
-				_ = sup.StopProcess(context.Background(), name)
-				_ = sup.StartProcess(context.Background(), name)
+				require.NoError(t, sup.StopProcess(context.Background(), name))
+				require.NoError(t, sup.StartProcess(context.Background(), name))
 			}
 		}(name)
 	}

--- a/internal/supervisor/supervisor_stop_test.go
+++ b/internal/supervisor/supervisor_stop_test.go
@@ -37,6 +37,37 @@ func (r *nameRunner) Start(_ context.Context, cfg domain.ProcessConfig, _ map[st
 	return fp, nil
 }
 
+// nameFactoryRunner mints a FRESH graceful fakeProcess on every Start, keyed by
+// process name: each name carries a base PID and a per-name launch counter, so
+// launch n of a given name comes back as a distinct live fake with PID base+n.
+//
+// Tests that RESTART a process need this rather than nameRunner. A restart is a
+// new process with a new PID, but a fakeProcess is single-use -- its Wait()
+// channel is closed for good by the first SIGTERM -- so a pre-built fake handed
+// back a second time would already be dead: the relaunched process's monitor
+// would see Wait() return immediately and commit crashed.
+type nameFactoryRunner struct {
+	mu       sync.Mutex
+	basePIDs map[string]int
+	calls    map[string]int
+}
+
+func newNameFactoryRunner(basePIDs map[string]int) *nameFactoryRunner {
+	return &nameFactoryRunner{basePIDs: basePIDs, calls: make(map[string]int, len(basePIDs))}
+}
+
+func (r *nameFactoryRunner) Start(_ context.Context, cfg domain.ProcessConfig, _ map[string]string) (Process, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	base, ok := r.basePIDs[cfg.Name]
+	if !ok {
+		panic("nameFactoryRunner: no base PID configured for process " + cfg.Name)
+	}
+	call := r.calls[cfg.Name]
+	r.calls[cfg.Name]++
+	return newGracefulFake(base + call), nil
+}
+
 // newStopSupervisor builds a supervisor over the given named fakes (each keyed by
 // process name), all sharing stopTimeout. It does not start the supervisor.
 func newStopSupervisor(t *testing.T, fakes map[string]*fakeProcess, stopTimeout string) *Supervisor {
@@ -51,6 +82,25 @@ func newStopSupervisor(t *testing.T, fakes map[string]*fakeProcess, stopTimeout 
 		cfg.Processes[name] = config.ProcessConfig{Cmd: "irrelevant", StopTimeout: stopTimeout}
 	}
 	return New(cfg, logMgr, newNameRunner(fakes), DefaultSupervisorConfig())
+}
+
+// newRestartSupervisor builds a supervisor whose runner mints a fresh graceful
+// fake per launch, one PID series per named process (base PID keyed by name),
+// all sharing stopTimeout. It is the counterpart to newStopSupervisor for tests
+// that stop and start the same process repeatedly. It does not start the
+// supervisor.
+func newRestartSupervisor(t *testing.T, basePIDs map[string]int, stopTimeout string) *Supervisor {
+	t.Helper()
+	logMgr := logs.NewManager(logs.ManagerConfig{BufferSize: 200})
+	t.Cleanup(func() { logMgr.Close() })
+	cfg := &config.Config{
+		API:       config.APIConfig{Port: 5556, Host: "127.0.0.1"},
+		Processes: make(map[string]config.ProcessConfig, len(basePIDs)),
+	}
+	for name := range basePIDs {
+		cfg.Processes[name] = config.ProcessConfig{Cmd: "irrelevant", StopTimeout: stopTimeout}
+	}
+	return New(cfg, logMgr, newNameFactoryRunner(basePIDs), DefaultSupervisorConfig())
 }
 
 // collectStopEvents drains sub non-blocking and returns the stop/crash events

--- a/internal/supervisor/supervisor_stop_test.go
+++ b/internal/supervisor/supervisor_stop_test.go
@@ -40,6 +40,8 @@ func (r *nameRunner) Start(_ context.Context, cfg domain.ProcessConfig, _ map[st
 // nameFactoryRunner mints a FRESH graceful fakeProcess on every Start, keyed by
 // process name: each name carries a base PID and a per-name launch counter, so
 // launch n of a given name comes back as a distinct live fake with PID base+n.
+// A name's series therefore occupies base..base+launches, so callers must space
+// their base PIDs further apart than any name's launch count.
 //
 // Tests that RESTART a process need this rather than nameRunner. A restart is a
 // new process with a new PID, but a fakeProcess is single-use -- its Wait()


### PR DESCRIPTION
Fixes a pre-existing CI flake in `internal/supervisor`, found when it failed the `test (ubuntu-latest)` job on #89 (a PR that touches no supervisor file — the identical commit passed in the duplicate run).

## Root cause — the fixture, not the supervisor

`nameRunner` returns the **same** pre-built `fakeProcess` on every `Start` (`supervisor_stop_test.go:30-38`), an assumption its own doc comment spells out: *"One start per name is assumed (these tests never restart)."* Three change-bus tests do restart.

A `fakeProcess` is single-use — `exitLeader` closes `waitCh` under a one-shot latch (`fake_runner_test.go:136-144`), `Wait()` is just `<-fp.waitCh` (`:95`), and `gracefulOnTerm` fires it on the first SIGTERM (`:170-175`). So per loop iteration:

1. `StopProcess` → SIGTERM → the fake dies, `waitCh` closed **permanently**, state `stopped`.
2. `StartProcess` → gets the same dead fake back, commits `state = running` (`process.go:779`), spawns the monitor (`:802`), returns nil.
3. The monitor's `inst.proc.Wait()` (`process.go:1223`) returns **immediately**, so it commits `state = crashed` (`:1292`).
4. The next `StopProcess` hits the terminal-state branch (`process.go:932-943`), sees `GroupAlive() == false`, and returns `ErrProcessNotRunning`.

The race is only *"does the test goroutine reach `StopProcess` before the monitor goroutine takes `p.mu`"* — which is why it is rare and load-dependent.

**Production code is correct and unchanged.** `ErrProcessNotRunning` on a terminal state is the documented, separately tested contract (`process.go:126`, `process_test.go:58`, `stop_episode_test.go:351-366`, mapped to an API error code at `internal/api/handlers.go:494`). Real users cannot hit this: it requires a process whose group is confirmed dead the instant it launched, where "process not running" is the right answer. Also refuted along the way: `StartProcess` returning before `running` (it commits under `p.mu` first) and any auto-restart/backoff actor (the supervisor has none — the monitor is the only competitor).

## Reproduction (before the fix)

| Configuration | Failures |
|---|---|
| `-run TestChangeBus_RapidTransitions… -count=2000` | **26 / 2000 (1.3%)** |
| same, `-count=200 -race` | 3 / 200 (1.5%) |
| `-cpu=2 -count=500` | 9 / 500 (1.8%) |
| `-cpu=1 -count=500` | 0 / 500 (needs real parallelism) |

`TestChangeBus_ConvergesOnStartStopAndRestartCount` flaked from the same cause at 1.2% (6/500), surfacing as a `converge` timeout whose last snapshot reads `State:crashed`.

## The fix

`nameFactoryRunner` mints a **fresh** graceful fake per launch (PID `base+n`, mutex-guarded counter), mirroring the existing `fakeRunner` factory pattern — which is what a restart actually is: a new process with a new PID. Each fresh fake blocks in `Wait()` until stopped, so the stop/start loops become deterministic. No sleeps, no retry-until-pass, no weakened assertions: the tests still prove rapid transitions wake subscribers and converge on the final state, and now perform 6 *real* stop/start cycles instead of 1 real plus 5 degenerate.

`nameRunner`/`newStopSupervisor` and every single-start test are untouched — including `TestChangeBus_ConvergesOnNaturalExit`, which keeps its direct fake handle for `exitLeader`.

Rejected alternative: re-arming the shared fake (a `revive()` reopening `waitCh`) is fewer lines but keeps one PID across restarts, models restarts less faithfully, and would need `Wait()` reworked to snapshot the channel under the fake's mutex (it currently reads `fp.waitCh` unlocked, which that change would race).

## Bonus: a silent coverage hole closed

`TestChangeBus_SnapshotFromWakeHandlerUnderChurn` discarded every start/stop error with `_ =`. Once its first stop landed, every subsequent call in the churn loop was a no-op — the test was not generating the churn it claims to. Those calls now genuinely succeed and are asserted with `require.NoError`. No `ErrProcessNotRunning` appeared in 2000 non-race + 500 race iterations, as expected structurally (one goroutine per process name, sequential stop/start pairs per process).

## Verification

`TestChangeBus_*` **2000x clean** and **500x clean under `-race`** (both configurations previously reproduced the failure); whole package 3x, and 2x under `-race`; full repo gate (`make lint && make test && make test-race && make build`) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QYoxAbd8V8ZsAiAYd7v8Fk


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved supervisor restart and rapid-transition test coverage.
  * Added coverage for concurrent stop and start operations, including expected error handling.
  * Corrected test port assignments and introduced unique process identifiers for restart scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->