### PR TITLE
docs: adopt the shared StrideLabs docs theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- **Docs now use the shared StrideLabs theme**
+  ([stridelabs-docs-theme](https://github.com/charliek/stridelabs-docs-theme)
+  v0.2.0), so this site and the other StrideLabs docs sites share one look
+  without copying CSS between repos. The header pairs the StrideLabs owl with
+  prox's own console icon; headings are Fraunces, body Inter, code JetBrains
+  Mono. Page URLs, structure and heading anchors are unchanged.
+
+  `zensical.toml` shrinks accordingly — the palette, fonts and feature
+  toggles now come from the theme and were deleted here. The theme installs
+  as a plain git dependency from a public repo, so there is no registry auth
+  and forks can still build the docs.
+
+  Fonts are **self-hosted** by the theme: the site no longer makes any
+  request to `fonts.googleapis.com` or `fonts.gstatic.com`, so no visitor IPs
+  reach a third party.
+
 - **Documentation now builds with [Zensical](https://zensical.org) instead of
   MkDocs + Material for MkDocs** (plan 025). Material for MkDocs entered
   maintenance mode in November 2025; Zensical is the successor from the same

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - **Docs now use the shared StrideLabs theme**
   ([stridelabs-docs-theme](https://github.com/charliek/stridelabs-docs-theme)
-  v0.2.0), so this site and the other StrideLabs docs sites share one look
+  v0.2.1), so this site and the other StrideLabs docs sites share one look
   without copying CSS between repos. The header pairs the StrideLabs owl with
   prox's own console icon; headings are Fraunces, body Inter, code JetBrains
   Mono. Page URLs, structure and heading anchors are unchanged.
@@ -19,8 +19,10 @@ All notable changes to this project will be documented in this file.
   and forks can still build the docs.
 
   Fonts are **self-hosted** by the theme: the site no longer makes any
-  request to `fonts.googleapis.com` or `fonts.gstatic.com`, so no visitor IPs
-  reach a third party.
+  request to `fonts.googleapis.com` or `fonts.gstatic.com`, so the Google
+  Fonts CDN never sees a visitor IP. (This covers fonts specifically — the
+  repo integration still calls `api.github.com` for star and fork counts,
+  since `repo_url` is set.)
 
 - **Documentation now builds with [Zensical](https://zensical.org) instead of
   MkDocs + Material for MkDocs** (plan 025). Material for MkDocs entered

--- a/README.md
+++ b/README.md
@@ -226,14 +226,14 @@ The documentation site is built with [Zensical](https://zensical.org),
 configured in `zensical.toml`.
 
 ```bash
-# Install dependencies
-uv sync --group docs
+# Install dependencies (--locked pins the exact theme commit from uv.lock)
+uv sync --locked --group docs
 
 # Local preview (http://127.0.0.1:7070)
-uv run zensical serve
+uv run --locked zensical serve
 
 # Build static site (--strict fails on broken links and anchors)
-uv run zensical build --strict
+uv run --locked zensical build --strict
 ```
 
 Documentation is automatically published to GitHub Pages on push to main.

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -90,12 +90,12 @@ The documentation site is built with [Zensical](https://zensical.org),
 configured in `zensical.toml`.
 
 ```bash
-# Install dependencies
-uv sync --group docs
+# Install dependencies (--locked pins the exact theme commit from uv.lock)
+uv sync --locked --group docs
 
 # Local preview (http://127.0.0.1:7070)
-uv run zensical serve
+uv run --locked zensical serve
 
 # Build static site (--strict fails on broken links and anchors)
-uv run zensical build --strict
+uv run --locked zensical build --strict
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,4 +14,4 @@ docs = [
 # PyPI or registry auth, so forks and outside contributors can build the docs
 # unchanged. uv.lock pins the resolved commit alongside the tag.
 [tool.uv.sources]
-stridelabs-docs-theme = { git = "https://github.com/charliek/stridelabs-docs-theme", tag = "v0.2.0" }
+stridelabs-docs-theme = { git = "https://github.com/charliek/stridelabs-docs-theme", tag = "v0.2.1" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,4 +7,11 @@ requires-python = ">=3.12"
 [dependency-groups]
 docs = [
     "zensical>=0.0.52",
+    "stridelabs-docs-theme",
 ]
+
+# Shared StrideLabs docs theme, installed straight from its public repo -- no
+# PyPI or registry auth, so forks and outside contributors can build the docs
+# unchanged. uv.lock pins the resolved commit alongside the tag.
+[tool.uv.sources]
+stridelabs-docs-theme = { git = "https://github.com/charliek/stridelabs-docs-theme", tag = "v0.2.0" }

--- a/uv.lock
+++ b/uv.lock
@@ -123,13 +123,17 @@ source = { virtual = "." }
 
 [package.dev-dependencies]
 docs = [
+    { name = "stridelabs-docs-theme" },
     { name = "zensical" },
 ]
 
 [package.metadata]
 
 [package.metadata.requires-dev]
-docs = [{ name = "zensical", specifier = ">=0.0.52" }]
+docs = [
+    { name = "stridelabs-docs-theme", git = "https://github.com/charliek/stridelabs-docs-theme?tag=v0.2.0" },
+    { name = "zensical", specifier = ">=0.0.52" },
+]
 
 [[package]]
 name = "pygments"
@@ -197,6 +201,14 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "stridelabs-docs-theme"
+version = "0.2.0"
+source = { git = "https://github.com/charliek/stridelabs-docs-theme?tag=v0.2.0#6626a0623e78a584e66276223ed5757930d2691d" }
+dependencies = [
+    { name = "zensical" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -131,7 +131,7 @@ docs = [
 
 [package.metadata.requires-dev]
 docs = [
-    { name = "stridelabs-docs-theme", git = "https://github.com/charliek/stridelabs-docs-theme?tag=v0.2.0" },
+    { name = "stridelabs-docs-theme", git = "https://github.com/charliek/stridelabs-docs-theme?tag=v0.2.1" },
     { name = "zensical", specifier = ">=0.0.52" },
 ]
 
@@ -205,8 +205,8 @@ wheels = [
 
 [[package]]
 name = "stridelabs-docs-theme"
-version = "0.2.0"
-source = { git = "https://github.com/charliek/stridelabs-docs-theme?tag=v0.2.0#6626a0623e78a584e66276223ed5757930d2691d" }
+version = "0.2.1"
+source = { git = "https://github.com/charliek/stridelabs-docs-theme?tag=v0.2.1#ba1a8de4b387a7cf6f73d466b8b215c356eb68f6" }
 dependencies = [
     { name = "zensical" },
 ]

--- a/zensical.toml
+++ b/zensical.toml
@@ -54,46 +54,15 @@ nav = [
 # -----------------------------------------------------------------------------
 # Theme
 # -----------------------------------------------------------------------------
+# The shared StrideLabs theme (stridelabs-docs-theme, pinned in pyproject.toml)
+# supplies the palette, the self-hosted type stack, the feature toggles, and
+# the owl + project-icon header lockup. Anything set here overrides it.
 [project.theme]
+name = "stridelabs"
 
-# Pinned explicitly rather than relying on the default. "classic" reproduces
-# the Material for MkDocs look if that is ever wanted.
-variant = "modern"
-
-features = [
-  "content.code.annotate",
-  "content.code.copy",
-  "content.tabs.link",
-  "navigation.expand",
-  "navigation.footer",
-  "navigation.sections",
-  "navigation.top",
-  "search.highlight",
-  "search.share",
-]
-
+# The icon that says *which* tool this is -- rendered beside the shared owl.
 [project.theme.icon]
 logo = "material/console"
-
-[project.theme.font]
-text = "Roboto"
-code = "Roboto Mono"
-
-[[project.theme.palette]]
-media = "(prefers-color-scheme: light)"
-scheme = "default"
-primary = "indigo"
-accent = "indigo"
-toggle.icon = "lucide/sun"
-toggle.name = "Switch to dark mode"
-
-[[project.theme.palette]]
-media = "(prefers-color-scheme: dark)"
-scheme = "slate"
-primary = "indigo"
-accent = "indigo"
-toggle.icon = "lucide/moon"
-toggle.name = "Switch to light mode"
 
 # -----------------------------------------------------------------------------
 # Extra


### PR DESCRIPTION
Adopts the shared [stridelabs-docs-theme](https://github.com/charliek/stridelabs-docs-theme) v0.2.0, so prox's docs and the other StrideLabs docs sites share one look without copying CSS between repos.

Follows #103 (the MkDocs → Zensical migration). prox is the reference implementation the theme's templates were derived from.

## What changed

`zensical.toml` **shrinks by ~35 lines**. The palette, font stack and feature toggles now come from the theme; what remains is what's genuinely prox-specific:

```toml
[project.theme]
name = "stridelabs"

# the icon that says *which* tool this is — rendered beside the shared owl
[project.theme.icon]
logo = "material/console"
```

Plus the dependency, pinned by tag:

```toml
docs = ["zensical>=0.0.52", "stridelabs-docs-theme"]

[tool.uv.sources]
stridelabs-docs-theme = { git = "https://github.com/charliek/stridelabs-docs-theme", tag = "v0.2.0" }
```

## Why a git dependency rather than Artifact Registry

Considered using GAR, as `stridelabs-python` does. Rejected it, and not on setup cost: **these are public repos with public docs builds.** An auth-gated index would mean `docs-pr.yml` fails for every PR from a fork, and anyone cloning prox couldn't build the docs without access to the GCP project. GAR is right for private libraries consumed by services you control; a public docs theme is the opposite shape.

`uv.lock` pins the resolved commit SHA alongside the tag, so this is as reproducible as a registry wheel — verified, `uv sync --locked` works unchanged.

## Fonts

The theme **self-hosts** Fraunces, Inter and JetBrains Mono. The published site now makes **zero** requests to `fonts.googleapis.com` or `fonts.gstatic.com`, so no visitor IPs reach a third party, and pages render identically offline.

Verified on a real page load: 18 network requests, none to any external host, and exactly 3 woff2 files fetched (latin subsets only — the latin-ext and italic variants correctly aren't downloaded unless those glyphs appear).

This also removed a redundancy: Zensical's font loader fetches exactly two families, so the Fraunces display face had required a *second* `<link>` to Google on every page.

## Verification

- **HTML page set identical** to `main` — 13 pages, empty diff.
- **Heading anchors unchanged** — `reference/cli` still has 18, so deep links still resolve.
- Theme markup present (owl lockup, project icon, both stylesheets); all 8 woff2 files copied into the output; **0** third-party font requests.
- Browser check of home and `guides/local-dns` — renders correctly, no console errors.
- `actionlint` clean; `uv run --locked zensical build --strict` clean.
- Full `make lint && make test && make test-race && make build` — 0 lint issues, 0 test failures under `-race`.

Sibling PR: charliek/cc-plugins#19 updates the `docs-workflows` skills so the remaining ~23 repos land on the theme when they migrate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documentation site to use the shared StrideLabs theme v0.2.0.
  * Preserved existing documentation URLs, structure, heading anchors, and console icon.
  * Added self-hosted fonts, eliminating requests to Google Fonts domains.
  * Documented the theme update in the unreleased changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->