### PR TITLE
docs: bump shared theme to v0.2.2 (mobile drawer fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - **Docs now use the shared StrideLabs theme**
   ([stridelabs-docs-theme](https://github.com/charliek/stridelabs-docs-theme)
-  v0.2.1), so this site and the other StrideLabs docs sites share one look
+  v0.2.2), so this site and the other StrideLabs docs sites share one look
   without copying CSS between repos. The header pairs the StrideLabs owl with
   prox's own console icon; headings are Fraunces, body Inter, code JetBrains
   Mono. Page URLs, structure and heading anchors are unchanged.
@@ -42,6 +42,13 @@ All notable changes to this project will be documented in this file.
   transitively via `zensical`. The config still declares eight `pymdownx.*`
   extensions, so if a future Zensical release drops that dependency the docs
   build will need a direct pin again.
+
+- **Fixed the docs header lockup overlapping the site title in the mobile
+  drawer.** Behind the hamburger menu on a phone, the divider and project icon
+  painted on top of the site name. Zensical sizes that drawer slot for a single
+  glyph, so the wider lockup overflowed it. Fixed upstream in
+  [stridelabs-docs-theme](https://github.com/charliek/stridelabs-docs-theme)
+  v0.2.2; this bumps the pin. Desktop was never affected.
 
 ## v0.3.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,4 +14,4 @@ docs = [
 # PyPI or registry auth, so forks and outside contributors can build the docs
 # unchanged. uv.lock pins the resolved commit alongside the tag.
 [tool.uv.sources]
-stridelabs-docs-theme = { git = "https://github.com/charliek/stridelabs-docs-theme", tag = "v0.2.1" }
+stridelabs-docs-theme = { git = "https://github.com/charliek/stridelabs-docs-theme", tag = "v0.2.2" }

--- a/uv.lock
+++ b/uv.lock
@@ -131,7 +131,7 @@ docs = [
 
 [package.metadata.requires-dev]
 docs = [
-    { name = "stridelabs-docs-theme", git = "https://github.com/charliek/stridelabs-docs-theme?tag=v0.2.1" },
+    { name = "stridelabs-docs-theme", git = "https://github.com/charliek/stridelabs-docs-theme?tag=v0.2.2" },
     { name = "zensical", specifier = ">=0.0.52" },
 ]
 
@@ -205,8 +205,8 @@ wheels = [
 
 [[package]]
 name = "stridelabs-docs-theme"
-version = "0.2.1"
-source = { git = "https://github.com/charliek/stridelabs-docs-theme?tag=v0.2.1#ba1a8de4b387a7cf6f73d466b8b215c356eb68f6" }
+version = "0.2.2"
+source = { git = "https://github.com/charliek/stridelabs-docs-theme?tag=v0.2.2#6ce3083a4110817b45c39ad0160fd76c5d01cf1a" }
 dependencies = [
     { name = "zensical" },
 ]


### PR DESCRIPTION
Bumps [stridelabs-docs-theme](https://github.com/charliek/stridelabs-docs-theme) to **v0.2.2**, which fixes the header lockup overlapping the site title in the mobile drawer.

## The bug

Zensical sizes the drawer's logo slot for a single glyph:

```css
.md-nav__title[for=__drawer] .md-logo { width: 1.6rem; height: 1.6rem }
```

The lockup is roughly 3.8rem wide and its parts are `flex: none`, so they overflowed that box and painted on top of the site name sitting beside it — the divider and project icon landed mid-word.

**Desktop was never affected.** It only showed behind the hamburger menu on narrow viewports, which is why it shipped in theme v0.1.0 and survived four repos before being reported from a phone.

## Verification

Reproduced at a 412px viewport with Playwright, fixed, and re-verified: the drawer's logo slot now sizes to its content (32px → 71px) and the title starts clear of it. Also checked at 360px, in dark mode, and with a site name long enough to wrap — it wraps cleanly instead of pushing the lockup out of its slot.

Locally here: `uv run --locked zensical build --strict` exits 0 and the drawer overrides are present in this repo's own built `css/stridelabs.css`, not just in the theme package.

Two upstream tests guard the fix, both confirmed to fail when the override is removed. They assert on selector **specificity**, not just presence, since Zensical ships a competing `.md-logo svg { height: 100% }` rule and an override that merely exists but loses the cascade is the same bug.

Diff is the theme pin, the lockfile, and a changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AT8jq8wGZ2iZvotVJYrMAy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed mobile navigation drawer header overlap.
* **Documentation**
  * Updated the unreleased changelog to reflect the mobile layout fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->