### PR TITLE
New-user experience: first impression, exit contract, daemon warnings (plan 028)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,124 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- **A foreground `prox up` whose whole process stack has died now ends the
+  session instead of sitting there supervising nothing** (plan 028, #96). A
+  typo in `cmd:` used to leave the terminal open indefinitely, showing
+  nothing, until the user thought to press Ctrl-C — the trigger channel
+  `prox up` waited on is closed by a signal, `POST /shutdown`, or a TUI quit,
+  and by nothing a process does. It now notices for itself: once every
+  process is dead **and** at least one of them ended in `crashed` or
+  `blocked` (a partial crash with something still serving does not count,
+  and an all-`completed` task config or a deliberate API-driven stop does
+  not either), the session tears down and prints the same `Crashed:`/
+  `Blocked:` summary `prox up -d`, `start` and `restart` already print.
+
+  **This is a breaking exit-code change: a plain or piped foreground
+  `prox up` previously always exited `0`.** It now exits non-zero whenever
+  its whole stack ends up dead, printing the crash summary and a one-line
+  hint before returning. A script that treated any foreground `prox up`
+  return as "the session ended, nothing more to check" now needs to look at
+  the exit code the way it already should for `prox up -d`.
+
+  **The interactive TUI does the opposite on purpose.** A TUI session does
+  *not* auto-exit — the user is right there reading, and pulling the screen
+  away would take the crash output with it. Instead it shows a persistent
+  full-width banner between the process panel and the viewport border: `All
+  processes have stopped — 2 crashed. Nothing is running. Press q to quit.`
+  Colour is emphasis only; the sentence survives ANSI stripping. This also
+  applies in `prox attach`, since the banner is computed from the same
+  process snapshots the TUI already streams.
+
+  **Not in the `-d` child.** `--detach` short-circuits straight to plain
+  mode internally, so without an explicit guard this watcher would have run
+  inside the detached daemon too — and killed it moments after `prox up -d`
+  told the user "The daemon is still running; stop it with `prox down`",
+  taking the API and the crash logs with it. The daemon staying up on a
+  crashed stack is the existing, deliberate contract; only the daemon child
+  is exempted.
+
+- **prox gained a channel for warning you about things it previously either
+  swallowed or never checked** (plan 028). Two long-deferred warnings (#97,
+  #98) both needed a way to get from wherever prox actually observes a
+  problem to wherever the person who typed the command is looking, across
+  all three run modes — including the shared proxy daemon, whose own
+  stdout/stderr are `/dev/null`, and a `prox up -d` child, whose
+  stdout/stderr are `.prox/prox.log`. That channel now exists
+  (`domain.Warning{code, message, hint}`), and it is additive on the wire in
+  both directions: the daemon's register response and `GET /status` each
+  gained a `warnings` field.
+
+  Warnings print as `Warning: <message>` (with an indented `<hint>` line
+  underneath, when there is one) in a plain `prox up`, in the TUI's pinned
+  startup preamble (and therefore the system log and `prox logs`), and in
+  `prox status`. **A warning never changes any exit code** — including
+  `prox status`'s, which already has its own exit contract for crashed/
+  blocked processes and a down proxy — because turning a script red over an
+  untrusted CA it never asked about would be its own kind of false alarm.
+
+  **API change (additive):** `GET /status` gains `warnings` (an array of
+  `{code, message, hint}`, omitted when empty) and `warnings_sealed` (a
+  bool, always present). The latter matters because a warning can still be
+  in flight when a `prox up -d` parent takes its one status snapshot after
+  the readiness + settle wait; the parent now polls `warnings_sealed`
+  (bounded at 2.5s) rather than trusting a single race-prone fetch. See
+  [`GET /status`](https://charliek.github.io/prox/reference/api/#get-status).
+
+- **`prox` now surfaces mkcert's own untrusted-CA warning** (plan 028, #97).
+  Running `brew install mkcert` (or equivalent) without also running
+  `mkcert -install` used to leave prox reporting every process healthy while
+  every HTTPS request through the proxy failed in the browser — mkcert
+  itself explains exactly why, but in shared mode that explanation used to
+  go straight to the daemon's `/dev/null`. prox now captures mkcert's output
+  and carries its line **verbatim** through the warning channel above,
+  followed by the hint `run 'mkcert -install' and restart prox`. It still
+  implements no trust-store detection of its own — that stays entirely
+  mkcert's job, correctly, per OS/browser — and it withdraws the warning
+  automatically once mkcert reports the CA as trusted again. Because mkcert
+  only speaks when it *generates* a certificate, and a warm cert cache (the
+  normal case, since `CLAUDE.md`/`RELEASING.md` require a daemon restart
+  after every release) would otherwise never re-trigger it, a lightweight
+  probe re-asks mkcert directly whenever the last known verdict was bad.
+
+- **`prox` now warns when a registered hostname does not resolve** (plan
+  028, #98). `prox up` prints `Registered domains: app.sec.test`, which
+  looks fine right up until it's pasted into a browser and comes back
+  NXDOMAIN, because a `.test` domain needs local DNS setup that a public
+  wildcard like `*.lvh.me` does not. prox now resolves each registered
+  hostname once at startup and warns, naming the actual configured domain
+  and linking the [local DNS
+  guide](https://charliek.github.io/prox/guides/local-dns/), when one
+  fails. **The check only fires on a positive NXDOMAIN** — a timeout,
+  offline resolver, or any other lookup error is treated as "cannot tell",
+  never as "unresolvable", so a developer on a plane or behind a
+  network-sandboxed CI runner is not told their perfectly good setup is
+  broken. Runs in both shared and standalone proxy modes and never delays
+  startup past its own short budget.
+
+- **The TUI process panel states, and the requests pane's empty state, no
+  longer rely on colour or silence to say what happened** (plan 028, #92).
+  `styles.Crashed`/`styles.Blocked` and `styles.Stopped`/`styles.Completed`
+  have always shared a style, so those pairs were only ever
+  colour-distinguishable — nothing at all once ANSI is stripped (piped
+  output, `TERM=dumb`, a screenshot) or to a colour-blind reader. Every
+  process state but `running` now appends a word to the name in the panel:
+  `web (crashed)`, `migrate (done)`, `api (blocked on: db)`, `worker
+  (waiting on: redis)`, `db (stopped)`, `web (starting)`, `web (stopping)`.
+  `running` costs nothing extra, so the steady-state panel is unchanged.
+
+  The requests pane's empty state used to read "No requests yet — traffic
+  through the proxy appears here" **unconditionally**, telling a project
+  with no `proxy:` block to wait for traffic that could never arrive. It now
+  says why the pane is empty: "No proxy running — enable a proxy: block in
+  prox.yaml to capture requests" when there is no proxy running this
+  session, or "No requests yet — capture is off, so rows will show metadata
+  only" when there is a proxy but `proxy.capture.enabled: false`. The
+  request detail view gained the matching explanation for a record with no
+  headers or body: "Capture is disabled (proxy.capture.enabled: false) — no
+  headers or bodies were recorded". Also removed: the detail footer's
+  `[FOLLOW] N/M lines` tag, which described a scrolling state the detail
+  view never actually has.
+
 - **`prox up -d`, `prox start` and `prox restart` now report the resulting
   state, not just that the request was accepted** (plan 027, #94). They exit
   non-zero when a process is `crashed` or `blocked` within 500ms of starting,
@@ -48,6 +166,18 @@ All notable changes to this project will be documented in this file.
   comma-separated lists, and `--follow`.
 
 ### Fixed
+
+- **A crashed process no longer keeps its health checker running against a
+  dead pid** (plan 028, #107). A process that crashed on its own used to
+  keep re-executing its `healthcheck:` command — with whatever side effects
+  that command has — until some later `Stop` happened to arrive, and
+  `healthcheck.enabled` on `GET /processes/{name}` reported `true` the whole
+  time (plan 027 made that field truthful, which is what made the bug
+  visible). The health checker now stops the instant the process exits on
+  its own, not only when it is explicitly stopped: a crashed (or otherwise
+  terminally failed) process's `healthcheck.enabled` reads `false`
+  immediately, and its check command stops executing right then rather than
+  continuing indefinitely until some later stop request happened to arrive.
 
 - **Errors no longer claim prox is down when it just answered** (plan 027,
   #95). "Is prox running? Try 'prox up' first." was appended to every client

--- a/docs/guides/local-dns.md
+++ b/docs/guides/local-dns.md
@@ -42,6 +42,12 @@ If you prefer a custom domain like `local.myapp.dev`, add entries to `/etc/hosts
 127.0.0.1 local.myapp.dev app.local.myapp.dev api.local.myapp.dev
 ```
 
+### If a registered hostname doesn't resolve
+
+`prox up` checks whether each hostname it registers actually resolves on this machine, and warns if one doesn't — this is exactly the `.test`-domain trap above: `Registered domains: app.sec.test` looks fine until it's pasted into a browser and comes back NXDOMAIN, because `.test` needs the local setup on this page and doesn't resolve on its own the way `*.lvh.me` does.
+
+The check is deliberately quiet the rest of the time. It only warns on a definite "no such host" answer; a slow, offline, or sandboxed resolver — a laptop on a plane, a VPN, a network-restricted CI runner — is reported as "cannot tell", never as "broken", so a perfectly good setup never triggers a false alarm.
+
 ## HTTPS Certificates
 
 ### One-Time Setup
@@ -58,6 +64,8 @@ brew install mkcert
 # Install the CA into your system trust store (run once)
 mkcert -install
 ```
+
+If you skip `mkcert -install` (or run it before installing a browser that keeps its own trust store), prox now surfaces mkcert's own warning about it — `Warning: Note: the local CA is not installed in the system trust store.`, followed by a hint to run `mkcert -install` and restart prox — instead of reporting every process healthy while HTTPS quietly fails in the browser. The warning is mkcert's own sentence, carried through verbatim, and clears itself automatically once mkcert reports the CA as trusted.
 
 ### Automatic Certificate Generation
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -96,7 +96,15 @@ Supervisor status.
       "check": "tcp localhost:5432",
       "start_invoked": false
     }
-  ]
+  ],
+  "warnings": [
+    {
+      "code": "mkcert_ca_untrusted",
+      "message": "Note: the local CA is not installed in the system trust store.",
+      "hint": "run 'mkcert -install' and restart prox"
+    }
+  ],
+  "warnings_sealed": true
 }
 ```
 
@@ -127,6 +135,18 @@ Supervisor status.
 | `start_invoked` | Whether the `start:` command was launched this generation (always `false` when the initial check already passed) |
 
 Only `failed` trips the exit-1 contract (see [`prox status`](cli.md#status) for the full precedence); `warned`/`pending`/`checking`/`polling`/`healthy`/`canceled` do not.
+
+`warnings` carries this session's user-facing advisories (plan 028) — things prox noticed that are not failures, most of them raised somewhere the person who typed the command cannot see directly (inside the shared proxy daemon, whose own stdout/stderr are `/dev/null`, or inside a `prox up -d` child, whose stdout/stderr are `.prox/prox.log`). Omitted when there are none (never an empty array). Each entry:
+
+| Field | Description |
+|-------|-------------|
+| `code` | A stable machine identifier for the warning kind, e.g. `mkcert_ca_untrusted` or `hostname_unresolved`. Wording under `message`/`hint` may change; `code` does not |
+| `message` | One or more complete, user-facing sentences describing what is wrong |
+| `hint` | The next action to take, when there is one; omitted otherwise |
+
+`warnings_sealed` reports whether every startup warning producer for this session has finished. Some producers (the mkcert trust probe, the hostname resolution check) run asynchronously and can still be in flight when a `prox up -d` parent takes its post-readiness status snapshot; polling this flag (rather than trusting a single fetch) is how that parent avoids silently losing a warning to the race. Always present (unlike `warnings`, it is not `omitempty`): `false` is itself the meaningful value a poller is waiting to flip.
+
+**A warning never changes any exit code.** `prox status`, `prox up`, and `prox up -d` all render `warnings` the same way (`Warning: <message>`, with `<hint>` indented underneath) and none of their exit contracts consult it.
 
 ### GET /processes
 
@@ -207,7 +227,7 @@ Get detailed process info.
 }
 ```
 
-The `healthcheck` block is present only when a `healthcheck:` **is** configured; a process reporting `"health": "none"` omits it entirely. Its `enabled` field reports whether the check loop is currently running: `false` once the process is stopped, or before it has ever been launched, in which case `health` is `unknown` because the configured check has produced no verdict.
+The `healthcheck` block is present only when a `healthcheck:` **is** configured; a process reporting `"health": "none"` omits it entirely. Its `enabled` field reports whether the check loop is currently running: `false` once the process has exited for any reason — stopped deliberately, `crashed` on its own, or `completed` — or before it has ever been launched, in which case `health` is `unknown` because the configured check has produced no verdict. A process that crashes on its own stops its checker (and flips `enabled` to `false`) the instant the exit is observed, not only once a later stop request arrives (plan 028, #107) — so a crashed process's check command is not still re-executing against a dead pid in the background.
 
 `stop_timeout` is the effective SIGTERM→SIGKILL escalation budget in force for this process (its own `stop_timeout`, else the global `shutdown_timeout`, else the `10s` default), as a duration string. It is the budget governing a `POST /processes/{name}/stop` or `POST /processes/{name}/restart`. See [Stop Timeout](configuration.md#stop-timeout).
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -86,7 +86,8 @@ Supervisor status.
     "last_connected_at": "2025-01-19T10:32:01.123Z",
     "dropped_events": 0,
     "backfill_failures": 0,
-    "heal_state": "healthy"
+    "heal_state": "healthy",
+    "capture_enabled": true
   },
   "dependencies": [
     {
@@ -111,6 +112,7 @@ Supervisor status.
 | `dropped_events` | Request-stream events lost to a full subscriber channel |
 | `backfill_failures` | Post-connect ring snapshot fetch failures |
 | `heal_state` | `healthy`, `healing`, or `version_mismatch`; empty when not in shared mode |
+| `capture_enabled` | Whether request/response capture is effectively on (a proxy is running for this session **and** `proxy.capture.enabled` is true). Daemons predating this field omit it entirely; an absent `capture_enabled` means "unknown", **not** `false` |
 
 `prox status` (the CLI command) renders this block as a `Proxy:` line and, when `mode` is `shared` and `daemon_reachable` is `false`, prints `Proxy: DOWN — shared proxy daemon unreachable (proxied routes are dead). Check 'prox proxy status'.` and **exits with status 1** even though the project's own processes may be healthy. The project self-heals automatically (re-registers with a fresh or recovered daemon), worst case within ~45s — treat a brief `daemon_reachable: false` as transient rather than a hard failure. See [`prox status`](cli.md#status).
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -112,6 +112,23 @@ A non-zero exit from step 2 means something different from one from step 1: **th
 
 `.prox/prox.log` is never truncated — it accumulates across every run — but the printed diagnostics are scoped to the failed run alone: each daemon child writes a `--- run <time> pid=<pid> ---` marker to the log as its first line, and the failure diagnostic tails only the content after that run's own marker, not the whole file. So iterating on a broken config never buries the current failure under every past one. This scoping needs a marker to key off; a legacy log with no markers, or a failure so early the child never reached the point of writing one, falls back to the last ~20 lines of the file instead.
 
+**Foreground exit contract:** a plain (non-`--detach`) `prox up` used to wait indefinitely for a signal, `POST /shutdown`, or a TUI quit — nothing a process itself does — so a stack that died entirely (the classic first-run mistake: a typo in `cmd:`) left the terminal open and silent until the user pressed Ctrl-C. It now ends the session itself once **every process is dead and at least one of them ended in a terminal failure** (`crashed` or `blocked`; an all-`completed` task config, or a stack stopped deliberately through the API, does not count — `completed` is success and both are cases where nothing failed). When that happens, `prox up` tears the session down and exits non-zero, printing the same `Crashed:`/`Blocked:` summary `prox up -d`, `start` and `restart` print (see above), so a crash reads identically whichever command reports it.
+
+**Breaking change:** foreground `prox up` previously always exited `0`. A script that ran `prox up` in the foreground and treated its return as "the session ended, nothing more to check" now needs to look at the exit code the same way it already should for `prox up -d`.
+
+**The `-d` child does NOT exit on a dead stack.** `--detach` short-circuits straight to plain mode internally, so without an explicit guard this same watcher would run inside the detached daemon too — and it would kill the daemon moments after `prox up -d` told the user the daemon was still running and pointed them at `prox down`, taking the API and the crash logs with it. The daemon staying up while its processes are down is the deliberate `-d` contract described above; only the daemon child is exempt from this exit behavior.
+
+**The interactive TUI never auto-exits on a dead stack**, deliberately: the user is present and reading, and pulling the screen away would take the crash output with it. Instead it shows a persistent banner — see [the dead-stack banner](tui.md#dead-stack-banner).
+
+**Warnings.** Advisories that are not failures — an untrusted mkcert CA, a registered hostname that does not resolve — print as `Warning: <message>` on stderr, with an indented hint line underneath when there is one:
+
+```
+Warning: Note: the local CA is not installed in the system trust store.
+         run 'mkcert -install' and restart prox
+```
+
+They appear in a plain `prox up`'s terminal output, in the TUI's pinned startup preamble, in a `prox up -d` parent (read back from the child over the API), and in `prox status`. **A warning never changes any exit code** — not `up`'s, not `up -d`'s, not `status`'s — advisory and failure are kept on separate axes throughout. See [`GET /status`](api.md#get-status) for the wire shape.
+
 **TUI mode resolution.** Whether `prox up` opens the interactive TUI is decided by, in order of precedence: a flag that asserts something, then the `PROX_TUI` environment variable, then whether the terminal can host it. A bare foreground `prox up` **prefers the TUI**: it opens on a terminal that can host one and falls back to plain log streaming everywhere else, without an error.
 
 | Source | Effect |
@@ -165,6 +182,8 @@ prox status --json
 **Precedence.** All applicable human-readable lines print regardless of which condition holds — a crashed process, a blocked process, a failed dependency, and a down proxy can all show up in the same output. The single primary stderr sentinel (and the process's own exit code stays `1` either way) follows a fixed precedence: **proxy-down > crashed > blocked > failed-dependency**. Scripts that need to react to a specific condition should parse `prox status --json` (its per-process `status`, and each dependency's `state`, are authoritative) rather than `prox status || true`, which also masks discovery errors and an unreachable supervisor.
 
 **Proxy line:** when a proxy is configured, output includes a `Proxy:` line reporting the shared-proxy health tracked by [the `proxy` block of `GET /status`](api.md#get-status) — `Proxy: shared (running, vX.Y.Z)` when healthy, `Proxy: standalone` for an in-process proxy, or the `Proxy: DOWN` line above when the shared daemon is unreachable.
+
+**Warnings:** any session warnings (see [`Warnings` under `up`](#up)) print after the process table, in the same `Warning: <message>` form. They are advisory and **never affect `prox status`'s exit code** — a script that checks the exit code should not start failing because of an untrusted mkcert CA it never asked about.
 
 **STATUS column decoration.** A `waiting` process shows its still-resolving `depends_on` targets inline — `waiting(postgres, redis)` — and a `blocked` process shows the targets that failed it — `blocked(postgres)` — in declaration order. The JSON `status` field stays the bare state name in both cases (`waiting`/`blocked`); only the human table decorates it. The PID column shows `-` whenever there is no live PID, including a `waiting` process and a `completed` task (whose uptime is frozen at completion rather than reading `0`).
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -122,7 +122,7 @@ A non-zero exit from step 2 means something different from one from step 1: **th
 
 **Warnings.** Advisories that are not failures — an untrusted mkcert CA, a registered hostname that does not resolve — print as `Warning: <message>` on stderr, with an indented hint line underneath when there is one:
 
-```
+```text
 Warning: Note: the local CA is not installed in the system trust store.
          run 'mkcert -install' and restart prox
 ```

--- a/docs/reference/tui.md
+++ b/docs/reference/tui.md
@@ -70,6 +70,16 @@ On narrow terminals hints drop right-to-left (non-sticky pairs first; `? help` a
 - **Dropdown menus** use rounded borders. Each row shows a right-aligned **hint** column (keyboard shortcut) when space allows; long menus clamp with “… N more …” rows.
 - **Help modal** is a centred rounded box with a **focused** border colour and the view name spliced into the top border (`─ Help — Logs ─`). On very narrow frames side padding and then the border degrade before content.
 
+### Dead-stack banner
+
+When every process has stopped and at least one of them `crashed` or was `blocked` on a failed dependency, a persistent full-width row appears between the process panel and the viewport's top border:
+
+```text
+ All processes have stopped — 2 crashed. Nothing is running. Press q to quit.
+```
+
+The TUI does **not** exit on its own here — unlike a plain, piped `prox up`, which does (see [the foreground exit contract](cli.md#up)) — because the user is present and reading, and pulling the screen away would take the crash output with it. The sentence names both `crashed` and `blocked` counts (never just "crashed", if a launch was actually blocked by a failed dependency) and, like the process labels above, is readable with every escape code stripped — colour is emphasis only. It appears identically in `prox up` and `prox attach`, and clears itself the moment any process becomes live again (a `restart`, for example).
+
 ## Themes
 
 Six built-in presets ship with prox: `tokyo-night` (default), `dark`, `light`, `catppuccin`, `gruvbox`, and `legacy` (approximates the pre-redesign ANSI look).
@@ -110,7 +120,20 @@ The processes panel colour-codes each process name by its state, including the s
 | `blocked` | error, bold |
 | `completed` | dim |
 
-A `waiting` or `blocked` process also gets an inline annotation naming what it's gated on. A process with a [healthcheck](configuration.md#health-check-fields) shows a health dot after its name: green `●` while healthy, red `✗` while unhealthy.
+**Colour is emphasis, not the only signal.** `crashed`/`blocked` share one colour role, as do `stopped`/`completed`, so those pairs are only colour-distinguishable — nothing at all once ANSI is stripped (piped output, `TERM=dumb`, a screenshot) or to a colour-blind reader. Every state but `running` therefore appends a parenthesized word to the process name, and that label is what actually survives stripping:
+
+| State | Name suffix |
+| ----- | ------------ |
+| `running` | *(none)* |
+| `crashed` | ` (crashed)` |
+| `blocked` | ` (blocked)`, or ` (blocked on: <target>[, ...])` naming the failed `depends_on` targets |
+| `waiting` | ` (waiting)`, or ` (waiting on: <target>[, ...])` naming the still-resolving targets |
+| `completed` | ` (done)` |
+| `stopped` | ` (stopped)` |
+| `starting` | ` (starting)` |
+| `stopping` | ` (stopping)` |
+
+A process with a [healthcheck](configuration.md#health-check-fields) shows a health dot after its name (and its state label): green `●` while healthy, red `✗` while unhealthy. A process with no healthcheck configured, or whose check has not reported yet, shows no dot.
 
 Click a process chip in the panel (logs view) to solo that process — the same as pressing its `1`–`9` key. Click again to clear solo.
 
@@ -191,6 +214,14 @@ The **Filter menu** edits the same state as the `s` bar; menu changes rewrite th
 
 The requests view has an explicit **cursor row** (marked with `❯`). Navigation moves that cursor; the viewport scrolls to keep it visible.
 
+**Empty state.** With no active filter, the empty view names *why* there are no rows rather than showing one generic message for every cause:
+
+- No proxy running this session (no `proxy:` block, one that is `enabled: false`, or `--no-proxy`): "No proxy running — enable a proxy: block in prox.yaml to capture requests".
+- A proxy is running but `proxy.capture.enabled: false`: "No requests yet — capture is off, so rows will show metadata only" — rows still arrive with capture off (method, URL, status, timing), they just carry no headers or bodies.
+- Otherwise: "No requests yet — traffic through the proxy appears here".
+
+An active filter with no matches instead shows what didn't match ("No lines match …").
+
 Open the **View** menu (`v`) for a **Columns** checkbox section (Requests and Request Detail views): toggle Time, Host, Method, Status, Duration, and ID. **URL is always shown.** Defaults are all on; choices persist under `[requests]` in config. `/` search matches only visible columns; copy keys (`y`, `c`) are unaffected.
 
 | Key | Action |
@@ -241,6 +272,8 @@ Fields:
 | Scroll wheel | Scroll detail content |
 
 Detail views live-update when the open request completes.
+
+**Capture-disabled records.** When `proxy.capture.enabled: false`, a completed request's detail view has no headers and no body sections to show — the record was written with no captured details — and says so rather than rendering an unexplained blank view: "Capture is disabled (proxy.capture.enabled: false) — no headers or bodies were recorded". An in-flight request (still running) shows its own, unrelated note instead, since its details simply haven't arrived yet.
 
 ## Search vs. Filter
 

--- a/docs/reference/tui.md
+++ b/docs/reference/tui.md
@@ -122,16 +122,18 @@ The processes panel colour-codes each process name by its state, including the s
 
 **Colour is emphasis, not the only signal.** `crashed`/`blocked` share one colour role, as do `stopped`/`completed`, so those pairs are only colour-distinguishable — nothing at all once ANSI is stripped (piped output, `TERM=dumb`, a screenshot) or to a colour-blind reader. Every state but `running` therefore appends a parenthesized word to the process name, and that label is what actually survives stripping:
 
+Each suffix is appended after the process name, separated by a space.
+
 | State | Name suffix |
 | ----- | ------------ |
 | `running` | *(none)* |
-| `crashed` | ` (crashed)` |
-| `blocked` | ` (blocked)`, or ` (blocked on: <target>[, ...])` naming the failed `depends_on` targets |
-| `waiting` | ` (waiting)`, or ` (waiting on: <target>[, ...])` naming the still-resolving targets |
-| `completed` | ` (done)` |
-| `stopped` | ` (stopped)` |
-| `starting` | ` (starting)` |
-| `stopping` | ` (stopping)` |
+| `crashed` | `(crashed)` |
+| `blocked` | `(blocked)`, or `(blocked on: <target>[, ...])` naming the failed `depends_on` targets |
+| `waiting` | `(waiting)`, or `(waiting on: <target>[, ...])` naming the still-resolving targets |
+| `completed` | `(done)` |
+| `stopped` | `(stopped)` |
+| `starting` | `(starting)` |
+| `stopping` | `(stopping)` |
 
 A process with a [healthcheck](configuration.md#health-check-fields) shows a health dot after its name (and its state label): green `●` while healthy, red `✗` while unhealthy. A process with no healthcheck configured, or whose check has not reported yet, shows no dot.
 

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -53,6 +53,10 @@ type Handlers struct {
 	projectDir  string
 	shutdown    ShutdownController
 	proxyStatus ProxyStatusProvider
+	// warnings supplies the session's user-facing advisories for GET /status
+	// (plan 028 A2). Injected by the `prox up` path; nil in unit-test handlers,
+	// which then report no warnings and an unsealed latch.
+	warnings WarningProvider
 
 	// sseHeartbeatInterval overrides constants.SSEHeartbeatInterval for the SSE
 	// handlers (StreamLogs, StreamProxyRequests, StreamProcesses). Zero means
@@ -137,6 +141,14 @@ func (h *Handlers) SetProxyStatusProvider(p ProxyStatusProvider) {
 	h.proxyStatus = p
 }
 
+// SetWarningProvider injects this session's warning sink (plan 028 A2),
+// mirroring SetProxyStatusProvider: the provider is a `prox up` runtime object,
+// wired in as the session assembles. When unset, GET /status reports no
+// warnings and warnings_sealed false.
+func (h *Handlers) SetWarningProvider(p WarningProvider) {
+	h.warnings = p
+}
+
 // GetStatus handles GET /api/v1/status
 func (h *Handlers) GetStatus(w http.ResponseWriter, r *http.Request) {
 	status := h.supervisor.Status()
@@ -150,6 +162,10 @@ func (h *Handlers) GetStatus(w http.ResponseWriter, r *http.Request) {
 	}
 	if h.proxyStatus != nil {
 		resp.Proxy = h.proxyStatus.ProxyStatus()
+	}
+	if h.warnings != nil {
+		resp.Warnings = h.warnings.Warnings()
+		resp.WarningsSealed = h.warnings.WarningsSealed()
 	}
 	if deps := h.supervisor.DependencyStatuses(); len(deps) > 0 {
 		resp.Dependencies = make([]DependencyStatusResponse, len(deps))

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -72,6 +72,86 @@ func TestGetStatus(t *testing.T) {
 	assert.Equal(t, "prox.yaml", resp.ConfigFile)
 }
 
+// fakeWarningProvider is a WarningProvider whose answers a test controls (plan
+// 028 A2).
+type fakeWarningProvider struct {
+	warnings []domain.Warning
+	sealed   bool
+}
+
+func (f fakeWarningProvider) Warnings() []domain.Warning { return f.warnings }
+func (f fakeWarningProvider) WarningsSealed() bool       { return f.sealed }
+
+// TestGetStatus_Warnings covers the publishing half of the warning channel: the
+// advisories and the completion latch that the `prox up -d` parent polls, and
+// the absent-when-empty shape that keeps every other client's payload unchanged.
+func TestGetStatus_Warnings(t *testing.T) {
+	t.Run("no provider: no warnings, unsealed, key absent", func(t *testing.T) {
+		server, _, _, cleanup := setupTestServer(t)
+		defer cleanup()
+
+		req := httptest.NewRequest("GET", "/api/v1/status", nil)
+		w := httptest.NewRecorder()
+		server.router.ServeHTTP(w, req)
+
+		body := w.Body.String()
+		assert.NotContains(t, body, `"warnings"`, "omitempty must drop the key when there are none")
+		assert.Contains(t, body, `"warnings_sealed":false`,
+			"the latch is NOT omitempty: false is the value the parent polls on")
+
+		var resp StatusResponse
+		require.NoError(t, json.Unmarshal([]byte(body), &resp))
+		assert.Nil(t, resp.Warnings)
+		assert.False(t, resp.WarningsSealed)
+	})
+
+	t.Run("provider: warnings and the latch are published", func(t *testing.T) {
+		server, _, _, cleanup := setupTestServer(t)
+		defer cleanup()
+
+		server.handlers.SetWarningProvider(fakeWarningProvider{
+			warnings: []domain.Warning{
+				{Code: domain.WarningCodeMkcertCAUntrusted, Message: "the CA is not installed.", Hint: "Run 'mkcert -install'."},
+				{Code: "other", Message: "no hint on this one"},
+			},
+			sealed: true,
+		})
+
+		req := httptest.NewRequest("GET", "/api/v1/status", nil)
+		w := httptest.NewRecorder()
+		server.router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		var resp StatusResponse
+		require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+
+		require.Len(t, resp.Warnings, 2)
+		assert.Equal(t, domain.WarningCodeMkcertCAUntrusted, resp.Warnings[0].Code)
+		assert.Equal(t, "the CA is not installed.", resp.Warnings[0].Message)
+		assert.Equal(t, "Run 'mkcert -install'.", resp.Warnings[0].Hint)
+		assert.Empty(t, resp.Warnings[1].Hint)
+		assert.True(t, resp.WarningsSealed)
+	})
+
+	t.Run("provider with warnings but still running: unsealed", func(t *testing.T) {
+		server, _, _, cleanup := setupTestServer(t)
+		defer cleanup()
+
+		server.handlers.SetWarningProvider(fakeWarningProvider{
+			warnings: []domain.Warning{{Code: "c", Message: "so far"}},
+		})
+
+		req := httptest.NewRequest("GET", "/api/v1/status", nil)
+		w := httptest.NewRecorder()
+		server.router.ServeHTTP(w, req)
+
+		var resp StatusResponse
+		require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+		assert.Len(t, resp.Warnings, 1)
+		assert.False(t, resp.WarningsSealed, "an unfinished producer must be visible as such")
+	})
+}
+
 func TestGetProcesses(t *testing.T) {
 	server, _, _, cleanup := setupTestServer(t)
 	defer cleanup()

--- a/internal/api/responses.go
+++ b/internal/api/responses.go
@@ -90,6 +90,19 @@ type ProxyStatusResponse struct {
 	// HealState is "healthy" when the shared daemon is reachable, "" otherwise
 	// (C5). C6 refines it to "healing"/"version_mismatch".
 	HealState string `json:"heal_state,omitempty"`
+	// CaptureEnabled reports whether request/response capture is effectively on
+	// for this project (proxy enabled AND capture.enabled), so a client can say
+	// WHY a request list or a request detail is empty instead of promising
+	// traffic that will never be recorded.
+	//
+	// It is a POINTER on purpose. The project API carries no version gate --
+	// unlike the shared daemon, which requires an exact version match with its
+	// clients -- so `prox attach` can legitimately talk to an older daemon that
+	// predates this field. A plain bool would decode that daemon's absent field
+	// as false and assert "capture is off" about a daemon that never had an
+	// opinion. nil means UNKNOWN and callers must fall back to their
+	// capture-agnostic wording rather than treating it as disabled.
+	CaptureEnabled *bool `json:"capture_enabled,omitempty"`
 }
 
 // ProxyStatusProvider supplies the proxy block for GET /status. The daemon

--- a/internal/api/responses.go
+++ b/internal/api/responses.go
@@ -51,6 +51,23 @@ type StatusResponse struct {
 	// second endpoint so `prox status` reads a consistent snapshot in one fetch.
 	// Additive: omitted (nil) when no dependencies are configured.
 	Dependencies []DependencyStatusResponse `json:"dependencies,omitempty"`
+	// Warnings are this session's user-facing advisories (plan 028 A2), most of
+	// them raised where the person who typed the command cannot see them: inside
+	// the shared proxy daemon (stdout/stderr are /dev/null) or inside a
+	// `prox up -d` child (output goes to .prox/prox.log). Publishing them here is
+	// what lets the detached parent print them on the terminal the user is
+	// actually looking at, and `prox status` re-print them later.
+	Warnings []domain.Warning `json:"warnings,omitempty"`
+	// WarningsSealed reports whether every startup warning producer has
+	// finished. Some are asynchronous and can still be running when the
+	// `prox up -d` parent finishes its readiness + settle wait, so a single
+	// status fetch at that moment would race them and silently lose a warning;
+	// the parent polls this flag instead (bounded).
+	//
+	// NOT omitempty: false is the meaningful value the parent polls on, and a
+	// key that vanishes exactly when it is false is a key a client cannot
+	// distinguish from a daemon that never had the field.
+	WarningsSealed bool `json:"warnings_sealed"`
 }
 
 // DependencyStatusResponse reports one configured dependency's resolution state
@@ -112,6 +129,20 @@ type ProxyStatusResponse struct {
 // drive GetStatus with a fake.
 type ProxyStatusProvider interface {
 	ProxyStatus() *ProxyStatusResponse
+}
+
+// WarningProvider supplies this session's user-facing warnings, and the
+// completion latch that says whether every startup producer has finished, for
+// GET /status (plan 028 A2). The daemon injects an implementation (the cli's
+// warningSink); like ProxyStatusProvider it is defined here as a narrow
+// interface so the api package does not depend on internal/cli and tests can
+// drive GetStatus with a fake.
+//
+// Two methods rather than one returning both, so each maps to exactly one
+// response field and neither can be silently swapped for the other.
+type WarningProvider interface {
+	Warnings() []domain.Warning
+	WarningsSealed() bool
 }
 
 // ProcessListResponse represents the response for GET /processes

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -109,6 +109,19 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	// visible even when the shared proxy is down (which then forces exit 1).
 	renderProxyStatus(status.Proxy)
 
+	// Session warnings (plan 028 A2). They are advisory, so they are PRINTED
+	// here and deliberately absent from statusExitError below: a warning is not
+	// a failure, and turning `prox status` red for one would make every script
+	// that checks the exit code start failing over an untrusted CA.
+	//
+	// Printed to stdout with the rest of the human report (the --json path
+	// carries them automatically, inside "status"). A daemon that predates the
+	// field simply sends none.
+	if len(status.Warnings) > 0 {
+		fmt.Println()
+		writeWarnings(os.Stdout, status.Warnings)
+	}
+
 	// Crashed line (D1, #72). Printed after the proxy line, naming the crashed
 	// process(es) in the order the supervisor reported them (no sort), with a
 	// pointer at their logs. Printed even when the proxy is also down so neither

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -732,6 +732,10 @@ func runAttach(cmd *cobra.Command, args []string) error {
 		ProjectName:     tui.StatusProjectName(status.ProjectDir),
 		ShutdownCh:      nil,
 	}
+	// Attach has no config of its own: the daemon it connects to resolved the
+	// proxy path (including --no-proxy) at ITS `up` time, so the status block
+	// is the only truthful source for why the requests pane may stay empty.
+	opts.ProxyConfigured, opts.CaptureEnabled = attachProxyFacts(status.Proxy)
 	// Attach owns no log manager, so its alt screen gets the deferred-buffer
 	// target: mid-session diagnostics (the shared SSE-parse warnings in
 	// client.go, an http.Server dump, anything else reaching the stdlib logger)
@@ -744,6 +748,29 @@ func runAttach(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("TUI error: %w", err)
 	}
 	return nil
+}
+
+// attachProxyFacts derives the TUI's two proxy facts from a GET /status proxy
+// block: whether a proxy is running for the attached project, and whether it
+// captures requests.
+//
+// Both default to TRUE for anything unknown, and that is deliberate: true is
+// "say nothing new", the pre-existing wording. The project API has no version
+// gate, so attach can be talking to a daemon older than either signal — a nil
+// block (no proxy provider at all) or a nil CaptureEnabled (a daemon predating
+// the field). Guessing "off" there would print a confident, wrong explanation
+// for an empty list; falling back to the generic wording merely fails to add
+// the new hint.
+func attachProxyFacts(p *api.ProxyStatusResponse) (proxyConfigured, captureEnabled bool) {
+	if p == nil {
+		return true, true
+	}
+	proxyConfigured = p.Mode != proxyModeDisabled
+	captureEnabled = true
+	if p.CaptureEnabled != nil {
+		captureEnabled = *p.CaptureEnabled
+	}
+	return proxyConfigured, captureEnabled
 }
 
 // Requests command flags

--- a/internal/cli/commands_test.go
+++ b/internal/cli/commands_test.go
@@ -1840,3 +1840,36 @@ func TestRunStatus_CrashedAndProxyDownPrecedenceJSON(t *testing.T) {
 		t.Errorf("JSON output missing the crashed process; got:\n%s", stdout)
 	}
 }
+
+// TestAttachProxyFacts pins how `prox attach` reads the two proxy facts off a
+// status block — including the versions of the block it can legitimately meet.
+// The project API has no version gate, so attach can be talking to a daemon
+// older than capture_enabled; unknown must degrade to the pre-existing wording
+// (true/true), never to a confident "capture is off".
+func TestAttachProxyFacts(t *testing.T) {
+	ptr := func(b bool) *bool { return &b }
+
+	cases := []struct {
+		name        string
+		proxy       *api.ProxyStatusResponse
+		wantProxy   bool
+		wantCapture bool
+	}{
+		{"nil block", nil, true, true},
+		{"older daemon: capture unknown", &api.ProxyStatusResponse{Mode: proxyModeShared}, true, true},
+		{"shared with capture on", &api.ProxyStatusResponse{Mode: proxyModeShared, CaptureEnabled: ptr(true)}, true, true},
+		{"standalone with capture off", &api.ProxyStatusResponse{Mode: proxyModeStandalone, CaptureEnabled: ptr(false)}, true, false},
+		{"disabled", &api.ProxyStatusResponse{Mode: proxyModeDisabled, CaptureEnabled: ptr(false)}, false, false},
+		{"disabled, capture unknown", &api.ProxyStatusResponse{Mode: proxyModeDisabled}, false, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotProxy, gotCapture := attachProxyFacts(tc.proxy)
+			if gotProxy != tc.wantProxy || gotCapture != tc.wantCapture {
+				t.Errorf("attachProxyFacts = (%v, %v), want (%v, %v)",
+					gotProxy, gotCapture, tc.wantProxy, tc.wantCapture)
+			}
+		})
+	}
+}

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -44,7 +44,27 @@ func newShutdownCoordinator() *shutdownCoordinator {
 // /shutdown, or a signal racing an API trigger) is a no-op rather than a
 // double-close panic.
 func (c *shutdownCoordinator) Trigger() {
-	c.triggerOnce.Do(func() { close(c.triggerCh) })
+	c.TriggerWith(nil)
+}
+
+// TriggerWith requests shutdown and, if THIS call is the one that actually
+// requested it, runs onWin first -- inside the same sync.Once, so it happens
+// before triggerCh closes and cannot interleave with another trigger.
+//
+// It exists because one trigger source needs to record WHY: the dead-stack
+// watcher (dead_stack.go, #96) latches a verdict that turns into `prox up`'s
+// non-zero exit code. "Latch, then trigger" is not enough on its own -- a
+// Ctrl-C landing between the two would make an intentional shutdown exit
+// non-zero (codex review finding). Deciding the reason inside triggerOnce
+// makes the exit code follow whoever genuinely ended the session: if a signal
+// or POST /shutdown got here first, onWin never runs and the session exits 0.
+func (c *shutdownCoordinator) TriggerWith(onWin func()) {
+	c.triggerOnce.Do(func() {
+		if onWin != nil {
+			onWin()
+		}
+		close(c.triggerCh)
+	})
 }
 
 // TriggerCh is closed once shutdown has been requested. runUp selects on it (in

--- a/internal/cli/coordinator_test.go
+++ b/internal/cli/coordinator_test.go
@@ -133,3 +133,91 @@ func TestShutdownCoordinator_OutcomeBeforeDone(t *testing.T) {
 	}
 	assert.Nil(t, c.Outcome(), "Outcome before Done is nil (indistinguishable from clean; do not read it)")
 }
+
+// TestShutdownCoordinator_TriggerWithOnlyTheWinnerRecordsItsReason pins the
+// arbitration that decides `prox up`'s exit code when a dead stack and a
+// deliberate shutdown race (plan 028 C3, codex review finding).
+//
+// The dead-stack watcher records WHY it ended the session; a Ctrl-C records
+// nothing, because an intentional shutdown exits 0. "Latch, then trigger" left
+// a window in which a Ctrl-C arriving between the two still exited non-zero, so
+// the reason is now decided INSIDE triggerOnce: whoever actually requests the
+// shutdown is the only one that gets to say why.
+func TestShutdownCoordinator_TriggerWithOnlyTheWinnerRecordsItsReason(t *testing.T) {
+	t.Run("a shutdown that lost records nothing", func(t *testing.T) {
+		c := newShutdownCoordinator()
+		ran := false
+
+		c.Trigger() // the signal handler gets there first
+		c.TriggerWith(func() { ran = true })
+
+		assert.False(t, ran,
+			"the watcher lost the trigger, so it must not record a reason -- "+
+				"an intentional shutdown exits 0")
+		assertClosed(t, c.TriggerCh())
+	})
+
+	t.Run("a shutdown that won records its reason", func(t *testing.T) {
+		c := newShutdownCoordinator()
+		ran := false
+
+		c.TriggerWith(func() { ran = true })
+		c.Trigger() // a signal arriving afterwards changes nothing
+
+		assert.True(t, ran, "the watcher won the trigger, so its reason stands")
+		assertClosed(t, c.TriggerCh())
+	})
+
+	t.Run("under contention exactly one caller wins", func(t *testing.T) {
+		// The callback must also run BEFORE the channel closes: a reader woken
+		// by TriggerCh reads the latched reason immediately, and would race a
+		// callback that ran after the close.
+		const racers = 64
+		for range 32 {
+			c := newShutdownCoordinator()
+			var mu sync.Mutex
+			wins := 0
+			closedBeforeCallback := false
+
+			var wg sync.WaitGroup
+			wg.Add(racers)
+			for i := range racers {
+				go func() {
+					defer wg.Done()
+					if i%2 == 0 {
+						c.Trigger()
+						return
+					}
+					c.TriggerWith(func() {
+						mu.Lock()
+						defer mu.Unlock()
+						wins++
+						select {
+						case <-c.TriggerCh():
+							closedBeforeCallback = true
+						default:
+						}
+					})
+				}()
+			}
+			wg.Wait()
+
+			mu.Lock()
+			require.LessOrEqual(t, wins, 1, "more than one caller recorded a reason")
+			assert.False(t, closedBeforeCallback,
+				"the reason must be recorded before TriggerCh closes")
+			mu.Unlock()
+			assertClosed(t, c.TriggerCh())
+		}
+	})
+}
+
+// assertClosed fails unless ch is already closed.
+func assertClosed(t *testing.T, ch <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatal("trigger channel was never closed")
+	}
+}

--- a/internal/cli/daemon_startup.go
+++ b/internal/cli/daemon_startup.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/charliek/prox/internal/constants"
 	"github.com/charliek/prox/internal/daemon"
+	"github.com/charliek/prox/internal/domain"
 )
 
 // daemonChild is the parent's handle on the detached daemon process. The real
@@ -55,12 +56,20 @@ type daemonStartupOps struct {
 	// reports what it saw (plan 027 C13, #94). Its error return is the
 	// OBSERVATION's failure, never a process's -- see awaitProcessSettle.
 	settle func(addr string) (settleVerdict, error)
+	// fetchWarnings reads the child's session warnings and its completion latch
+	// off GET /status (plan 028 A2). sealed false means "startup producers are
+	// still running"; see awaitDaemonWarnings.
+	fetchWarnings func(addr string) (warnings []domain.Warning, sealed bool, err error)
 
 	sleep func(time.Duration)
 
 	readyTimeout time.Duration // total budget for the child to become ready
 	pollInterval time.Duration // interval between readiness polls
 	killGrace    time.Duration // grace after SIGTERM before escalating to SIGKILL
+	// warningsTimeout is the total budget for waiting on the child's warning
+	// latch, and warningsPoll the gap between fetches.
+	warningsTimeout time.Duration
+	warningsPoll    time.Duration
 }
 
 // killWaitBound caps how long the parent waits for the post-SIGKILL reap
@@ -72,15 +81,76 @@ const killWaitBound = 2 * time.Second
 // readiness budget polled at 200ms, and a 5s SIGTERM→SIGKILL grace.
 func defaultDaemonStartupOps() daemonStartupOps {
 	return daemonStartupOps{
-		loadState: daemon.LoadState,
-		healthOK:  probeHealth,
-		logTail:   daemonLogTail,
-		settle:    settleDaemonProcesses,
-		sleep:     time.Sleep,
+		loadState:     daemon.LoadState,
+		healthOK:      probeHealth,
+		logTail:       daemonLogTail,
+		settle:        settleDaemonProcesses,
+		fetchWarnings: fetchDaemonWarnings,
+		sleep:         time.Sleep,
 
 		readyTimeout: 15 * time.Second,
 		pollInterval: 200 * time.Millisecond,
 		killGrace:    5 * time.Second,
+		// 2.5s of polling at 100ms. The common case costs ONE fetch: a session
+		// with no asynchronous producer has already sealed by the time it serves
+		// /status at all. The budget is for the case that has not, and it is a
+		// ceiling, not a wait — the loop returns the instant the latch flips.
+		warningsTimeout: 2500 * time.Millisecond,
+		warningsPoll:    100 * time.Millisecond,
+	}
+}
+
+// daemonWarningsFetchTimeout bounds ONE status fetch on the warning path. The
+// Client's own 30s timeout is far too generous here: the whole point of the
+// poll loop is a ~2.5s ceiling, and a single wedged listener that answered
+// /health and then stopped reading would otherwise hold `prox up -d` for half a
+// minute over an advisory.
+const daemonWarningsFetchTimeout = 1 * time.Second
+
+// fetchDaemonWarnings is the production warning read: one GET /status against
+// the daemon that just became ready, through the same client (and therefore the
+// same ~/.prox/token) settleDaemonProcesses uses.
+func fetchDaemonWarnings(addr string) ([]domain.Warning, bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), daemonWarningsFetchTimeout)
+	defer cancel()
+	resp, err := NewClient("http://" + addr).GetStatusWithContext(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+	return resp.Warnings, resp.WarningsSealed, nil
+}
+
+// awaitDaemonWarnings reads the child's warnings, waiting (bounded by
+// ops.warningsTimeout) for its completion latch (plan 028 A2).
+//
+// The latch is the whole point. A `-d` child's stdout and stderr are
+// .prox/prox.log, so anything it prints is invisible to the person who typed
+// `prox up -d`; the parent has to read the warnings back over the child's own
+// API. But some startup warning producers are asynchronous and can still be
+// running when the parent's readiness + settle wait finishes, so a single fetch
+// at that instant would race them and silently lose the warning.
+//
+// It never fails and never blocks meaningfully: a fetch error or an expired
+// budget yields the best answer seen so far (possibly none), because a warning
+// must never turn a working start into a failed or a slow one.
+func awaitDaemonWarnings(addr string, ops daemonStartupOps) []domain.Warning {
+	if ops.fetchWarnings == nil || ops.sleep == nil {
+		return nil
+	}
+	deadline := time.Now().Add(ops.warningsTimeout)
+	var latest []domain.Warning
+	for {
+		ws, sealed, err := ops.fetchWarnings(addr)
+		if err == nil {
+			latest = ws
+			if sealed {
+				return ws
+			}
+		}
+		if !time.Now().Before(deadline) {
+			return latest
+		}
+		ops.sleep(ops.warningsPoll)
 	}
 }
 
@@ -292,6 +362,18 @@ func startDetachedDaemon(child daemonChild, cwd string, ops daemonStartupOps) er
 	pid := child.Pid()
 
 	verdict, settleErr := ops.settle(addr)
+	// The outcome is decided and PRINTED first, then the warnings are fetched
+	// and printed under it: a warning is advisory, so it must neither delay the
+	// headline the user is waiting for nor displace it as the last thing said
+	// about a failure.
+	outcome := reportSettleOutcome(pid, addr, verdict, settleErr)
+	writeWarnings(os.Stderr, awaitDaemonWarnings(addr, ops))
+	return outcome
+}
+
+// reportSettleOutcome prints what `prox up -d` has to say about the settle step
+// and returns the command's exit verdict (nil for success).
+func reportSettleOutcome(pid int, addr string, verdict settleVerdict, settleErr error) error {
 	switch {
 	case settleErr != nil:
 		// The OBSERVATION failed, not the processes. Readiness was already

--- a/internal/cli/daemon_startup_test.go
+++ b/internal/cli/daemon_startup_test.go
@@ -309,6 +309,13 @@ func TestStartDetachedDaemon_WarningsPrintOnAFailedStartToo(t *testing.T) {
 // running. A single fetch at that instant would return nothing.
 func TestAwaitDaemonWarnings_PollsUntilSealed(t *testing.T) {
 	ops := fastStartupOps()
+	// Generous, because this test is about the POLLING, not the budget: the
+	// default 40ms deadline is real wall-clock time, so a scheduling hiccup
+	// between fetches could expire it and end the loop early, making the
+	// assertion below fail for a reason that has nothing to do with the latch
+	// (CodeRabbit, PR #110). ops.sleep is a no-op, so a large budget costs
+	// nothing.
+	ops.warningsTimeout = time.Minute
 	fetches := 0
 	ops.fetchWarnings = func(string) ([]domain.Warning, bool, error) {
 		fetches++

--- a/internal/cli/daemon_startup_test.go
+++ b/internal/cli/daemon_startup_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/charliek/prox/internal/daemon"
+	"github.com/charliek/prox/internal/domain"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -66,11 +67,16 @@ func fastStartupOps() daemonStartupOps {
 		// Default: nothing failed within the settle window (plan 027 C13).
 		// Tests that care about the post-readiness verdict override it.
 		settle: func(string) (settleVerdict, error) { return settleVerdict{}, nil },
-		sleep:  func(time.Duration) {},
+		// Default: a sealed session with nothing to say (plan 028 A2), so a test
+		// about anything else sees no extra output.
+		fetchWarnings: func(string) ([]domain.Warning, bool, error) { return nil, true, nil },
+		sleep:         func(time.Duration) {},
 
-		readyTimeout: 40 * time.Millisecond,
-		pollInterval: time.Millisecond,
-		killGrace:    30 * time.Millisecond,
+		readyTimeout:    40 * time.Millisecond,
+		pollInterval:    time.Millisecond,
+		killGrace:       30 * time.Millisecond,
+		warningsTimeout: 40 * time.Millisecond,
+		warningsPoll:    time.Millisecond,
 	}
 }
 
@@ -239,6 +245,157 @@ func TestStartDetachedDaemon_NeverReadySkipsSettle(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to become ready")
 	assert.False(t, settled, "readiness failed; there is nothing to settle")
+}
+
+// TestStartDetachedDaemon_WarningsReachTheParentsStderr: a `-d` child's stdout
+// and stderr are .prox/prox.log, so anything it printed is invisible to the
+// person who typed `prox up -d`. The parent reads the warnings back over the
+// child's own API and prints them itself — AFTER the success headline, since a
+// warning is advisory and must not displace the outcome (plan 028 A2).
+func TestStartDetachedDaemon_WarningsReachTheParentsStderr(t *testing.T) {
+	child := newFakeChild(5100)
+	t.Cleanup(func() { child.exit(nil) })
+
+	ops := readyStartupOps(5100)
+	var fetchedAddr string
+	ops.fetchWarnings = func(addr string) ([]domain.Warning, bool, error) {
+		fetchedAddr = addr
+		return []domain.Warning{{
+			Code: domain.WarningCodeMkcertCAUntrusted, Message: "the CA is not installed.", Hint: "Run 'mkcert -install'.",
+		}}, true, nil
+	}
+
+	var err error
+	stdout, stderr := captureOutput(t, func() {
+		err = startDetachedDaemon(child, t.TempDir(), ops)
+	})
+
+	require.NoError(t, err, "a warning must never turn a working start into a failed one")
+	assert.Equal(t, "127.0.0.1:12345", fetchedAddr, "warnings come from the daemon that just became ready")
+	assert.Contains(t, stdout, "prox started (pid 5100")
+	assert.Equal(t, "Warning: the CA is not installed.\n         Run 'mkcert -install'.\n", stderr)
+}
+
+// TestStartDetachedDaemon_WarningsPrintOnAFailedStartToo: the process verdict
+// and the advisories answer different questions, so a non-zero start still
+// reports what the daemon had to say.
+func TestStartDetachedDaemon_WarningsPrintOnAFailedStartToo(t *testing.T) {
+	child := newFakeChild(5101)
+	t.Cleanup(func() { child.exit(nil) })
+
+	ops := readyStartupOps(5101)
+	ops.settle = func(string) (settleVerdict, error) {
+		return settleVerdict{crashed: []string{"web"}}, nil
+	}
+	ops.fetchWarnings = func(string) ([]domain.Warning, bool, error) {
+		return []domain.Warning{{Code: "c", Message: "advisory"}}, true, nil
+	}
+
+	var err error
+	_, stderr := captureOutput(t, func() {
+		err = startDetachedDaemon(child, t.TempDir(), ops)
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, stderr, "Crashed: web")
+	assert.Contains(t, stderr, "Warning: advisory")
+	assert.Less(t, strings.Index(stderr, "Crashed: web"), strings.Index(stderr, "Warning: advisory"),
+		"the failure is still the headline; the advisory follows it")
+}
+
+// TestAwaitDaemonWarnings_PollsUntilSealed is the race the completion latch
+// exists for, at the unit level: the child is serving /status (so readiness and
+// the settle window are long past) while an asynchronous producer is still
+// running. A single fetch at that instant would return nothing.
+func TestAwaitDaemonWarnings_PollsUntilSealed(t *testing.T) {
+	ops := fastStartupOps()
+	fetches := 0
+	ops.fetchWarnings = func(string) ([]domain.Warning, bool, error) {
+		fetches++
+		if fetches < 3 {
+			return nil, false, nil // producer still running
+		}
+		return []domain.Warning{{Code: "late", Message: "sealed after the settle window"}}, true, nil
+	}
+
+	got := awaitDaemonWarnings("127.0.0.1:1", ops)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, "sealed after the settle window", got[0].Message)
+	assert.Equal(t, 3, fetches, "it polls until the latch flips, then stops")
+}
+
+// TestAwaitDaemonWarnings_SealedImmediatelyCostsOneFetch: the common case (no
+// asynchronous producer, so the session sealed before it ever served /status)
+// must not pay the polling budget.
+func TestAwaitDaemonWarnings_SealedImmediatelyCostsOneFetch(t *testing.T) {
+	ops := fastStartupOps()
+	fetches := 0
+	ops.fetchWarnings = func(string) ([]domain.Warning, bool, error) {
+		fetches++
+		return nil, true, nil
+	}
+
+	assert.Nil(t, awaitDaemonWarnings("127.0.0.1:1", ops))
+	assert.Equal(t, 1, fetches)
+}
+
+// TestAwaitDaemonWarnings_NeverSealedPrintsWhatItHas: if the latch never flips
+// the parent gives up on time and reports the best answer it saw. A warning must
+// never delay startup meaningfully, and never fail it.
+func TestAwaitDaemonWarnings_NeverSealedPrintsWhatItHas(t *testing.T) {
+	ops := fastStartupOps()
+	// A real (short) sleep here, not the no-op fake: the deadline is wall-clock,
+	// so a no-op sleep would spin the poll loop for the whole budget.
+	ops.sleep = time.Sleep
+	ops.warningsTimeout = 30 * time.Millisecond
+	ops.warningsPoll = 5 * time.Millisecond
+	ops.fetchWarnings = func(string) ([]domain.Warning, bool, error) {
+		return []domain.Warning{{Code: "partial", Message: "seen but never sealed"}}, false, nil
+	}
+
+	start := time.Now()
+	got := awaitDaemonWarnings("127.0.0.1:1", ops)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, "seen but never sealed", got[0].Message)
+	assert.Less(t, time.Since(start), 2*time.Second, "the wait is bounded by warningsTimeout")
+}
+
+// TestAwaitDaemonWarnings_FetchErrorsAreSurvivable: the daemon is up (readiness
+// proved it), so a flaky status read is a reason to retry and then say nothing —
+// never a reason to fail the start.
+func TestAwaitDaemonWarnings_FetchErrorsAreSurvivable(t *testing.T) {
+	ops := fastStartupOps()
+	ops.sleep = time.Sleep
+	ops.warningsTimeout = 30 * time.Millisecond
+	ops.warningsPoll = 5 * time.Millisecond
+	ops.fetchWarnings = func(string) ([]domain.Warning, bool, error) {
+		return nil, false, errors.New("connection refused")
+	}
+
+	assert.Nil(t, awaitDaemonWarnings("127.0.0.1:1", ops))
+
+	// A transient error followed by a sealed answer still yields the warning.
+	calls := 0
+	ops.fetchWarnings = func(string) ([]domain.Warning, bool, error) {
+		calls++
+		if calls == 1 {
+			return nil, false, errors.New("connection refused")
+		}
+		return []domain.Warning{{Code: "c", Message: "arrived on the retry"}}, true, nil
+	}
+	got := awaitDaemonWarnings("127.0.0.1:1", ops)
+	require.Len(t, got, 1)
+	assert.Equal(t, "arrived on the retry", got[0].Message)
+}
+
+// TestAwaitDaemonWarnings_NoFetcherIsANoOp guards the unit-test ops literals
+// (and any future caller) that never wire a fetcher.
+func TestAwaitDaemonWarnings_NoFetcherIsANoOp(t *testing.T) {
+	ops := fastStartupOps()
+	ops.fetchWarnings = nil
+	assert.Nil(t, awaitDaemonWarnings("127.0.0.1:1", ops))
 }
 
 // TestAwaitDaemonStartup_EarlyDeath: the child exits (non-zero) before becoming

--- a/internal/cli/dead_stack.go
+++ b/internal/cli/dead_stack.go
@@ -1,0 +1,278 @@
+package cli
+
+import (
+	"sync"
+	"time"
+
+	"github.com/charliek/prox/internal/domain"
+)
+
+// This file implements the dead-stack watcher (plan 028 C3, #96).
+//
+// A foreground `prox up` used to wait on the shutdown coordinator's trigger
+// channel and nothing else. That channel is closed by a signal, by POST
+// /shutdown, and by a TUI quit -- never by a process dying. So the single most
+// common first-run mistake, a typo in `cmd:`, left the user holding a terminal
+// that supervised nothing at all, with no output, until they thought to press
+// Ctrl-C. The session is now torn down (and `prox up` exits non-zero, printing
+// the same crashed summary `prox up -d` prints) once every process is dead and
+// at least one of them died a FAILURE.
+//
+// TWO GATES, AND BOTH MATTER (see deadStack):
+//
+//   - "no live process" rather than "any crashed process": a partial crash --
+//     one of three processes down, two still serving -- is emphatically not a
+//     reason to tear a developer's stack down.
+//   - "at least one terminal failure" rather than "nothing live": a config of
+//     run-to-completion tasks that all finished is SUCCESS, and a user who
+//     stopped every process through the API expressed an INTENT. Neither may
+//     end the session, and both are states where nothing is live.
+//
+// WHERE IT DOES NOT RUN: the detached daemon child. `--detach` short-circuits
+// TUI resolution to plain mode, so the daemon child runs the very same wait
+// block a foreground `prox up` does -- and a watcher there would kill the
+// daemon moments after `prox up -d` told the user "The daemon is still running;
+// stop it with 'prox down'", taking the API and the logs of the crash with it.
+// `prox up -d` reports crashes at settle time (process_settle.go) and exits
+// non-zero on its own; the daemon staying up is the contract. See the
+// daemon.IsDaemonChild() gate at the call site in up.go.
+
+// deadStackSource is the slice of *supervisor.Supervisor the watcher needs: a
+// snapshot reader and the change bus. An interface rather than the concrete
+// type so the unit tests can drive the state machine deterministically, without
+// launching processes.
+type deadStackSource interface {
+	Processes() []domain.ProcessInfo
+	Subscribe() (string, <-chan struct{})
+	Unsubscribe(id string)
+}
+
+// deadStack reports whether procs describe a session with nothing left to
+// supervise and a failure to answer for.
+//
+// It is pure, and it is the whole decision -- read the two-gate note at the top
+// of this file before widening either half. IsLive/IsTerminalFailure are the
+// domain predicates (domain/process.go); IsStopped is NOT usable here, because
+// it also covers `completed`, which is a task's terminal SUCCESS.
+func deadStack(procs []domain.ProcessInfo) bool {
+	if len(procs) == 0 {
+		// No processes at all is not a dead stack: an empty config has nothing
+		// to fail, and tearing the session down would break `prox up` as a way
+		// to run the proxy and API alone.
+		return false
+	}
+	failed := false
+	for _, p := range procs {
+		if p.State.IsLive() {
+			return false
+		}
+		if p.State.IsTerminalFailure() {
+			failed = true
+		}
+	}
+	return failed
+}
+
+// settleProcessesFromInfo projects the supervisor's own ProcessInfo onto the
+// settle check's wire-shaped view.
+//
+// It exists so this path reuses evaluateProcessSettle and settleVerdict.writeTo
+// rather than growing a second implementation of "which of these failed, and
+// how do I say so": `prox up`, `prox up -d`, `prox start` and `prox restart`
+// then report a crash in one voice, with one exit-code vocabulary.
+func settleProcessesFromInfo(procs []domain.ProcessInfo) []settleProcess {
+	out := make([]settleProcess, 0, len(procs))
+	for _, p := range procs {
+		out = append(out, settleProcess{
+			Name:      p.Name,
+			Status:    string(p.State),
+			BlockedOn: p.BlockedOn,
+		})
+	}
+	return out
+}
+
+// deadStackWatcher is one running watcher: the goroutine, the stop handle, and
+// the verdict it latched (if it fired).
+type deadStackWatcher struct {
+	stopCh   chan struct{}
+	doneCh   chan struct{}
+	stopOnce sync.Once
+
+	// mu guards verdict. The goroutine writes it before Trigger, and runUp
+	// reads it after the wait loop; stop() joins the goroutine, so the mutex is
+	// belt and braces rather than the only ordering -- but it makes reading the
+	// latch safe from anywhere, which is what keeps a future caller honest.
+	mu      sync.Mutex
+	verdict *settleVerdict
+}
+
+// startDeadStackWatcher subscribes to sup's change bus and starts watching, at
+// the production timings.
+//
+// trigger is the coordinator's TriggerWith: it requests shutdown and runs the
+// callback ONLY if this call is the one that actually requested it, so the
+// watcher's verdict and the shutdown it causes are decided together (see run).
+// triggered is the coordinator's channel, which tells the watcher a shutdown is
+// already under way and it has nothing left to decide.
+func startDeadStackWatcher(sup deadStackSource, trigger func(onWin func()), triggered <-chan struct{}) *deadStackWatcher {
+	return startDeadStackWatcherWithTiming(sup, trigger, triggered, processSettleTimeout, processSettlePollInterval)
+}
+
+// startDeadStackWatcherWithTiming is startDeadStackWatcher with the window and
+// poll interval supplied, so tests can run the same state machine in
+// milliseconds.
+func startDeadStackWatcherWithTiming(
+	sup deadStackSource,
+	trigger func(onWin func()),
+	triggered <-chan struct{},
+	window, interval time.Duration,
+) *deadStackWatcher {
+	w := &deadStackWatcher{
+		stopCh: make(chan struct{}),
+		doneCh: make(chan struct{}),
+	}
+	// Subscribe BEFORE the goroutine starts, so that a caller which stops the
+	// watcher immediately still unsubscribes exactly one subscription, and so
+	// that no transition between the caller's decision to watch and the
+	// goroutine's first snapshot can be missed.
+	id, wake := sup.Subscribe()
+	go func() {
+		defer close(w.doneCh)
+		defer sup.Unsubscribe(id)
+		w.run(sup, wake, trigger, triggered, window, interval)
+	}()
+	return w
+}
+
+// run is the watcher's state machine.
+//
+// It evaluates a snapshot FIRST, before waiting on any wake. Subscribe is a
+// change latch, not a replay stream, so a stack that was already dead before
+// the watcher existed -- which is exactly the shape of the mid-run TUI-failure
+// fallback, and of a stack that dies during a slow startup -- would otherwise
+// wait forever for a transition that already happened.
+func (w *deadStackWatcher) run(
+	sup deadStackSource,
+	wake <-chan struct{},
+	trigger func(onWin func()),
+	triggered <-chan struct{},
+	window, interval time.Duration,
+) {
+	for {
+		if v, ok := w.confirmDeadStack(sup, triggered, window, interval); ok {
+			// The verdict is built from the CONFIRMING snapshot, because
+			// shutdown drives every process to stopped: read afterwards, the
+			// evidence of what failed is gone.
+			//
+			// It is latched INSIDE the trigger's sync.Once, not before it. The
+			// window between confirming and triggering is small but real, and a
+			// Ctrl-C arriving inside it would otherwise make an intentional
+			// shutdown exit non-zero (codex review finding). Handing the latch
+			// to TriggerWith makes the two decisions one atomic step: the
+			// verdict is recorded if and only if this watcher is what actually
+			// ended the session.
+			trigger(func() { w.latch(v) })
+			return
+		}
+		select {
+		case _, open := <-wake:
+			if !open {
+				// CloseEvents (Supervisor.Stop's deferred call) closed the bus:
+				// the supervisor is going away. That is "stop watching", never
+				// "fire" -- the session is already ending, and the exit code it
+				// ends with is not this watcher's to decide.
+				return
+			}
+		case <-triggered:
+			// Shutdown is already under way (Ctrl-C, POST /shutdown, a TUI
+			// quit). Everything is about to become stopped; an intentional
+			// shutdown latches nothing and exits 0.
+			return
+		case <-w.stopCh:
+			return
+		}
+	}
+}
+
+// confirmDeadStack answers "is the stack dead, and did it stay dead".
+//
+// It returns immediately when the current snapshot is not a dead stack.
+// Otherwise it POLLS for the whole window rather than trusting further wakes,
+// and that is deliberate: the change bus is a capacity-1 coalescing latch, so a
+// transition that arrives while a wake is already pending is dropped, and a
+// purely wake-driven design could both miss a recovery and fire on a stale
+// sample after a `restart` had already cleared the condition.
+func (w *deadStackWatcher) confirmDeadStack(
+	sup deadStackSource,
+	triggered <-chan struct{},
+	window, interval time.Duration,
+) (settleVerdict, bool) {
+	procs := sup.Processes()
+	if !deadStack(procs) {
+		return settleVerdict{}, false
+	}
+
+	deadline := time.Now().Add(window)
+	for {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			// Held for the full window, on every observation in it.
+			return evaluateProcessSettle(settleProcessesFromInfo(procs)), true
+		}
+		sleep := interval
+		if remaining < sleep {
+			sleep = remaining
+		}
+		select {
+		case <-time.After(sleep):
+		case <-triggered:
+			return settleVerdict{}, false
+		case <-w.stopCh:
+			return settleVerdict{}, false
+		}
+
+		procs = sup.Processes()
+		if !deadStack(procs) {
+			// A `prox start`/`restart` (or a slow process finally coming up)
+			// broke the condition: abandon the window entirely and go back to
+			// waiting on wakes. Nothing partial is remembered.
+			return settleVerdict{}, false
+		}
+	}
+}
+
+// latch stores the verdict the watcher fired on.
+func (w *deadStackWatcher) latch(v settleVerdict) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.verdict = &v
+}
+
+// latchedVerdict reports the verdict the watcher fired on, and whether it fired
+// at all. A false second return means the session ended for some other reason
+// (a signal, an API shutdown, a TUI quit), which must not change the exit code.
+func (w *deadStackWatcher) latchedVerdict() (settleVerdict, bool) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.verdict == nil {
+		return settleVerdict{}, false
+	}
+	return *w.verdict, true
+}
+
+// stop ends the watch and waits for the goroutine to unsubscribe and return.
+// Idempotent, and safe to call after the watcher has already fired.
+//
+// The join matters: callers read latchedVerdict straight after stop, and the
+// watcher must be finished deciding by then.
+func (w *deadStackWatcher) stop() {
+	w.stopOnce.Do(func() { close(w.stopCh) })
+	<-w.doneCh
+}
+
+// deadStackHint is the remediation line printed under the crashed/blocked
+// summary when the watcher ends a foreground session. It answers the question
+// the user actually has at that moment -- "why did my terminal come back?" --
+// and mirrors the shape of the hint `prox up -d` prints for the same failure.
+const deadStackHint = "No processes are left running, so prox exited. Fix the command above and run 'prox up' again."

--- a/internal/cli/dead_stack_test.go
+++ b/internal/cli/dead_stack_test.go
@@ -1,0 +1,462 @@
+package cli
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/charliek/prox/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- the predicate -----------------------------------------------------------
+
+// TestDeadStack_Predicate pins the ONE decision this feature makes: when is a
+// foreground session worth tearing down?
+//
+// Both halves of the predicate are load-bearing and each has a case here that
+// fails without it:
+//
+//   - drop "no live process" and the live+crashed row fires, killing a
+//     developer's working stack because one of three processes died.
+//   - drop "some terminal failure" and the completed-only row fires (a task
+//     config that SUCCEEDED) and the stopped-only row fires (a user who stopped
+//     everything through the API, or a `prox up web` that started one process
+//     out of several and then stopped it).
+func TestDeadStack_Predicate(t *testing.T) {
+	proc := func(name string, state domain.ProcessState) domain.ProcessInfo {
+		return domain.ProcessInfo{Name: name, State: state}
+	}
+
+	cases := []struct {
+		name  string
+		procs []domain.ProcessInfo
+		want  bool
+		why   string
+	}{
+		{
+			name: "empty",
+			want: false,
+			why:  "an empty config has nothing to fail; `prox up` may legitimately run only the proxy and API",
+		},
+		{
+			name:  "all running",
+			procs: []domain.ProcessInfo{proc("web", domain.ProcessStateRunning), proc("api", domain.ProcessStateRunning)},
+			want:  false,
+		},
+		{
+			name:  "live plus crashed",
+			procs: []domain.ProcessInfo{proc("web", domain.ProcessStateRunning), proc("ghost", domain.ProcessStateCrashed)},
+			want:  false,
+			why:   "a PARTIAL crash must never tear down the processes that are still serving",
+		},
+		{
+			name:  "starting plus crashed",
+			procs: []domain.ProcessInfo{proc("slow", domain.ProcessStateStarting), proc("ghost", domain.ProcessStateCrashed)},
+			want:  false,
+			why:   "starting is live: the stack has not finished coming up",
+		},
+		{
+			name:  "waiting plus crashed",
+			procs: []domain.ProcessInfo{proc("gated", domain.ProcessStateWaiting), proc("ghost", domain.ProcessStateCrashed)},
+			want:  false,
+			why:   "waiting is limbo, not death: the gated process is still scheduled to launch",
+		},
+		{
+			name:  "stopping plus crashed",
+			procs: []domain.ProcessInfo{proc("web", domain.ProcessStateStopping), proc("ghost", domain.ProcessStateCrashed)},
+			want:  false,
+			why:   "stopping is still live; the session is already ending on its own terms",
+		},
+		{
+			name:  "crashed only",
+			procs: []domain.ProcessInfo{proc("ghost", domain.ProcessStateCrashed)},
+			want:  true,
+			why:   "the #96 case: a typo in cmd: leaves a terminal supervising nothing",
+		},
+		{
+			name:  "blocked only",
+			procs: []domain.ProcessInfo{proc("gated", domain.ProcessStateBlocked)},
+			want:  true,
+			why:   "blocked is terminal: a failed required dependency means it will never launch",
+		},
+		{
+			name:  "completed only",
+			procs: []domain.ProcessInfo{proc("migrate", domain.ProcessStateCompleted)},
+			want:  false,
+			why:   "completed is terminal SUCCESS; a task config that finished is not a failure",
+		},
+		{
+			name:  "stopped only",
+			procs: []domain.ProcessInfo{proc("web", domain.ProcessStateStopped)},
+			want:  false,
+			why:   "everything stopped through the API is an INTENT, and a never-started process is stopped too",
+		},
+		{
+			name:  "completed plus crashed",
+			procs: []domain.ProcessInfo{proc("migrate", domain.ProcessStateCompleted), proc("ghost", domain.ProcessStateCrashed)},
+			want:  true,
+			why:   "one success does not cancel a failure once nothing is live",
+		},
+		{
+			name:  "stopped plus crashed",
+			procs: []domain.ProcessInfo{proc("web", domain.ProcessStateStopped), proc("ghost", domain.ProcessStateCrashed)},
+			want:  true,
+		},
+		{
+			name:  "stopped plus completed",
+			procs: []domain.ProcessInfo{proc("web", domain.ProcessStateStopped), proc("migrate", domain.ProcessStateCompleted)},
+			want:  false,
+			why:   "nothing failed, so nothing to report and nothing to exit non-zero about",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, deadStack(tc.procs), tc.why)
+		})
+	}
+}
+
+// TestSettleProcessesFromInfo_CarriesNameStatusAndBlockedOn pins the adapter
+// that lets this path reuse the settle evaluator and formatter instead of
+// growing a second way to say "crashed".
+func TestSettleProcessesFromInfo_CarriesNameStatusAndBlockedOn(t *testing.T) {
+	got := settleProcessesFromInfo([]domain.ProcessInfo{
+		{Name: "ghost", State: domain.ProcessStateCrashed},
+		{Name: "gated", State: domain.ProcessStateBlocked, BlockedOn: []string{"pg"}},
+	})
+	require.Len(t, got, 2)
+	assert.Equal(t, settleProcess{Name: "ghost", Status: "crashed"}, got[0])
+	assert.Equal(t, settleProcess{Name: "gated", Status: "blocked", BlockedOn: []string{"pg"}}, got[1])
+
+	// And the evaluator built on it renders the same verdict `prox up -d` would.
+	v := evaluateProcessSettle(got)
+	assert.Equal(t, []string{"ghost"}, v.crashed)
+	require.Len(t, v.blocked, 1)
+	assert.Equal(t, "gated", v.blocked[0].Name)
+	assert.Error(t, v.err())
+}
+
+// --- the watcher -------------------------------------------------------------
+
+// fakeStack is a deadStackSource whose snapshot a test sets directly, with the
+// same coalescing capacity-1 change bus the real supervisor has (so a test can
+// reproduce a dropped wake) and a subscriber count so unsubscription can be
+// asserted rather than assumed.
+type fakeStack struct {
+	mu     sync.Mutex
+	procs  []domain.ProcessInfo
+	subs   map[string]chan struct{}
+	nextID int
+	closed bool
+	// reads counts Processes() calls, so a test can prove the watcher really
+	// POLLED the window rather than trusting one sample.
+	reads int
+}
+
+func newFakeStack(procs ...domain.ProcessInfo) *fakeStack {
+	return &fakeStack{procs: procs, subs: map[string]chan struct{}{}}
+}
+
+func (f *fakeStack) Processes() []domain.ProcessInfo {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.reads++
+	out := make([]domain.ProcessInfo, len(f.procs))
+	copy(out, f.procs)
+	return out
+}
+
+func (f *fakeStack) Subscribe() (string, <-chan struct{}) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	ch := make(chan struct{}, 1)
+	if f.closed {
+		close(ch)
+		return "closed", ch
+	}
+	f.nextID++
+	id := string(rune('a' + f.nextID))
+	f.subs[id] = ch
+	return id, ch
+}
+
+func (f *fakeStack) Unsubscribe(id string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	ch, ok := f.subs[id]
+	if !ok {
+		return
+	}
+	delete(f.subs, id)
+	close(ch)
+}
+
+// set replaces the snapshot and wakes every subscriber, exactly as a real
+// transition does.
+func (f *fakeStack) set(procs ...domain.ProcessInfo) {
+	f.mu.Lock()
+	f.procs = procs
+	subs := make([]chan struct{}, 0, len(f.subs))
+	for _, ch := range f.subs {
+		subs = append(subs, ch)
+	}
+	f.mu.Unlock()
+	for _, ch := range subs {
+		select {
+		case ch <- struct{}{}:
+		default: // the latch is already set; this is the real bus's behavior
+		}
+	}
+}
+
+// setQuietly replaces the snapshot WITHOUT a wake — the dropped-transition case
+// the coalescing latch makes possible, and the reason the watcher polls its
+// window instead of waiting for another wake.
+func (f *fakeStack) setQuietly(procs ...domain.ProcessInfo) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.procs = procs
+}
+
+// closeEvents is Supervisor.CloseEvents: every subscriber channel closes and
+// later subscribers get an already-closed one.
+func (f *fakeStack) closeEvents() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.closed = true
+	for id, ch := range f.subs {
+		delete(f.subs, id)
+		close(ch)
+	}
+}
+
+func (f *fakeStack) subscriberCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.subs)
+}
+
+func (f *fakeStack) readCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.reads
+}
+
+// watcher timings for the unit tests: the same state machine as production, two
+// orders of magnitude faster.
+const (
+	testDeadStackWindow   = 100 * time.Millisecond
+	testDeadStackInterval = 10 * time.Millisecond
+	// testDeadStackWait bounds "did it fire" / "did it stay quiet" assertions.
+	// Comfortably more than the window, so a pass is not a scheduling accident.
+	testDeadStackWait = 3 * time.Second
+)
+
+// startTestWatcher starts a watcher over f and returns it plus a channel closed
+// when it triggers.
+func startTestWatcher(f *fakeStack, triggered chan struct{}) (*deadStackWatcher, <-chan struct{}) {
+	fired := make(chan struct{})
+	var once sync.Once
+	trigger := func(onWin func()) {
+		once.Do(func() {
+			// Mirrors shutdownCoordinator.TriggerWith: onWin runs only for the
+			// call that actually wins the trigger, and it runs BEFORE the
+			// channel closes. A fake that latched outside the once would hide
+			// exactly the race this ordering exists to close.
+			if onWin != nil {
+				onWin()
+			}
+			close(fired)
+			// The real coordinator's Trigger closes the channel the watcher is
+			// also selecting on; mirror that so the fake cannot pass on a
+			// friendlier lifecycle than production's.
+			if triggered != nil {
+				close(triggered)
+			}
+		})
+	}
+	w := startDeadStackWatcherWithTiming(f, trigger, triggered, testDeadStackWindow, testDeadStackInterval)
+	return w, fired
+}
+
+// awaitReads blocks until the watcher has taken at least n snapshots, so a test
+// that wants to change the world "after the watcher has looked" can say so
+// instead of guessing with a sleep.
+func awaitReads(t *testing.T, f *fakeStack, n int) {
+	t.Helper()
+	deadline := time.Now().Add(testDeadStackWait)
+	for time.Now().Before(deadline) {
+		if f.readCount() >= n {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("the watcher took fewer than %d snapshots within %s", n, testDeadStackWait)
+}
+
+// TestDeadStackWatcher_FiresOnAnAlreadyDeadSnapshot is the case a wake-driven
+// watcher gets wrong.
+//
+// The stack is dead BEFORE the watcher exists, and no transition ever happens
+// afterwards, so no wake is ever delivered. Subscribe is a change latch, not a
+// replay stream — a watcher that waited for a wake before its first look would
+// hang here forever, which is precisely the shape of the mid-run TUI-failure
+// fallback (the stack may have been dead for minutes by the time plain mode
+// takes over) and of a stack that dies during a slow startup.
+func TestDeadStackWatcher_FiresOnAnAlreadyDeadSnapshot(t *testing.T) {
+	f := newFakeStack(
+		domain.ProcessInfo{Name: "ghost", State: domain.ProcessStateCrashed},
+		domain.ProcessInfo{Name: "migrate", State: domain.ProcessStateCompleted},
+	)
+	w, fired := startTestWatcher(f, make(chan struct{}))
+	defer w.stop()
+
+	select {
+	case <-fired:
+	case <-time.After(testDeadStackWait):
+		t.Fatalf("the watcher never fired against a stack that was already dead when it started")
+	}
+
+	w.stop()
+	verdict, ok := w.latchedVerdict()
+	require.True(t, ok, "a watcher that triggered must latch the reason, or runUp cannot exit non-zero")
+	assert.Equal(t, []string{"ghost"}, verdict.crashed)
+	assert.Empty(t, verdict.blocked)
+	assert.Error(t, verdict.err(), "the latched verdict is what makes `prox up` exit non-zero")
+
+	// It polled the window rather than deciding on a single sample.
+	assert.Greater(t, f.readCount(), 1, "the window must be polled, not sampled once")
+	// And it let go of its subscription.
+	assert.Zero(t, f.subscriberCount(), "the watcher must unsubscribe when it returns")
+}
+
+// TestDeadStackWatcher_DoesNotFireWhenTheConditionBreaksMidWindow is the other
+// half: a stack that recovers inside the settle window is not a dead stack.
+//
+// The recovery is delivered WITHOUT a wake (setQuietly), which is the case that
+// justifies polling: the real change bus is a capacity-1 coalescing latch, so a
+// transition arriving while a wake is already pending is dropped, and a purely
+// wake-driven watcher would fire on the stale sample it had.
+func TestDeadStackWatcher_DoesNotFireWhenTheConditionBreaksMidWindow(t *testing.T) {
+	f := newFakeStack(domain.ProcessInfo{Name: "flaky", State: domain.ProcessStateCrashed})
+	w, fired := startTestWatcher(f, make(chan struct{}))
+	defer w.stop()
+
+	// Inside the window (which only starts once the watcher's first snapshot
+	// sees the dead stack), somebody runs `prox start flaky`.
+	time.Sleep(testDeadStackInterval * 2)
+	f.setQuietly(domain.ProcessInfo{Name: "flaky", State: domain.ProcessStateRunning})
+
+	select {
+	case <-fired:
+		t.Fatalf("the watcher tore the session down for a stack that recovered inside the window")
+	case <-time.After(testDeadStackWindow * 5):
+	}
+
+	w.stop()
+	_, ok := w.latchedVerdict()
+	assert.False(t, ok, "no fire means no verdict, so `prox up` keeps its existing exit code")
+}
+
+// TestDeadStackWatcher_FiresAfterALaterDeath covers the ordinary path: the
+// stack is healthy when the watcher starts, and dies later. The abandoned
+// window must not leave the watcher deaf — it goes back to waiting on wakes.
+func TestDeadStackWatcher_FiresAfterALaterDeath(t *testing.T) {
+	f := newFakeStack(domain.ProcessInfo{Name: "web", State: domain.ProcessStateRunning})
+	w, fired := startTestWatcher(f, make(chan struct{}))
+	defer w.stop()
+
+	select {
+	case <-fired:
+		t.Fatalf("the watcher fired against a running stack")
+	case <-time.After(testDeadStackWindow * 2):
+	}
+
+	f.set(domain.ProcessInfo{Name: "web", State: domain.ProcessStateCrashed})
+	select {
+	case <-fired:
+	case <-time.After(testDeadStackWait):
+		t.Fatalf("the watcher missed a death that happened after it started")
+	}
+
+	w.stop()
+	verdict, ok := w.latchedVerdict()
+	require.True(t, ok)
+	assert.Equal(t, []string{"web"}, verdict.crashed)
+}
+
+// TestDeadStackWatcher_ClosedChangeBusStopsWatching: CloseEvents means the
+// supervisor is going away (Supervisor.Stop runs it from a defer). That is
+// "stop watching", never "fire" — the session is already ending, and its exit
+// code is not this watcher's to decide.
+func TestDeadStackWatcher_ClosedChangeBusStopsWatching(t *testing.T) {
+	f := newFakeStack(domain.ProcessInfo{Name: "web", State: domain.ProcessStateRunning})
+	w, fired := startTestWatcher(f, make(chan struct{}))
+	defer w.stop()
+
+	// The bus closes while the stack still looks alive; then everything dies,
+	// as it does during teardown. No wake can be delivered on a closed bus.
+	//
+	// The wait is not incidental: without it the watcher's very first snapshot
+	// can land after the crash below, and the test would be asserting about a
+	// dead stack it never meant to create.
+	awaitReads(t, f, 1)
+	f.closeEvents()
+	f.setQuietly(domain.ProcessInfo{Name: "web", State: domain.ProcessStateCrashed})
+
+	select {
+	case <-fired:
+		t.Fatalf("the watcher fired off a closed change bus")
+	case <-time.After(testDeadStackWindow * 3):
+	}
+
+	w.stop()
+	_, ok := w.latchedVerdict()
+	assert.False(t, ok)
+}
+
+// TestDeadStackWatcher_IntentionalShutdownLatchesNothing: a Ctrl-C or POST
+// /shutdown closes the coordinator's trigger channel. Everything is about to
+// become stopped, so the watcher must let go without latching — an intentional
+// shutdown still exits 0.
+func TestDeadStackWatcher_IntentionalShutdownLatchesNothing(t *testing.T) {
+	f := newFakeStack(domain.ProcessInfo{Name: "ghost", State: domain.ProcessStateCrashed})
+	triggered := make(chan struct{})
+	close(triggered) // shutdown is already under way before the watcher looks
+
+	fired := make(chan struct{})
+	var once sync.Once
+	w := startDeadStackWatcherWithTiming(f, func(onWin func()) {
+		once.Do(func() {
+			if onWin != nil {
+				onWin()
+			}
+			close(fired)
+		})
+	}, triggered, testDeadStackWindow, testDeadStackInterval)
+	defer w.stop()
+
+	select {
+	case <-fired:
+		t.Fatalf("the watcher fired during a shutdown somebody else requested")
+	case <-time.After(testDeadStackWindow * 3):
+	}
+
+	w.stop()
+	_, ok := w.latchedVerdict()
+	assert.False(t, ok, "an intentional shutdown must keep `prox up` at exit 0")
+}
+
+// TestDeadStackWatcher_StopIsIdempotentAndUnsubscribes: runUp calls stop()
+// before performShutdown and the watcher may also have stopped itself by then.
+func TestDeadStackWatcher_StopIsIdempotentAndUnsubscribes(t *testing.T) {
+	f := newFakeStack(domain.ProcessInfo{Name: "web", State: domain.ProcessStateRunning})
+	w, _ := startTestWatcher(f, make(chan struct{}))
+
+	w.stop()
+	w.stop()
+	assert.Zero(t, f.subscriberCount(), "stop must unsubscribe from the change bus")
+}

--- a/internal/cli/hostname_check.go
+++ b/internal/cli/hostname_check.go
@@ -1,0 +1,271 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/charliek/prox/internal/config"
+	"github.com/charliek/prox/internal/domain"
+)
+
+// docsBaseURL is the published docs site's base URL (zensical.toml's
+// site_url). It is the one place in the Go code that spells that URL out —
+// every doc link this package builds derives from it, so the base cannot
+// drift between call sites the way two hand-typed URLs eventually do.
+const docsBaseURL = "https://charliek.github.io/prox/"
+
+// localDNSGuideURL is the local-DNS guide (docs/guides/local-dns.md), which
+// explains why a `.test` (or similar non-resolving) domain needs local setup
+// and what to do about it — see hostnameUnresolvedWarning.
+const localDNSGuideURL = docsBaseURL + "guides/local-dns/"
+
+// hostnameResolutionBudget bounds the WHOLE batch of hostname lookups this
+// session runs at startup (see startHostnameResolutionCheck), not any single
+// lookup. A resolver that is merely slow must never delay startup or produce
+// a false "unresolvable" warning.
+//
+// It is deliberately SHORTER than warningProducerJoinTimeout rather than equal
+// to it. At equal budgets a batch that answers correctly just before its own
+// deadline still loses the race against the join -- there is real work after
+// the last lookup (build the warning, Add it, Done the WaitGroup) that the
+// join's timer does not wait for -- so the run that most needed the warning
+// would be the one that dropped it (CodeRabbit review). The margin is what
+// makes a slow-but-successful check still reach the terminal.
+const hostnameResolutionBudget = 1500 * time.Millisecond
+
+// hostnameResolver is the DNS lookup this package needs, narrowed to the one
+// method so a test can inject a fake instead of hitting real DNS.
+// *net.Resolver (net.DefaultResolver in production) already satisfies it.
+type hostnameResolver interface {
+	LookupHost(ctx context.Context, host string) ([]string, error)
+}
+
+// startHostnameResolutionCheck queues the async warning producer that checks
+// whether hostnames resolve on this machine (issue #98: `prox up` printing a
+// `.test` hostname that then NXDOMAINs in the user's browser). It runs via
+// sink.Go so it overlaps startup instead of adding to it, and — like every
+// producer registered with Go — it is joined (bounded by
+// warningProducerJoinTimeout) before runUp renders and seals.
+//
+// Callers are both proxy-startup paths (tryDaemonProxy for the shared-daemon
+// case, startProxy's standalone fallback), because the check has to be true
+// regardless of which one the daemon-availability branch took (plan 028 B2
+// design pin) — a hostname resolves or it doesn't independent of how prox
+// got it registered.
+//
+// An empty hostnames list (proxy disabled, or --no-proxy) is a no-op: no
+// sink.Go call, so no goroutine and no resolver call at all.
+func startHostnameResolutionCheck(sink *warningSink, ctx context.Context, resolver hostnameResolver, hostnames []string) {
+	// Deduplicate first. The shared-daemon path passes RegisterResponse.Registered
+	// straight through, and the registry appends one entry per (service x
+	// configured port) -- so a project with BOTH http_port and https_port set
+	// (the dual-stack shape, and the one docs/guides/local-dns.md itself shows)
+	// lists every hostname twice. Undeduped that means two lookups per name and
+	// a warning that reads "app.sec.test, app.sec.test" (CodeRabbit review).
+	// Doing it here rather than at one call site keeps the two paths identical.
+	hostnames = uniqueStrings(hostnames)
+	if len(hostnames) == 0 || resolver == nil {
+		return
+	}
+	sink.Go(func() []domain.Warning {
+		unresolved := checkHostnames(ctx, resolver, hostnames, hostnameResolutionBudget)
+		if len(unresolved) == 0 {
+			return nil
+		}
+		return []domain.Warning{hostnameUnresolvedWarning(unresolved)}
+	})
+}
+
+// checkHostnames resolves every hostname concurrently against resolver,
+// bounded by a single budget shared across the whole batch (not per-lookup),
+// and returns the ones that did NOT resolve, in the same order they were
+// given — never completion order, so the warning this feeds reads the same
+// way on every run regardless of which lookup happens to answer first.
+//
+// It never fails: on any error, or if the batch does not finish inside
+// budget, it treats that as "cannot tell" rather than "unresolvable" and
+// returns nil. A resolver that is offline, sandboxed or merely slow must
+// never turn into a false warning — the whole point is prox only speaking up
+// when it actually knows the hostname will NXDOMAIN in a browser.
+func checkHostnames(parent context.Context, resolver hostnameResolver, hostnames []string, budget time.Duration) []string {
+	if len(hostnames) == 0 {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(parent, budget)
+	defer cancel()
+
+	// notFound[i] is set ONLY when the resolver positively answered "no such
+	// host". Success and every other kind of failure both leave it false, which
+	// is the difference between "this will NXDOMAIN in your browser" and "I
+	// could not find out" (CodeRabbit review).
+	notFound := make([]bool, len(hostnames))
+	var wg sync.WaitGroup
+	wg.Add(len(hostnames))
+	for i, h := range hostnames {
+		go func(i int, h string) {
+			defer wg.Done()
+			_, err := resolver.LookupHost(ctx, h)
+			notFound[i] = isHostNotFound(err)
+		}(i, h)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Every lookup answered inside the budget; notFound[] is safe to read
+		// — close(done) happens-after every write above.
+	case <-ctx.Done():
+		// The batch did not finish in time (or the caller's context was
+		// cancelled). Some lookups may have completed and others may still be
+		// running in the background, but a partial read of notFound here would produce a
+		// warning keyed on which goroutines happened to lose the race rather
+		// than on DNS truth — so report nothing rather than guess.
+		return nil
+	}
+
+	var unresolved []string
+	for i, missing := range notFound {
+		if missing {
+			unresolved = append(unresolved, hostnames[i])
+		}
+	}
+	return unresolved
+}
+
+// isHostNotFound reports whether err is the resolver positively saying the name
+// does not exist, as opposed to any other reason a lookup can fail.
+//
+// This distinction is the whole feature. Treating every error as "does not
+// resolve" would mean a developer on a plane, behind a VPN, or in a
+// network-sandboxed CI runner gets told their perfectly good `.test` or
+// `lvh.me` setup is broken (CodeRabbit review) -- prox stating something false,
+// which is exactly the class of bug plan 028 exists to remove. A timeout, an
+// unreachable network or a misbehaving server all mean "I could not find out",
+// and prox says nothing about what it could not find out.
+func isHostNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	var dnsErr *net.DNSError
+	if !errors.As(err, &dnsErr) {
+		return false
+	}
+	// IsNotFound is the authoritative NXDOMAIN/no-such-host answer. The other
+	// two are explicitly NOT it, and are checked as belt and braces in case a
+	// platform ever reports a timeout without setting IsNotFound false.
+	return dnsErr.IsNotFound && !dnsErr.IsTimeout && !dnsErr.IsTemporary
+}
+
+// hostnameUnresolvedWarning builds the one warning naming every hostname
+// that failed to resolve, in the order given (see checkHostnames).
+func hostnameUnresolvedWarning(unresolved []string) domain.Warning {
+	return domain.Warning{
+		Code:    domain.WarningCodeHostnameUnresolved,
+		Message: fmt.Sprintf("registered hostname(s) do not resolve on this machine: %s", strings.Join(unresolved, ", ")),
+		Hint:    hostnameUnresolvedHint(unresolved),
+	}
+}
+
+// hostnameUnresolvedHint builds the hint's "*.<domain> needs local DNS"
+// clause from the unresolved hostnames themselves — never a hardcoded
+// `*.test` — because the whole point of this warning is naming the ACTUAL
+// configured domain (issue #98 was specifically about `.test` not
+// resolving, but any project's domain can be in the same spot).
+//
+// A hostname is always `<service>.<domain>` (registry.go's construction), so
+// the domain is everything after the first '.'. Domains are deduplicated and
+// sorted for a stable message; the rare case where the unresolved set spans
+// more than one domain (registered against multiple proxy domains, or a
+// future multi-domain project) is handled by listing every `*.<domain>`
+// wildcard rather than picking just one, with "need" instead of "needs" so
+// the sentence still reads correctly.
+func hostnameUnresolvedHint(unresolved []string) string {
+	domains := uniqueHostDomains(unresolved)
+	if len(domains) == 0 {
+		return ""
+	}
+	wildcards := make([]string, len(domains))
+	for i, d := range domains {
+		wildcards[i] = "*." + d
+	}
+	verb := "needs"
+	if len(wildcards) > 1 {
+		verb = "need"
+	}
+	return fmt.Sprintf("%s %s local DNS — see %s", strings.Join(wildcards, ", "), verb, localDNSGuideURL)
+}
+
+// uniqueStrings returns in the same order, without duplicates.
+func uniqueStrings(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if _, dup := seen[s]; dup {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}
+
+// uniqueHostDomains extracts the domain (everything after the first '.')
+// from each `<service>.<domain>` hostname, returning the distinct set
+// sorted. A hostname with no '.' is not one of ours (registry.go always
+// produces svcName + "." + domain) and is skipped rather than guessed at.
+func uniqueHostDomains(hostnames []string) []string {
+	seen := make(map[string]struct{}, len(hostnames))
+	var domains []string
+	for _, h := range hostnames {
+		idx := strings.IndexByte(h, '.')
+		if idx < 0 || idx == len(h)-1 {
+			continue
+		}
+		d := h[idx+1:]
+		if _, ok := seen[d]; ok {
+			continue
+		}
+		seen[d] = struct{}{}
+		domains = append(domains, d)
+	}
+	sort.Strings(domains)
+	return domains
+}
+
+// defaultHostnameResolver is the production hostnameResolver: the standard
+// library's resolver, which honors the context deadline checkHostnames gives
+// it for every lookup.
+var defaultHostnameResolver hostnameResolver = net.DefaultResolver
+
+// registeredHostnames builds the standalone-mode hostname list with the
+// SAME construction the daemon uses (registry.go: `svcName + "." +
+// req.Domain`), so a standalone session gets the identical resolution check
+// a shared-daemon session gets instead of this being a shared-mode-only
+// feature (plan 028 B2 design pin). Sorted for a deterministic check order —
+// cfg.Services is a map, so iteration order is not itself stable.
+func registeredHostnames(cfg *config.Config) []string {
+	if cfg == nil || cfg.Proxy == nil || cfg.Proxy.Domain == "" {
+		return nil
+	}
+	hostnames := make([]string, 0, len(cfg.Services))
+	for svcName := range cfg.Services {
+		hostnames = append(hostnames, fmt.Sprintf("%s.%s", svcName, cfg.Proxy.Domain))
+	}
+	sort.Strings(hostnames)
+	return hostnames
+}

--- a/internal/cli/hostname_check_test.go
+++ b/internal/cli/hostname_check_test.go
@@ -1,0 +1,275 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/charliek/prox/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file covers the hostname-resolution check (plan 028 B2, #98): `prox up`
+// prints `Registered domains: app.sec.test`, which NXDOMAINs in a browser
+// because `.test` does not resolve without local DNS setup, and nothing warns
+// the user at the moment it matters. No test here may perform a real DNS
+// lookup — every resolver is a fake.
+
+// fakeResolver answers LookupHost from a fixed set of resolvable hostnames,
+// optionally releasing answers out of completion order via release channels
+// keyed by hostname, and records the hostnames it was actually asked to look
+// up (mutex-guarded — checkHostnames calls it concurrently).
+type fakeResolver struct {
+	// forcedErr, when set, is returned for every lookup instead of the
+	// resolvable-map answer — so a test can model a failure that is NOT
+	// NXDOMAIN.
+	forcedErr error
+
+	resolvable map[string]bool
+
+	mu      sync.Mutex
+	release map[string]chan struct{} // if set for a host, LookupHost blocks on it
+	called  []string
+
+	hang bool // if true, every lookup blocks until ctx is done and stays hung after
+}
+
+func (f *fakeResolver) LookupHost(ctx context.Context, host string) ([]string, error) {
+	if f.forcedErr != nil {
+		f.mu.Lock()
+		f.called = append(f.called, host)
+		f.mu.Unlock()
+		return nil, f.forcedErr
+	}
+	f.mu.Lock()
+	f.called = append(f.called, host)
+	ch := f.release[host]
+	f.mu.Unlock()
+
+	if f.hang {
+		// A resolver that does not honor context cancellation at all — the
+		// "truly hung" case checkHostnames must survive without hanging
+		// itself or reporting a false positive.
+		select {}
+	}
+	if ch != nil {
+		<-ch
+	}
+
+	if f.resolvable[host] {
+		return []string{"127.0.0.1"}, nil
+	}
+	// A REAL *net.DNSError with IsNotFound, not a bare error: prox only warns
+	// on a positive "no such host", so a fake returning something generic
+	// would be testing a code path production can never take.
+	return nil, &net.DNSError{Err: "no such host", Name: host, IsNotFound: true}
+}
+
+func (f *fakeResolver) calledHosts() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.called))
+	copy(out, f.called)
+	return out
+}
+
+// TestCheckHostnames_AllResolve: nothing unresolved, nothing to warn about.
+func TestCheckHostnames_AllResolve(t *testing.T) {
+	r := &fakeResolver{resolvable: map[string]bool{"app.sec.test": true, "api.sec.test": true}}
+	got := checkHostnames(context.Background(), r, []string{"app.sec.test", "api.sec.test"}, time.Second)
+	assert.Empty(t, got)
+}
+
+// TestCheckHostnames_SomeFail_OrderIsInputOrderNotCompletionOrder: the fake
+// deliberately releases hostnames in the REVERSE of the order they were
+// given, so a result ordered by completion would come back backwards. The
+// warning must instead read in input order every time (deterministic across
+// runs, not a race between goroutines).
+func TestCheckHostnames_SomeFail_OrderIsInputOrderNotCompletionOrder(t *testing.T) {
+	hostnames := []string{"app.sec.test", "api.sec.test", "web.sec.test"}
+	release := map[string]chan struct{}{
+		"app.sec.test": make(chan struct{}),
+		"api.sec.test": make(chan struct{}),
+		"web.sec.test": make(chan struct{}),
+	}
+	r := &fakeResolver{
+		resolvable: map[string]bool{}, // none resolve
+		release:    release,
+	}
+
+	done := make(chan []string, 1)
+	go func() {
+		done <- checkHostnames(context.Background(), r, hostnames, 2*time.Second)
+	}()
+
+	// Release in reverse of input order, with a small stagger so completion
+	// order is provably the opposite of input order.
+	close(release["web.sec.test"])
+	time.Sleep(10 * time.Millisecond)
+	close(release["api.sec.test"])
+	time.Sleep(10 * time.Millisecond)
+	close(release["app.sec.test"])
+
+	got := <-done
+	assert.Equal(t, hostnames, got, "unresolved hosts must come back in INPUT order, not completion order")
+}
+
+// TestCheckHostnames_AllFail: one warning naming all of them, still in order.
+func TestCheckHostnames_AllFail(t *testing.T) {
+	hostnames := []string{"app.sec.test", "api.sec.test"}
+	r := &fakeResolver{resolvable: map[string]bool{}}
+	got := checkHostnames(context.Background(), r, hostnames, time.Second)
+	assert.Equal(t, hostnames, got)
+}
+
+// TestCheckHostnames_ResolverHangs_BoundedByBudget_NoWarning: a resolver that
+// never returns (does not even honor context cancellation) must not hang the
+// caller past the injected budget, and must produce NO result (not "all
+// failed") — silence is the correct answer for "cannot tell", not a false
+// positive.
+func TestCheckHostnames_ResolverHangs_BoundedByBudget_NoWarning(t *testing.T) {
+	r := &fakeResolver{hang: true}
+	hostnames := []string{"app.sec.test", "api.sec.test"}
+
+	start := time.Now()
+	budget := 50 * time.Millisecond
+	got := checkHostnames(context.Background(), r, hostnames, budget)
+	elapsed := time.Since(start)
+
+	assert.Nil(t, got, "a timed-out batch must report nothing, not a false 'all unresolved'")
+	assert.Less(t, elapsed, 2*time.Second, "must be bounded by the injected budget, not some larger default")
+}
+
+// TestCheckHostnames_Empty_NoWarningNoResolverCalls: nothing to check, and
+// critically, the resolver is never even called — confirmed via
+// startHostnameResolutionCheck, which must not queue a producer at all.
+func TestCheckHostnames_Empty_NoWarningNoResolverCalls(t *testing.T) {
+	r := &fakeResolver{resolvable: map[string]bool{}}
+	got := checkHostnames(context.Background(), r, nil, time.Second)
+	assert.Nil(t, got)
+	assert.Empty(t, r.calledHosts())
+
+	sink := newWarningSink()
+	startHostnameResolutionCheck(sink, context.Background(), r, nil)
+	require.True(t, sink.Wait(time.Second), "no producer should have been queued for an empty hostname list")
+	assert.Empty(t, sink.Warnings())
+	assert.Empty(t, r.calledHosts())
+}
+
+// TestStartHostnameResolutionCheck_AllResolve_NoWarning exercises the full
+// sink.Go wiring end to end with a resolver that answers everything.
+func TestStartHostnameResolutionCheck_AllResolve_NoWarning(t *testing.T) {
+	r := &fakeResolver{resolvable: map[string]bool{"app.sec.test": true}}
+	sink := newWarningSink()
+	startHostnameResolutionCheck(sink, context.Background(), r, []string{"app.sec.test"})
+	require.True(t, sink.Wait(time.Second))
+	assert.Empty(t, sink.Warnings())
+}
+
+// TestHostnameUnresolvedWarning_HintCarriesActualDomainAndDocsURL: the hint
+// must name the ACTUAL configured domain (never a hardcoded `*.test`) and the
+// docs URL must be built from the one docsBaseURL constant, not typed out
+// again.
+func TestHostnameUnresolvedWarning_HintCarriesActualDomainAndDocsURL(t *testing.T) {
+	w := hostnameUnresolvedWarning([]string{"app.sec.test", "api.sec.test"})
+
+	assert.Equal(t, "hostname_unresolved", w.Code)
+	assert.Equal(t, "registered hostname(s) do not resolve on this machine: app.sec.test, api.sec.test", w.Message)
+	assert.Contains(t, w.Hint, "*.sec.test needs local DNS")
+	assert.Contains(t, w.Hint, docsBaseURL+"guides/local-dns/")
+	assert.Equal(t, localDNSGuideURL, docsBaseURL+"guides/local-dns/")
+}
+
+// TestHostnameUnresolvedWarning_MultipleDomains: hostnames spanning more than
+// one domain get every wildcard named, pluralized correctly, rather than
+// silently picking one and dropping the other.
+func TestHostnameUnresolvedWarning_MultipleDomains(t *testing.T) {
+	w := hostnameUnresolvedWarning([]string{"app.sec.test", "api.other.dev"})
+	assert.Contains(t, w.Hint, "*.other.dev")
+	assert.Contains(t, w.Hint, "*.sec.test")
+	assert.Contains(t, w.Hint, " need local DNS", "plural verb when more than one domain is involved")
+}
+
+// TestRegisteredHostnames_MatchesDaemonConstruction: standalone mode must
+// derive `<service>.<domain>` the SAME way the daemon does
+// (registry.go:~152's `fmt.Sprintf("%s.%s", svcName, req.Domain)`), or the
+// check would silently only run in shared-daemon mode.
+func TestRegisteredHostnames_MatchesDaemonConstruction(t *testing.T) {
+	cfg := &config.Config{
+		Proxy: &config.ProxyConfig{Enabled: true, Domain: "sec.test"},
+		Services: map[string]config.ServiceConfig{
+			"app": {Port: 3000},
+			"api": {Port: 4000},
+		},
+	}
+	got := registeredHostnames(cfg)
+	want := []string{"api.sec.test", "app.sec.test"}
+	sort.Strings(got)
+	assert.Equal(t, want, got)
+}
+
+// TestRegisteredHostnames_NoProxyDomain_Empty: no proxy configured (or no
+// domain set) must never synthesize hostnames out of nothing.
+func TestRegisteredHostnames_NoProxyDomain_Empty(t *testing.T) {
+	assert.Empty(t, registeredHostnames(&config.Config{}))
+	assert.Empty(t, registeredHostnames(nil))
+}
+
+// TestCheckHostnames_AmbiguousErrorsNeverWarn is the anti-false-alarm test.
+//
+// A lookup can fail for reasons that say nothing about the hostname: a laptop
+// on a plane, a VPN-only network, a sandboxed CI runner with no resolver. If
+// prox treated those as "does not resolve" it would confidently tell a user
+// their perfectly good setup was broken — the same class of untruth as the
+// silence this feature replaces, pointed the other way. Only a positive
+// NXDOMAIN counts.
+func TestCheckHostnames_AmbiguousErrorsNeverWarn(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"network unreachable", &net.DNSError{Err: "connect: network is unreachable", Name: "app.sec.test"}},
+		{"timeout", &net.DNSError{Err: "i/o timeout", Name: "app.sec.test", IsTimeout: true}},
+		{"temporary server failure", &net.DNSError{Err: "server misbehaving", Name: "app.sec.test", IsTemporary: true}},
+		{"not a DNS error at all", errors.New("something else entirely")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &fakeResolver{resolvable: map[string]bool{}, forcedErr: tc.err}
+			got := checkHostnames(context.Background(), r, []string{"app.sec.test"}, time.Second)
+			assert.Empty(t, got,
+				"a lookup that failed for a reason other than NXDOMAIN means "+
+					"'I could not find out', and prox must not warn about what it does not know")
+		})
+	}
+}
+
+// TestStartHostnameResolutionCheck_DedupesHostnames pins the dual-stack shape.
+//
+// The registry appends one entry per (service x configured port), so a project
+// with both http_port and https_port — the shape docs/guides/local-dns.md
+// itself shows — reports every hostname twice in RegisterResponse.Registered.
+// Undeduped that is two lookups per name and a warning reading
+// "app.sec.test, app.sec.test".
+func TestStartHostnameResolutionCheck_DedupesHostnames(t *testing.T) {
+	r := &fakeResolver{resolvable: map[string]bool{}}
+	sink := newWarningSink()
+
+	startHostnameResolutionCheck(sink, context.Background(), r,
+		[]string{"app.sec.test", "api.sec.test", "app.sec.test", "api.sec.test"})
+	require.True(t, sink.Wait(5*time.Second))
+
+	assert.ElementsMatch(t, []string{"app.sec.test", "api.sec.test"}, r.calledHosts(),
+		"each hostname is looked up once, however many ports registered it")
+
+	ws := sink.Warnings()
+	require.Len(t, ws, 1)
+	assert.Equal(t,
+		"registered hostname(s) do not resolve on this machine: app.sec.test, api.sec.test",
+		ws[0].Message, "no hostname may appear twice in the sentence")
+}

--- a/internal/cli/process_settle.go
+++ b/internal/cli/process_settle.go
@@ -80,26 +80,16 @@ func settleProcessFromDetail(p *api.ProcessDetailResponse) []settleProcess {
 // isTerminalFailureState reports whether a reported process status means the
 // start has definitively FAILED.
 //
-// The set is exactly two states, and widening it is a behavior change to three
-// commands' exit codes:
-//
-//   - crashed — exited unexpectedly, or failed to start. Terminal: prox has no
-//     restart/backoff policy, so a crashed process stays crashed and this check
-//     cannot false-positive on a process that is merely mid-restart.
-//   - blocked — a gated process a failed required dependency will never let
-//     launch.
-//
-// Everything else is NOT a failure: starting and stopping are transient,
-// waiting is limbo (the process is still scheduled to launch), stopped is
-// deliberate, running is the goal, and completed is a task's terminal SUCCESS.
-//
-// Do NOT reach for domain.ProcessState.IsStopped here — it collapses stopped,
-// crashed, blocked AND completed, so a task that finished cleanly would be
-// reported as a failed start. TestIsTerminalFailureState_CoversEveryState pins
-// the whole enum against exactly this.
+// The truth lives in domain.ProcessState.IsTerminalFailure (crashed or
+// blocked; widening it is a behavior change to three commands' exit codes).
+// This wrapper stays STRING-typed rather than taking a domain.ProcessState:
+// status comes off the wire, and an unknown value from a newer daemon must
+// fall through as "not a terminal failure" rather than being forced into the
+// enum (a bad ProcessState conversion has no zero value that means "I don't
+// know"). TestIsTerminalFailureState_CoversEveryState pins the whole enum
+// against exactly this.
 func isTerminalFailureState(status string) bool {
-	return status == string(domain.ProcessStateCrashed) ||
-		status == string(domain.ProcessStateBlocked)
+	return domain.ProcessState(status).IsTerminalFailure()
 }
 
 // settleVerdict is what one observation of the processes concluded.

--- a/internal/cli/process_settle_test.go
+++ b/internal/cli/process_settle_test.go
@@ -16,12 +16,14 @@ import (
 // TestIsTerminalFailureState_CoversEveryState is the guard on the ONE decision
 // this commit makes: which process states mean "the start failed".
 //
-// It enumerates every domain.ProcessState by its constant, so the table cannot
-// silently fall behind the enum — a renamed or deleted constant breaks the
-// build here, and the count assertion at the end fails the moment a new state
-// is added without a deliberate decision about which side of the line it falls
-// on. That matters because widening this set silently changes the exit code of
-// `prox up -d`, `prox start` and `prox restart`.
+// It iterates domain.AllProcessStates() rather than a literal map, so the
+// table cannot silently fall behind the enum — a require.Len(cases, 8) guard
+// against a hand-written map does NOT fail when a 9th state is added (the map
+// and the literal both stay at 8 unless someone remembers to touch both);
+// iterating the enum's own enumeration does, because the length assertion is
+// against len(AllProcessStates()), not a number typed by hand. That matters
+// because widening this set silently changes the exit code of `prox up -d`,
+// `prox start` and `prox restart`.
 //
 // The specific trap it exists to prevent: reaching for ProcessState.IsStopped
 // as the predicate. IsStopped is true for completed — a task's terminal SUCCESS
@@ -42,9 +44,12 @@ func TestIsTerminalFailureState_CoversEveryState(t *testing.T) {
 	// If this fails, domain.ProcessState gained (or lost) a member: decide
 	// explicitly whether it is a terminal FAILURE and add it above. Do not just
 	// bump the number.
-	require.Len(t, cases, 8, "every domain.ProcessState must be classified here")
+	require.Len(t, cases, len(domain.AllProcessStates()), "every domain.ProcessState must be classified here")
 
-	for state, wantFailure := range cases {
+	for _, state := range domain.AllProcessStates() {
+		wantFailure, ok := cases[state]
+		require.True(t, ok, "state %q not classified above", state)
+
 		got := isTerminalFailureState(string(state))
 		assert.Equal(t, wantFailure, got, "state %q", state)
 

--- a/internal/cli/proxy_runtime.go
+++ b/internal/cli/proxy_runtime.go
@@ -80,6 +80,15 @@ type proxyRuntime struct {
 	// can explain an empty request list. Guarded by mu.
 	captureEnabled bool
 
+	// warnings is this session's warning sink (plan 028 A2). The shared daemon
+	// returns user-facing advisories on the register response — on the FIRST
+	// register (tryDaemonProxy) and on every self-heal re-register (heal) — and
+	// the daemon's own stdout/stderr are /dev/null, so this sink is the only way
+	// they reach the user. Guarded by mu; nil is a usable no-op sink (every
+	// warningSink method is nil-receiver safe), which is what unit-test runtimes
+	// get.
+	warnings *warningSink
+
 	// healState overrides the derived heal_state while the shared daemon is
 	// unreachable (D6b): "" (down, no heal attempted yet), "healing" (heal
 	// attempts failing), or "version_mismatch" (a busy different-version daemon).
@@ -137,6 +146,23 @@ func (r *proxyRuntime) SetCaptureEnabled(enabled bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.captureEnabled = enabled
+}
+
+// SetWarningSink injects the session's warning sink (plan 028 A2). Called once
+// from runUp before the proxy path resolves, so both register arms — the first
+// one and every heal re-register — land in the same collection.
+func (r *proxyRuntime) SetWarningSink(s *warningSink) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.warnings = s
+}
+
+// WarningSink returns the session's warning sink, or nil when none was injected
+// (a nil sink is a no-op, not a crash).
+func (r *proxyRuntime) WarningSink() *warningSink {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.warnings
 }
 
 // Mode returns the current proxy mode.
@@ -429,6 +455,23 @@ func (r *proxyRuntime) heal(ops healOps) bool {
 	r.setHealState(healStateHealthy)
 	r.invalidateProbeCache()
 	log.Printf("prox: shared proxy daemon healed — re-registered %d domain(s) with a fresh daemon", len(resp.Registered))
+
+	// The re-register carries the SAME advisories the first one did (plan 028
+	// A2): a fresh daemon re-runs the checks behind them, so a heal is often the
+	// first time a project hears about, say, an untrusted mkcert CA. Everything
+	// but len(resp.Registered) used to be discarded here.
+	//
+	// This runs on the FORWARDER's goroutine, not runUp's, so the preamble is
+	// off limits (it is unsynchronized by construction). Only the sink — which
+	// is mutex-guarded and feeds GET /status — plus the stdlib logger, which is
+	// routed through the stdio sink and therefore reaches a TUI's log pane or
+	// plain stderr. Add's return means each advisory is announced once, not once
+	// per heal.
+	for _, w := range r.WarningSink().Add(resp.Warnings...) {
+		for _, line := range formatWarning(w) {
+			log.Print(line)
+		}
+	}
 	return true
 }
 

--- a/internal/cli/proxy_runtime.go
+++ b/internal/cli/proxy_runtime.go
@@ -74,6 +74,12 @@ type proxyRuntime struct {
 	// never disturbs the supervisor. nil until the shared-mode forwarder launches.
 	forwarderCancel context.CancelFunc
 
+	// captureEnabled is this project's EFFECTIVE capture state — the proxy is
+	// actually running for this session AND capture is enabled in its config
+	// (see resolveProxyRuntimeState). Reported in the status block so a client
+	// can explain an empty request list. Guarded by mu.
+	captureEnabled bool
+
 	// healState overrides the derived heal_state while the shared daemon is
 	// unreachable (D6b): "" (down, no heal attempted yet), "healing" (heal
 	// attempts failing), or "version_mismatch" (a busy different-version daemon).
@@ -124,11 +130,28 @@ func (r *proxyRuntime) SetMode(mode string) {
 	r.mode = mode
 }
 
+// SetCaptureEnabled records whether request/response capture is effectively on
+// for this session. runUp calls it once, from the same resolved runtime state
+// that decides whether to start the proxy at all.
+func (r *proxyRuntime) SetCaptureEnabled(enabled bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.captureEnabled = enabled
+}
+
 // Mode returns the current proxy mode.
 func (r *proxyRuntime) Mode() string {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.mode
+}
+
+// CaptureEnabled returns the effective capture state recorded by
+// SetCaptureEnabled (false until resolved).
+func (r *proxyRuntime) CaptureEnabled() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.captureEnabled
 }
 
 // SetClient stores the active daemon client. C6 calls this again on heal.
@@ -263,10 +286,15 @@ func (r *proxyRuntime) ForwarderBackfillFailed() {
 // mode only, with no probe.
 func (r *proxyRuntime) ProxyStatus() *api.ProxyStatusResponse {
 	mode := r.Mode()
+	// Always non-nil from a current daemon: nil is reserved for the wire case
+	// of an OLDER daemon that predates the field (see CaptureEnabled's doc), so
+	// a live runtime must state its answer even when that answer is false.
+	capture := r.CaptureEnabled()
 	resp := &api.ProxyStatusResponse{
 		Mode:                mode,
 		ConsecutiveFailures: r.consecutiveFailures.Load(),
 		BackfillFailures:    r.backfillFailures.Load(),
+		CaptureEnabled:      &capture,
 	}
 	if ns := r.lastConnectedAt.Load(); ns > 0 {
 		t := time.Unix(0, ns)

--- a/internal/cli/proxy_runtime_heal_test.go
+++ b/internal/cli/proxy_runtime_heal_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/charliek/prox/internal/domain"
 	"github.com/charliek/prox/internal/proxyd"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -48,6 +49,68 @@ func TestHeal_SuccessSwapsClient(t *testing.T) {
 	assert.Same(t, fresh, rt.Client(), "heal must swap in the fresh client for deregister (D6c)")
 	assert.Equal(t, int64(0), rt.consecutiveFailures.Load(), "heal must reset the failure counter")
 	assert.Equal(t, healStateHealthy, rt.getHealState())
+}
+
+// TestHeal_CollectsRegisterWarningsOnce pins the self-heal hop of the warning
+// channel (plan 028 A2). The re-register carries the same advisories the first
+// one did — a fresh daemon re-runs the checks behind them — and everything but
+// len(resp.Registered) used to be discarded here. Repeated heals must not stack
+// the same advisory up, since the forwarder heals for as long as the outage
+// lasts.
+func TestHeal_CollectsRegisterWarningsOnce(t *testing.T) {
+	sock := startFakeRegisterDaemon(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(proxyd.RegisterResponse{
+			Registered: []string{"api.local.dev"},
+			Warnings: []domain.Warning{{
+				Code:    domain.WarningCodeMkcertCAUntrusted,
+				Message: "the CA is not installed.",
+				Hint:    "Run 'mkcert -install'.",
+			}},
+		})
+	})
+	fresh := proxyd.NewClient(sock)
+
+	sink := newWarningSink()
+	rt := newProxyRuntime()
+	rt.SetMode(proxyModeShared)
+	rt.SetWarningSink(sink)
+	rt.SetRegisterRequest(proxyd.RegisterRequest{ProjectDir: "/p", PID: os.Getpid(), Version: "test"})
+
+	ops := healOps{
+		ensureRunning: func() (*proxyd.Client, error) { return fresh, nil },
+		sleep:         func(time.Duration) {},
+		retryDelay:    time.Millisecond,
+	}
+
+	require.True(t, rt.heal(ops))
+	require.Len(t, sink.Warnings(), 1, "the heal re-register's warnings must reach the session sink")
+	assert.Equal(t, domain.WarningCodeMkcertCAUntrusted, sink.Warnings()[0].Code)
+
+	require.True(t, rt.heal(ops))
+	assert.Len(t, sink.Warnings(), 1, "a second heal must not duplicate the same advisory")
+}
+
+// TestHeal_WithNoWarningSinkIsSafe: a runtime that was never handed a sink (unit
+// tests, and any future caller) must heal exactly as before, not panic.
+func TestHeal_WithNoWarningSinkIsSafe(t *testing.T) {
+	sock := startFakeRegisterDaemon(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(proxyd.RegisterResponse{
+			Registered: []string{"api.local.dev"},
+			Warnings:   []domain.Warning{{Code: "c", Message: "nobody is collecting this"}},
+		})
+	})
+
+	rt := newProxyRuntime()
+	rt.SetMode(proxyModeShared)
+	rt.SetRegisterRequest(proxyd.RegisterRequest{ProjectDir: "/p", PID: os.Getpid(), Version: "test"})
+
+	assert.True(t, rt.heal(healOps{
+		ensureRunning: func() (*proxyd.Client, error) { return proxyd.NewClient(sock), nil },
+		sleep:         func(time.Duration) {},
+		retryDelay:    time.Millisecond,
+	}))
 }
 
 // TestHeal_VersionMismatchKeepsWaiting pins D6b: EnsureRunning reporting a busy

--- a/internal/cli/proxy_runtime_test.go
+++ b/internal/cli/proxy_runtime_test.go
@@ -74,6 +74,38 @@ func TestProxyRuntime_ProxyStatus_StandaloneNoProbe(t *testing.T) {
 	}
 }
 
+// TestProxyRuntime_ProxyStatus_CaptureEnabled pins that a LIVE runtime always
+// states its capture answer, both ways. The pointer's nil case is reserved for
+// the wire — a daemon older than the field — so a nil here would make a current
+// daemon indistinguishable from one that has no opinion (see
+// api.ProxyStatusResponse.CaptureEnabled).
+func TestProxyRuntime_ProxyStatus_CaptureEnabled(t *testing.T) {
+	for _, want := range []bool{true, false} {
+		t.Run(fmt.Sprintf("%v", want), func(t *testing.T) {
+			rt := newProxyRuntime()
+			rt.SetMode(proxyModeStandalone) // avoid the shared-mode probe
+			rt.SetCaptureEnabled(want)
+
+			s := rt.ProxyStatus()
+			if s.CaptureEnabled == nil {
+				t.Fatal("CaptureEnabled = nil from a live runtime; want a stated answer")
+			}
+			if *s.CaptureEnabled != want {
+				t.Errorf("CaptureEnabled = %v, want %v", *s.CaptureEnabled, want)
+			}
+		})
+	}
+
+	t.Run("unset defaults to false", func(t *testing.T) {
+		rt := newProxyRuntime()
+		rt.SetMode(proxyModeDisabled)
+		s := rt.ProxyStatus()
+		if s.CaptureEnabled == nil || *s.CaptureEnabled {
+			t.Errorf("CaptureEnabled = %v, want a stated false", s.CaptureEnabled)
+		}
+	})
+}
+
 // TestProxyRuntime_ProbeCacheTTL pins D5: a second status within the TTL reuses
 // the cached probe result rather than re-probing; past the TTL it re-probes.
 func TestProxyRuntime_ProbeCacheTTL(t *testing.T) {

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -502,6 +502,18 @@ func runUp(cmd *cobra.Command, args []string) (err error) {
 	// connection state, and (C6) holds the client swapped in on heal. Created
 	// here (mode defaults to disabled) and resolved to shared/standalone below.
 	runtime := newProxyRuntime()
+	// This session's user-facing advisories (plan 028 A2). Created before the
+	// proxy path resolves, because the shared daemon's register response is the
+	// first producer; published on GET /status (which is how the `prox up -d`
+	// parent reads them back out of a child whose output goes to a log file) and
+	// rendered once at the end of startup below.
+	warnings := newWarningSink()
+	runtime.SetWarningSink(warnings)
+	handlers.SetWarningProvider(warnings)
+	// The suite's only way to produce a warning that finishes AFTER the
+	// `prox up -d` parent's settle window — the race the completion latch
+	// exists for. Unset in every real run.
+	registerTestWarningProducer(warnings, os.Getenv(warningTestHookEnvVar))
 	// The RESOLVED runtime proxy state for this session — what the proxy path
 	// below actually does, not what the file asks for (see
 	// resolveProxyRuntimeState). It gates the proxy start, feeds the status
@@ -659,6 +671,30 @@ func runUp(cmd *cobra.Command, args []string) (err error) {
 			}
 		}
 	}()
+
+	// END OF STARTUP: join the asynchronous warning producers, render everything
+	// this session has to say, and seal (plan 028 A2).
+	//
+	// All three steps are here, on runUp's own goroutine, deliberately:
+	//
+	//   - rendering goes through the preamble, which is unsynchronized by
+	//     construction, so it can only happen here;
+	//   - ONE render point means the user meets every advisory in one block and
+	//     one order, whatever produced it;
+	//   - sealing after this point (and after the API server above began
+	//     serving) is what makes warnings_sealed worth publishing at all. GET
+	//     /status can already be answered while a producer is still running,
+	//     which is exactly the window the `prox up -d` parent lands in — it
+	//     polls the latch rather than trusting a single fetch.
+	//
+	// The join is bounded: a warning must never meaningfully delay startup. A
+	// producer that misses the budget still reaches GET /status when it lands,
+	// it just misses the parent's read.
+	if !warnings.Wait(warningProducerJoinTimeout) {
+		log.Printf("prox: startup warning checks did not finish within %s; continuing", warningProducerJoinTimeout)
+	}
+	reportStartupWarnings(warnings.Warnings(), preamble, os.Stderr)
+	warnings.Seal()
 
 	// Handle TUI vs terminal output. tuiErr survives the block: a failed TUI
 	// session must reach the exit contract below.
@@ -1415,6 +1451,12 @@ func startProxy(cfg *config.Config, cwd string, ctx context.Context, handlers *a
 	// configured, so a create/start failure here is fatal (D1): `prox up` must
 	// never start a project with the proxy silently disabled. --no-proxy is the
 	// escape hatch (named in the returned error).
+	//
+	// Warnings (plan 028 A2): this mode has no wire to carry them — mkcert runs
+	// in THIS process (internal/proxy) — so a producer added here reports
+	// straight into rt.WarningSink().Add(...) and is rendered and sealed by the
+	// same end-of-startup step in runUp as the shared-daemon path. There is no
+	// producer yet; B1 adds one.
 	svc, err := startStandaloneProxy(cfg, cwd, ctx, handlers, logOut, pre)
 	if err != nil {
 		return nil, nil, err
@@ -1517,6 +1559,17 @@ func tryDaemonProxy(cfg *config.Config, cwd string, ctx context.Context, handler
 	if len(resp.Registered) > 0 {
 		pre.printf("Registered domains: %s", strings.Join(resp.Registered, ", "))
 	}
+
+	// Advisories the shared daemon raised while setting this project up (plan
+	// 028 A2). They ride the register response — both arms, the first attempt
+	// and the post-SHUTTING_DOWN retry (retryRegisterAfterShutdown returns the
+	// healed response into `resp` above) — because the daemon's own stdout and
+	// stderr are /dev/null, so anything it printed would be seen by nobody.
+	//
+	// They are only COLLECTED here. Rendering happens once, at the end of
+	// startup on runUp's goroutine (see reportStartupWarnings), so a warning
+	// from any producer prints in one place and in one order.
+	rt.WarningSink().Add(resp.Warnings...)
 
 	// Create a local RequestManager and start the SSE forwarder to bridge
 	// daemon proxy requests into this project's TUI and API. The runtime records

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -26,6 +26,7 @@ import (
 	"github.com/charliek/prox/internal/domain"
 	"github.com/charliek/prox/internal/logs"
 	"github.com/charliek/prox/internal/proxy"
+	"github.com/charliek/prox/internal/proxy/certs"
 	"github.com/charliek/prox/internal/proxyd"
 	"github.com/charliek/prox/internal/supervisor"
 	"github.com/charliek/prox/internal/tui"
@@ -1453,16 +1454,51 @@ func startProxy(cfg *config.Config, cwd string, ctx context.Context, handlers *a
 	// escape hatch (named in the returned error).
 	//
 	// Warnings (plan 028 A2): this mode has no wire to carry them — mkcert runs
-	// in THIS process (internal/proxy) — so a producer added here reports
-	// straight into rt.WarningSink().Add(...) and is rendered and sealed by the
-	// same end-of-startup step in runUp as the shared-daemon path. There is no
-	// producer yet; B1 adds one.
+	// in THIS process (internal/proxy) — so the producer below reports straight
+	// into the session's warning sink and is rendered and sealed by the same
+	// end-of-startup step in runUp as the shared-daemon path.
 	svc, err := startStandaloneProxy(cfg, cwd, ctx, handlers, logOut, pre)
 	if err != nil {
 		return nil, nil, err
 	}
 	rt.SetMode(proxyModeStandalone)
+
+	// Must run AFTER the proxy started: if HTTPS was configured and mkcert
+	// actually generated certs just now, that run already answered the
+	// CA-trust question and the resolver returns its verdict without probing.
+	//
+	// Asynchronous (Go, not Add) because the fallback — a probe, when the certs
+	// were already warm — shells out to mkcert, and no diagnostic gets to hold
+	// up a user's startup. There is no clear-side here: a standalone session's
+	// sink starts empty every run, so "trusted" simply means nothing is added.
+	//
+	// Gated on HTTPS: with no HTTPS listener there is no certificate to be
+	// distrusted, so the warning would be true and irrelevant — which is its own
+	// kind of untrue. The daemon side needs no equivalent gate: its cert phase
+	// only runs for a registration that declares an HTTPS port (server.go).
+	if cfg.Proxy.HTTPSPort > 0 {
+		rt.WarningSink().Go(func() []domain.Warning {
+			return mkcertTrustWarnings(ctx, certs.SharedTrust())
+		})
+	}
 	return nil, svc, nil
+}
+
+// caTrustResolver is the CA-trust verdict source startProxy consumes, narrowed
+// to the one method so a test can supply a verdict without a real mkcert.
+type caTrustResolver interface {
+	Resolve(context.Context) certs.TrustVerdict
+}
+
+// mkcertTrustWarnings turns the process's CA-trust verdict into the warnings to
+// report. It adds nothing for a trusted CA and nothing for an unknown one:
+// prox says something here only when mkcert itself said the CA is missing from
+// the trust stores.
+func mkcertTrustWarnings(ctx context.Context, r caTrustResolver) []domain.Warning {
+	if w := r.Resolve(ctx).Warning; w != nil {
+		return []domain.Warning{*w}
+	}
+	return nil
 }
 
 // tryDaemonProxy attempts to register with the shared proxy daemon.

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -1481,6 +1481,12 @@ func startProxy(cfg *config.Config, cwd string, ctx context.Context, handlers *a
 			return mkcertTrustWarnings(ctx, certs.SharedTrust())
 		})
 	}
+
+	// Same hostname-resolution check as the shared-daemon path (plan 028 B2,
+	// #98), built from config with the identical <service>.<domain>
+	// construction the daemon uses (registeredHostnames) so the check is not
+	// shared-mode-only.
+	startHostnameResolutionCheck(rt.WarningSink(), ctx, defaultHostnameResolver, registeredHostnames(cfg))
 	return nil, svc, nil
 }
 
@@ -1606,6 +1612,14 @@ func tryDaemonProxy(cfg *config.Config, cwd string, ctx context.Context, handler
 	// startup on runUp's goroutine (see reportStartupWarnings), so a warning
 	// from any producer prints in one place and in one order.
 	rt.WarningSink().Add(resp.Warnings...)
+
+	// Whether these hostnames actually resolve on THIS machine (plan 028 B2,
+	// #98): `Registered domains: app.sec.test` printed above is only useful
+	// if pasting it into a browser works, and a `.test` domain (unlike a
+	// public wildcard such as `*.lvh.me`) does not resolve without local DNS
+	// setup. Async and best-effort — see startHostnameResolutionCheck — so a
+	// slow or offline resolver never delays this session's startup.
+	startHostnameResolutionCheck(rt.WarningSink(), ctx, defaultHostnameResolver, resp.Registered)
 
 	// Create a local RequestManager and start the SSE forwarder to bridge
 	// daemon proxy requests into this project's TUI and API. The runtime records

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -779,15 +779,51 @@ func runUp(cmd *cobra.Command, args []string) (err error) {
 			}
 		}
 	}
+	// deadVerdict is the dead-stack watcher's verdict, latched only if it fired
+	// (plan 028 C3, #96). It survives the block below to reach the exit contract.
+	var deadVerdict *settleVerdict
 	if !tuiEnabled {
 		// Log subscription + consumer were already started above, before the
 		// supervisor started any process (D2, #92) — or, for a preferred-mode
 		// TUI that failed, a moment ago with the ring replayed behind it.
 
+		// A foreground session with every process dead used to wait here
+		// forever: the trigger channel is closed by signals, POST /shutdown and
+		// a TUI quit, and by nothing a process does (#96). The watcher supplies
+		// the missing wake — and the reason for it, which the coordinator does
+		// not carry — so a stack that is entirely down ends the session and
+		// exits non-zero.
+		//
+		// NOT in the detached daemon child: `--detach` short-circuits TUI
+		// resolution to plain mode, so it runs this very block, and a watcher
+		// here would kill the daemon `prox up -d` just promised was still
+		// running. See dead_stack.go.
+		//
+		// Started here rather than beside sup.Start so that sequential startup
+		// can never present a transient "nothing live" window, and so the
+		// mid-run TUI-failure fallback above (which flips tuiEnabled and falls
+		// into this block) is covered by the same call.
+		var deadWatcher *deadStackWatcher
+		if !daemon.IsDaemonChild() {
+			deadWatcher = startDeadStackWatcher(sup, coordinator.TriggerWith, coordinator.TriggerCh())
+		}
+
 		// Wait for shutdown. Both a signal (via forwardShutdownSignal above, which
 		// also logs it) and an API/TUI-quit trigger arrive as a coordinator trigger,
 		// so this selects on the one channel.
 		<-coordinator.TriggerCh()
+
+		if deadWatcher != nil {
+			// Stopped BEFORE performShutdown, not merely deferred to runUp's
+			// return: teardown drives every process to stopped, and a watcher
+			// still running through that would see a crashed-plus-stopped stack
+			// and latch a verdict for a shutdown the user asked for. stop()
+			// joins the goroutine, so the read below is of a finished decision.
+			deadWatcher.stop()
+			if v, fired := deadWatcher.latchedVerdict(); fired {
+				deadVerdict = &v
+			}
+		}
 		fmt.Println() // Print newline (past any echoed ^C)
 	}
 
@@ -829,6 +865,18 @@ func runUp(cmd *cobra.Command, args []string) (err error) {
 		reportStdioDrops(sink)
 	}
 
+	// The dead-stack half of the exit contract (plan 028 C3, #96). Printed here,
+	// after teardown, so it is the LAST thing on the terminal rather than a line
+	// the shutdown log stream scrolls away — and printed through the same
+	// formatter `prox up -d`, `start` and `restart` use, so a crash reads
+	// identically whichever command reports it. Only ever non-nil in plain,
+	// non-daemon-child mode.
+	var deadStackErr error
+	if deadVerdict != nil {
+		deadVerdict.writeTo(os.Stderr, deadStackHint)
+		deadStackErr = deadVerdict.err()
+	}
+
 	// Foreground exit contract: a surviving process group makes `prox up` exit
 	// non-zero (cobra maps a non-nil RunE error to exit 1). Intentional split:
 	// per-process detail already went to the log stream via SystemLog inside
@@ -839,11 +887,12 @@ func runUp(cmd *cobra.Command, args []string) (err error) {
 	// Breaking change: foreground `prox up` previously always exited 0 (CHANGELOG
 	// in C5).
 	if outcome != nil {
-		// errors.Join keeps a TUI failure visible alongside the shutdown
-		// verdict; either alone still makes `up` exit non-zero.
-		return errors.Join(tuiErr, fmt.Errorf("shutdown incomplete: %w", outcome))
+		// errors.Join keeps a TUI failure — and a dead stack — visible alongside
+		// the shutdown verdict; any one alone still makes `up` exit non-zero.
+		return errors.Join(tuiErr, deadStackErr, fmt.Errorf("shutdown incomplete: %w", outcome))
 	}
-	return tuiErr
+	// errors.Join of all-nil is nil, so an ordinary Ctrl-C still exits 0.
+	return errors.Join(tuiErr, deadStackErr)
 }
 
 // dialableAPIURL builds the base URL a process uses to reach its OWN in-process

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -502,6 +502,12 @@ func runUp(cmd *cobra.Command, args []string) (err error) {
 	// connection state, and (C6) holds the client swapped in on heal. Created
 	// here (mode defaults to disabled) and resolved to shared/standalone below.
 	runtime := newProxyRuntime()
+	// The RESOLVED runtime proxy state for this session — what the proxy path
+	// below actually does, not what the file asks for (see
+	// resolveProxyRuntimeState). It gates the proxy start, feeds the status
+	// block, and tells the TUI why a request list may stay empty.
+	proxyFacts := resolveProxyRuntimeState(cfg, noProxy)
+	runtime.SetCaptureEnabled(proxyFacts.CaptureEnabled)
 	handlers.SetProxyStatusProvider(runtime)
 
 	apiServer := api.NewServer(api.ServerConfig{
@@ -540,7 +546,7 @@ func runUp(cmd *cobra.Command, args []string) (err error) {
 	// Start proxy — either via shared daemon or standalone fallback.
 	var proxyService *proxy.Service
 	var daemonClient *proxyd.Client
-	if !noProxy && cfg.Proxy != nil && cfg.Proxy.Enabled {
+	if proxyFacts.Configured {
 		var proxyErr error
 		daemonClient, proxyService, proxyErr = startProxy(cfg, cwd, ctx, handlers, runtime, sink, preamble)
 		if proxyErr != nil {
@@ -697,6 +703,12 @@ func runUp(cmd *cobra.Command, args []string) (err error) {
 			// about to hide — pinned in the log pane so the proxy URL survives a
 			// startup chatty enough to have evicted them from the log ring.
 			Preamble: preamble.Lines(),
+			// Why the requests pane may stay empty. Sourced from the SAME
+			// resolved runtime state that gated the proxy start above, so a
+			// `--no-proxy` session reports "no proxy configured" rather than
+			// promising traffic this run can never see.
+			ProxyConfigured: proxyFacts.Configured,
+			CaptureEnabled:  proxyFacts.CaptureEnabled,
 		}
 		// Ports feed curl-copy only; pass them when a proxy is actually
 		// listening (disabled/--no-proxy → port-less https://<host><url>).
@@ -1339,6 +1351,42 @@ func captureDiskBudget(cfg *config.Config) int64 {
 		return 0
 	}
 	return n
+}
+
+// resolveProxyRuntimeState answers the two questions the rest of the session
+// asks about the proxy path: is a proxy actually running for this project, and
+// will requests actually be captured?
+//
+// Both answers are RUNTIME state, not config state, and the gap between the two
+// is the whole point of this function: `prox up --no-proxy` leaves the config's
+// `proxy:` block enabled while refusing to start anything, so keying a UI hint
+// on cfg.Proxy.Enabled alone would tell the user to wait for traffic that this
+// session can never see. captureEnabled is gated on proxyConfigured for the same
+// reason — capture cannot happen without a proxy to capture from.
+//
+// CaptureEffectivelyEnabled is nil-receiver safe, so the second expression is
+// safe even with no proxy: block at all.
+//
+// It returns a STRUCT rather than two bools because the two are adjacent, both
+// bool, and consumed at three call sites — the proxy gate, the status block and
+// the TUI options. Returned positionally, swapping them at any of those sites
+// compiles, passes every test (each is tested in isolation) and silently gives
+// a `--no-proxy` session the wrong hint. Named fields make that mistake visible
+// at the call site instead (CodeRabbit review finding).
+func resolveProxyRuntimeState(cfg *config.Config, noProxy bool) proxyRuntimeFacts {
+	configured := !noProxy && cfg.Proxy != nil && cfg.Proxy.Enabled
+	return proxyRuntimeFacts{
+		Configured:     configured,
+		CaptureEnabled: configured && cfg.Proxy.CaptureEffectivelyEnabled(),
+	}
+}
+
+// proxyRuntimeFacts is the resolved runtime state of this session's proxy path:
+// whether a proxy is actually running, and whether requests will actually be
+// captured. Both are runtime answers, not config answers.
+type proxyRuntimeFacts struct {
+	Configured     bool
+	CaptureEnabled bool
 }
 
 // startProxy attempts to register with the shared proxy daemon. If the daemon

--- a/internal/cli/up_test.go
+++ b/internal/cli/up_test.go
@@ -900,3 +900,39 @@ func TestClassifyTUIExit(t *testing.T) {
 		})
 	}
 }
+
+// TestResolveProxyRuntimeState pins the RUNTIME-vs-config distinction the TUI's
+// empty-state hints depend on. The trap is `--no-proxy`: the config's proxy:
+// block stays enabled (capture with it), yet nothing proxies and nothing can be
+// captured, so a hint keyed on the config alone would promise traffic this
+// session can never see.
+func TestResolveProxyRuntimeState(t *testing.T) {
+	enabledProxy := func() *config.ProxyConfig {
+		return &config.ProxyConfig{Enabled: true, Capture: &config.CaptureConfig{Enabled: true}}
+	}
+
+	cases := []struct {
+		name        string
+		proxy       *config.ProxyConfig
+		noProxy     bool
+		wantProxy   bool
+		wantCapture bool
+	}{
+		{"no proxy block", nil, false, false, false},
+		{"proxy and capture enabled", enabledProxy(), false, true, true},
+		{"--no-proxy overrides an enabled block", enabledProxy(), true, false, false},
+		{"proxy block disabled", &config.ProxyConfig{Enabled: false, Capture: &config.CaptureConfig{Enabled: true}}, false, false, false},
+		{"capture disabled", &config.ProxyConfig{Enabled: true, Capture: &config.CaptureConfig{Enabled: false}}, false, true, false},
+		{"capture absent", &config.ProxyConfig{Enabled: true}, false, true, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveProxyRuntimeState(&config.Config{Proxy: tc.proxy}, tc.noProxy)
+			if got.Configured != tc.wantProxy || got.CaptureEnabled != tc.wantCapture {
+				t.Errorf("resolveProxyRuntimeState = %+v, want {Configured:%v CaptureEnabled:%v}",
+					got, tc.wantProxy, tc.wantCapture)
+			}
+		})
+	}
+}

--- a/internal/cli/warnings.go
+++ b/internal/cli/warnings.go
@@ -1,0 +1,283 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/charliek/prox/internal/domain"
+	"github.com/charliek/prox/internal/version"
+)
+
+// warningPrefix is the label every user-facing advisory carries. It matches the
+// bare `fmt.Fprintf(os.Stderr, "Warning: ...")` convention already used all over
+// this package (up.go, daemon_startup.go), so a warning that arrived from the
+// shared daemon reads exactly like one raised locally.
+const warningPrefix = "Warning: "
+
+// warningHintIndent lines a warning's hint up under its message rather than
+// under the label, so the two-line block reads as one item:
+//
+//	Warning: mkcert's local CA is not installed in your trust stores.
+//	         Run 'mkcert -install' and restart prox.
+var warningHintIndent = strings.Repeat(" ", len(warningPrefix))
+
+// warningProducerJoinTimeout bounds how long runUp waits for asynchronous
+// warning producers before it seals (see warningSink.Wait). A warning must never
+// meaningfully delay startup: when the budget expires the session seals with
+// whatever has landed, and a producer that reports later still reaches
+// GET /status — it just misses the `prox up -d` parent's read.
+const warningProducerJoinTimeout = 2 * time.Second
+
+// formatWarning renders one warning as the lines to print, hint included only
+// when there is one. Returned as lines (not one embedded-newline string) because
+// every destination — the terminal, the TUI's pinned preamble, the system log —
+// is line-oriented, and a two-line log entry is not two log entries.
+func formatWarning(w domain.Warning) []string {
+	lines := []string{warningPrefix + w.Message}
+	if w.Hint != "" {
+		lines = append(lines, warningHintIndent+w.Hint)
+	}
+	return lines
+}
+
+// writeWarnings writes every warning to out in order. It is the single renderer:
+// `prox status`, the `prox up -d` parent and the `prox up` startup path all go
+// through it, so the shape cannot drift between the three places a user meets
+// the same warning.
+func writeWarnings(out io.Writer, ws []domain.Warning) {
+	for _, w := range ws {
+		for _, line := range formatWarning(w) {
+			fmt.Fprintln(out, line)
+		}
+	}
+}
+
+// reportStartupWarnings routes this session's warnings to whichever screen the
+// user is actually going to look at. It is the reportTUIWarnings template
+// (preamble.go) applied to domain warnings, for the same reasons:
+//
+//   - the preamble, so a TUI session sees them on the screen bubbletea is about
+//     to hide the terminal behind (and, through the preamble's system-log path,
+//     so `prox logs` and the daemon log get them too);
+//   - stderr, ALWAYS, because the preamble is only ever rendered if the TUI
+//     actually opens — and because plain `prox up` has no other channel. In a
+//     `-d` child, stderr is .prox/prox.log, which is why the parent reads them
+//     back over the API instead (see startDetachedDaemon).
+//
+// MUST be called from runUp's own goroutine: startupPreamble is explicitly
+// single-goroutine and unsynchronized.
+func reportStartupWarnings(ws []domain.Warning, pre *startupPreamble, stderr io.Writer) {
+	for _, w := range ws {
+		for _, line := range formatWarning(w) {
+			// note (not printf): printf writes to stdout, and these lines go to
+			// stderr below. note is a no-op unless the preamble is enabled (TUI).
+			pre.note("%s", line)
+		}
+	}
+	writeWarnings(stderr, ws)
+}
+
+// warningTestHookEnvVar injects a synthetic, deliberately SLOW warning producer
+// into a real `prox` process. It exists for exactly one thing the suite cannot
+// otherwise reach: proving that a warning sealed AFTER the `prox up -d` parent's
+// readiness + settle wait still reaches that parent's terminal — the race
+// warnings_sealed exists for. Reproducing it needs a producer that finishes at a
+// controlled instant well after the API server starts serving, and no real
+// producer can be asked to do that.
+//
+// Value: "<delay>|<code>|<message>[|<hint>]", e.g.
+// "1200ms|test_warning|the CA is not installed|run mkcert -install".
+// A malformed value is ignored in full — a broken test hook must never break a
+// real startup. Unset (the case for every user), nothing runs at all.
+const warningTestHookEnvVar = "PROX_TEST_STARTUP_WARNING"
+
+// registerTestWarningProducer wires the warningTestHookEnvVar producer into s,
+// if the variable is set and parses. See that constant for why it exists.
+//
+// It is inert in RELEASE-PIPELINE builds. This is the one mechanism in prox
+// that can put a warning in front of a user which nothing actually observed,
+// and the whole point of plan 028 is that prox does not tell people things that
+// are not true, so the shipped artifact should not carry the capability at all.
+// Only .goreleaser.yaml sets the version ldflag, so `version.Version != "dev"`
+// is precisely "built by the release pipeline".
+//
+// Be exact about what that does NOT cover: `make build` and
+// `go install ...@latest` both leave Version at "dev", so a source-built prox
+// still honours the variable (CodeRabbit review). That residue is accepted
+// rather than engineered away — a build tag would mean the integration suite
+// tested a different binary from the one users run, which is a worse trade —
+// and the blast radius is a user who exports a variable in their own shell to
+// print one line to their own terminal.
+func registerTestWarningProducer(s *warningSink, spec string) {
+	if version.Version != "dev" {
+		return
+	}
+	delay, w, ok := parseTestWarningSpec(spec)
+	if !ok {
+		return
+	}
+	s.Go(func() []domain.Warning {
+		time.Sleep(delay)
+		return []domain.Warning{w}
+	})
+}
+
+// parseTestWarningSpec parses "<delay>|<code>|<message>[|<hint>]". ok is false
+// for an empty or malformed spec.
+func parseTestWarningSpec(spec string) (time.Duration, domain.Warning, bool) {
+	parts := strings.Split(spec, "|")
+	if len(parts) < 3 || len(parts) > 4 {
+		return 0, domain.Warning{}, false
+	}
+	delay, err := time.ParseDuration(parts[0])
+	if err != nil || delay < 0 {
+		return 0, domain.Warning{}, false
+	}
+	w := domain.Warning{Code: parts[1], Message: parts[2]}
+	if len(parts) == 4 {
+		w.Hint = parts[3]
+	}
+	if w.Code == "" || w.Message == "" {
+		return 0, domain.Warning{}, false
+	}
+	return delay, w, true
+}
+
+// warningSink is this session's collection of user-facing advisories
+// (domain.Warning) — most of them raised somewhere the person who typed the
+// command cannot see: inside the shared proxy daemon, whose stdout/stderr are
+// /dev/null, or inside a `prox up -d` child, whose output goes to .prox/prox.log.
+//
+// Writes happen on runUp's own goroutine during startup, plus the forwarder's
+// goroutine on a self-heal re-register (proxyRuntime.heal). The mutex is what
+// makes both safe against the READS, which come from HTTP handler goroutines
+// serving GET /status.
+//
+// A nil *warningSink is a usable no-op sink, so a code path that was never
+// handed one (a unit-test runtime, a future caller) does not have to nil-check
+// before every Add.
+type warningSink struct {
+	mu       sync.Mutex
+	warnings []domain.Warning
+	// sealed is the completion latch GET /status publishes as warnings_sealed.
+	// See Seal.
+	sealed bool
+
+	// pending tracks asynchronous startup producers registered with Go, so Wait
+	// can join them before the session seals.
+	pending sync.WaitGroup
+}
+
+func newWarningSink() *warningSink { return &warningSink{} }
+
+// Add records warnings, dropping any that duplicate one already held, and
+// returns the ones that were actually NEW. Callers use that return to log or
+// print a warning exactly once even when the producing path runs repeatedly (the
+// forwarder's heal loop re-registers on every recovery).
+//
+// Identity is domain.DedupeWarnings' identity — Code AND Message, hint excluded
+// — so the two producers of the same advisory cannot make it appear twice.
+func (s *warningSink) Add(ws ...domain.Warning) []domain.Warning {
+	if s == nil || len(ws) == 0 {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	before := len(s.warnings)
+	// s.warnings is already deduped, so the surviving prefix is unchanged and
+	// everything past `before` is genuinely new.
+	s.warnings = domain.DedupeWarnings(append(s.warnings, ws...))
+	if len(s.warnings) == before {
+		return nil
+	}
+	added := make([]domain.Warning, len(s.warnings)-before)
+	copy(added, s.warnings[before:])
+	return added
+}
+
+// Warnings returns a COPY of the collected warnings, nil when there are none so
+// an omitempty JSON field disappears rather than serializing as []. The copy is
+// what lets an HTTP goroutine encode a response while startup is still adding.
+func (s *warningSink) Warnings() []domain.Warning {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.warnings) == 0 {
+		return nil
+	}
+	out := make([]domain.Warning, len(s.warnings))
+	copy(out, s.warnings)
+	return out
+}
+
+// Seal latches "every startup warning producer has finished", which GET /status
+// publishes as warnings_sealed. It exists for one reader: the `prox up -d`
+// parent, which fetches status once its child is ready and its processes have
+// settled. Some producers are asynchronous and can still be running at that
+// instant, so an unlatched single fetch would race them and silently lose a
+// warning; the parent instead polls until this is true (bounded — see
+// awaitDaemonWarnings).
+//
+// Sealing does NOT freeze the sink: a warning raised later in the session (a
+// forwarder self-heal re-register) is still recorded and still served. The latch
+// says startup is done, not that nothing more can ever be said.
+func (s *warningSink) Seal() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sealed = true
+}
+
+// WarningsSealed reports the completion latch (see Seal).
+func (s *warningSink) WarningsSealed() bool {
+	if s == nil {
+		return false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.sealed
+}
+
+// Go runs an asynchronous startup warning producer, recording whatever it
+// returns. It is the seam for checks that must not block startup while they run
+// but MUST be finished before the session seals: register them here, and Wait
+// joins them at the seal point.
+func (s *warningSink) Go(produce func() []domain.Warning) {
+	if s == nil || produce == nil {
+		return
+	}
+	s.pending.Add(1)
+	go func() {
+		defer s.pending.Done()
+		s.Add(produce()...)
+	}()
+}
+
+// Wait blocks until every producer registered with Go has finished, or until
+// timeout expires, reporting whether they all finished. Every Go call happens on
+// runUp's goroutine before this one, so there is no Add-after-Wait race on the
+// WaitGroup itself.
+func (s *warningSink) Wait(timeout time.Duration) bool {
+	if s == nil {
+		return true
+	}
+	done := make(chan struct{})
+	go func() {
+		s.pending.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return true
+	case <-time.After(timeout):
+		return false
+	}
+}

--- a/internal/cli/warnings_test.go
+++ b/internal/cli/warnings_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -16,6 +17,7 @@ import (
 
 	"github.com/charliek/prox/internal/api"
 	"github.com/charliek/prox/internal/domain"
+	"github.com/charliek/prox/internal/proxy/certs"
 )
 
 // This file covers the session warning sink and its renderer (plan 028 A2): the
@@ -362,4 +364,74 @@ func TestRegisterTestWarningProducer_ReleaseBuildsCannotFabricateWarnings(t *tes
 	registerTestWarningProducer(s, "1ms|hooked|hook fired")
 	s.Wait(time.Second)
 	require.Len(t, s.Warnings(), 1, "a dev build still runs it, or the suite loses its only latch test")
+}
+
+// stubTrustResolver stands in for certs.SharedTrust in standalone mode, so this
+// test pins the CLI's translation of a verdict without a real mkcert. What
+// mkcert's output MEANS is tested where it is parsed (internal/proxy/certs).
+type stubTrustResolver struct {
+	verdict certs.TrustVerdict
+	ctx     context.Context
+}
+
+func (s *stubTrustResolver) Resolve(ctx context.Context) certs.TrustVerdict {
+	s.ctx = ctx
+	return s.verdict
+}
+
+// TestMkcertTrustWarnings covers the standalone half of the producer: with no
+// daemon to carry warnings, mkcert runs in THIS process and its verdict has to
+// reach the session's own sink.
+func TestMkcertTrustWarnings(t *testing.T) {
+	untrusted := domain.Warning{
+		Code:    domain.WarningCodeMkcertCAUntrusted,
+		Message: "Note: the local CA is not installed in the system trust store! ⚠️",
+		Hint:    "run 'mkcert -install' and restart prox",
+	}
+
+	t.Run("reports an untrusted CA", func(t *testing.T) {
+		r := &stubTrustResolver{verdict: certs.TrustVerdict{Known: true, Warning: &untrusted}}
+		assert.Equal(t, []domain.Warning{untrusted}, mkcertTrustWarnings(context.Background(), r))
+	})
+
+	t.Run("says nothing for a trusted CA", func(t *testing.T) {
+		r := &stubTrustResolver{verdict: certs.TrustVerdict{Known: true}}
+		assert.Nil(t, mkcertTrustWarnings(context.Background(), r))
+	})
+
+	t.Run("says nothing when the verdict is unknown", func(t *testing.T) {
+		// No mkcert, no CA, or a probe that failed: prox must not invent a
+		// warning it has no evidence for, and must not error either.
+		r := &stubTrustResolver{}
+		assert.Nil(t, mkcertTrustWarnings(context.Background(), r))
+	})
+
+	t.Run("passes the session context through", func(t *testing.T) {
+		// The probe shells out to mkcert; a cancelled session must be able to
+		// cut it short rather than hold up shutdown.
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		r := &stubTrustResolver{}
+		mkcertTrustWarnings(ctx, r)
+		assert.Equal(t, ctx, r.ctx)
+	})
+}
+
+// TestMkcertTrustWarnings_FeedsTheSink pins the wiring shape startProxy uses:
+// the producer runs through warningSink.Go, so a slow probe cannot delay
+// startup, and its result still lands before the session seals.
+func TestMkcertTrustWarnings_FeedsTheSink(t *testing.T) {
+	untrusted := domain.Warning{
+		Code:    domain.WarningCodeMkcertCAUntrusted,
+		Message: "Note: the local CA is not installed in the system trust store! ⚠️",
+		Hint:    "run 'mkcert -install' and restart prox",
+	}
+	r := &stubTrustResolver{verdict: certs.TrustVerdict{Known: true, Warning: &untrusted}}
+
+	s := newWarningSink()
+	s.Go(func() []domain.Warning { return mkcertTrustWarnings(context.Background(), r) })
+	require.True(t, s.Wait(2*time.Second), "the producer must finish well inside the join budget")
+	s.Seal()
+
+	assert.Equal(t, []domain.Warning{untrusted}, s.Warnings())
 }

--- a/internal/cli/warnings_test.go
+++ b/internal/cli/warnings_test.go
@@ -1,0 +1,365 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/charliek/prox/internal/version"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/charliek/prox/internal/api"
+	"github.com/charliek/prox/internal/domain"
+)
+
+// This file covers the session warning sink and its renderer (plan 028 A2): the
+// collection every producer writes into, the two-line shape the user reads, and
+// the completion latch the `prox up -d` parent polls.
+
+func testWarning(code, message, hint string) domain.Warning {
+	return domain.Warning{Code: code, Message: message, Hint: hint}
+}
+
+// TestWarningSink_AddDedupesAndReturnsOnlyNewOnes: the same advisory reported
+// twice (the shared daemon returns it on the first register AND on every
+// self-heal re-register) is ONE warning, and the second Add reports nothing new
+// — which is what keeps the heal path from logging it once per heal.
+func TestWarningSink_AddDedupesAndReturnsOnlyNewOnes(t *testing.T) {
+	s := newWarningSink()
+
+	added := s.Add(testWarning("a", "first", "hint a"), testWarning("b", "second", ""))
+	require.Len(t, added, 2)
+	assert.Equal(t, "first", added[0].Message)
+	assert.Equal(t, "second", added[1].Message)
+
+	// Same Code+Message, different hint: still a duplicate (hint is not part of
+	// the identity — see domain.DedupeWarnings), and the FIRST copy is kept.
+	assert.Empty(t, s.Add(testWarning("a", "first", "a different hint")))
+
+	added = s.Add(testWarning("c", "third", ""))
+	require.Len(t, added, 1)
+	assert.Equal(t, "third", added[0].Message)
+
+	got := s.Warnings()
+	require.Len(t, got, 3)
+	assert.Equal(t, []string{"first", "second", "third"}, []string{got[0].Message, got[1].Message, got[2].Message})
+	assert.Equal(t, "hint a", got[0].Hint, "the first-seen copy, hint and all, is the one kept")
+}
+
+// TestWarningSink_EmptyAndNilAreNoOps: a nil sink is a usable sink, so no
+// producer has to nil-check before every Add, and an empty collection reports
+// nil (not []) so the omitempty JSON field disappears.
+func TestWarningSink_EmptyAndNilAreNoOps(t *testing.T) {
+	var s *warningSink
+	assert.NotPanics(t, func() {
+		assert.Nil(t, s.Add(testWarning("a", "m", "")))
+		assert.Nil(t, s.Warnings())
+		assert.False(t, s.WarningsSealed())
+		s.Seal()
+		s.Go(func() []domain.Warning { return nil })
+		assert.True(t, s.Wait(time.Second))
+	})
+
+	live := newWarningSink()
+	assert.Nil(t, live.Warnings(), "an empty sink reports nil, not an empty slice")
+	assert.Nil(t, live.Add(), "adding nothing adds nothing")
+}
+
+// TestWarningSink_WarningsReturnsACopy: the reader is an HTTP goroutine
+// encoding a response while startup may still be adding, so it must never be
+// handed the sink's own backing array.
+func TestWarningSink_WarningsReturnsACopy(t *testing.T) {
+	s := newWarningSink()
+	s.Add(testWarning("a", "original", ""))
+
+	got := s.Warnings()
+	got[0].Message = "mutated by the caller"
+
+	assert.Equal(t, "original", s.Warnings()[0].Message)
+}
+
+// TestWarningSink_SealLatchesWithoutFreezing: Seal says "startup producers are
+// done" (which is all warnings_sealed claims), NOT "nothing more can be said" —
+// a forwarder self-heal re-register still records its advisories afterwards.
+func TestWarningSink_SealLatchesWithoutFreezing(t *testing.T) {
+	s := newWarningSink()
+	assert.False(t, s.WarningsSealed(), "a fresh sink is unsealed")
+
+	s.Seal()
+	assert.True(t, s.WarningsSealed())
+	s.Seal()
+	assert.True(t, s.WarningsSealed(), "sealing twice is idempotent")
+
+	require.Len(t, s.Add(testWarning("late", "raised by a heal", "")), 1)
+	assert.Len(t, s.Warnings(), 1, "a post-seal warning is still recorded and still served")
+	assert.True(t, s.WarningsSealed())
+}
+
+// TestWarningSink_ConcurrentReadWhileWriting is the reason the sink has a mutex
+// at all: GET /status is served from HTTP goroutines while startup (and later
+// the forwarder's heal loop) is still adding. Run under -race.
+func TestWarningSink_ConcurrentReadWhileWriting(t *testing.T) {
+	s := newWarningSink()
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	for r := 0; r < 4; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					_ = s.Warnings()
+					_ = s.WarningsSealed()
+				}
+			}
+		}()
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			s.Add(testWarning("code", "message "+string(rune('a'+i%26)), "hint"))
+		}
+		s.Seal()
+		close(stop)
+	}()
+
+	wg.Wait()
+	assert.Len(t, s.Warnings(), 26, "dedupe held across the concurrent writes")
+	assert.True(t, s.WarningsSealed())
+}
+
+// TestWarningSink_WaitJoinsProducers: Wait is the seal-time join for
+// asynchronous producers — the whole reason a warning can land after the API
+// server is already serving.
+func TestWarningSink_WaitJoinsProducers(t *testing.T) {
+	s := newWarningSink()
+	release := make(chan struct{})
+	s.Go(func() []domain.Warning {
+		<-release
+		return []domain.Warning{testWarning("slow", "produced late", "")}
+	})
+
+	assert.False(t, s.Wait(20*time.Millisecond), "a producer still running must not report finished")
+	assert.Nil(t, s.Warnings(), "and its warning has not landed yet")
+
+	close(release)
+	assert.True(t, s.Wait(2*time.Second))
+	require.Len(t, s.Warnings(), 1)
+	assert.Equal(t, "produced late", s.Warnings()[0].Message)
+}
+
+// TestWarningSink_WaitTimeoutStillCollectsLater: blowing the join budget must
+// not lose the warning — startup seals without it, and it is served the moment
+// it lands.
+func TestWarningSink_WaitTimeoutStillCollectsLater(t *testing.T) {
+	s := newWarningSink()
+	started := make(chan struct{})
+	s.Go(func() []domain.Warning {
+		close(started)
+		time.Sleep(30 * time.Millisecond)
+		return []domain.Warning{testWarning("slow", "late", "")}
+	})
+	<-started
+
+	assert.False(t, s.Wait(time.Millisecond))
+	s.Seal()
+
+	require.True(t, s.Wait(2*time.Second))
+	assert.Len(t, s.Warnings(), 1, "a warning that missed the seal is still recorded")
+}
+
+// TestFormatWarning_ShapeAndHintIndent pins the exact two-line block, hint
+// lined up under the message, and the single line when there is no hint.
+func TestFormatWarning_ShapeAndHintIndent(t *testing.T) {
+	lines := formatWarning(testWarning("c", "mkcert's local CA is not installed.", "Run 'mkcert -install'."))
+	require.Len(t, lines, 2)
+	assert.Equal(t, "Warning: mkcert's local CA is not installed.", lines[0])
+	assert.Equal(t, "         Run 'mkcert -install'.", lines[1])
+	assert.Equal(t, len("Warning: "), strings.Index(lines[1], "Run"),
+		"the hint lines up under the message, not under the label")
+
+	lines = formatWarning(testWarning("c", "no hint here", ""))
+	require.Len(t, lines, 1, "the hint line is omitted entirely when there is no hint")
+	assert.Equal(t, "Warning: no hint here", lines[0])
+}
+
+// TestWriteWarnings_WritesEveryWarningInOrder covers the shared renderer used by
+// `prox status` and the `prox up -d` parent.
+func TestWriteWarnings_WritesEveryWarningInOrder(t *testing.T) {
+	var buf bytes.Buffer
+	writeWarnings(&buf, []domain.Warning{
+		testWarning("a", "first", "do this"),
+		testWarning("b", "second", ""),
+	})
+	assert.Equal(t, "Warning: first\n         do this\nWarning: second\n", buf.String())
+
+	buf.Reset()
+	writeWarnings(&buf, nil)
+	assert.Empty(t, buf.String(), "no warnings, no output")
+}
+
+// TestReportStartupWarnings_PlainModeReachesStderr: plain `prox up` has no
+// preamble, so stderr is the only channel — and it must carry the full block.
+func TestReportStartupWarnings_PlainModeReachesStderr(t *testing.T) {
+	pre := newStartupPreamble(false)
+	var stderr bytes.Buffer
+
+	reportStartupWarnings([]domain.Warning{testWarning("c", "something is off", "fix it")}, pre, &stderr)
+
+	assert.Equal(t, "Warning: something is off\n         fix it\n", stderr.String())
+	assert.Empty(t, pre.Lines(), "a disabled preamble records nothing")
+}
+
+// TestReportStartupWarnings_TUIAlsoRecordsInThePreamble: under a TUI, stderr is
+// about to be hidden behind the alt screen for the whole session, so the same
+// lines have to go into the preamble as well — the reportTUIWarnings contract,
+// applied to domain warnings.
+func TestReportStartupWarnings_TUIAlsoRecordsInThePreamble(t *testing.T) {
+	pre := newStartupPreamble(true)
+	var stderr bytes.Buffer
+
+	reportStartupWarnings([]domain.Warning{testWarning("c", "hidden screen", "look here")}, pre, &stderr)
+
+	assert.Equal(t, []string{"Warning: hidden screen", "         look here"}, pre.Lines())
+	assert.Contains(t, stderr.String(), "Warning: hidden screen",
+		"the stderr copy is kept: a startup that fails before the TUI opens would otherwise lose it")
+}
+
+// TestParseTestWarningSpec_RejectsMalformedSpecs: the integration hook must
+// never be able to break a real startup, so anything it cannot parse is ignored
+// in full.
+func TestParseTestWarningSpec_RejectsMalformedSpecs(t *testing.T) {
+	for _, spec := range []string{
+		"",                     // unset
+		"1s|only-two-fields",   // too few
+		"1s|c|m|h|extra",       // too many
+		"notaduration|c|m",     // bad delay
+		"-5ms|c|m",             // negative delay
+		"1s||m",                // no code
+		"1s|c|",                // no message
+		"just some prose here", // not a spec at all
+	} {
+		_, _, ok := parseTestWarningSpec(spec)
+		assert.False(t, ok, "spec %q must be rejected", spec)
+	}
+
+	delay, w, ok := parseTestWarningSpec("250ms|test_code|the message|the hint")
+	require.True(t, ok)
+	assert.Equal(t, 250*time.Millisecond, delay)
+	assert.Equal(t, domain.Warning{Code: "test_code", Message: "the message", Hint: "the hint"}, w)
+
+	// The hint is optional.
+	_, w, ok = parseTestWarningSpec("0s|test_code|the message")
+	require.True(t, ok)
+	assert.Empty(t, w.Hint)
+}
+
+// TestRegisterTestWarningProducer_IgnoresAnUnsetHook: with the variable unset —
+// every real run — nothing is registered and the seal join is instant.
+func TestRegisterTestWarningProducer_IgnoresAnUnsetHook(t *testing.T) {
+	s := newWarningSink()
+	registerTestWarningProducer(s, "")
+	assert.True(t, s.Wait(time.Millisecond))
+	assert.Nil(t, s.Warnings())
+
+	registerTestWarningProducer(s, "1ms|hooked|hook fired|")
+	assert.True(t, s.Wait(2*time.Second))
+	require.Len(t, s.Warnings(), 1)
+	assert.Equal(t, "hook fired", s.Warnings()[0].Message)
+}
+
+// TestRunStatus_WarningsPrintedButNeverChangeTheExitCode is the `prox status`
+// half of the contract: a warning is advisory, so it prints — and the command
+// still exits 0. A red `prox status` for an untrusted CA would break every
+// script that checks the exit code.
+func TestRunStatus_WarningsPrintedButNeverChangeTheExitCode(t *testing.T) {
+	statusServerWithWarnings(t, []domain.Warning{
+		testWarning(domain.WarningCodeMkcertCAUntrusted, "mkcert's local CA is not installed.", "Run 'mkcert -install'."),
+	})
+
+	var runErr error
+	stdout, _ := captureOutput(t, func() {
+		runErr = runStatus(statusCmd, []string{})
+	})
+
+	assert.NoError(t, runErr, "a warning is not a failure")
+	assert.Contains(t, stdout, "Warning: mkcert's local CA is not installed.")
+	assert.Contains(t, stdout, "         Run 'mkcert -install'.")
+}
+
+// TestRunStatus_NoWarningsPrintsNothingExtra: the section is absent, not empty.
+func TestRunStatus_NoWarningsPrintsNothingExtra(t *testing.T) {
+	statusServerWithWarnings(t, nil)
+
+	var runErr error
+	stdout, _ := captureOutput(t, func() {
+		runErr = runStatus(statusCmd, []string{})
+	})
+
+	assert.NoError(t, runErr)
+	assert.NotContains(t, stdout, "Warning:")
+}
+
+// statusServerWithWarnings starts a fake API server whose status payload
+// carries the given warnings, and points apiAddr at it for the test — the
+// statusServerWithProxy pattern, for the warnings field.
+func statusServerWithWarnings(t *testing.T, warnings []domain.Warning) {
+	t.Helper()
+	originalApiAddr := apiAddr
+	t.Cleanup(func() { apiAddr = originalApiAddr })
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/status":
+			_ = json.NewEncoder(w).Encode(api.StatusResponse{
+				Status:         "running",
+				UptimeSeconds:  10,
+				ConfigFile:     "prox.yaml",
+				APIVersion:     "v1",
+				Warnings:       warnings,
+				WarningsSealed: true,
+			})
+		case "/api/v1/processes":
+			_ = json.NewEncoder(w).Encode(api.ProcessListResponse{Processes: []api.ProcessResponse{
+				{Name: "web", Status: "running", PID: 1234, UptimeSeconds: 5, Health: "healthy"},
+			}})
+		}
+	}))
+	t.Cleanup(server.Close)
+	apiAddr = server.URL
+}
+
+// TestRegisterTestWarningProducer_ReleaseBuildsCannotFabricateWarnings pins that
+// the synthetic producer is inert in anything but a dev build. It is the only
+// mechanism in prox that can show a user a warning nothing observed, and a
+// released binary must not carry that capability.
+func TestRegisterTestWarningProducer_ReleaseBuildsCannotFabricateWarnings(t *testing.T) {
+	orig := version.Version
+	t.Cleanup(func() { version.Version = orig })
+
+	version.Version = "v1.2.3"
+	s := newWarningSink()
+	registerTestWarningProducer(s, "1ms|hooked|hook fired")
+	s.Wait(time.Second)
+	require.Empty(t, s.Warnings(), "a release build must ignore the hook entirely")
+
+	version.Version = "dev"
+	s = newWarningSink()
+	registerTestWarningProducer(s, "1ms|hooked|hook fired")
+	s.Wait(time.Second)
+	require.Len(t, s.Warnings(), 1, "a dev build still runs it, or the suite loses its only latch test")
+}

--- a/internal/domain/process.go
+++ b/internal/domain/process.go
@@ -75,6 +75,61 @@ func (s ProcessState) IsStopped() bool {
 		s == ProcessStateBlocked || s == ProcessStateCompleted
 }
 
+// IsTerminalFailure reports whether the state means the process definitively
+// FAILED. The set is exactly two states, and widening it is a behavior change
+// to the exit codes of `prox up`, `up -d`, `start` and `restart`:
+//
+//   - crashed -- exited unexpectedly, or failed to start. Terminal: prox has
+//     no restart/backoff policy anywhere (there is no RestartPolicy in the
+//     tree), so a crashed process STAYS crashed and this predicate cannot
+//     false-positive on one that is merely mid-relaunch.
+//   - blocked -- a gated process that a failed required dependency will never
+//     let launch.
+//
+// Everything else is NOT a failure: starting and stopping are transient,
+// waiting is limbo (the process is still scheduled to launch), stopped is
+// deliberate, running is the goal, and completed is a task's terminal
+// SUCCESS.
+//
+// Do NOT reach for IsStopped when you mean this: it collapses stopped,
+// crashed, blocked AND completed together, so a task that finished cleanly
+// would be reported as a failed start.
+func (s ProcessState) IsTerminalFailure() bool {
+	return s == ProcessStateCrashed || s == ProcessStateBlocked
+}
+
+// IsLive reports whether the state can still change on its own: running,
+// starting, stopping, or waiting. Against today's 8 states this predicate and
+// IsStopped are arithmetically opposite, but they are kept as two separate
+// functions on purpose: they answer different questions -- "can this still
+// change on its own?" versus "should PID be reported as 0?" -- and a 9th
+// state added later is not guaranteed to answer both the same way. Defining
+// IsLive as "not IsStopped" would make that future drift silent.
+func (s ProcessState) IsLive() bool {
+	return s == ProcessStateRunning || s == ProcessStateStarting ||
+		s == ProcessStateStopping || s == ProcessStateWaiting
+}
+
+// AllProcessStates returns the canonical enumeration of every ProcessState.
+// It exists so tests of the predicates above (and any future one) can be
+// genuinely exhaustive: a table keyed by a literal count like
+// require.Len(cases, 8) does not fail when a 9th state is added, because
+// nothing enumerates the enum against that literal. Iterating this slice
+// does. Returns a fresh slice each call so callers cannot mutate a
+// package-level array.
+func AllProcessStates() []ProcessState {
+	return []ProcessState{
+		ProcessStateRunning,
+		ProcessStateStopped,
+		ProcessStateStarting,
+		ProcessStateStopping,
+		ProcessStateCrashed,
+		ProcessStateWaiting,
+		ProcessStateBlocked,
+		ProcessStateCompleted,
+	}
+}
+
 // ProcessConfig defines the configuration for a single process
 type ProcessConfig struct {
 	Name        string

--- a/internal/domain/process_states_ast_test.go
+++ b/internal/domain/process_states_ast_test.go
@@ -1,0 +1,111 @@
+package domain
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAllProcessStates_MatchesTheEnumDeclaration is the meta-test that makes
+// AllProcessStates trustworthy.
+//
+// Every exhaustive predicate table in this repo -- IsLive/IsTerminalFailure
+// here, isTerminalFailureState in internal/cli, stateLabel in internal/tui --
+// is exhaustive only because it iterates AllProcessStates(). That reduces the
+// whole question to "does AllProcessStates() actually list every state?", and
+// nothing in Go answers it: constants are not enumerable at runtime, so a 9th
+// ProcessState added to the const block but forgotten here would leave every
+// one of those tables silently passing over 8 of 9 states.
+//
+// So this test asks the SOURCE instead. It parses the package's own
+// declarations, collects every constant explicitly typed ProcessState, and
+// requires the set to be exactly what AllProcessStates() returns. Adding a
+// state to the const block without adding it here now fails the build, which
+// is the only version of this guarantee that survives someone who has never
+// read this comment. (Same technique as test/integration/hygiene_test.go,
+// plan 027.)
+func TestAllProcessStates_MatchesTheEnumDeclaration(t *testing.T) {
+	declared := processStateConstsFromSource(t)
+
+	returned := make(map[string]bool, len(AllProcessStates()))
+	for _, s := range AllProcessStates() {
+		require.False(t, returned[string(s)],
+			"AllProcessStates() returns %q more than once", s)
+		returned[string(s)] = true
+	}
+
+	for value, name := range declared {
+		assert.True(t, returned[value],
+			"const %s (%q) is declared as a ProcessState but AllProcessStates() omits it -- "+
+				"add it there, or every exhaustive predicate table in this repo silently skips it",
+			name, value)
+	}
+	for value := range returned {
+		_, ok := declared[value]
+		assert.True(t, ok,
+			"AllProcessStates() returns %q, which is not declared as a ProcessState constant "+
+				"in this package -- a stale or misspelled entry", value)
+	}
+}
+
+// processStateConstsFromSource returns value -> constant name for every
+// constant in this package explicitly typed ProcessState. Test files are
+// excluded: a fixture declaring its own state must not count as part of the
+// enum.
+func processStateConstsFromSource(t *testing.T) map[string]string {
+	t.Helper()
+
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, ".", func(fi fs.FileInfo) bool {
+		return !strings.HasSuffix(fi.Name(), "_test.go")
+	}, 0)
+	require.NoError(t, err, "parsing the domain package's own source")
+
+	found := make(map[string]string)
+	for _, pkg := range pkgs {
+		for _, file := range pkg.Files {
+			for _, decl := range file.Decls {
+				gen, ok := decl.(*ast.GenDecl)
+				if !ok || gen.Tok != token.CONST {
+					continue
+				}
+				for _, spec := range gen.Specs {
+					vs, ok := spec.(*ast.ValueSpec)
+					if !ok {
+						continue
+					}
+					ident, ok := vs.Type.(*ast.Ident)
+					if !ok || ident.Name != "ProcessState" {
+						continue
+					}
+					for i, name := range vs.Names {
+						if i >= len(vs.Values) {
+							continue
+						}
+						lit, ok := vs.Values[i].(*ast.BasicLit)
+						if !ok || lit.Kind != token.STRING {
+							continue
+						}
+						value, err := strconv.Unquote(lit.Value)
+						require.NoError(t, err, "unquoting %s's value", name.Name)
+						found[value] = name.Name
+					}
+				}
+			}
+		}
+	}
+
+	// A parser that silently matched nothing would make this whole test a
+	// no-op that passes forever.
+	require.NotEmpty(t, found,
+		"found no ProcessState constants in the package source -- the AST walk is broken, "+
+			"not the enum")
+	return found
+}

--- a/internal/domain/process_test.go
+++ b/internal/domain/process_test.go
@@ -130,9 +130,15 @@ func TestProcessState_IsLiveAndIsTerminalFailure(t *testing.T) {
 			assert.Equal(t, tt.wantTerminalFailure, state.IsTerminalFailure(), "IsTerminalFailure")
 
 			// The two predicates must never both be true for the same state: a
-			// state cannot be both "still changing on its own" and "definitively
-			// failed".
-			assert.False(t, tt.wantLive && tt.wantTerminalFailure, "state %q cannot be both live and a terminal failure", state)
+			// state cannot be both "still changing on its own" and
+			// "definitively failed".
+			//
+			// Asserted on the METHOD results, not on the table literals above.
+			// Reading tt.wantLive && tt.wantTerminalFailure here would only
+			// prove the table is self-consistent, and would pass against any
+			// implementation at all (CodeRabbit, PR #110).
+			assert.False(t, state.IsLive() && state.IsTerminalFailure(),
+				"state %q cannot be both live and a terminal failure", state)
 		})
 	}
 }

--- a/internal/domain/process_test.go
+++ b/internal/domain/process_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestProcessState_String(t *testing.T) {
@@ -70,6 +71,68 @@ func TestProcessState_IsStopped(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.state.String(), func(t *testing.T) {
 			assert.Equal(t, tt.want, tt.state.IsStopped())
+		})
+	}
+}
+
+func TestAllProcessStates(t *testing.T) {
+	want := []ProcessState{
+		ProcessStateRunning,
+		ProcessStateStopped,
+		ProcessStateStarting,
+		ProcessStateStopping,
+		ProcessStateCrashed,
+		ProcessStateWaiting,
+		ProcessStateBlocked,
+		ProcessStateCompleted,
+	}
+	got := AllProcessStates()
+	assert.ElementsMatch(t, want, got)
+	assert.Len(t, got, 8)
+
+	seen := make(map[ProcessState]bool, len(got))
+	for _, s := range got {
+		assert.False(t, seen[s], "duplicate state %q", s)
+		seen[s] = true
+	}
+
+	// The returned slice must be a fresh copy each call: mutating it must not
+	// affect a later call.
+	got[0] = "mutated"
+	assert.NotEqual(t, ProcessState("mutated"), AllProcessStates()[0])
+}
+
+// TestProcessState_IsLiveAndIsTerminalFailure pins IsLive and
+// IsTerminalFailure against every member of AllProcessStates, keyed by state
+// so an unlisted new state fails the length assertion rather than silently
+// passing with a default zero value.
+func TestProcessState_IsLiveAndIsTerminalFailure(t *testing.T) {
+	cases := map[ProcessState]struct {
+		wantLive            bool
+		wantTerminalFailure bool
+	}{
+		ProcessStateRunning:   {wantLive: true, wantTerminalFailure: false},
+		ProcessStateStopped:   {wantLive: false, wantTerminalFailure: false},
+		ProcessStateStarting:  {wantLive: true, wantTerminalFailure: false},
+		ProcessStateStopping:  {wantLive: true, wantTerminalFailure: false},
+		ProcessStateCrashed:   {wantLive: false, wantTerminalFailure: true},
+		ProcessStateWaiting:   {wantLive: true, wantTerminalFailure: false},
+		ProcessStateBlocked:   {wantLive: false, wantTerminalFailure: true},
+		ProcessStateCompleted: {wantLive: false, wantTerminalFailure: false},
+	}
+	require.Len(t, cases, len(AllProcessStates()), "every state in AllProcessStates must be classified here")
+
+	for _, state := range AllProcessStates() {
+		tt, ok := cases[state]
+		require.True(t, ok, "state %q not classified", state)
+		t.Run(state.String(), func(t *testing.T) {
+			assert.Equal(t, tt.wantLive, state.IsLive(), "IsLive")
+			assert.Equal(t, tt.wantTerminalFailure, state.IsTerminalFailure(), "IsTerminalFailure")
+
+			// The two predicates must never both be true for the same state: a
+			// state cannot be both "still changing on its own" and "definitively
+			// failed".
+			assert.False(t, tt.wantLive && tt.wantTerminalFailure, "state %q cannot be both live and a terminal failure", state)
 		})
 	}
 }

--- a/internal/domain/warning.go
+++ b/internal/domain/warning.go
@@ -33,6 +33,14 @@ const (
 	// through the proxy will show certificate errors until `mkcert -install`
 	// runs.
 	WarningCodeMkcertCAUntrusted = "mkcert_ca_untrusted"
+
+	// WarningCodeHostnameUnresolved means one or more of this session's
+	// registered `<service>.<domain>` hostnames did not resolve via DNS on
+	// this machine — e.g. a `.test` domain, which does not resolve without
+	// local setup, as opposed to a public wildcard like `*.lvh.me`. Pasting
+	// such a hostname into a browser gets NXDOMAIN even though prox itself is
+	// listening (issue #98).
+	WarningCodeHostnameUnresolved = "hostname_unresolved"
 )
 
 // DedupeWarnings returns ws with duplicates (same Code AND Message) removed,

--- a/internal/domain/warning.go
+++ b/internal/domain/warning.go
@@ -1,0 +1,62 @@
+package domain
+
+// Warning is a single user-facing advisory produced somewhere the person who
+// typed the command cannot see — most importantly inside the shared proxy
+// daemon, whose stdout/stderr are /dev/null (internal/proxyd/daemon.go). It is
+// the one warning shape on the wire: internal/proxyd and internal/api both use
+// this type DIRECTLY rather than each defining a look-alike DTO plus a mapper,
+// because two near-identical structs are exactly how Code and Hint wording
+// drifts apart between the daemon that emits a warning and the CLI that prints
+// it.
+//
+// Message and Hint are already user-facing prose, not error strings to be
+// wrapped: whatever produces a Warning owns the wording, and the CLI prints it
+// verbatim.
+type Warning struct {
+	// Code is a stable machine identifier for the warning kind (e.g.
+	// WarningCodeMkcertCAUntrusted). It never changes wording, so clients and
+	// tests can key off it; use the constants below rather than literals.
+	Code string `json:"code"`
+	// Message is one or more complete, user-facing sentences describing what is
+	// wrong.
+	Message string `json:"message"`
+	// Hint is the next action the user should take, when there is one.
+	Hint string `json:"hint,omitempty"`
+}
+
+// Warning codes. Both the producer (the daemon's cert layer) and the consumer
+// (the CLI) reference these constants so a warning cannot be emitted under one
+// spelling and matched under another.
+const (
+	// WarningCodeMkcertCAUntrusted means mkcert generated certificates but its
+	// local CA is not installed in the system/browser trust stores, so HTTPS
+	// through the proxy will show certificate errors until `mkcert -install`
+	// runs.
+	WarningCodeMkcertCAUntrusted = "mkcert_ca_untrusted"
+)
+
+// DedupeWarnings returns ws with duplicates (same Code AND Message) removed,
+// preserving first-seen order. Hint is deliberately NOT part of the identity:
+// two warnings that say the same thing are one warning to the user even if a
+// producer attached a hint to only one of them, and the first-seen copy (hint
+// and all) is the one kept.
+//
+// It is safe on nil and empty input, returning nil so an omitempty JSON field
+// disappears rather than serializing as [].
+func DedupeWarnings(ws []Warning) []Warning {
+	if len(ws) == 0 {
+		return nil
+	}
+	type key struct{ code, message string }
+	seen := make(map[key]struct{}, len(ws))
+	out := make([]Warning, 0, len(ws))
+	for _, w := range ws {
+		k := key{w.Code, w.Message}
+		if _, dup := seen[k]; dup {
+			continue
+		}
+		seen[k] = struct{}{}
+		out = append(out, w)
+	}
+	return out
+}

--- a/internal/domain/warning_test.go
+++ b/internal/domain/warning_test.go
@@ -1,0 +1,66 @@
+package domain
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDedupeWarnings pins the identity rule: same Code AND Message collapses,
+// same Code with a different Message does not, and first-seen order survives.
+func TestDedupeWarnings(t *testing.T) {
+	t.Run("nil and empty are safe", func(t *testing.T) {
+		assert.Nil(t, DedupeWarnings(nil))
+		assert.Nil(t, DedupeWarnings([]Warning{}), "empty must collapse to nil so omitempty drops the key")
+	})
+
+	t.Run("same code and message collapses", func(t *testing.T) {
+		w := Warning{Code: WarningCodeMkcertCAUntrusted, Message: "CA is not trusted.", Hint: "Run mkcert -install."}
+		got := DedupeWarnings([]Warning{w, w, w})
+		require.Len(t, got, 1)
+		assert.Equal(t, w, got[0], "the first-seen copy, hint and all, is kept")
+	})
+
+	t.Run("same code different message is kept", func(t *testing.T) {
+		a := Warning{Code: WarningCodeMkcertCAUntrusted, Message: "CA is not trusted."}
+		b := Warning{Code: WarningCodeMkcertCAUntrusted, Message: "CA is not trusted for firefox."}
+		got := DedupeWarnings([]Warning{a, b})
+		assert.Equal(t, []Warning{a, b}, got, "the message is part of the identity, not just the code")
+	})
+
+	t.Run("hint is not part of the identity", func(t *testing.T) {
+		withHint := Warning{Code: "c", Message: "m", Hint: "do the thing"}
+		noHint := Warning{Code: "c", Message: "m"}
+		got := DedupeWarnings([]Warning{withHint, noHint})
+		require.Len(t, got, 1, "same code+message is one warning to the user regardless of hint")
+		assert.Equal(t, withHint, got[0], "the first-seen copy wins, keeping its hint")
+	})
+
+	t.Run("first-seen order is preserved", func(t *testing.T) {
+		a := Warning{Code: "a", Message: "1"}
+		b := Warning{Code: "b", Message: "2"}
+		c := Warning{Code: "c", Message: "3"}
+		got := DedupeWarnings([]Warning{b, a, b, c, a})
+		assert.Equal(t, []Warning{b, a, c}, got)
+	})
+
+	t.Run("input is not mutated", func(t *testing.T) {
+		in := []Warning{{Code: "a", Message: "1"}, {Code: "a", Message: "1"}, {Code: "b", Message: "2"}}
+		_ = DedupeWarnings(in)
+		assert.Equal(t, []Warning{{Code: "a", Message: "1"}, {Code: "a", Message: "1"}, {Code: "b", Message: "2"}}, in)
+	})
+}
+
+// TestWarning_JSONShape pins the wire field names and that an absent Hint is
+// omitted (the CLI renders a hintless warning differently).
+func TestWarning_JSONShape(t *testing.T) {
+	b, err := json.Marshal(Warning{Code: "c", Message: "m"})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"code":"c","message":"m"}`, string(b))
+
+	b, err = json.Marshal(Warning{Code: "c", Message: "m", Hint: "h"})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"code":"c","message":"m","hint":"h"}`, string(b))
+}

--- a/internal/proxy/certs/certs.go
+++ b/internal/proxy/certs/certs.go
@@ -3,6 +3,7 @@
 package certs
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -16,6 +17,11 @@ import (
 type Manager struct {
 	certsDir string
 	domain   string
+	// trust is where this manager reports what mkcert said about its own local
+	// CA. It is process-scoped, not manager-scoped (see TrustResolver): every
+	// manager in a process feeds the same verdict, so one real generation
+	// answers for every other manager and spares them the probe.
+	trust *TrustResolver
 }
 
 // CertPaths contains the paths to the certificate and key files.
@@ -24,11 +30,24 @@ type CertPaths struct {
 	KeyFile  string
 }
 
-// NewManager creates a new certificate manager.
+// NewManager creates a new certificate manager reporting to the process-wide
+// trust resolver.
 func NewManager(certsDir, domain string) *Manager {
+	return NewManagerWithTrust(certsDir, domain, SharedTrust())
+}
+
+// NewManagerWithTrust is NewManager with an explicit trust resolver. It exists
+// for callers that own a resolver deliberately — chiefly tests, which must not
+// have one test's mkcert verdict latched into the next test's process-wide
+// resolver.
+func NewManagerWithTrust(certsDir, domain string, trust *TrustResolver) *Manager {
+	if trust == nil {
+		trust = SharedTrust()
+	}
 	return &Manager{
 		certsDir: expandPath(certsDir),
 		domain:   domain,
+		trust:    trust,
 	}
 }
 
@@ -43,21 +62,33 @@ func (m *Manager) CheckMkcert() error {
 
 // EnsureCerts ensures that valid certificates exist for the configured domain.
 // If certificates don't exist, they will be generated.
-// Returns the paths to the certificate and key files.
-func (m *Manager) EnsureCerts() (*CertPaths, error) {
+//
+// It returns the paths to the certificate and key files plus the notable lines
+// mkcert printed while generating them — empty when nothing was generated,
+// because the certs were already on disk. Those lines are the only channel
+// mkcert's advice has: in shared mode this runs inside the daemon, whose
+// stdout and stderr are /dev/null (internal/proxyd/daemon.go), so anything
+// mkcert says is discarded outright unless it is captured here.
+//
+// The lines are also fed to the process-wide TrustResolver, so a generation
+// that happened for ANY domain answers the CA-trust question for the whole
+// process for free.
+func (m *Manager) EnsureCerts() (*CertPaths, []string, error) {
 	paths := m.getCertPaths()
 
 	// Check if certificates already exist
 	if m.certsExist(paths) {
-		return paths, nil
+		return paths, nil, nil
 	}
 
 	// Generate new certificates
-	if err := m.generateCerts(paths); err != nil {
-		return nil, err
+	out, err := m.generateCerts(paths)
+	if err != nil {
+		return nil, out, err
 	}
+	m.trust.observe(out)
 
-	return paths, nil
+	return paths, out, nil
 }
 
 func (m *Manager) getCertPaths() *CertPaths {
@@ -79,14 +110,23 @@ func (m *Manager) certsExist(paths *CertPaths) bool {
 	return true
 }
 
-func (m *Manager) generateCerts(paths *CertPaths) error {
+// generateCerts shells to mkcert and returns the notable lines it printed.
+//
+// It CAPTURES mkcert's combined stdout and stderr rather than wiring them to
+// this process's own streams, which is what makes the CA-untrusted note usable
+// at all: in the shared daemon those streams are /dev/null, so the one warning
+// that tells a user why every HTTPS request in their browser fails was being
+// thrown away. Captured, it reaches the person who typed the command — and on
+// failure it is attached to the error, which is a strict improvement over
+// today for the same reason.
+func (m *Manager) generateCerts(paths *CertPaths) ([]string, error) {
 	if err := m.CheckMkcert(); err != nil {
-		return err
+		return nil, err
 	}
 
 	// Ensure the certs directory exists
 	if err := os.MkdirAll(m.certsDir, constants.DirPermissionPrivate); err != nil {
-		return fmt.Errorf("creating certs directory: %w", err)
+		return nil, fmt.Errorf("creating certs directory: %w", err)
 	}
 
 	// Generate wildcard certificate for the domain
@@ -98,14 +138,26 @@ func (m *Manager) generateCerts(paths *CertPaths) error {
 		wildcardDomain,
 		m.domain,
 	)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	// Capturing into a buffer means exec creates a pipe and Wait blocks until
+	// EOF -- so any grandchild mkcert leaves holding that pipe would hang
+	// EnsureCerts, and with it register() under lifecycleMu (CodeRabbit
+	// review). Before the capture, Stdout was an *os.File handed over as a raw
+	// fd and Wait only waited on the process.
+	cmd.WaitDelay = probeWaitDelay
 
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("generating certificates for %s: %w", m.domain, err)
+		lines := notableLines(buf.String())
+		if len(lines) > 0 {
+			return lines, fmt.Errorf("generating certificates for %s: %w\nmkcert output:\n%s",
+				m.domain, err, strings.Join(lines, "\n"))
+		}
+		return nil, fmt.Errorf("generating certificates for %s: %w", m.domain, err)
 	}
 
-	return nil
+	return notableLines(buf.String()), nil
 }
 
 // expandPath expands ~ to the user's home directory

--- a/internal/proxy/certs/certs.go
+++ b/internal/proxy/certs/certs.go
@@ -4,6 +4,7 @@ package certs
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -132,7 +133,19 @@ func (m *Manager) generateCerts(paths *CertPaths) ([]string, error) {
 	// Generate wildcard certificate for the domain
 	// mkcert -cert-file <cert> -key-file <key> "*.domain" "domain"
 	wildcardDomain := fmt.Sprintf("*.%s", m.domain)
-	cmd := exec.Command("mkcert",
+	// Bounded, because this runs inside register() while the daemon holds
+	// lifecycleMu: an mkcert that never returns would wedge every other
+	// project's registration and the shutdown barrier with it. The bound is
+	// deliberately generous -- issuing one certificate is sub-second, and this
+	// exists to break a hang, not to race a slow machine (CodeRabbit, PR #110;
+	// the unbounded exec predates plan 028).
+	//
+	// WaitDelay is NOT a substitute: it only bounds pipe cleanup AFTER the
+	// process exits, which is the separate hazard the capture below introduced.
+	// Both are needed, and they cover different failures.
+	ctx, cancel := context.WithTimeout(context.Background(), mkcertGenerateTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "mkcert",
 		"-cert-file", paths.CertFile,
 		"-key-file", paths.KeyFile,
 		wildcardDomain,

--- a/internal/proxy/certs/trust.go
+++ b/internal/proxy/certs/trust.go
@@ -51,6 +51,13 @@ const trustProbeTimeout = 5 * time.Second
 // still took 60s to return.)
 const probeWaitDelay = 500 * time.Millisecond
 
+// mkcertGenerateTimeout bounds a real certificate generation. Generation runs
+// inside the daemon's register() under lifecycleMu, so an mkcert that hangs
+// would take every other project's registration down with it. Far more
+// generous than trustProbeTimeout because this one does real work a user is
+// waiting on, rather than answering a diagnostic question.
+const mkcertGenerateTimeout = 60 * time.Second
+
 // probeHostname is the name the probe asks mkcert to certify. It is under the
 // reserved .invalid TLD (RFC 2606), so the throwaway certificate can never be
 // valid for anything real, and the name cannot resolve.
@@ -159,14 +166,38 @@ type TrustResolver struct {
 	// probeMu serializes the probe itself. It is separate from mu so the state
 	// lock is never held across an exec, and probed (guarded by it) is what
 	// makes the probe at-most-once even if the first attempt fails.
-	probeMu sync.Mutex
-	probed  bool
+	probeMu   sync.Mutex
+	probed    bool
+	lastProbe time.Time
+
+	// now is time.Now, swappable in tests. Nothing else in this file reads the
+	// clock, so a test can drive the re-probe interval without sleeping.
+	now func() time.Time
 }
+
+// reProbeInterval is the floor between re-probes while the verdict is BAD.
+//
+// Re-asking is what lets a fixed machine stop being warned at (see Resolve),
+// but the probe runs inside the daemon's register() under lifecycleMu, so an
+// unthrottled one would make every registration on a broken machine pay for a
+// subprocess while every other project waits (CodeRabbit, PR #110). A user who
+// runs `mkcert -install` and re-runs `prox up` is not doing it twice within
+// this window, so the floor costs them nothing.
+const reProbeInterval = 30 * time.Second
 
 // NewTrustResolver returns a resolver with no verdict yet. Production code uses
 // SharedTrust; this exists so a test can have a resolver whose once-per-process
 // latch is its own.
-func NewTrustResolver() *TrustResolver { return &TrustResolver{} }
+func NewTrustResolver() *TrustResolver { return &TrustResolver{now: time.Now} }
+
+// clock reads the resolver's time source, defaulting to time.Now so a
+// zero-value TrustResolver stays usable.
+func (r *TrustResolver) clock() time.Time {
+	if r.now == nil {
+		return time.Now()
+	}
+	return r.now()
+}
 
 // sharedTrust is the process-wide resolver. Every production caller shares it,
 // which is what lets a real generation in one component answer for a probe that
@@ -235,7 +266,16 @@ func (r *TrustResolver) Resolve(ctx context.Context) TrustVerdict {
 	if !r.verdict().Known && r.probed {
 		return TrustVerdict{}
 	}
+	// Re-asking a BAD verdict is throttled: see reProbeInterval. Until the
+	// window elapses the held verdict stands, so the warning keeps being
+	// reported -- it just is not re-derived on every single registration.
+	if v := r.verdict(); v.Known && v.Warning != nil {
+		if !r.lastProbe.IsZero() && r.clock().Sub(r.lastProbe) < reProbeInterval {
+			return v
+		}
+	}
 	r.probed = true
+	r.lastProbe = r.clock()
 
 	lines, ok := probeCATrust(ctx)
 	if !ok {

--- a/internal/proxy/certs/trust.go
+++ b/internal/proxy/certs/trust.go
@@ -1,0 +1,316 @@
+package certs
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/charliek/prox/internal/domain"
+)
+
+// caUntrustedMarker is the case-insensitive STEM shared by both of the strings
+// mkcert prints when it issues a certificate while its own local CA is missing
+// from the trust stores:
+//
+//	Note: the local CA is not installed in the system trust store.
+//	Note: the local CA is not installed in the %s trust store.
+//
+// Matching on the stem rather than on either full string is deliberate: the
+// second is a format string whose verb is filled with "Firefox and/or
+// Chrome/Chromium", so no single literal covers both, and the trailing wording
+// is exactly the part mkcert is free to reword.
+//
+// This is the WHOLE of prox's trust detection, and that is the point. Whether a
+// CA is installed is per-OS, per-OS-release, and per-browser; mkcert already
+// implements it correctly, and a second implementation living here would be
+// wrong in ways nobody notices. prox therefore never inspects a trust store —
+// it reads mkcert's own verdict, and carries mkcert's own sentence to the user.
+const caUntrustedMarker = "the local ca is not installed in"
+
+// mkcertInstallHint is the next action for an untrusted CA. It is a constant
+// (not prose repeated at each producer) because the daemon and the standalone
+// CLI both emit this warning, and two copies is how two wordings happen.
+const mkcertInstallHint = "run 'mkcert -install' and restart prox"
+
+// trustProbeTimeout bounds the probe. mkcert issuing one certificate is fast
+// (well under a second); the budget exists so a wedged binary cannot stall a
+// registration or a startup, not because the work is slow.
+const trustProbeTimeout = 5 * time.Second
+
+// probeWaitDelay is how long a killed probe gets to release its pipes before
+// exec abandons them. It is NOT decoration: the probe captures into a buffer,
+// so exec.Cmd.Wait waits on the copy goroutines, and any grandchild the killed
+// mkcert left behind still holds the write end — without this, a cancelled
+// probe blocks until that grandchild exits, defeating the whole timeout. (A
+// test with a stalling fake mkcert caught exactly that: cancelling at 200ms
+// still took 60s to return.)
+const probeWaitDelay = 500 * time.Millisecond
+
+// probeHostname is the name the probe asks mkcert to certify. It is under the
+// reserved .invalid TLD (RFC 2606), so the throwaway certificate can never be
+// valid for anything real, and the name cannot resolve.
+const probeHostname = "prox-trust-probe.invalid"
+
+// caRootFile is the file whose existence means mkcert already HAS a local CA.
+const caRootFile = "rootCA.pem"
+
+// caUntrustedWarning is the ONE place a captured mkcert line becomes a
+// domain.Warning. Both producers — the shared daemon (internal/proxyd/certs.go)
+// and standalone mode (internal/cli/up.go) — reach it through Resolve, so the
+// code and the hint cannot drift between the two paths that show a user the
+// same problem.
+//
+// The message is mkcert's own line VERBATIM. prox does not paraphrase it: the
+// sentence a user then searches for, or pastes into an issue, is the one the
+// tool that detected the problem actually wrote.
+func caUntrustedWarning(line string) domain.Warning {
+	return domain.Warning{
+		Code:    domain.WarningCodeMkcertCAUntrusted,
+		Message: line,
+		Hint:    mkcertInstallHint,
+	}
+}
+
+// notableLines splits captured mkcert output into non-empty, trimmed lines.
+// Callers hand these to a user or to an error, so trailing blank lines and the
+// final newline are noise.
+func notableLines(out string) []string {
+	var lines []string
+	for _, raw := range strings.Split(out, "\n") {
+		if line := strings.TrimSpace(raw); line != "" {
+			lines = append(lines, line)
+		}
+	}
+	return lines
+}
+
+// javaStoreMarker identifies mkcert's note about the JAVA trust store, which
+// this warning deliberately IGNORES.
+//
+// mkcert checks the system store, the NSS (Firefox/Chrome) stores and the Java
+// store independently, and prints a separate note for each one that is missing.
+// The Java store has nothing to do with #97: a machine where `mkcert -install`
+// ran and a JDK was installed afterwards prints ONLY the Java note, and warning
+// there would tell a user their HTTPS is broken when every browser on the
+// machine works fine. That is a false alarm, which is the same failure as the
+// missing warning this feature exists to fix, pointed the other way.
+const javaStoreMarker = "java trust store"
+
+// findCAUntrustedLine returns the first line reporting a trust store that
+// actually affects browsing. mkcert can print the note once per store it
+// checked; the user has one fix, so the first relevant line answers for all of
+// them, and Java-only output is not an answer at all.
+func findCAUntrustedLine(lines []string) (string, bool) {
+	for _, line := range lines {
+		lower := strings.ToLower(line)
+		if !strings.Contains(lower, caUntrustedMarker) {
+			continue
+		}
+		if strings.Contains(lower, javaStoreMarker) {
+			continue
+		}
+		return line, true
+	}
+	return "", false
+}
+
+// TrustVerdict is what this process knows about mkcert's local CA.
+//
+// Known separates "we asked and the CA IS trusted" from "we could not find
+// out", which is the distinction that makes the warning withdrawable: only the
+// first justifies CLEARING a previously reported warning. Treating unknown as
+// trusted would silently retract a true warning; treating it as untrusted would
+// invent a false one.
+type TrustVerdict struct {
+	// Known is true once mkcert has actually told us, one way or the other.
+	Known bool
+	// Warning is non-nil exactly when the CA is NOT installed in the trust
+	// stores. It is built by caUntrustedWarning, so its Code and Hint are the
+	// same whichever producer surfaces it.
+	Warning *domain.Warning
+}
+
+// TrustResolver answers "is mkcert's local CA installed in the trust stores?"
+// ONCE PER PROCESS.
+//
+// Process scope, not per-domain scope, because that is the scope of the fact:
+// the CA is a property of the machine and the user's trust stores, not of any
+// base domain prox happens to serve.
+//
+// Once, because of how the answer is obtained. mkcert only speaks when it
+// generates something, and generation only happens when the cert FILES are
+// absent (see EnsureCerts). A daemon restarted onto a new release — which
+// RELEASING.md requires after every release — starts with warm certs on disk
+// and would never run mkcert again, so without a deliberate probe the whole
+// feature would do nothing for most users, most of the time. The probe closes
+// that hole; running it at most once keeps it off the per-registration path.
+//
+// The zero value is a usable resolver that has not asked anything yet.
+type TrustResolver struct {
+	mu      sync.Mutex
+	known   bool
+	warning *domain.Warning
+
+	// probeMu serializes the probe itself. It is separate from mu so the state
+	// lock is never held across an exec, and probed (guarded by it) is what
+	// makes the probe at-most-once even if the first attempt fails.
+	probeMu sync.Mutex
+	probed  bool
+}
+
+// NewTrustResolver returns a resolver with no verdict yet. Production code uses
+// SharedTrust; this exists so a test can have a resolver whose once-per-process
+// latch is its own.
+func NewTrustResolver() *TrustResolver { return &TrustResolver{} }
+
+// sharedTrust is the process-wide resolver. Every production caller shares it,
+// which is what lets a real generation in one component answer for a probe that
+// another component would otherwise have to run.
+var sharedTrust = NewTrustResolver()
+
+// SharedTrust returns the process-wide resolver (see TrustResolver).
+func SharedTrust() *TrustResolver { return sharedTrust }
+
+// observe records the verdict implied by a real mkcert run's captured output.
+// It is called for every genuine generation, so the free answer is always
+// preferred to the probe.
+func (r *TrustResolver) observe(lines []string) {
+	line, untrusted := findCAUntrustedLine(lines)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.known = true
+	if !untrusted {
+		r.warning = nil
+		return
+	}
+	w := caUntrustedWarning(line)
+	r.warning = &w
+}
+
+// verdict returns the currently held answer.
+func (r *TrustResolver) verdict() TrustVerdict {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return TrustVerdict{Known: r.known, Warning: r.warning}
+}
+
+// Resolve returns this process's verdict, running the probe at most once if
+// nothing has answered yet.
+//
+// It never fails and never blocks longer than trustProbeTimeout: every probe
+// failure — no mkcert, no CA, a timeout, a non-zero exit — yields an unknown
+// verdict, which records nothing and clears nothing. A diagnostic that cannot
+// be produced must not become a startup error.
+func (r *TrustResolver) Resolve(ctx context.Context) TrustVerdict {
+	// A settled GOOD verdict is final for the life of the process: a CA that is
+	// installed does not spontaneously stop being installed, so re-asking would
+	// pay for a subprocess on every registration forever to learn nothing.
+	if v := r.verdict(); v.Known && v.Warning == nil {
+		return v
+	}
+
+	r.probeMu.Lock()
+	defer r.probeMu.Unlock()
+	if v := r.verdict(); v.Known && v.Warning == nil {
+		return v
+	}
+
+	// A settled BAD verdict is re-asked, and that is what makes the warning's
+	// own hint true. The hint tells the user to run `mkcert -install` and
+	// restart prox — but in shared mode the DAEMON holds this verdict and
+	// outlives their restart, so a latched "untrusted" would keep being
+	// reported at a machine the user had already fixed. Re-probing while the
+	// answer is bad costs one short subprocess per registration, and only ever
+	// while something is actually wrong; once mkcert says the CA is installed,
+	// the branch above makes it free again forever.
+	//
+	// The at-most-once latch therefore applies only to the UNKNOWN case, where
+	// a probe that could not answer (no mkcert, no CA, a failure) must not be
+	// retried on every registration for the life of the process.
+	if !r.verdict().Known && r.probed {
+		return TrustVerdict{}
+	}
+	r.probed = true
+
+	lines, ok := probeCATrust(ctx)
+	if !ok {
+		// Return whatever is currently held rather than a bare zero value: a
+		// real generation may have recorded a verdict while this probe ran, and
+		// discarding it would report "unknown" over a known answer.
+		return r.verdict()
+	}
+	r.observe(lines)
+	return r.verdict()
+}
+
+// probeCATrust asks mkcert about the CA without prox having to know anything
+// about trust stores: it issues a throwaway certificate for an inert name into
+// a temp directory and reads the note mkcert prints. The temp directory (and
+// therefore the certificate and its key) is deleted before returning.
+//
+// It runs ONLY when a CA already exists. mkcert CREATES a local CA when it
+// finds none, and prox generating a CA as the side effect of a diagnostic —
+// installing nothing, explaining nothing — would be a far worse behaviour than
+// the missing warning it was trying to produce. Checking for rootCA.pem is not
+// a reimplementation of trust-store detection: it is only "has mkcert been run
+// at all"; the trust verdict itself still comes from mkcert's own output.
+//
+// ok is false for every failure, and the caller ignores it entirely.
+func probeCATrust(ctx context.Context) ([]string, bool) {
+	ctx, cancel := context.WithTimeout(ctx, trustProbeTimeout)
+	defer cancel()
+
+	if _, err := exec.LookPath("mkcert"); err != nil {
+		return nil, false
+	}
+	caroot, ok := mkcertCAROOT(ctx)
+	if !ok {
+		return nil, false
+	}
+	if _, err := os.Stat(filepath.Join(caroot, caRootFile)); err != nil {
+		return nil, false // no CA yet: never provoke mkcert into creating one
+	}
+
+	dir, err := os.MkdirTemp("", "prox-catrust-")
+	if err != nil {
+		return nil, false
+	}
+	defer func() { _ = os.RemoveAll(dir) }()
+
+	var buf bytes.Buffer
+	cmd := exec.CommandContext(ctx, "mkcert",
+		"-cert-file", filepath.Join(dir, "probe.pem"),
+		"-key-file", filepath.Join(dir, "probe-key.pem"),
+		probeHostname,
+	)
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	cmd.WaitDelay = probeWaitDelay
+	if err := cmd.Run(); err != nil {
+		return nil, false
+	}
+	return notableLines(buf.String()), true
+}
+
+// mkcertCAROOT reads the directory mkcert keeps its CA in. Asking mkcert beats
+// reconstructing the path from CAROOT/XDG_DATA_HOME/%LOCALAPPDATA% rules that
+// differ per platform — the same argument as the rest of this file.
+func mkcertCAROOT(ctx context.Context) (string, bool) {
+	var out bytes.Buffer
+	cmd := exec.CommandContext(ctx, "mkcert", "-CAROOT")
+	cmd.Stdout = &out
+	cmd.WaitDelay = probeWaitDelay
+	if err := cmd.Run(); err != nil {
+		return "", false
+	}
+	caroot := strings.TrimSpace(out.String())
+	if caroot == "" {
+		return "", false
+	}
+	return caroot, true
+}

--- a/internal/proxy/certs/trust_test.go
+++ b/internal/proxy/certs/trust_test.go
@@ -346,11 +346,27 @@ func TestTrustResolver_BadVerdictIsReAsked(t *testing.T) {
 		Stdout: mkcertCreatedNote + "\n" + mkcertSystemNote + "\n",
 	})
 	tr := NewTrustResolver()
+	// Drive the clock rather than sleep: re-probing a bad verdict is throttled
+	// by reProbeInterval so a broken machine does not shell out on every single
+	// registration (CodeRabbit, PR #110), and this test is about the re-ask
+	// happening at all, not about how long it waits.
+	clock := time.Now()
+	tr.now = func() time.Time { return clock }
 
 	v := tr.Resolve(context.Background())
 	require.NotNil(t, v.Warning, "precondition: the CA is reported untrusted")
 
-	// Still broken: prox keeps asking rather than trusting a stale verdict.
+	// Inside the throttle window the held verdict stands, and no subprocess
+	// runs -- the warning is still reported, just not re-derived.
+	before := len(fake.generationCalls(t))
+	v = tr.Resolve(context.Background())
+	require.NotNil(t, v.Warning, "the warning keeps being reported while throttled")
+	require.Equal(t, before, len(fake.generationCalls(t)),
+		"a re-ask inside the throttle window must not shell out")
+
+	// Past the window: still broken, so prox asks again rather than trusting a
+	// stale verdict.
+	clock = clock.Add(reProbeInterval + time.Second)
 	v = tr.Resolve(context.Background())
 	require.NotNil(t, v.Warning)
 	require.GreaterOrEqual(t, len(fake.generationCalls(t)), 2,
@@ -358,15 +374,18 @@ func TestTrustResolver_BadVerdictIsReAsked(t *testing.T) {
 
 	// The user runs `mkcert -install`: mkcert stops printing the note.
 	fake.setStdout(t, mkcertCreatedNote+"\n")
+	clock = clock.Add(reProbeInterval + time.Second)
 
 	v = tr.Resolve(context.Background())
 	require.True(t, v.Known)
 	assert.Nil(t, v.Warning, "the warning must be withdrawn once mkcert says the CA is installed")
 
-	// ...and having settled good, it stops probing.
-	before := len(fake.generationCalls(t))
+	// ...and having settled good, it stops probing -- even well past the
+	// throttle window, because a good verdict is final for the process.
+	clock = clock.Add(10 * reProbeInterval)
+	settled := len(fake.generationCalls(t))
 	require.Nil(t, tr.Resolve(context.Background()).Warning)
-	assert.Equal(t, before, len(fake.generationCalls(t)))
+	assert.Equal(t, settled, len(fake.generationCalls(t)))
 }
 
 // TestTrustResolver_ProbesAtMostOncePerProcess pins the latch. The probe is a

--- a/internal/proxy/certs/trust_test.go
+++ b/internal/proxy/certs/trust_test.go
@@ -1,0 +1,468 @@
+package certs
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charliek/prox/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The two strings mkcert actually prints when its CA is not in the trust
+// stores, read out of the installed binary. The second is a format string whose
+// verb mkcert fills with a browser list, which is why the marker matches only
+// their shared stem.
+const (
+	mkcertSystemNote  = "Note: the local CA is not installed in the system trust store! ⚠️"
+	mkcertBrowserNote = "Note: the local CA is not installed in the Firefox and/or Chrome/Chromium trust store! ⚠️"
+	mkcertCreatedNote = "Created a new certificate valid for the following names 📜"
+)
+
+// fakeMkcertOpts configures the stand-in mkcert.
+type fakeMkcertOpts struct {
+	// Stdout and Stderr are what the fake prints when asked to GENERATE a
+	// certificate (the -CAROOT query always answers with the CAROOT path).
+	Stdout string
+	Stderr string
+	// ExitCode is the fake's exit status for a generation.
+	ExitCode int
+	// NoCA leaves CAROOT without a rootCA.pem, i.e. mkcert has never run on
+	// this machine — the state in which prox must never provoke a probe.
+	NoCA bool
+	// SleepSeconds stalls a generation, for proving the probe is bounded.
+	SleepSeconds int
+}
+
+// fakeMkcert is a shell script named `mkcert`, on a PATH that contains nothing
+// else executable of that name. It is how these tests exercise the real
+// capture/marker/probe code without a real mkcert — and, critically, without
+// ever touching the developer's actual CAROOT, which a probe against the real
+// binary would read and a generation could create.
+type fakeMkcert struct {
+	dir    string
+	caroot string
+	calls  string
+}
+
+// setStdout rewrites what the fake prints, so a test can model the user going
+// away and running `mkcert -install` between two resolves.
+func (f *fakeMkcert) setStdout(t *testing.T, out string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(f.dir, "stdout.txt"), []byte(out), 0o600))
+}
+
+func newFakeMkcert(t *testing.T, opts fakeMkcertOpts) *fakeMkcert {
+	t.Helper()
+
+	dir := t.TempDir()
+	caroot := filepath.Join(dir, "caroot")
+	require.NoError(t, os.MkdirAll(caroot, 0o755))
+	if !opts.NoCA {
+		require.NoError(t, os.WriteFile(filepath.Join(caroot, caRootFile), []byte("fake root CA"), 0o600))
+	}
+
+	calls := filepath.Join(dir, "calls.log")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "stdout.txt"), []byte(opts.Stdout), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "stderr.txt"), []byte(opts.Stderr), 0o600))
+
+	sleep := ""
+	if opts.SleepSeconds > 0 {
+		// exec, so the sleep REPLACES the shell rather than becoming its child:
+		// killing the process on timeout then kills the sleep too. Without this
+		// the shell dies and the orphaned sleep lingers for its full duration —
+		// and this repo is deliberately intolerant of stranded fixture
+		// processes (CodeRabbit review).
+		sleep = fmt.Sprintf("exec sleep %d\n", opts.SleepSeconds)
+	}
+
+	// Records every invocation, answers -CAROOT, and otherwise writes the cert
+	// and key files it was asked for so the caller's own bookkeeping proceeds.
+	script := fmt.Sprintf(`#!/bin/sh
+printf '%%s\n' "$*" >> %[1]q
+if [ "$1" = "-CAROOT" ]; then
+  printf '%%s\n' %[2]q
+  exit 0
+fi
+%[3]scert=""
+key=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -cert-file) cert="$2"; shift 2 ;;
+    -key-file) key="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+if [ -n "$cert" ]; then printf 'fake-cert\n' > "$cert"; fi
+if [ -n "$key" ]; then printf 'fake-key\n' > "$key"; fi
+cat %[4]q
+cat %[5]q >&2
+exit %[6]d
+`, calls, caroot, sleep, filepath.Join(dir, "stdout.txt"), filepath.Join(dir, "stderr.txt"), opts.ExitCode)
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "mkcert"), []byte(script), 0o755))
+	// /bin and /usr/bin stay reachable for the script's own `cat`/`sleep`; the
+	// real mkcert (typically /opt/homebrew/bin) does not.
+	t.Setenv("PATH", dir+":/bin:/usr/bin")
+
+	return &fakeMkcert{dir: dir, caroot: caroot, calls: calls}
+}
+
+// callArgs returns the argument line of each invocation, in order.
+func (f *fakeMkcert) callArgs(t *testing.T) []string {
+	t.Helper()
+	raw, err := os.ReadFile(f.calls)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	require.NoError(t, err)
+	var out []string
+	for _, line := range strings.Split(strings.TrimRight(string(raw), "\n"), "\n") {
+		if line != "" {
+			out = append(out, line)
+		}
+	}
+	return out
+}
+
+// generationCalls returns only the invocations that generated a certificate.
+func (f *fakeMkcert) generationCalls(t *testing.T) []string {
+	t.Helper()
+	var out []string
+	for _, c := range f.callArgs(t) {
+		if !strings.Contains(c, "-CAROOT") {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// TestEnsureCerts_CapturesMkcertOutput is the headline test: mkcert's own
+// advice must survive generation. Before this commit the output went to
+// os.Stdout/os.Stderr, which in the shared daemon are /dev/null — so the note
+// telling a user why every HTTPS request fails was discarded, and prox reported
+// perfect health (#97).
+func TestEnsureCerts_CapturesMkcertOutput(t *testing.T) {
+	tests := []struct {
+		name        string
+		stdout      string
+		stderr      string
+		wantWarning string // "" means the CA is trusted
+	}{
+		{
+			name:        "marker on stdout",
+			stdout:      mkcertCreatedNote + "\n" + mkcertSystemNote + "\n",
+			wantWarning: mkcertSystemNote,
+		},
+		{
+			name:        "marker on stderr",
+			stdout:      mkcertCreatedNote + "\n",
+			stderr:      mkcertSystemNote + "\n",
+			wantWarning: mkcertSystemNote,
+		},
+		{
+			name:   "marker absent",
+			stdout: mkcertCreatedNote + "\n",
+		},
+		{
+			// mkcert prints one note per trust store it checked. The user has
+			// one problem and one fix, so the first line answers for all.
+			name:        "multiple matching lines",
+			stdout:      mkcertCreatedNote + "\n" + mkcertSystemNote + "\n" + mkcertBrowserNote + "\n",
+			wantWarning: mkcertSystemNote,
+		},
+		{
+			// The marker is matched case-insensitively, so a reworded prefix
+			// does not silently disable the whole feature.
+			name:        "marker in different case",
+			stdout:      "NOTE: The Local CA Is Not Installed In the system trust store!\n",
+			wantWarning: "NOTE: The Local CA Is Not Installed In the system trust store!",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := newFakeMkcert(t, fakeMkcertOpts{Stdout: tc.stdout, Stderr: tc.stderr})
+			tr := NewTrustResolver()
+			m := NewManagerWithTrust(t.TempDir(), "test.dev", tr)
+
+			paths, lines, err := m.EnsureCerts()
+			require.NoError(t, err)
+			require.NotNil(t, paths, "the paths must survive the signature change — both callers need them")
+			assert.FileExists(t, paths.CertFile)
+			assert.FileExists(t, paths.KeyFile)
+
+			// Every non-empty line mkcert wrote, from BOTH streams, is captured.
+			for _, want := range notableLines(tc.stdout + tc.stderr) {
+				assert.Contains(t, lines, want)
+			}
+
+			v := tr.Resolve(context.Background())
+			require.True(t, v.Known, "a real generation always answers the question")
+			if tc.wantWarning == "" {
+				assert.Nil(t, v.Warning)
+				assert.Empty(t, fake.generationCalls(t)[1:], "a generation answered, so nothing should probe")
+				return
+			}
+			require.NotNil(t, v.Warning)
+			assert.Equal(t, tc.wantWarning, v.Warning.Message, "the user gets mkcert's own sentence, verbatim")
+		})
+	}
+}
+
+// TestEnsureCerts_FailureIncludesOutput pins the strict improvement on the
+// error path: whatever mkcert said about WHY it failed used to go to the
+// daemon's /dev/null, leaving the user with a bare exit status.
+func TestEnsureCerts_FailureIncludesOutput(t *testing.T) {
+	newFakeMkcert(t, fakeMkcertOpts{
+		Stderr:   "failed to load the CA key: open /nope/rootCA-key.pem: permission denied\n",
+		ExitCode: 1,
+	})
+	tr := NewTrustResolver()
+	m := NewManagerWithTrust(t.TempDir(), "test.dev", tr)
+
+	paths, lines, err := m.EnsureCerts()
+	require.Error(t, err)
+	assert.Nil(t, paths)
+	assert.Contains(t, err.Error(), "failed to load the CA key")
+	assert.Contains(t, err.Error(), "permission denied")
+	assert.Contains(t, lines, "failed to load the CA key: open /nope/rootCA-key.pem: permission denied")
+
+	assert.False(t, tr.verdict().Known,
+		"a failed generation proves nothing about the trust stores")
+}
+
+// TestEnsureCerts_WarmCertsSkipMkcert pins the case that motivates the probe:
+// with the cert files already on disk, mkcert never runs at all, so nothing can
+// be learned from its output. This is the NORMAL state of a daemon restarted
+// onto a new release, not an edge case.
+func TestEnsureCerts_WarmCertsSkipMkcert(t *testing.T) {
+	fake := newFakeMkcert(t, fakeMkcertOpts{Stdout: mkcertSystemNote + "\n"})
+	tr := NewTrustResolver()
+	dir := t.TempDir()
+	m := NewManagerWithTrust(dir, "test.dev", tr)
+
+	paths := m.getCertPaths()
+	require.NoError(t, os.WriteFile(paths.CertFile, []byte("warm cert"), 0o600))
+	require.NoError(t, os.WriteFile(paths.KeyFile, []byte("warm key"), 0o600))
+
+	got, lines, err := m.EnsureCerts()
+	require.NoError(t, err)
+	assert.Equal(t, paths, got)
+	assert.Empty(t, lines, "nothing was generated, so there is no output to report")
+	assert.Empty(t, fake.callArgs(t), "mkcert must not run when the certs are already on disk")
+	assert.False(t, tr.verdict().Known, "and therefore nothing is known about the CA yet")
+}
+
+// TestCAUntrustedWarning_PinnedShape pins the ONE constructor both producers go
+// through. Code and Hint live here rather than at each producer precisely so
+// the daemon and standalone paths cannot describe the same problem differently.
+func TestCAUntrustedWarning_PinnedShape(t *testing.T) {
+	w := caUntrustedWarning(mkcertSystemNote)
+	assert.Equal(t, domain.WarningCodeMkcertCAUntrusted, w.Code)
+	assert.Equal(t, mkcertSystemNote, w.Message, "mkcert's line, verbatim")
+	assert.Equal(t, "run 'mkcert -install' and restart prox", w.Hint)
+}
+
+// TestTrustResolver_ProbesWhenCertsAreWarm is the test for the step that makes
+// the feature work at all: with nothing generated, the resolver asks mkcert
+// directly rather than reporting nothing.
+func TestTrustResolver_ProbesWhenCertsAreWarm(t *testing.T) {
+	fake := newFakeMkcert(t, fakeMkcertOpts{Stdout: mkcertCreatedNote + "\n" + mkcertSystemNote + "\n"})
+	tr := NewTrustResolver()
+
+	v := tr.Resolve(context.Background())
+	require.True(t, v.Known)
+	require.NotNil(t, v.Warning)
+	assert.Equal(t, mkcertSystemNote, v.Warning.Message)
+	assert.Equal(t, domain.WarningCodeMkcertCAUntrusted, v.Warning.Code)
+
+	gen := fake.generationCalls(t)
+	require.Len(t, gen, 1, "exactly one throwaway generation")
+	assert.Contains(t, gen[0], probeHostname, "the probe certifies an inert .invalid name, never a real one")
+
+	// The throwaway cert, its key, and their directory are gone.
+	for _, field := range []string{"-cert-file", "-key-file"} {
+		path := argAfter(t, gen[0], field)
+		assert.NoFileExists(t, path, "the probe must not leave %s behind", field)
+		assert.NoDirExists(t, filepath.Dir(path), "the probe must delete its temp dir")
+	}
+}
+
+// TestTrustResolver_SkipsProbeWithoutRootCA is a safety property, not an
+// optimisation: mkcert CREATES a local CA when it finds none, and prox must
+// never create one as the side effect of a diagnostic — installing nothing and
+// explaining nothing.
+func TestTrustResolver_SkipsProbeWithoutRootCA(t *testing.T) {
+	fake := newFakeMkcert(t, fakeMkcertOpts{NoCA: true, Stdout: mkcertSystemNote + "\n"})
+	tr := NewTrustResolver()
+
+	v := tr.Resolve(context.Background())
+	assert.False(t, v.Known, "no CA means no verdict — not a guess in either direction")
+	assert.Nil(t, v.Warning)
+	assert.Empty(t, fake.generationCalls(t), "mkcert must never be asked to generate, which would create a CA")
+	assert.NoFileExists(t, filepath.Join(fake.caroot, caRootFile))
+}
+
+// TestTrustResolver_GoodGenerationAnswersWithoutProbing pins the free path: a
+// real generation said the CA IS installed, which is final for the process, so
+// no probe ever runs.
+func TestTrustResolver_GoodGenerationAnswersWithoutProbing(t *testing.T) {
+	fake := newFakeMkcert(t, fakeMkcertOpts{Stdout: mkcertCreatedNote + "\n"})
+	tr := NewTrustResolver()
+	m := NewManagerWithTrust(t.TempDir(), "test.dev", tr)
+
+	_, _, err := m.EnsureCerts()
+	require.NoError(t, err)
+
+	for range 3 {
+		v := tr.Resolve(context.Background())
+		require.True(t, v.Known)
+		require.Nil(t, v.Warning)
+	}
+
+	gen := fake.generationCalls(t)
+	require.Len(t, gen, 1, "a settled good verdict must never pay for a probe again")
+	assert.NotContains(t, gen[0], probeHostname)
+}
+
+// TestTrustResolver_BadVerdictIsReAsked is the anti-lying test, and it is the
+// reason the latch is not simply "once per process".
+//
+// The warning's own hint tells the user to run `mkcert -install` and restart
+// prox. In shared mode the DAEMON holds this verdict and outlives that restart,
+// so a latched "untrusted" would keep being reported at a machine the user had
+// already fixed — prox stating something untrue, which is the same bug as
+// stating nothing at all, pointed the other way. So while the answer is bad it
+// is re-asked, and the moment mkcert says the CA is installed the warning is
+// withdrawn and the probing stops for good.
+func TestTrustResolver_BadVerdictIsReAsked(t *testing.T) {
+	fake := newFakeMkcert(t, fakeMkcertOpts{
+		Stdout: mkcertCreatedNote + "\n" + mkcertSystemNote + "\n",
+	})
+	tr := NewTrustResolver()
+
+	v := tr.Resolve(context.Background())
+	require.NotNil(t, v.Warning, "precondition: the CA is reported untrusted")
+
+	// Still broken: prox keeps asking rather than trusting a stale verdict.
+	v = tr.Resolve(context.Background())
+	require.NotNil(t, v.Warning)
+	require.GreaterOrEqual(t, len(fake.generationCalls(t)), 2,
+		"a bad verdict must be re-asked, or the user can never be told they fixed it")
+
+	// The user runs `mkcert -install`: mkcert stops printing the note.
+	fake.setStdout(t, mkcertCreatedNote+"\n")
+
+	v = tr.Resolve(context.Background())
+	require.True(t, v.Known)
+	assert.Nil(t, v.Warning, "the warning must be withdrawn once mkcert says the CA is installed")
+
+	// ...and having settled good, it stops probing.
+	before := len(fake.generationCalls(t))
+	require.Nil(t, tr.Resolve(context.Background()).Warning)
+	assert.Equal(t, before, len(fake.generationCalls(t)))
+}
+
+// TestTrustResolver_ProbesAtMostOncePerProcess pins the latch. The probe is a
+// subprocess; running it per registration would put mkcert on the hot path of
+// every project joining the daemon.
+func TestTrustResolver_ProbesAtMostOncePerProcess(t *testing.T) {
+	// Exit 1: the probe FAILS, which is the case that most easily degenerates
+	// into retrying forever.
+	fake := newFakeMkcert(t, fakeMkcertOpts{ExitCode: 1})
+	tr := NewTrustResolver()
+
+	for range 5 {
+		v := tr.Resolve(context.Background())
+		assert.False(t, v.Known, "a failed probe yields no verdict")
+		assert.Nil(t, v.Warning)
+	}
+	assert.Len(t, fake.generationCalls(t), 1, "one attempt, however often it is asked")
+}
+
+// TestTrustResolver_ProbeBoundedByContext proves a wedged mkcert cannot stall
+// startup: the probe is dropped when its context expires, and dropped means
+// unknown — no warning, no error.
+func TestTrustResolver_ProbeBoundedByContext(t *testing.T) {
+	newFakeMkcert(t, fakeMkcertOpts{SleepSeconds: 30, Stdout: mkcertSystemNote + "\n"})
+	tr := NewTrustResolver()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	v := tr.Resolve(ctx)
+	elapsed := time.Since(start)
+
+	assert.False(t, v.Known)
+	assert.Nil(t, v.Warning)
+	// Generous but far below both the fake's 60s stall and the resolver's own
+	// 5s cap: the point is that cancellation actually RETURNS. Without
+	// probeWaitDelay this took the full 60s, because the stalled child still
+	// held the capture pipe after mkcert itself was killed.
+	assert.Less(t, elapsed, 2*time.Second, "the probe must not outlive its context")
+}
+
+// TestTrustResolver_NoMkcertIsSilent covers the user who has no mkcert at all:
+// prox already reports that separately, and a probe has nothing to say.
+func TestTrustResolver_NoMkcertIsSilent(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	tr := NewTrustResolver()
+
+	v := tr.Resolve(context.Background())
+	assert.False(t, v.Known)
+	assert.Nil(t, v.Warning)
+}
+
+// TestTrustResolver_TrustedVerdictWithdrawsWarning pins the anti-lying half:
+// once mkcert says the CA IS installed, the resolver stops reporting a warning,
+// so consumers can withdraw one they published earlier.
+func TestTrustResolver_TrustedVerdictWithdrawsWarning(t *testing.T) {
+	tr := NewTrustResolver()
+	tr.observe([]string{mkcertCreatedNote, mkcertSystemNote})
+	require.NotNil(t, tr.verdict().Warning, "precondition: the CA was untrusted")
+
+	// The user ran `mkcert -install`; the next mkcert run says nothing.
+	tr.observe([]string{mkcertCreatedNote})
+
+	v := tr.verdict()
+	assert.True(t, v.Known)
+	assert.Nil(t, v.Warning, "a fixed problem must stop being reported")
+}
+
+// TestSharedTrust_IsProcessWide pins that production callers share one verdict —
+// the property that lets one component's real generation spare every other
+// component the probe.
+func TestSharedTrust_IsProcessWide(t *testing.T) {
+	assert.Same(t, SharedTrust(), SharedTrust())
+	m := NewManager(t.TempDir(), "test.dev")
+	assert.Same(t, SharedTrust(), m.trust, "NewManager reports to the process-wide resolver")
+	assert.Same(t, SharedTrust(), NewManagerWithTrust(t.TempDir(), "test.dev", nil).trust,
+		"a nil resolver falls back to the shared one rather than panicking")
+}
+
+// TestNotableLines pins the line-splitting the captured output goes through.
+func TestNotableLines(t *testing.T) {
+	assert.Nil(t, notableLines(""))
+	assert.Nil(t, notableLines("\n\n  \n"))
+	assert.Equal(t, []string{"one", "two"}, notableLines("one\n\n  two  \n\n"))
+}
+
+// argAfter returns the token following flag in a recorded invocation line.
+func argAfter(t *testing.T, call, flag string) string {
+	t.Helper()
+	fields := strings.Fields(call)
+	for i, f := range fields {
+		if f == flag && i+1 < len(fields) {
+			return fields[i+1]
+		}
+	}
+	t.Fatalf("no %s in %q", flag, call)
+	return ""
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -177,8 +177,11 @@ func (s *Service) startHTTPS(router http.Handler) error {
 		return fmt.Errorf("certificates not configured for HTTPS proxy")
 	}
 
-	// Ensure certificates exist
-	certPaths, err := s.certs.EnsureCerts()
+	// Ensure certificates exist. The captured mkcert lines are dropped here on
+	// purpose: this process's verdict about mkcert's CA is held by the
+	// process-wide certs.TrustResolver that EnsureCerts feeds, and the CLI reads
+	// it from there (internal/cli/up.go) — a proxy service does not print.
+	certPaths, _, err := s.certs.EnsureCerts()
 	if err != nil {
 		return fmt.Errorf("ensuring certificates: %w", err)
 	}

--- a/internal/proxyd/cert_lock_test.go
+++ b/internal/proxyd/cert_lock_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/charliek/prox/internal/proxy/certs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -27,6 +28,10 @@ import (
 // deadlock rather than silently stall — the structural backstop for this boundary.
 func TestMultiDomainCertManager_SlowGenerateDoesNotBlockOtherDomain(t *testing.T) {
 	m := NewMultiDomainCertManager(t.TempDir())
+	// EnsureDomain applies the CA-trust verdict on every call, so a test that
+	// constructs the real manager must pin the verdict source or it would shell
+	// out to the developer's actual mkcert. Unknown touches nothing.
+	m.resolveTrust = func() certs.TrustVerdict { return certs.TrustVerdict{} }
 
 	certA, err := generateWildcardCert("a.test")
 	require.NoError(t, err)
@@ -101,6 +106,10 @@ func TestMultiDomainCertManager_SlowGenerateDoesNotBlockOtherDomain(t *testing.T
 // to CERT_GENERATION_FAILED and roll back cleanly.
 func TestMultiDomainCertManager_GenerateError_PublishesNothing(t *testing.T) {
 	m := NewMultiDomainCertManager(t.TempDir())
+	// EnsureDomain applies the CA-trust verdict on every call, so a test that
+	// constructs the real manager must pin the verdict source or it would shell
+	// out to the developer's actual mkcert. Unknown touches nothing.
+	m.resolveTrust = func() certs.TrustVerdict { return certs.TrustVerdict{} }
 
 	wantErr := errors.New("forced generate failure")
 	m.generate = func(domain string) (*tls.Certificate, error) {

--- a/internal/proxyd/cert_registration_test.go
+++ b/internal/proxyd/cert_registration_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/charliek/prox/internal/domain"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -32,6 +33,10 @@ type fakeCertManager struct {
 	certs   map[string]*tls.Certificate // base domain -> cert
 	ensured map[string]int              // domain -> EnsureDomain call count
 	failFor map[string]error            // domain -> forced EnsureDomain error
+	// warnings is the same CA-scoped holder the real manager uses, so tests that
+	// drive the register flow through this fake exercise the production holder
+	// (record + snapshot + dedupe), not a test-only reimplementation of it.
+	warnings certWarningHolder
 }
 
 func newFakeCertManager() *fakeCertManager {
@@ -77,6 +82,22 @@ func (f *fakeCertManager) EnsureDomain(domain string) error {
 	}
 	f.certs[domain] = cert
 	return nil
+}
+
+// RecordWarning stands in for the real producer (B1's mkcert trust detection):
+// it records a warning the cert layer "observed".
+func (f *fakeCertManager) RecordWarning(w domain.Warning) {
+	f.warnings.set(w)
+}
+
+// ClearWarning stands in for the producer withdrawing a resolved warning.
+func (f *fakeCertManager) ClearWarning(code string) {
+	f.warnings.clear(code)
+}
+
+// Warnings satisfies certManager, returning the recorded warnings.
+func (f *fakeCertManager) Warnings() []domain.Warning {
+	return f.warnings.snapshot()
 }
 
 // GetCertificate is the SNI callback: it selects a cert by the ClientHello's

--- a/internal/proxyd/cert_trust_hygiene_test.go
+++ b/internal/proxyd/cert_trust_hygiene_test.go
@@ -1,0 +1,96 @@
+package proxyd
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestNoTestConstructsTheCertManagerWithoutPinningTrust stops a unit test in
+// this package from shelling out to the developer's real mkcert.
+//
+// EnsureDomain applies the CA-trust verdict on EVERY call (plan 028 B1), so a
+// test holding a real *MultiDomainCertManager reaches certs.SharedTrust(),
+// which will run `mkcert -CAROOT` and issue a throwaway certificate on any
+// machine that has mkcert installed. Overriding `generate` — which used to be
+// enough, because the verdict was only applied during generation — no longer
+// keeps mkcert out.
+//
+// The failure mode is nasty precisely because it is not a failure: the tests
+// still pass, just slower, with behaviour that depends on whether the machine
+// running them happens to have mkcert and a CA. So the rule is enforced
+// structurally rather than trusted to reviewers: every construction of the real
+// manager inside a _test.go file in this package must also assign
+// resolveTrust.
+func TestNoTestConstructsTheCertManagerWithoutPinningTrust(t *testing.T) {
+	const ctor = "NewMultiDomainCertManager"
+
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, ".", func(fi fs.FileInfo) bool {
+		return strings.HasSuffix(fi.Name(), "_test.go")
+	}, 0)
+	require.NoError(t, err, "parsing this package's test files")
+
+	type site struct {
+		file string
+		line int
+		fn   string
+	}
+	var unpinned []site
+	seen := 0
+
+	for _, pkg := range pkgs {
+		for name, file := range pkg.Files {
+			for _, decl := range file.Decls {
+				fn, ok := decl.(*ast.FuncDecl)
+				if !ok || fn.Body == nil {
+					continue
+				}
+				// Does this function construct the real manager, and if so does
+				// it also pin resolveTrust? Both questions are answered over the
+				// same function body, since that is the scope a test sets up in.
+				constructs, pins := false, false
+				ast.Inspect(fn.Body, func(n ast.Node) bool {
+					switch v := n.(type) {
+					case *ast.CallExpr:
+						if id, ok := v.Fun.(*ast.Ident); ok && id.Name == ctor {
+							constructs = true
+						}
+					case *ast.SelectorExpr:
+						if v.Sel != nil && v.Sel.Name == "resolveTrust" {
+							pins = true
+						}
+					}
+					return true
+				})
+				if !constructs {
+					continue
+				}
+				seen++
+				if !pins {
+					unpinned = append(unpinned, site{
+						file: name,
+						line: fset.Position(fn.Pos()).Line,
+						fn:   fn.Name.Name,
+					})
+				}
+			}
+		}
+	}
+
+	// A walk that matched nothing would be a test that passes forever.
+	require.NotZero(t, seen,
+		"found no %s call in any test file — the AST walk is broken, not the tests", ctor)
+
+	for _, s := range unpinned {
+		t.Errorf("%s:%d: %s constructs a real %s without assigning resolveTrust, "+
+			"so EnsureDomain will shell out to the machine's actual mkcert. "+
+			"Add: m.resolveTrust = func() certs.TrustVerdict { return certs.TrustVerdict{} }",
+			s.file, s.line, s.fn, ctor)
+	}
+}

--- a/internal/proxyd/certs.go
+++ b/internal/proxyd/certs.go
@@ -1,6 +1,7 @@
 package proxyd
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"strings"
@@ -24,8 +25,10 @@ import (
 // EnsureDomain short-circuits on its own loaded-cert cache, so a daemon that
 // starts with certs already on disk — the normal case, since a release requires
 // restarting the daemon while its certs dir persists — may never re-enter
-// generation. A verdict recorded once (by whatever observes it) therefore has to
-// keep answering for later registrations that generate nothing.
+// generation. The verdict therefore comes from certs.TrustResolver (a real
+// generation's output when there was one, a probe when there was not), and
+// EnsureDomain re-applies it on every registration so it keeps answering for
+// registrations that generate nothing.
 //
 // Its mutex is a leaf: it is never held across mkcert, file I/O, or any other
 // lock, and in particular it is NOT MultiDomainCertManager.mu — recording a
@@ -119,6 +122,19 @@ type MultiDomainCertManager struct {
 	// warnings holds the CA-scoped user-facing warnings observed by the cert
 	// layer (see certWarningHolder). Guarded by its own mutex, never by mu.
 	warnings certWarningHolder
+
+	// trust answers "is mkcert's local CA installed in the trust stores?" once
+	// per process — from a real generation's output when there was one, from a
+	// probe when the certs were already warm. It is the SOURCE of every warning
+	// in `warnings` above, and it is handed to each per-domain certs.Manager so
+	// their generations feed the same verdict.
+	trust *certs.TrustResolver
+
+	// resolveTrust reads that verdict. Set once in the constructor; overridable
+	// in tests ONLY (like generate above), so a test can pin the record/clear
+	// wiring without a real mkcert on PATH — what mkcert's output MEANS is
+	// tested where it is parsed, in internal/proxy/certs.
+	resolveTrust func() certs.TrustVerdict
 }
 
 // NewMultiDomainCertManager creates a new multi-domain cert manager.
@@ -127,8 +143,10 @@ func NewMultiDomainCertManager(certsDir string) *MultiDomainCertManager {
 		certsDir: certsDir,
 		managers: make(map[string]*certs.Manager),
 		loaded:   make(map[string]*tls.Certificate),
+		trust:    certs.SharedTrust(),
 	}
 	m.generate = m.generateViaMkcert
+	m.resolveTrust = func() certs.TrustVerdict { return m.trust.Resolve(context.Background()) }
 	return m
 }
 
@@ -145,6 +163,22 @@ func NewMultiDomainCertManager(certsDir string) *MultiDomainCertManager {
 // single-flight MUST be reintroduced: two concurrent EnsureCerts on the same
 // *certs.Manager would race on the cert files.
 func (m *MultiDomainCertManager) EnsureDomain(baseDomain string) error {
+	// Refresh the CA-trust verdict on EVERY registration that touches certs,
+	// not just on a generation.
+	//
+	// Doing it only inside generateViaMkcert made the withdraw path nearly
+	// unreachable: a warm daemon never generates again, so a user who followed
+	// the warning's own hint (`mkcert -install`, restart prox) would keep being
+	// told their CA was untrusted by a daemon that outlived their restart
+	// (CodeRabbit review). Here it runs whenever a project registers, which is
+	// exactly when a user would expect prox to notice they fixed it.
+	//
+	// It is cheap in the case that matters: Resolve returns a settled GOOD
+	// verdict without touching a subprocess, so the steady state costs one map
+	// read. Only a machine that is actually broken pays for a probe, and only
+	// until it is fixed.
+	m.applyCATrust()
+
 	// Fast path: already loaded — RLock only, never blocks on generation.
 	m.mu.RLock()
 	_, ok := m.loaded[baseDomain]
@@ -178,11 +212,21 @@ func (m *MultiDomainCertManager) EnsureDomain(baseDomain string) error {
 func (m *MultiDomainCertManager) generateViaMkcert(baseDomain string) (*tls.Certificate, error) {
 	mgr := m.managerFor(baseDomain)
 
-	// Ensure certs exist (generate via mkcert if needed).
-	paths, err := mgr.EnsureCerts()
+	// Ensure certs exist (generate via mkcert if needed). The captured mkcert
+	// output has already been handed to m.trust by EnsureCerts, so the verdict
+	// below is free whenever generation actually ran.
+	paths, _, err := mgr.EnsureCerts()
 	if err != nil {
 		return nil, fmt.Errorf("ensuring certs for %s: %w", baseDomain, err)
 	}
+
+	// Publish (or withdraw) the CA-trust warning for the client that cannot see
+	// this process's output. Doing it HERE, rather than only on the generation
+	// path, is what covers the warm-cert case: a daemon restarted onto a new
+	// release finds its certs already on disk, runs mkcert never, and would
+	// otherwise report nothing at all.
+	// (The trust verdict is applied by EnsureDomain, which runs on every
+	// registration — not only on the generations that reach here.)
 
 	// Load the certificate.
 	cert, err := tls.LoadX509KeyPair(paths.CertFile, paths.KeyFile)
@@ -190,6 +234,30 @@ func (m *MultiDomainCertManager) generateViaMkcert(baseDomain string) (*tls.Cert
 		return nil, fmt.Errorf("loading cert for %s: %w", baseDomain, err)
 	}
 	return &cert, nil
+}
+
+// applyCATrust resolves this process's mkcert CA-trust verdict and reflects it
+// into the warning holder: record when the CA is NOT installed, WITHDRAW when
+// mkcert says it is.
+//
+// Both directions matter. A verdict that could only be added would keep telling
+// a user their CA is untrusted after they fixed it, and prox reporting something
+// that is no longer true is the same class of bug as prox reporting nothing at
+// all. An UNKNOWN verdict (no mkcert, no CA yet, probe failed) touches neither:
+// it is not evidence of trust, so it must not retract a warning, and it is not
+// evidence of a problem, so it must not raise one.
+//
+// It is called at the top of EnsureDomain — before the cache fast path, so a
+// warm daemon that never generates again still re-checks — outside m.mu, and it
+// takes only the holder's leaf mutex, so it never blocks a TLS handshake.
+func (m *MultiDomainCertManager) applyCATrust() {
+	v := m.resolveTrust()
+	switch {
+	case v.Warning != nil:
+		m.RecordWarning(*v.Warning)
+	case v.Known:
+		m.ClearWarning(domain.WarningCodeMkcertCAUntrusted)
+	}
 }
 
 // RecordWarning records (or replaces) a user-facing warning observed while
@@ -224,7 +292,7 @@ func (m *MultiDomainCertManager) managerFor(domain string) *certs.Manager {
 	defer m.mu.Unlock()
 	mgr, ok := m.managers[domain]
 	if !ok {
-		mgr = certs.NewManager(m.certsDir, domain)
+		mgr = certs.NewManagerWithTrust(m.certsDir, domain, m.trust)
 		m.managers[domain] = mgr
 	}
 	return mgr

--- a/internal/proxyd/certs.go
+++ b/internal/proxyd/certs.go
@@ -6,8 +6,100 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/charliek/prox/internal/domain"
 	"github.com/charliek/prox/internal/proxy/certs"
 )
+
+// certWarningHolder caches the user-facing warnings the cert layer observed, so
+// register() can hand them back to the CLI that cannot see the daemon's output.
+//
+// It is deliberately CA-SCOPED, not per-domain: the state these warnings
+// describe (is mkcert's local CA installed in the trust stores?) is a property
+// of the CA and the machine, not of any one base domain, so one verdict is held
+// for the daemon's whole process lifetime and every registration reads the same
+// one.
+//
+// That scoping is what makes a warning survive the warm-cert case. mkcert only
+// runs when the cert FILES are absent (internal/proxy/certs/certs.go) and
+// EnsureDomain short-circuits on its own loaded-cert cache, so a daemon that
+// starts with certs already on disk — the normal case, since a release requires
+// restarting the daemon while its certs dir persists — may never re-enter
+// generation. A verdict recorded once (by whatever observes it) therefore has to
+// keep answering for later registrations that generate nothing.
+//
+// Its mutex is a leaf: it is never held across mkcert, file I/O, or any other
+// lock, and in particular it is NOT MultiDomainCertManager.mu — recording a
+// warning mid-generation must not take the cache lock that EnsureDomain
+// deliberately drops for the duration of generation.
+//
+// It is keyed BY CODE and holds at most one warning per code, which does two
+// things an append-only slice could not (CodeRabbit review, N1/N2):
+//
+//   - It makes a warning CLEARABLE. A condition like "the CA is untrusted" is
+//     one the user goes and fixes; a verdict that could only ever be added
+//     would keep telling them their CA is untrusted for the rest of a
+//     long-lived daemon's life after they ran `mkcert -install`. Telling the
+//     user something false is the exact bug this whole plan exists to remove,
+//     so the producer (B1) re-derives the verdict and calls clear when it no
+//     longer holds.
+//   - It bounds the holder by the number of distinct codes rather than by how
+//     many times a producer happens to observe something.
+//
+// Insertion order is preserved so the output is stable across reads.
+type certWarningHolder struct {
+	mu       sync.Mutex
+	order    []string
+	warnings map[string]domain.Warning
+}
+
+// set records (or replaces) the warning for w.Code. Replacing rather than
+// appending means a producer that observes the same condition on several
+// domains yields one warning, not one per domain.
+func (h *certWarningHolder) set(w domain.Warning) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.warnings == nil {
+		h.warnings = make(map[string]domain.Warning, 1)
+	}
+	if _, seen := h.warnings[w.Code]; !seen {
+		h.order = append(h.order, w.Code)
+	}
+	h.warnings[w.Code] = w
+}
+
+// clear drops the warning for code, if any. It is how a resolved condition
+// stops being reported without waiting for the daemon to restart.
+func (h *certWarningHolder) clear(code string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if _, ok := h.warnings[code]; !ok {
+		return
+	}
+	delete(h.warnings, code)
+	for i, c := range h.order {
+		if c == code {
+			h.order = append(h.order[:i:i], h.order[i+1:]...)
+			break
+		}
+	}
+}
+
+// snapshot returns a copy of the recorded warnings in insertion order; the
+// caller may retain or mutate it freely.
+func (h *certWarningHolder) snapshot() []domain.Warning {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if len(h.warnings) == 0 {
+		return nil
+	}
+	out := make([]domain.Warning, 0, len(h.warnings))
+	for _, code := range h.order {
+		if w, ok := h.warnings[code]; ok {
+			out = append(out, w)
+		}
+	}
+	return out
+}
 
 // MultiDomainCertManager manages TLS certificates for multiple base domains.
 // It wraps the existing certs.Manager, creating one per base domain, and
@@ -23,6 +115,10 @@ type MultiDomainCertManager struct {
 	// in the constructor; overridable in tests ONLY (do not mutate
 	// post-construction).
 	generate func(domain string) (*tls.Certificate, error)
+
+	// warnings holds the CA-scoped user-facing warnings observed by the cert
+	// layer (see certWarningHolder). Guarded by its own mutex, never by mu.
+	warnings certWarningHolder
 }
 
 // NewMultiDomainCertManager creates a new multi-domain cert manager.
@@ -48,10 +144,10 @@ func NewMultiDomainCertManager(certsDir string) *MultiDomainCertManager {
 // unnecessary. IF a future non-register caller is added, a per-domain
 // single-flight MUST be reintroduced: two concurrent EnsureCerts on the same
 // *certs.Manager would race on the cert files.
-func (m *MultiDomainCertManager) EnsureDomain(domain string) error {
+func (m *MultiDomainCertManager) EnsureDomain(baseDomain string) error {
 	// Fast path: already loaded — RLock only, never blocks on generation.
 	m.mu.RLock()
-	_, ok := m.loaded[domain]
+	_, ok := m.loaded[baseDomain]
 	m.mu.RUnlock()
 	if ok {
 		return nil
@@ -61,17 +157,17 @@ func (m *MultiDomainCertManager) EnsureDomain(domain string) error {
 	// EnsureCerts(mkcert) + LoadX509KeyPair; only managerFor briefly locks
 	// m.mu for the managers map). GetCertificate's RLock is therefore never
 	// blocked by mkcert — the whole point of the refactor.
-	cert, err := m.generate(domain)
+	cert, err := m.generate(baseDomain)
 	if err != nil {
 		return err // already wrapped by m.generate
 	}
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if _, ok := m.loaded[domain]; ok { // double-check: a concurrent caller won
+	if _, ok := m.loaded[baseDomain]; ok { // double-check: a concurrent caller won
 		return nil
 	}
-	m.loaded[domain] = cert
+	m.loaded[baseDomain] = cert
 	return nil
 }
 
@@ -79,21 +175,45 @@ func (m *MultiDomainCertManager) EnsureDomain(domain string) error {
 // certs.Manager, shells to mkcert to generate the cert files if needed, then
 // loads the key pair. It holds NO m.mu except via managerFor's brief lock on the
 // managers map — never across mkcert or file I/O.
-func (m *MultiDomainCertManager) generateViaMkcert(domain string) (*tls.Certificate, error) {
-	mgr := m.managerFor(domain)
+func (m *MultiDomainCertManager) generateViaMkcert(baseDomain string) (*tls.Certificate, error) {
+	mgr := m.managerFor(baseDomain)
 
 	// Ensure certs exist (generate via mkcert if needed).
 	paths, err := mgr.EnsureCerts()
 	if err != nil {
-		return nil, fmt.Errorf("ensuring certs for %s: %w", domain, err)
+		return nil, fmt.Errorf("ensuring certs for %s: %w", baseDomain, err)
 	}
 
 	// Load the certificate.
 	cert, err := tls.LoadX509KeyPair(paths.CertFile, paths.KeyFile)
 	if err != nil {
-		return nil, fmt.Errorf("loading cert for %s: %w", domain, err)
+		return nil, fmt.Errorf("loading cert for %s: %w", baseDomain, err)
 	}
 	return &cert, nil
+}
+
+// RecordWarning records (or replaces) a user-facing warning observed while
+// preparing certificates. It is the PRODUCER SEAM of the daemon→client warning
+// channel: B1's mkcert detection calls this once it can actually detect an
+// untrusted CA, and tests call it directly to stand in for that detection. It
+// takes no cache lock, so it is safe to call from inside generation, which runs
+// outside mu by design.
+func (m *MultiDomainCertManager) RecordWarning(w domain.Warning) {
+	m.warnings.set(w)
+}
+
+// ClearWarning withdraws a previously recorded warning. It is half of the
+// producer seam and not optional decoration: a warning that could only be added
+// would outlive the condition it describes, so a user who fixed the problem
+// would keep being told it was still there until the daemon restarted.
+func (m *MultiDomainCertManager) ClearWarning(code string) {
+	m.warnings.clear(code)
+}
+
+// Warnings returns the warnings recorded so far, newest last, as a fresh slice.
+// register() calls it on every success arm; it never blocks on cert generation.
+func (m *MultiDomainCertManager) Warnings() []domain.Warning {
+	return m.warnings.snapshot()
 }
 
 // managerFor returns the certs.Manager for a base domain, creating and caching

--- a/internal/proxyd/dynamic_proxy.go
+++ b/internal/proxyd/dynamic_proxy.go
@@ -17,14 +17,20 @@ import (
 
 	"github.com/charliek/prox/internal/constants"
 	"github.com/charliek/prox/internal/daemon"
+	"github.com/charliek/prox/internal/domain"
 	"github.com/charliek/prox/internal/proxy"
 )
 
 // certManager is the cert capability the dynamic proxy and register flow need:
-// per-domain cert generation plus SNI cert selection.
+// per-domain cert generation, SNI cert selection, and the user-facing warnings
+// the cert layer observed (Warnings), which register() returns to the CLI
+// because the daemon itself has nowhere to print them.
 type certManager interface {
 	EnsureDomain(domain string) error
 	GetCertificate(*tls.ClientHelloInfo) (*tls.Certificate, error)
+	// Warnings returns the CA-scoped warnings recorded so far. It must be cheap
+	// and non-blocking: register() calls it while holding lifecycleMu.
+	Warnings() []domain.Warning
 }
 
 // managedListener tracks a dynamically created port listener.

--- a/internal/proxyd/server.go
+++ b/internal/proxyd/server.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/charliek/prox/internal/constants"
 	"github.com/charliek/prox/internal/daemon"
+	"github.com/charliek/prox/internal/domain"
 	"github.com/charliek/prox/internal/proxy"
 	"github.com/go-chi/chi/v5"
 )
@@ -319,7 +320,14 @@ func (s *Server) register(req RegisterRequest) (int, any) {
 			if s.registry.registrationMatches(req) {
 				s.logger.Info("idempotent re-register: config unchanged, no-op refresh",
 					"project", conflict.Dir, "pid", conflict.PID, "start_time", conflict.StartTime)
-				return http.StatusOK, RegisterResponse{Registered: s.registry.ProjectHostnames(conflict.Dir)}
+				// The no-op arm returns BEFORE the cert phase, so it generates no
+				// warnings of its own — but it must still report the daemon's current
+				// ones. This is the self-heal path (cli.proxy_runtime), and a client
+				// reconnecting here is exactly a client that has not seen them yet.
+				return http.StatusOK, RegisterResponse{
+					Registered: s.registry.ProjectHostnames(conflict.Dir),
+					Warnings:   s.currentWarnings(),
+				}
 			}
 			// FIX 2: the same process re-registers with a CHANGED config (rare).
 			// Keep the remove+add, but make it failure-atomic: snapshot the current
@@ -423,7 +431,23 @@ func (s *Server) register(req RegisterRequest) (int, any) {
 	// the effective daemon-wide bound and enforce it (#69). Covers the fresh,
 	// changed-config, and stale-replacement register arms (all reach here).
 	s.syncCaptureBudget()
-	return http.StatusOK, RegisterResponse{Registered: hostnames}
+	return http.StatusOK, RegisterResponse{Registered: hostnames, Warnings: s.currentWarnings()}
+}
+
+// currentWarnings returns the daemon's user-facing warnings for a register
+// response, deduped. The warnings live on the cert manager because that is where
+// they are observed and because they are CA-scoped rather than per-project: every
+// registration gets the same current set, including registrations that generated
+// no certs at all (a warm certs dir) and the no-op refresh that never reaches the
+// cert phase.
+//
+// Callers hold lifecycleMu; the holder's mutex is a leaf taken only for a slice
+// copy, so this never blocks the lifecycle transaction on cert generation.
+func (s *Server) currentWarnings() []domain.Warning {
+	if s.proxy == nil || s.proxy.certMgr == nil {
+		return nil
+	}
+	return domain.DedupeWarnings(s.proxy.certMgr.Warnings())
 }
 
 func (s *Server) handleDeregister(w http.ResponseWriter, r *http.Request) {

--- a/internal/proxyd/types.go
+++ b/internal/proxyd/types.go
@@ -5,6 +5,8 @@ package proxyd
 
 import (
 	"time"
+
+	"github.com/charliek/prox/internal/domain"
 )
 
 // ServiceTarget represents a backend service to proxy to.
@@ -50,6 +52,23 @@ type RegisterRequest struct {
 // RegisterResponse is returned after a successful registration.
 type RegisterResponse struct {
 	Registered []string `json:"registered"` // fully-qualified hostnames registered
+	// Warnings carries user-facing advisories the daemon observed on the
+	// project's behalf — things the invoking CLI could never have seen itself,
+	// because in shared mode they happen inside the daemon process, whose
+	// stdout/stderr are /dev/null (daemon.go). The register response is the one
+	// point where the daemon can hand them to the person who typed the command.
+	// It is populated on BOTH success arms of register(), including the
+	// idempotent no-op refresh the self-heal path takes, so a reconnecting
+	// client still learns about them.
+	//
+	// Compatibility: this is ordinary additive JSON — an older daemon simply
+	// omits the field and it decodes to nil; an older client ignores the unknown
+	// key. That, not the register version gate, is what makes it safe: local
+	// `make build` binaries all report version "dev"
+	// (internal/version/version.go), so the exact-version-match requirement does
+	// NOT separate two different development builds, and a dev client can very
+	// well talk to a dev daemon built before this field existed.
+	Warnings []domain.Warning `json:"warnings,omitempty"`
 }
 
 // DeregisterRequest is sent by prox down to remove a project's routes.

--- a/internal/proxyd/warnings_test.go
+++ b/internal/proxyd/warnings_test.go
@@ -1,0 +1,410 @@
+package proxyd
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/charliek/prox/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testWarning is the stand-in for the warning B1's mkcert detection will
+// produce. It uses the shared code constant so this test cannot drift from the
+// producer's spelling.
+var testWarning = domain.Warning{
+	Code:    domain.WarningCodeMkcertCAUntrusted,
+	Message: "The mkcert local CA is not installed in your trust stores, so HTTPS URLs will show certificate errors.",
+	Hint:    "Run `mkcert -install`, then restart your browser.",
+}
+
+// registerResp drives a register to success and returns the typed success body.
+// Like registerOK it tolerates the transient PORT_BIND_FAILED a fresh-port bind
+// can hit when the OS briefly holds a just-closed ephemeral port; unlike it, the
+// response body is the point of the call.
+func registerResp(t *testing.T, s *Server, req RegisterRequest) RegisterResponse {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		status, body := s.register(req)
+		if status == http.StatusOK {
+			resp, ok := body.(RegisterResponse)
+			require.True(t, ok, "success body should be a RegisterResponse, got %T", body)
+			return resp
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("register never succeeded: status=%d body=%v", status, body)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// TestRegisterResponse_WarningsWireRoundTrip pins the wire contract of the new
+// field: it round-trips losslessly, it disappears entirely when there are no
+// warnings (omitempty), and an older daemon's payload — which has no "warnings"
+// key at all — still decodes cleanly to nil. That last case is the whole
+// compatibility argument: the version gate does NOT separate two "dev" builds,
+// so a new client really can meet an old daemon's payload.
+func TestRegisterResponse_WarningsWireRoundTrip(t *testing.T) {
+	t.Run("round-trips losslessly", func(t *testing.T) {
+		in := RegisterResponse{
+			Registered: []string{"api.local.dev", "web.local.dev"},
+			Warnings: []domain.Warning{
+				testWarning,
+				{Code: "other", Message: "Something else."},
+			},
+		}
+		raw, err := json.Marshal(in)
+		require.NoError(t, err)
+
+		var out RegisterResponse
+		require.NoError(t, json.Unmarshal(raw, &out))
+		assert.Equal(t, in, out)
+	})
+
+	t.Run("omits the key when there are no warnings", func(t *testing.T) {
+		raw, err := json.Marshal(RegisterResponse{Registered: []string{"api.local.dev"}})
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"registered":["api.local.dev"]}`, string(raw))
+
+		raw, err = json.Marshal(RegisterResponse{Registered: []string{"api.local.dev"}, Warnings: []domain.Warning{}})
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"registered":["api.local.dev"]}`, string(raw),
+			"an empty (non-nil) slice must also omit the key")
+	})
+
+	t.Run("older daemon payload decodes to nil warnings", func(t *testing.T) {
+		var out RegisterResponse
+		require.NoError(t, json.Unmarshal([]byte(`{"registered":["api.local.dev"]}`), &out))
+		assert.Equal(t, []string{"api.local.dev"}, out.Registered)
+		assert.Nil(t, out.Warnings)
+	})
+}
+
+// TestRegister_NormalArmReturnsWarnings pins that the ordinary success arm of
+// register() carries the daemon's recorded warnings back to the CLI.
+func TestRegister_NormalArmReturnsWarnings(t *testing.T) {
+	backendHost, backendPort := backendTarget(t)
+	fake := newFakeCertManager()
+	s := newProxyServerWithCertMgr(t, fake)
+
+	// The producer seam: stand in for B1's detection during cert preparation.
+	fake.RecordWarning(testWarning)
+
+	resp := registerResp(t, s, RegisterRequest{
+		ProjectDir: "/projects/normal", PID: os.Getpid(), Version: "test", Domain: "normal.test",
+		Services:  map[string]ServiceTarget{"svc": {Host: backendHost, Port: backendPort}},
+		HTTPSPort: freePort(t),
+	})
+
+	assert.Equal(t, []string{"svc.normal.test"}, resp.Registered)
+	assert.Equal(t, []domain.Warning{testWarning}, resp.Warnings,
+		"the normal register arm must return the daemon's warnings")
+}
+
+// TestRegister_NoOpReRegisterReturnsWarnings is the regression this commit is
+// most likely to lose: the idempotent no-op refresh arm returns BEFORE the cert
+// phase, so it is the easiest success return to forget. It is also the self-heal
+// path (cli.proxy_runtime), i.e. precisely the client that has not yet seen the
+// warning.
+//
+// It drives a REAL second registration with an unchanged config so
+// registrationMatches takes that branch, and proves the branch was taken by the
+// cert manager's EnsureDomain count staying at one — the config-changed arm would
+// have re-run the cert phase.
+func TestRegister_NoOpReRegisterReturnsWarnings(t *testing.T) {
+	backendHost, backendPort := backendTarget(t)
+	fake := newFakeCertManager()
+	s := newProxyServerWithCertMgr(t, fake)
+	pid, token := liveIdentity(t)
+
+	fake.RecordWarning(testWarning)
+
+	req := RegisterRequest{
+		ProjectDir: "/projects/noop", PID: pid, StartTime: token, Version: "test", Domain: "noop.test",
+		Services:  map[string]ServiceTarget{"svc": {Host: backendHost, Port: backendPort}},
+		HTTPSPort: freePort(t),
+	}
+	registerOK(t, s, req)
+	// A BASELINE, not a literal 1: registerOK retries a transient
+	// PORT_BIND_FAILED, and the cert phase runs before the listener bind, so a
+	// retried first register legitimately leaves the count above one. What the
+	// assertion below needs is only that the SECOND register adds nothing.
+	baseline := fake.ensureCount("noop.test")
+	require.GreaterOrEqual(t, baseline, 1, "precondition: the first register ran the cert phase")
+
+	// Same identity, same config: a true no-op refresh.
+	resp := registerResp(t, s, req)
+
+	require.Equal(t, baseline, fake.ensureCount("noop.test"),
+		"the second register must have taken the no-op refresh arm (which never reaches the cert phase)")
+	assert.Equal(t, []string{"svc.noop.test"}, resp.Registered)
+	assert.Equal(t, []domain.Warning{testWarning}, resp.Warnings,
+		"the no-op refresh arm must still report the daemon's warnings")
+}
+
+// TestRegister_WarningsSurviveWarmCertGeneration pins the CA-scoped cache: a
+// registration that generates NOTHING (the cert for its domain is already
+// loaded — the warm-certs case a restarted daemon lives in) still gets the
+// warning recorded by the one generation that did run. A per-domain or
+// per-generation store would silently drop it here, reverting to today's
+// swallowed-warning bug.
+//
+// It uses the real MultiDomainCertManager (real holder, real EnsureDomain cache)
+// with only the generator replaced by a synthetic producer that records the
+// warning the way B1's detection will.
+func TestRegister_WarningsSurviveWarmCertGeneration(t *testing.T) {
+	backendHost, backendPort := backendTarget(t)
+
+	m := NewMultiDomainCertManager(t.TempDir())
+	var generated atomic.Int32
+	m.generate = func(d string) (*tls.Certificate, error) {
+		generated.Add(1)
+		m.RecordWarning(testWarning) // the producer seam, fired during generation
+		return generateWildcardCert(d)
+	}
+	s := newProxyServerWithCertMgr(t, m)
+	port := freePort(t)
+
+	respA := registerResp(t, s, RegisterRequest{
+		ProjectDir: "/projects/a", PID: os.Getpid(), Version: "test", Domain: "warm.test",
+		Services:  map[string]ServiceTarget{"a": {Host: backendHost, Port: backendPort}},
+		HTTPSPort: port,
+	})
+	require.EqualValues(t, 1, generated.Load(), "precondition: the first register generated the cert")
+	require.Equal(t, []domain.Warning{testWarning}, respA.Warnings)
+
+	// A second project on the SAME base domain: EnsureDomain hits its loaded-cert
+	// fast path, so the producer never fires again.
+	respB := registerResp(t, s, RegisterRequest{
+		ProjectDir: "/projects/b", PID: os.Getpid(), Version: "test", Domain: "warm.test",
+		Services:  map[string]ServiceTarget{"b": {Host: backendHost, Port: backendPort}},
+		HTTPSPort: port,
+	})
+
+	assert.EqualValues(t, 1, generated.Load(), "precondition: the second register generated nothing")
+	assert.Equal(t, []domain.Warning{testWarning}, respB.Warnings,
+		"a registration that generated no certs must still report the CA-scoped warning")
+}
+
+// TestRegister_DedupesWarnings pins that a condition observed several times (the
+// producer runs per domain, the CA state is ONE state) reaches the user once.
+//
+// The holder is keyed by code, so repeated observations of the same code
+// collapse at the point of RECORDING rather than only at the point of reading —
+// which is what keeps it bounded no matter how often a producer speaks. A later
+// observation replaces the earlier wording; distinct codes are distinct
+// warnings.
+func TestRegister_DedupesWarnings(t *testing.T) {
+	backendHost, backendPort := backendTarget(t)
+	fake := newFakeCertManager()
+	s := newProxyServerWithCertMgr(t, fake)
+
+	fake.RecordWarning(testWarning)
+	fake.RecordWarning(testWarning)
+	// Same code, revised wording: the latest verdict wins rather than stacking.
+	revised := domain.Warning{Code: domain.WarningCodeMkcertCAUntrusted, Message: "A different message."}
+	fake.RecordWarning(revised)
+	// A genuinely different code is a genuinely different warning.
+	unrelated := domain.Warning{Code: "some_other_condition", Message: "Unrelated."}
+	fake.RecordWarning(unrelated)
+
+	resp := registerResp(t, s, RegisterRequest{
+		ProjectDir: "/projects/dupe", PID: os.Getpid(), Version: "test", Domain: "dupe.test",
+		Services:  map[string]ServiceTarget{"svc": {Host: backendHost, Port: backendPort}},
+		HTTPSPort: freePort(t),
+	})
+
+	assert.Equal(t, []domain.Warning{revised, unrelated}, resp.Warnings)
+}
+
+// TestRegister_NoWarningsOmitsField pins the clean case: with nothing recorded,
+// the response carries no warnings at all (so the key is absent on the wire), and
+// a daemon with no cert manager at all does not panic reaching for them.
+func TestRegister_NoWarningsOmitsField(t *testing.T) {
+	backendHost, backendPort := newTestBackend(t, func(http.ResponseWriter, *http.Request) {})
+
+	t.Run("cert manager with nothing recorded", func(t *testing.T) {
+		fake := newFakeCertManager()
+		s := newProxyServerWithCertMgr(t, fake)
+		resp := registerResp(t, s, RegisterRequest{
+			ProjectDir: "/projects/quiet", PID: os.Getpid(), Version: "test", Domain: "quiet.test",
+			Services:  map[string]ServiceTarget{"svc": {Host: backendHost, Port: backendPort}},
+			HTTPSPort: freePort(t),
+		})
+		assert.Empty(t, resp.Warnings)
+	})
+
+	t.Run("no cert manager at all", func(t *testing.T) {
+		s := newProxyServer(t) // wired with a nil certMgr
+		resp := registerResp(t, s, RegisterRequest{
+			ProjectDir: "/projects/nocert", PID: os.Getpid(), Version: "test", Domain: "nocert.test",
+			Services: map[string]ServiceTarget{"svc": {Host: backendHost, Port: backendPort}},
+			HTTPPort: freePort(t),
+		})
+		assert.Nil(t, resp.Warnings)
+	})
+}
+
+// TestClientRegister_PassesWarningsThrough closes the loop over the real
+// transport: a warning recorded in the daemon must reach a Client.Register
+// caller unchanged, having actually gone through JSON and the Unix socket. This
+// commit adds no CLI-side consumption (that is A2) — this only pins that the
+// field survives the trip.
+func TestClientRegister_PassesWarningsThrough(t *testing.T) {
+	server, client, _ := startTestServer(t)
+
+	// startTestServer wires no proxy; give it one with a fake cert manager so the
+	// daemon has somewhere to hold warnings.
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
+	fake := newFakeCertManager()
+	dp := NewDynamicProxy(server.registry, fake, server.managers, nil, logger)
+	server.SetProxy(dp)
+	t.Cleanup(func() { _ = dp.Shutdown(context.Background()) })
+
+	fake.RecordWarning(testWarning)
+
+	resp, err := client.Register(RegisterRequest{
+		ProjectDir: "/projects/wire", PID: os.Getpid(), Version: "test-version", Domain: "wire.test",
+		Services: map[string]ServiceTarget{"svc": {Host: "127.0.0.1", Port: 3000}},
+		HTTPPort: freePort(t),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"svc.wire.test"}, resp.Registered)
+	assert.Equal(t, []domain.Warning{testWarning}, resp.Warnings,
+		"the client must return the daemon's warnings to its caller unchanged")
+}
+
+// TestCertWarningHolder_Concurrent is the -race guard for the holder: recording
+// and reading run concurrently (as the cert layer and register() can), and the
+// snapshot must be a copy the caller can mutate without corrupting the holder.
+func TestCertWarningHolder_Concurrent(t *testing.T) {
+	m := NewMultiDomainCertManager(t.TempDir())
+	// Never shell to mkcert from a test: swap in the in-memory generator.
+	m.generate = func(d string) (*tls.Certificate, error) { return generateWildcardCert(d) }
+	backendHost, backendPort := backendTarget(t)
+	s := newProxyServerWithCertMgr(t, m)
+
+	const n = 16
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < n; i++ {
+		wg.Add(3)
+		go func() { defer wg.Done(); <-start; m.RecordWarning(testWarning) }()
+		go func() { defer wg.Done(); <-start; _ = m.Warnings() }()
+		go func() { defer wg.Done(); <-start; _ = s.currentWarnings() }()
+	}
+	close(start)
+	wg.Wait()
+
+	// Deduped, the n identical records are one warning.
+	assert.Equal(t, []domain.Warning{testWarning}, s.currentWarnings())
+
+	// The snapshot is a copy: mutating it must not corrupt the holder.
+	snap := m.Warnings()
+	require.NotEmpty(t, snap)
+	snap[0] = domain.Warning{Code: "mutated", Message: "mutated"}
+	assert.Equal(t, testWarning, m.Warnings()[0], "Warnings must hand out a copy")
+
+	// And a register concurrent-with-nothing still reports the deduped set.
+	resp := registerResp(t, s, RegisterRequest{
+		ProjectDir: "/projects/race", PID: os.Getpid(), Version: "test", Domain: "race.test",
+		Services:  map[string]ServiceTarget{"svc": {Host: backendHost, Port: backendPort}},
+		HTTPSPort: freePort(t),
+	})
+	assert.Equal(t, []domain.Warning{testWarning}, resp.Warnings)
+}
+
+// TestCertWarningHolder_SetIsIdempotentPerCode pins that the holder is keyed by
+// code rather than append-only. A producer that observes the same condition
+// while preparing several base domains must yield ONE warning, not one per
+// domain, and the holder must stay bounded by the number of distinct codes
+// however many times it is told (CodeRabbit review, N2).
+func TestCertWarningHolder_SetIsIdempotentPerCode(t *testing.T) {
+	var h certWarningHolder
+	for range 50 {
+		h.set(testWarning)
+	}
+	require.Len(t, h.snapshot(), 1, "same code recorded 50 times is still one warning")
+
+	// A later observation of the same code replaces the wording rather than
+	// stacking a second copy.
+	updated := testWarning
+	updated.Message = "revised wording"
+	h.set(updated)
+	got := h.snapshot()
+	require.Len(t, got, 1)
+	assert.Equal(t, "revised wording", got[0].Message)
+
+	// A different code is a different warning, and insertion order holds.
+	h.set(domain.Warning{Code: "other", Message: "second"})
+	got = h.snapshot()
+	require.Len(t, got, 2)
+	assert.Equal(t, domain.WarningCodeMkcertCAUntrusted, got[0].Code)
+	assert.Equal(t, "other", got[1].Code)
+}
+
+// TestCertWarningHolder_ClearWithdrawsAResolvedWarning is the anti-lying test.
+//
+// The condition these warnings describe is one the user goes and FIXES. A
+// verdict that could only ever be added would keep reporting an untrusted CA
+// for the rest of a long-lived daemon's life after the user ran
+// `mkcert -install` — telling them something false, which is the exact bug
+// plan 028 exists to remove (CodeRabbit review, N1).
+func TestCertWarningHolder_ClearWithdrawsAResolvedWarning(t *testing.T) {
+	var h certWarningHolder
+	h.set(testWarning)
+	h.set(domain.Warning{Code: "other", Message: "second"})
+	require.Len(t, h.snapshot(), 2)
+
+	h.clear(testWarning.Code)
+	got := h.snapshot()
+	require.Len(t, got, 1, "the cleared warning is gone")
+	assert.Equal(t, "other", got[0].Code, "and the survivor is untouched")
+
+	// Clearing something absent is a no-op, and clearing everything returns nil
+	// (not an empty slice) so the omitempty wire field disappears.
+	h.clear("never-recorded")
+	h.clear("other")
+	assert.Nil(t, h.snapshot(), "an emptied holder reports nil, so the JSON key vanishes")
+
+	// It can be re-recorded afterwards: the condition can come back.
+	h.set(testWarning)
+	require.Len(t, h.snapshot(), 1)
+}
+
+// TestRegister_ClearedWarningStopsBeingReported drives the same lifecycle
+// through the wire: a warning the daemon has withdrawn must not keep arriving
+// on later registrations.
+func TestRegister_ClearedWarningStopsBeingReported(t *testing.T) {
+	backendHost, backendPort := backendTarget(t)
+	fake := newFakeCertManager()
+	s := newProxyServerWithCertMgr(t, fake)
+	pid, token := liveIdentity(t)
+	fake.RecordWarning(testWarning)
+
+	req := RegisterRequest{
+		ProjectDir: "/projects/cleared", PID: pid, StartTime: token, Version: "test",
+		Domain:    "cleared.test",
+		Services:  map[string]ServiceTarget{"svc": {Host: backendHost, Port: backendPort}},
+		HTTPSPort: freePort(t),
+	}
+	resp := registerResp(t, s, req)
+	require.Len(t, resp.Warnings, 1, "precondition: the warning is being reported")
+
+	// The user fixed it; the producer withdraws the verdict.
+	fake.ClearWarning(testWarning.Code)
+
+	resp = registerResp(t, s, req)
+	assert.Empty(t, resp.Warnings,
+		"a withdrawn warning must not keep arriving — reporting a fixed problem is the bug, not the fix")
+}

--- a/internal/proxyd/warnings_test.go
+++ b/internal/proxyd/warnings_test.go
@@ -3,17 +3,22 @@ package proxyd
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"io"
 	"log/slog"
 	"net/http"
 	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/charliek/prox/internal/domain"
+	"github.com/charliek/prox/internal/proxy/certs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -172,6 +177,12 @@ func TestRegister_WarningsSurviveWarmCertGeneration(t *testing.T) {
 		m.RecordWarning(testWarning) // the producer seam, fired during generation
 		return generateWildcardCert(d)
 	}
+	// applyCATrust runs on EVERY EnsureDomain now, so the verdict source has to
+	// be pinned here for two reasons: an UNKNOWN verdict touches the holder
+	// neither way, leaving this test's synthetic RecordWarning to stand for the
+	// producer; and without it the real resolver would shell out to the
+	// developer's actual mkcert, which no unit test may do.
+	m.resolveTrust = func() certs.TrustVerdict { return certs.TrustVerdict{} }
 	s := newProxyServerWithCertMgr(t, m)
 	port := freePort(t)
 
@@ -289,8 +300,13 @@ func TestClientRegister_PassesWarningsThrough(t *testing.T) {
 // snapshot must be a copy the caller can mutate without corrupting the holder.
 func TestCertWarningHolder_Concurrent(t *testing.T) {
 	m := NewMultiDomainCertManager(t.TempDir())
-	// Never shell to mkcert from a test: swap in the in-memory generator.
+	// Never shell to mkcert from a test: swap in the in-memory generator AND
+	// pin the trust verdict. applyCATrust runs on every EnsureDomain, so the
+	// generator override alone no longer keeps the real mkcert out of a unit
+	// test — and an UNKNOWN verdict leaves this test's own RecordWarning
+	// standing, which is what it is measuring.
 	m.generate = func(d string) (*tls.Certificate, error) { return generateWildcardCert(d) }
+	m.resolveTrust = func() certs.TrustVerdict { return certs.TrustVerdict{} }
 	backendHost, backendPort := backendTarget(t)
 	s := newProxyServerWithCertMgr(t, m)
 
@@ -407,4 +423,95 @@ func TestRegister_ClearedWarningStopsBeingReported(t *testing.T) {
 	resp = registerResp(t, s, req)
 	assert.Empty(t, resp.Warnings,
 		"a withdrawn warning must not keep arriving — reporting a fixed problem is the bug, not the fix")
+}
+
+// warmCertFiles writes a usable cert/key pair to dir under the names
+// certs.Manager expects, standing in for "the certs are already on disk". It is
+// the state a daemon restarted onto a new release starts in — the one in which
+// mkcert never runs and therefore never says anything.
+func warmCertFiles(t *testing.T, dir, baseDomain string) {
+	t.Helper()
+	cert, err := generateWildcardCert(baseDomain)
+	require.NoError(t, err)
+	keyDER, err := x509.MarshalPKCS8PrivateKey(cert.PrivateKey)
+	require.NoError(t, err)
+
+	safe := strings.ReplaceAll(baseDomain, ".", "_")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, safe+".pem"),
+		pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Certificate[0]}), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, safe+"-key.pem"),
+		pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER}), 0o600))
+}
+
+// warmCertManager returns a real MultiDomainCertManager (real holder, real
+// EnsureDomain cache, real certs.Manager) whose certs are already on disk and
+// whose CA-trust verdict is the given one. Only the verdict is faked: what
+// mkcert's output MEANS is tested where it is parsed (internal/proxy/certs);
+// what the DAEMON does with the verdict is what these tests pin.
+func warmCertManager(t *testing.T, baseDomain string, v certs.TrustVerdict) *MultiDomainCertManager {
+	t.Helper()
+	dir := t.TempDir()
+	warmCertFiles(t, dir, baseDomain)
+	m := NewMultiDomainCertManager(dir)
+	m.resolveTrust = func() certs.TrustVerdict { return v }
+	return m
+}
+
+// TestGenerateViaMkcert_PublishesWarmCertVerdict is the case the daemon exists
+// to cover: certs already on disk, mkcert never runs, and the warning still
+// reaches the client. Before the trust probe this path could only ever report
+// nothing, which — given RELEASING.md requires restarting the daemon after every
+// release — is the state most users would have been in.
+func TestGenerateViaMkcert_PublishesWarmCertVerdict(t *testing.T) {
+	untrusted := testWarning
+	m := warmCertManager(t, "warmwarn.test", certs.TrustVerdict{Known: true, Warning: &untrusted})
+
+	require.NoError(t, m.EnsureDomain("warmwarn.test"))
+	assert.Equal(t, []domain.Warning{untrusted}, m.Warnings(),
+		"a generation-free cert load must still publish the CA-scoped verdict")
+}
+
+// TestGenerateViaMkcert_TrustedVerdictWithdrawsWarning is the anti-lying half
+// wired end to end: the user ran `mkcert -install`, so the daemon must stop
+// saying otherwise rather than repeating a fixed problem until it restarts.
+func TestGenerateViaMkcert_TrustedVerdictWithdrawsWarning(t *testing.T) {
+	m := warmCertManager(t, "fixed.test", certs.TrustVerdict{Known: true})
+	m.RecordWarning(testWarning)
+	require.Len(t, m.Warnings(), 1, "precondition: the warning is being reported")
+
+	require.NoError(t, m.EnsureDomain("fixed.test"))
+	assert.Empty(t, m.Warnings(), "a trusted verdict must withdraw the warning")
+}
+
+// TestGenerateViaMkcert_UnknownVerdictChangesNothing pins the third state. An
+// unknown verdict (no mkcert, no CA yet, a probe that failed) is not evidence
+// of trust, so it must not retract a warning, and not evidence of a problem, so
+// it must not raise one.
+func TestGenerateViaMkcert_UnknownVerdictChangesNothing(t *testing.T) {
+	m := warmCertManager(t, "unknown.test", certs.TrustVerdict{})
+	m.RecordWarning(testWarning)
+
+	require.NoError(t, m.EnsureDomain("unknown.test"))
+	assert.Equal(t, []domain.Warning{testWarning}, m.Warnings(),
+		"an unknown verdict must neither raise nor retract anything")
+}
+
+// TestRegister_ReportsCATrustWarningFromCertPhase closes the daemon loop over a
+// real register: the cert phase itself — not a test calling RecordWarning —
+// produces the warning the response carries.
+func TestRegister_ReportsCATrustWarningFromCertPhase(t *testing.T) {
+	backendHost, backendPort := backendTarget(t)
+	untrusted := testWarning
+	m := warmCertManager(t, "catrust.test", certs.TrustVerdict{Known: true, Warning: &untrusted})
+	s := newProxyServerWithCertMgr(t, m)
+
+	resp := registerResp(t, s, RegisterRequest{
+		ProjectDir: "/projects/catrust", PID: os.Getpid(), Version: "test", Domain: "catrust.test",
+		Services:  map[string]ServiceTarget{"svc": {Host: backendHost, Port: backendPort}},
+		HTTPSPort: freePort(t),
+	})
+
+	assert.Equal(t, []string{"svc.catrust.test"}, resp.Registered)
+	assert.Equal(t, []domain.Warning{untrusted}, resp.Warnings,
+		"the cert phase's own verdict must reach the client that cannot see the daemon's output")
 }

--- a/internal/supervisor/process.go
+++ b/internal/supervisor/process.go
@@ -1251,6 +1251,41 @@ func (p *ManagedProcess) monitor(inst *processInstance) {
 	claimedExit := inst.claimTerminal(claimExit)
 	inst.markExited()
 
+	// Tear down THIS instance's context the instant the leader is gone (#107).
+	// Before this, the only cancels were the launch-failure cleanup and stop(),
+	// so a process that crashed on its own left its health checker ticking --
+	// re-executing the user's check command against a dead pid, with whatever
+	// side effects that command has, until some later Stop happened to arrive
+	// (and reporting `"healthcheck": {"enabled": true}` the whole time).
+	//
+	// WHY HERE, before the output-drain wait, and not at the terminal-state
+	// commit below: the drain can take up to outputDrainTimeout (5s) when a
+	// grandchild is holding the pipe open, and cancelling at the commit point
+	// would keep the checker shelling out for that entire window. From the
+	// instant inst.proc.Wait() returns, the leader is gone and the health
+	// checker is meaningless.
+	//
+	// WHY IT IS SAFE:
+	//   - The only consumers of processCtx are healthChecker.Start and
+	//     runner.Start; the production ExecRunner explicitly ignores its ctx
+	//     (lifecycle is driven via Signal, see runner.go), so cancelling kills
+	//     nothing.
+	//   - Output draining is tracked on inst.outputWg, NOT on the context, so
+	//     this cannot truncate log capture -- the drain wait below is unaffected.
+	//   - Teardown is by inst.proc.Signal(...) in stop(). Cancelling sends no
+	//     signal and disturbs no pgid.
+	//   - Cancelling is NOT the same as releasing p.current: the instance (and
+	//     therefore the pgid) is deliberately retained below, so a surviving
+	//     group stays reapable by a later Stop. Only the health loop stops.
+	//   - It touches only this instance's context. A restart installs a fresh
+	//     HealthChecker on a fresh processCtx, so a stale monitor cancels only
+	//     its own dead checker.
+	//   - stop()'s later inst.cancel() becomes a no-op; context.CancelFunc is
+	//     idempotent by contract.
+	if inst.cancel != nil {
+		inst.cancel()
+	}
+
 	// Wait for this instance's output readers to finish draining pipes with a
 	// timeout. With manual pipes (not cmd.StdoutPipe), the pipes stay open
 	// until all processes (including grandchildren) close them, so graceful
@@ -1320,7 +1355,10 @@ func (p *ManagedProcess) monitor(inst *processInstance) {
 		}
 	}
 	// Deliberately do NOT null p.current: retaining it keeps the pgid reapable
-	// for a retry Stop.
+	// for a retry Stop. Note this is untouched by the instance-context cancel
+	// above (#107) -- cancelling the context is NOT releasing the instance: it
+	// stops the health loop and nothing else, so the retained pgid stays exactly
+	// as reapable as it was before.
 	stateChanged := p.state != prevState
 	p.mu.Unlock()
 

--- a/internal/supervisor/process_test.go
+++ b/internal/supervisor/process_test.go
@@ -3,6 +3,7 @@ package supervisor
 import (
 	"context"
 	"errors"
+	"os"
 	"testing"
 	"time"
 
@@ -253,6 +254,125 @@ func TestManagedProcess_Info_HealthSituations(t *testing.T) {
 		cancel()
 		assert.False(t, mp.Info().HealthDetails.Enabled)
 	})
+}
+
+// healthyForeverConfig is a healthcheck whose start period is longer than any
+// test run, so the checker's loop parks in its start-period select and never
+// shells out. The tests below observe HealthDetails.Enabled -- i.e. whether the
+// loop is alive at all -- so they need the loop RUNNING, not CHECKING, and this
+// keeps them free of subprocess timing.
+func healthyForeverConfig() *domain.HealthConfig {
+	return &domain.HealthConfig{
+		Cmd:         "true",
+		Interval:    time.Hour,
+		Timeout:     time.Minute,
+		Retries:     1,
+		StartPeriod: time.Hour,
+	}
+}
+
+// newHealthCheckedFake builds a ManagedProcess with a healthcheck configured,
+// wired to the given fake runner (mirrors newFakeManagedProcess).
+func newHealthCheckedFake(t *testing.T, runner ProcessRunner) *ManagedProcess {
+	t.Helper()
+	logMgr := logs.NewManager(logs.ManagerConfig{BufferSize: 100})
+	t.Cleanup(func() { logMgr.Close() })
+	return NewManagedProcess(domain.ProcessConfig{
+		Name:        "web",
+		Cmd:         "irrelevant",
+		Healthcheck: healthyForeverConfig(),
+	}, nil, runner, logMgr)
+}
+
+// TestManagedProcess_Monitor_NaturalExitStopsHealthChecker is the regression
+// test for #107: when a process dies on its own (no Stop), the health checker
+// must stop with it. Before the fix the instance context was cancelled ONLY by
+// stop() and the launch-failure path, so a crashed process kept re-running the
+// user's check command on its interval -- and reported enabled=true -- until
+// some later Stop tore it down.
+func TestManagedProcess_Monitor_NaturalExitStopsHealthChecker(t *testing.T) {
+	runner := newFakeRunner(func(call int) *fakeProcess { return newFakeProcess(7100 + call) })
+	mp := newHealthCheckedFake(t, runner)
+
+	require.NoError(t, mp.Start(context.Background()))
+	require.Equal(t, domain.ProcessStateRunning, mp.State())
+
+	before := mp.Info()
+	require.NotNil(t, before.HealthDetails)
+	require.True(t, before.HealthDetails.Enabled, "a live run must report an enabled check loop")
+
+	// The leader exits on its own -- no Stop, no signal. The group goes with it.
+	fp := runner.last()
+	fp.setAlive(false)
+	fp.exitLeader(errors.New("boom"))
+
+	waitForState(t, mp, domain.ProcessStateCrashed, 5*time.Second)
+
+	after := mp.Info()
+	require.NotNil(t, after.HealthDetails)
+	assert.False(t, after.HealthDetails.Enabled,
+		"a crashed process must not keep a health check loop running (#107)")
+}
+
+// TestManagedProcess_Monitor_HealthCheckerStopsBeforeOutputDrain pins the
+// INSERTION POINT of the #107 fix, which is the part that actually matters:
+// the cancel happens right after Wait() returns, BEFORE monitor's up-to-5s
+// output-drain wait. This test holds a pipe open past the leader's exit (what a
+// surviving grandchild does), so the drain is guaranteed to still be in
+// progress, and asserts the checker is already down.
+//
+// If the cancel were moved to the terminal-state commit -- the other natural
+// place for it -- this test fails: the checker would keep executing the user's
+// command for the whole outputDrainTimeout window.
+func TestManagedProcess_Monitor_HealthCheckerStopsBeforeOutputDrain(t *testing.T) {
+	// A pipe whose write end the test holds: the stdout reader blocks in Read
+	// until we close it, exactly like a grandchild that outlives the leader.
+	pr, pw, err := os.Pipe()
+	require.NoError(t, err)
+	defer pr.Close()
+	pipeClosed := false
+	closePipe := func() {
+		if !pipeClosed {
+			pipeClosed = true
+			pw.Close()
+		}
+	}
+	defer closePipe()
+
+	runner := newFakeRunner(func(call int) *fakeProcess {
+		fp := newFakeProcess(7200 + call)
+		fp.stdout = pr
+		return fp
+	})
+	mp := newHealthCheckedFake(t, runner)
+
+	require.NoError(t, mp.Start(context.Background()))
+	require.True(t, mp.Info().HealthDetails.Enabled)
+
+	fp := runner.last()
+	fp.setAlive(false)
+	start := time.Now()
+	fp.exitLeader(nil)
+
+	// The checker must go down promptly -- not after the drain window.
+	require.Eventually(t, func() bool {
+		return !mp.Info().HealthDetails.Enabled
+	}, outputDrainTimeout/2, 5*time.Millisecond,
+		"health checker must stop as soon as the leader exits, not wait out the output drain")
+	elapsed := time.Since(start)
+
+	// ...and prove the drain really was still pending when it did, so this is a
+	// statement about ordering rather than about a fast machine: the terminal
+	// state is only committed AFTER the drain, and the pipe is still open here.
+	assert.Equal(t, domain.ProcessStateRunning, mp.State(),
+		"the drain must still be in flight (state not yet committed) when the checker stops")
+	assert.Less(t, elapsed, outputDrainTimeout,
+		"checker stopped only after the full drain window")
+
+	// Release the grandchild so the monitor finishes before the log manager is
+	// torn down.
+	closePipe()
+	waitForState(t, mp, domain.ProcessStateCrashed, 5*time.Second)
 }
 
 // TestManagedProcess_Info_WaitingReportsNoPID pins the plan 013 D5 fix: a gated

--- a/internal/tui/base.go
+++ b/internal/tui/base.go
@@ -199,6 +199,15 @@ type BaseModel struct {
 	// resolved to the cwd base in RunClient.
 	projectName string
 
+	// proxyConfigured / captureEnabled mirror the ClientOptions fields of the
+	// same name: the resolved runtime state of the proxy path behind this
+	// session (see ClientOptions.ProxyConfigured). They live on BaseModel
+	// because both readers do — the requests empty state and the request
+	// detail's capture note. Static for the session; nothing mutates them
+	// after construction.
+	proxyConfigured bool
+	captureEnabled  bool
+
 	// Menu bar open state (WS3). openMenu is -1 when closed, otherwise a MenuID.
 	// menuHighlight is the full-list index of the highlighted dropdown row.
 	// menuWindow is the first visible item index — reset on open/sibling slide,
@@ -1884,6 +1893,44 @@ func (b *BaseModel) clampViewportToContent() {
 	}
 }
 
+// requestsEmptyHint explains an empty requests pane. The pane being empty is
+// almost never the interesting fact — WHY it is empty is — and every answer
+// here is either actionable or a promise the session can actually keep.
+//
+// Priority matters. An active filter wins outright: the user narrowed the list
+// themselves, so reporting the project's proxy configuration would be answering
+// a question nobody asked (and a filter can hide requests that plainly exist).
+// Below that, "no proxy" outranks the capture note, because capture is
+// meaningless without a proxy to capture from.
+//
+// EVERY BRANCH IS A TRUTH CLAIM, and getting one wrong is the bug this exists
+// to fix (#92), so two of them are worded carefully:
+//
+//   - The no-proxy branch says "no proxy running", not "no proxy configured".
+//     It fires for three different states — no proxy: block at all, one that is
+//     `enabled: false`, and `--no-proxy` on the command line — and only the
+//     first is fixed by adding a block. What is true in all three is that this
+//     SESSION has no proxy, so that is what it says.
+//   - Capture being off does NOT keep this list empty. Both proxy paths still
+//     publish a metadata-only record when capture is disabled (see the brw
+//     branch in internal/proxy/proxy.go, which Upserts with nil details), so
+//     rows DO arrive — they simply carry no headers or bodies. Saying "capture
+//     is disabled" on its own would imply nothing will ever show up, which is
+//     the same class of untruth as the unconditional hint this replaced. So the
+//     branch keeps the promise of traffic and qualifies what will land.
+func (b *BaseModel) requestsEmptyHint() string {
+	switch {
+	case !b.requestsFilter.LastGood.IsEmpty():
+		return "No lines match " + b.requestsFilter.LastGood.Serialize()
+	case !b.proxyConfigured:
+		return "No proxy running — enable a proxy: block in prox.yaml to capture requests"
+	case !b.captureEnabled:
+		return "No requests yet — capture is off, so rows will show metadata only"
+	default:
+		return "No requests yet — traffic through the proxy appears here"
+	}
+}
+
 // updateViewport updates the viewport content
 func (b *BaseModel) updateViewport() {
 	var lines []string
@@ -1900,10 +1947,7 @@ func (b *BaseModel) updateViewport() {
 		// invariant agree within this single render (D6/D8).
 		b.resolveRequestCursor(requests)
 		if len(requests) == 0 {
-			hint := "No requests yet — traffic through the proxy appears here"
-			if !b.requestsFilter.LastGood.IsEmpty() {
-				hint = "No lines match " + b.requestsFilter.LastGood.Serialize()
-			}
+			hint := b.requestsEmptyHint()
 			lines = centeredHint(hint, styles.Dim, b.viewport.Width, b.viewport.Height)
 		} else {
 			for i, req := range requests {
@@ -2087,6 +2131,26 @@ func (b *BaseModel) formatRequestDetail() []string {
 		default:
 			lines = append(lines, styles.Dim.Render("(request in flight — details arrive on completion)"))
 		}
+	} else if !b.captureEnabled {
+		// Capture off: this record is a completed request whose details were
+		// never recorded, so every section below renders nothing
+		// (renderBodySection returns nil for an absent body). Without this note
+		// the detail view is silently, unexplainably bare.
+		//
+		// It says "details", not "bodies": the capture path builds
+		// RequestDetails with request AND response HEADERS alongside the two
+		// bodies (internal/proxy/proxy.go), and with capture off the record is
+		// Upserted with nil details — so the headers are just as absent as the
+		// bodies, and naming only the bodies would leave the empty header
+		// sections unexplained.
+		//
+		// Deliberately an ELSE of the in-flight branch, not a second note: an
+		// in-flight record has no details YET for a reason that has nothing to do
+		// with capture, and stacking both would give one record two competing
+		// explanations. In-flight wins; when it completes, this note takes over
+		// (see clampViewportToContent for the height change that causes).
+		lines = append(lines, "")
+		lines = append(lines, styles.Dim.Render("Capture is disabled (proxy.capture.enabled: false) — no headers or bodies were recorded"))
 	}
 
 	// Request headers (key Dim, value default — C9)

--- a/internal/tui/base.go
+++ b/internal/tui/base.go
@@ -362,8 +362,17 @@ func (b *BaseModel) handleWindowSize(msg tea.WindowSizeMsg) {
 }
 
 // chromeAbove is the number of rows above the viewport (menu bar + process
-// panel). Derived from ACTUAL enabled chrome — not fixed reservations (Codex #8).
+// panel + dead-stack banner). Derived from ACTUAL enabled chrome — not fixed
+// reservations (Codex #8).
 func (b *BaseModel) chromeAbove() int {
+	return b.fixedChromeAbove() + b.deadStackBannerRows()
+}
+
+// fixedChromeAbove is the settings-driven part of chromeAbove: the rows that
+// change only on a WindowSizeMsg or a visibility toggle. Split out because the
+// dead-stack banner's own room check (showDeadStackBanner) needs the chrome
+// around it and would otherwise recurse through chromeAbove into itself.
+func (b *BaseModel) fixedChromeAbove() int {
 	h := 0
 	if b.settings.MenuBar {
 		h++ // menu bar row
@@ -466,7 +475,10 @@ func (b *BaseModel) isFooterY(y int) bool {
 // WindowSizeMsg, every visibility toggle (a toggle emits no resize, so
 // without this the viewport keeps stale geometry — Codex #8), and view-mode
 // switches (C11 requests header changes viewport height). C4 flips
-// ProcessPanel and calls relayout the same way. Panel border (C7) insets the
+// ProcessPanel and calls relayout the same way. Plan 028 C4 adds the one DATA
+// -driven caller: the dead-stack banner appears and disappears on a
+// ProcessesMsg, so that handler compares showDeadStackBanner across the
+// assignment and relayouts when it flips. Panel border (C7) insets the
 // viewport by panelBorder() rows/cols when contentRect is large enough; the
 // requests header (C11) further shrinks height and shifts YPosition.
 func (b *BaseModel) relayout() {
@@ -2902,6 +2914,14 @@ func (b *BaseModel) mainView(msg footerMsg) string {
 		if CurrentTheme().FullFill {
 			lines = append(lines, padFrameRow("", b.width))
 		}
+	}
+
+	// Dead-stack banner (plan 028 C4): between the process panel and the panel
+	// top border, counted in chromeAbove so the viewport is one row shorter
+	// while it is up. Its own band fill (styles.Err) spans the frame, so no
+	// padFrameRow wrapping — that would re-pad an already exact-width row.
+	if b.showDeadStackBanner() {
+		lines = append(lines, singleFrameLine(b.renderDeadStackBanner(b.width)))
 	}
 
 	drawPanel := b.canDrawPanel()

--- a/internal/tui/base.go
+++ b/internal/tui/base.go
@@ -2704,21 +2704,44 @@ func processStyle(state domain.ProcessState) lipgloss.Style {
 	}
 }
 
-// gatedDetail returns the inline gated-launch annotation for a process (plan 013
-// D5): " (waiting on: X, Y)" while waiting, " (blocked on: X)" while blocked, and
-// "" in every other state. Targets are shown in declaration order.
-func gatedDetail(p domain.ProcessInfo) string {
+// stateLabel returns the colour-independent state text appended after a
+// process name in the panel (issue #92 bug 1). processStyle colours the name,
+// but colour alone does not survive ANSI-stripped output (piped logs,
+// TERM=dumb, screenshots) or a colour-blind reader — and styles.Crashed /
+// styles.Blocked share one style, as do styles.Stopped / styles.Completed, so
+// those pairs are ONLY colour-distinguishable today. Every state but running
+// gets a parenthesized word suffix; running pays nothing so the common case
+// stays byte-identical.
+//
+// Subsumes the former gatedDetail (plan 013 D5): the waiting-on / blocked-on
+// forms below are byte-identical to its old output.
+func stateLabel(p domain.ProcessInfo) string {
 	switch p.State {
+	case domain.ProcessStateRunning:
+		return ""
 	case domain.ProcessStateWaiting:
 		if len(p.WaitingOn) > 0 {
 			return " (waiting on: " + strings.Join(p.WaitingOn, ", ") + ")"
 		}
+		return " (waiting)"
 	case domain.ProcessStateBlocked:
 		if len(p.BlockedOn) > 0 {
 			return " (blocked on: " + strings.Join(p.BlockedOn, ", ") + ")"
 		}
+		return " (blocked)"
+	case domain.ProcessStateCrashed:
+		return " (crashed)"
+	case domain.ProcessStateCompleted:
+		return " (done)"
+	case domain.ProcessStateStopped:
+		return " (stopped)"
+	case domain.ProcessStateStarting:
+		return " (starting)"
+	case domain.ProcessStateStopping:
+		return " (stopping)"
+	default:
+		return ""
 	}
-	return ""
 }
 
 // healthDot returns the process panel's health indicator (plan 018 D13): a
@@ -2759,11 +2782,11 @@ func (b *BaseModel) processPanel() string {
 			name = fmt.Sprintf("[%s]", proc.Name)
 		}
 
-		// Gated-launch detail (plan 013 D5): a waiting/blocked process shows what
-		// it is gated on inline, in declaration order, so the panel explains why it
-		// has not launched. Kept minimal — this compact panel has no separate
-		// detail area.
-		name += gatedDetail(proc)
+		// State label (issue #92 bug 1): every non-running state gets a
+		// colour-independent word suffix, so the panel does not rely on colour
+		// alone to convey e.g. crashed vs. running. Subsumes the former
+		// gated-launch detail (plan 013 D5) inline, in declaration order.
+		name += stateLabel(proc)
 
 		// Health dot (plan 018 D13): appended as a separately styled segment
 		// after the name so the name's state style cannot swallow or recolor
@@ -2943,11 +2966,19 @@ func (b *BaseModel) statusBar(msg footerMsg) string {
 	case ViewModeRequestDetail:
 		viewIndicator = "[Request Detail]"
 	}
-	followIndicator := "[FOLLOW]"
-	if !b.followMode {
-		followIndicator = "[PAUSED]"
+	// Detail view is not a scrolling list: it has no follow state and no
+	// line/request count of its own, so showing either would state something
+	// the view cannot mean (issue #92 bug 2). Render the view tag alone.
+	var countPlain string
+	if b.viewMode == ViewModeRequestDetail {
+		countPlain = viewIndicator
+	} else {
+		followIndicator := "[FOLLOW]"
+		if !b.followMode {
+			followIndicator = "[PAUSED]"
+		}
+		countPlain = fmt.Sprintf("%s %s %d/%d %s", viewIndicator, followIndicator, visible, total, label)
 	}
-	countPlain := fmt.Sprintf("%s %s %d/%d %s", viewIndicator, followIndicator, visible, total, label)
 	countStyled := styles.FooterLabel.Render(countPlain)
 
 	left, right := fitFooterRow(b.width, leftStyled, countStyled, defaultFooterHints(b.helpConfig.QuitHint))

--- a/internal/tui/client.go
+++ b/internal/tui/client.go
@@ -169,6 +169,27 @@ type ClientOptions struct {
 	ProxyHTTPSPort int
 	ProxyHTTPPort  int
 
+	// ProxyConfigured and CaptureEnabled describe the RESOLVED RUNTIME state of
+	// the proxy path behind this session, and exist so the requests pane can say
+	// why it is empty instead of promising traffic that can never arrive.
+	//
+	// Runtime, not config: `prox up --no-proxy` runs with a perfectly valid
+	// `proxy:` block and no proxy, so the caller derives these from what it
+	// actually did (up) or from the daemon's status block (attach) — see
+	// resolveProxyRuntimeState and attachProxyFacts in internal/cli.
+	//
+	// Both are STATIC for the session: the daemon loads its config once at `up`
+	// time, so neither value can change under an attached client. That is why
+	// they ride in on options rather than being fetched per frame through
+	// TUIClient — a live getter would widen the interface every fake implements
+	// to re-fetch a constant.
+	//
+	// The zero value (false, false) means "no proxy, no capture", so callers
+	// that know nothing must pass true/true — the wording that predates these
+	// fields — rather than leaving them unset.
+	ProxyConfigured bool
+	CaptureEnabled  bool
+
 	// ShutdownCh, when non-nil, quits the program on close. This is how an
 	// out-of-band shutdown request (POST /shutdown, via the coordinator's
 	// trigger channel) reaches a --tui daemon, which otherwise blocks in
@@ -235,6 +256,8 @@ func NewClientModel(client TUIClient, opts ClientOptions) ClientModel {
 		opts:      opts,
 	}
 	m.projectName = resolveProjectName(opts.ProjectName)
+	m.proxyConfigured = opts.ProxyConfigured
+	m.captureEnabled = opts.CaptureEnabled
 	// Seeded here rather than from Init: a command's message would arrive after
 	// the first View (and could race the first backfill batch), whereas the
 	// preamble is the one content this model is guaranteed to be able to show

--- a/internal/tui/client.go
+++ b/internal/tui/client.go
@@ -416,7 +416,24 @@ func (m ClientModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// deliberately NOT touched here: it is derived from stream health
 		// alone, and the OK transition that precedes the first snapshot has
 		// already cleared it.
+		//
+		// THE RELAYOUT IS LOAD-BEARING (plan 028 C4). The dead-stack banner is
+		// the first chrome row whose height changes on a DATA message: until
+		// now only WindowSizeMsg and the visibility toggles could change
+		// chromeAbove, and they are the only callers of relayout (see its doc
+		// comment). Without this the viewport keeps its pre-banner height and
+		// overflows the frame by exactly one row — the class of bug plan 024
+		// spent a whole batch fixing. It must fire in BOTH directions: a
+		// `prox restart` that revives the stack has to give the row back.
+		bannerBefore := m.showDeadStackBanner()
 		m.processes = []domain.ProcessInfo(msg)
+		if m.showDeadStackBanner() != bannerBefore {
+			m.relayout()
+			// Same order WindowSizeMsg uses: geometry first, then re-render
+			// content against it (the empty-state hints are sized to
+			// viewport.Height, so a stale render would be a row off).
+			m.updateViewport()
+		}
 
 	case RestartResultMsg:
 		m.lastRestartProcess = msg.Process

--- a/internal/tui/client_model_test.go
+++ b/internal/tui/client_model_test.go
@@ -266,6 +266,11 @@ func attachClientOptions() ClientOptions {
 			QuitMessage: "Quit (daemon continues running)",
 		},
 		ConnectedStatus: "Connected via API",
+		// What attach passes when it knows nothing: attachProxyFacts answers
+		// true/true for a nil status block or a daemon predating capture_enabled,
+		// i.e. "keep the wording that predates these fields".
+		ProxyConfigured: true,
+		CaptureEnabled:  true,
 	}
 }
 

--- a/internal/tui/dead_stack.go
+++ b/internal/tui/dead_stack.go
@@ -1,0 +1,149 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/charliek/prox/internal/domain"
+)
+
+// The dead-stack banner (plan 028 C4, #96).
+//
+// A foreground `prox up` whose every process has died used to sit there
+// supervising nothing, silent, until the user thought to press Ctrl-C. C3 fixed
+// that for plain/piped mode by ending the session non-zero. THE TUI IS
+// DELIBERATELY DIFFERENT: it does NOT auto-exit. The user is present and
+// reading, and pulling the screen out from under them would take the crash
+// output -- the very thing they need to see -- with it. So instead of exiting,
+// the TUI states the situation in a persistent, unmissable row and says how to
+// leave.
+//
+// Because it is computed from the process snapshots the TUI already receives
+// (ConsumeProcesses -> ProcessesMsg -> BaseModel.processes), nothing new is
+// plumbed for it, and it works in `prox attach` too.
+
+// deadStackProcs reports whether procs describe a session with nothing left to
+// supervise and a failure to answer for.
+//
+// This is the same rule the CLI's dead-stack watcher applies -- see deadStack in
+// internal/cli/dead_stack.go, which carries the full rationale for both gates.
+// The two are siblings, not a copy: internal/tui must not import internal/cli,
+// so each spells the predicate out locally, and BOTH derive it from the same
+// domain predicates (ProcessState.IsLive / IsTerminalFailure, domain/process.go).
+// That shared derivation is what keeps them honest -- widen the domain
+// predicates and both move together; widen one of these functions alone and the
+// banner and the exit code start disagreeing about what "dead" means.
+//
+// IsStopped is NOT usable here: it also covers `completed`, a task's terminal
+// SUCCESS, so an all-tasks-finished config would be branded a crash.
+func deadStackProcs(procs []domain.ProcessInfo) bool {
+	if len(procs) == 0 {
+		// Nothing configured (or nothing known yet) is not a dead stack.
+		return false
+	}
+	failed := false
+	for _, p := range procs {
+		if p.State.IsLive() {
+			return false
+		}
+		if p.State.IsTerminalFailure() {
+			failed = true
+		}
+	}
+	return failed
+}
+
+// deadStackBannerText is the banner's sentence, or "" when the stack is not
+// dead.
+//
+// The counts name BOTH halves of IsTerminalFailure, not just crashes: a stack
+// that never launched because a dependency failed is every bit as dead as one
+// that crashed, and "crashed" would be a lie about it.
+//
+// The KEY is `q` in both modes and is not derived from HelpConfig:
+// defaultFooterHints (footer.go) fixes the key and varies only its LABEL
+// (HelpConfig.QuitHint -- "stop" for `prox up`, "quit" for `prox attach`), so
+// naming the key here cannot drift from the footer. The VERB is deliberately
+// "quit" in both modes rather than the footer's label: owner mode's "stop"
+// means "quit, taking the processes down with you", and at the moment this
+// banner appears there is nothing left to take down -- "press q to stop" would
+// name an action that has already happened. Quitting is what q does here.
+func deadStackBannerText(procs []domain.ProcessInfo) string {
+	if !deadStackProcs(procs) {
+		return ""
+	}
+	var crashed, blocked int
+	for _, p := range procs {
+		switch p.State {
+		case domain.ProcessStateCrashed:
+			crashed++
+		case domain.ProcessStateBlocked:
+			blocked++
+		}
+	}
+	var parts []string
+	if crashed > 0 {
+		parts = append(parts, fmt.Sprintf("%d crashed", crashed))
+	}
+	if blocked > 0 {
+		parts = append(parts, fmt.Sprintf("%d blocked", blocked))
+	}
+	// deadStackProcs guarantees at least one terminal failure, so parts is
+	// never empty and the sentence never degenerates to "stopped — .".
+	return fmt.Sprintf("All processes have stopped — %s. Nothing is running. Press q to quit.",
+		strings.Join(parts, ", "))
+}
+
+// showDeadStackBanner reports whether the banner occupies a chrome row.
+//
+// It must NOT call chromeAbove: chromeAbove counts this row, so the room check
+// below reads the fixed chrome directly. The check mirrors requestsHeaderRows —
+// a chrome row never takes the last content row, because a frame with zero
+// viewport rows overflows its own height.
+func (b *BaseModel) showDeadStackBanner() bool {
+	if deadStackBannerText(b.processes) == "" {
+		return false
+	}
+	if b.width <= 0 {
+		return false // nothing renderable; geometry is stale anyway (relayout no-ops)
+	}
+	if b.height > 0 && b.height-(b.fixedChromeAbove()+b.chromeBelow()) < 2 {
+		return false
+	}
+	return true
+}
+
+// deadStackBannerRows is the banner's row cost (0 or 1), for chromeAbove.
+func (b *BaseModel) deadStackBannerRows() int {
+	if b.showDeadStackBanner() {
+		return 1
+	}
+	return 0
+}
+
+// renderDeadStackBanner builds the full-width banner row.
+//
+// styles.Err is the theme's error palette (ErrBadgeFG on ErrBadgeBG, bold) and
+// it paints the trailing fill too, so the row is a solid band under every theme
+// — no default-background hole (plan 024's frame-fill law), FullFill or legacy.
+// The colour is emphasis ONLY: strip every escape and the sentence still says
+// what happened and how to leave, which is the whole point of the feature.
+func (b *BaseModel) renderDeadStackBanner(width int) string {
+	text := deadStackBannerText(b.processes)
+	if text == "" || width <= 0 {
+		return ""
+	}
+	// Leading gutter matches the footer/header left inset.
+	row := styles.Err.Render(" " + text)
+	w := ansi.StringWidth(row)
+	switch {
+	case w > width:
+		return ansi.Cut(row, 0, width)
+	case w < width:
+		return row + styles.Err.Render(strings.Repeat(" ", width-w))
+	default:
+		return row
+	}
+}

--- a/internal/tui/dead_stack_test.go
+++ b/internal/tui/dead_stack_test.go
@@ -1,0 +1,345 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/charliek/prox/internal/domain"
+)
+
+// Dead-stack banner tests (plan 028 C4, #96). Every assertion here reads the
+// REAL rendered frame with styling stripped: the banner's contract is that its
+// text carries the meaning, so a test that inspected the model's fields instead
+// would pass on a banner nobody can read.
+
+// deadStackProcsOf builds a snapshot with one process per state (p0, p1, ...).
+func deadStackProcsOf(states ...domain.ProcessState) []domain.ProcessInfo {
+	out := make([]domain.ProcessInfo, 0, len(states))
+	for i, s := range states {
+		out = append(out, domain.ProcessInfo{Name: fmt.Sprintf("p%d", i), State: s})
+	}
+	return out
+}
+
+// deadStackModel drives the REAL message path: a sized model plus one
+// ProcessesMsg, exactly as the processes stream delivers it.
+func deadStackModel(t *testing.T, w, h int, states ...domain.ProcessState) ClientModel {
+	t.Helper()
+	m := newTestModel()
+	m = clientUpdate(m, tea.WindowSizeMsg{Width: w, Height: h})
+	m = clientUpdate(m, ProcessesMsg(deadStackProcsOf(states...)))
+	return m
+}
+
+const deadStackBannerLead = "All processes have stopped"
+
+// deadStackBannerRow returns the frame row (styling intact) holding the banner,
+// its index, and whether it was found.
+func deadStackBannerRow(m ClientModel) (string, int, bool) {
+	for i, line := range strings.Split(m.View(), "\n") {
+		if strings.Contains(ansi.Strip(line), deadStackBannerLead) {
+			return line, i, true
+		}
+	}
+	return "", -1, false
+}
+
+func TestDeadStackBanner_AbsentWhenStackIsNotDead(t *testing.T) {
+	pinANSIProfile(t)
+	withTestTheme(t, "tokyo-night")
+
+	cases := []struct {
+		name   string
+		states []domain.ProcessState
+	}{
+		{"no processes", nil},
+		{"all running", []domain.ProcessState{domain.ProcessStateRunning, domain.ProcessStateRunning}},
+		{"partial crash", []domain.ProcessState{domain.ProcessStateCrashed, domain.ProcessStateRunning}},
+		{"all completed", []domain.ProcessState{domain.ProcessStateCompleted, domain.ProcessStateCompleted}},
+		{"all stopped", []domain.ProcessState{domain.ProcessStateStopped, domain.ProcessStateStopped}},
+		// Live-but-not-running states are still live: nothing has settled yet.
+		{"crashed plus starting", []domain.ProcessState{domain.ProcessStateCrashed, domain.ProcessStateStarting}},
+		{"crashed plus waiting", []domain.ProcessState{domain.ProcessStateCrashed, domain.ProcessStateWaiting}},
+		{"crashed plus stopping", []domain.ProcessState{domain.ProcessStateCrashed, domain.ProcessStateStopping}},
+		{"completed and stopped", []domain.ProcessState{domain.ProcessStateCompleted, domain.ProcessStateStopped}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := deadStackModel(t, 100, 24, tc.states...)
+			assert.False(t, m.showDeadStackBanner())
+			_, _, found := deadStackBannerRow(m)
+			assert.False(t, found, "banner must not render for %s", tc.name)
+			assertFrameContract(t, m)
+		})
+	}
+}
+
+func TestDeadStackBanner_PresentAndWorded(t *testing.T) {
+	pinANSIProfile(t)
+	withTestTheme(t, "tokyo-night")
+
+	cases := []struct {
+		name   string
+		states []domain.ProcessState
+		want   string
+	}{
+		{
+			"one crashed",
+			[]domain.ProcessState{domain.ProcessStateCrashed},
+			"All processes have stopped — 1 crashed. Nothing is running. Press q to quit.",
+		},
+		{
+			"all crashed",
+			[]domain.ProcessState{domain.ProcessStateCrashed, domain.ProcessStateCrashed},
+			"All processes have stopped — 2 crashed. Nothing is running. Press q to quit.",
+		},
+		{
+			"one blocked",
+			[]domain.ProcessState{domain.ProcessStateBlocked},
+			"All processes have stopped — 1 blocked. Nothing is running. Press q to quit.",
+		},
+		{
+			"all blocked",
+			[]domain.ProcessState{domain.ProcessStateBlocked, domain.ProcessStateBlocked},
+			"All processes have stopped — 2 blocked. Nothing is running. Press q to quit.",
+		},
+		{
+			"mixed crashed and blocked",
+			[]domain.ProcessState{domain.ProcessStateCrashed, domain.ProcessStateBlocked},
+			"All processes have stopped — 1 crashed, 1 blocked. Nothing is running. Press q to quit.",
+		},
+		{
+			"plural of both",
+			[]domain.ProcessState{
+				domain.ProcessStateCrashed, domain.ProcessStateCrashed,
+				domain.ProcessStateBlocked, domain.ProcessStateBlocked,
+			},
+			"All processes have stopped — 2 crashed, 2 blocked. Nothing is running. Press q to quit.",
+		},
+		{
+			// Nothing live and one failure: a finished task does not excuse the
+			// crash, and completed is NOT counted as a failure.
+			"crashed plus completed",
+			[]domain.ProcessState{domain.ProcessStateCrashed, domain.ProcessStateCompleted},
+			"All processes have stopped — 1 crashed. Nothing is running. Press q to quit.",
+		},
+		{
+			"crashed plus stopped",
+			[]domain.ProcessState{domain.ProcessStateCrashed, domain.ProcessStateStopped},
+			"All processes have stopped — 1 crashed. Nothing is running. Press q to quit.",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := deadStackModel(t, 100, 24, tc.states...)
+			require.True(t, m.showDeadStackBanner())
+			row, _, found := deadStackBannerRow(m)
+			require.True(t, found, "banner row missing")
+			assert.Contains(t, ansi.Strip(row), tc.want)
+			assertFrameContract(t, m)
+		})
+	}
+}
+
+// TestDeadStackBanner_LegibleWithColourStripped is the point of the feature:
+// the row is styled with the error palette, but strip every escape byte and the
+// whole sentence — what happened AND how to leave — is still there.
+func TestDeadStackBanner_LegibleWithColourStripped(t *testing.T) {
+	pinANSIProfile(t)
+	withTestTheme(t, "tokyo-night")
+
+	m := deadStackModel(t, 100, 24, domain.ProcessStateCrashed, domain.ProcessStateBlocked)
+	row, _, found := deadStackBannerRow(m)
+	require.True(t, found)
+
+	require.NotEqual(t, row, ansi.Strip(row), "banner is expected to carry styling at all")
+	plain := ansi.Strip(row)
+	assert.Contains(t, plain, "All processes have stopped")
+	assert.Contains(t, plain, "1 crashed, 1 blocked")
+	assert.Contains(t, plain, "Nothing is running")
+	assert.Contains(t, plain, "Press q to quit")
+
+	// The same holds under a second theme: no theme may encode the meaning in
+	// colour alone.
+	withTestTheme(t, "legacy")
+	row2, _, found2 := deadStackBannerRow(m)
+	require.True(t, found2)
+	assert.Equal(t, plain, ansi.Strip(row2))
+}
+
+// TestDeadStackBanner_RelayoutBothDirections is the load-bearing test: the
+// viewport must shrink by exactly one row when the banner appears and grow back
+// when it goes, driven only by ProcessesMsg. Deleting the relayout() call in
+// the ProcessesMsg handler must fail this.
+func TestDeadStackBanner_RelayoutBothDirections(t *testing.T) {
+	pinANSIProfile(t)
+	withTestTheme(t, "tokyo-night")
+
+	m := deadStackModel(t, 100, 24, domain.ProcessStateRunning, domain.ProcessStateRunning)
+	baseH := m.viewport.Height
+	baseChrome := m.chromeAbove()
+	_, baseOY := m.viewportOrigin()
+	require.False(t, m.showDeadStackBanner())
+	assertFrameContract(t, m)
+
+	// false -> true
+	m = clientUpdate(m, ProcessesMsg(deadStackProcsOf(
+		domain.ProcessStateCrashed, domain.ProcessStateCrashed)))
+	require.True(t, m.showDeadStackBanner())
+	assert.Equal(t, baseChrome+1, m.chromeAbove(), "banner is counted in chromeAbove")
+	assert.Equal(t, baseH-1, m.viewport.Height, "banner costs exactly one viewport row")
+	_, oy := m.viewportOrigin()
+	assert.Equal(t, baseOY+1, oy, "viewport origin shifts down by the banner row")
+	assertFrameContract(t, m)
+
+	// true -> false (a `prox restart` revives the stack)
+	m = clientUpdate(m, ProcessesMsg(deadStackProcsOf(
+		domain.ProcessStateRunning, domain.ProcessStateRunning)))
+	require.False(t, m.showDeadStackBanner())
+	assert.Equal(t, baseChrome, m.chromeAbove())
+	assert.Equal(t, baseH, m.viewport.Height, "the row is given back")
+	_, oy = m.viewportOrigin()
+	assert.Equal(t, baseOY, oy)
+	assertFrameContract(t, m)
+}
+
+// TestDeadStackBanner_FrameContract sweeps sizes and views with the banner up:
+// every row of the frame is exactly the frame width (no default-background
+// hole, no overflow), including narrow frames where the sentence truncates.
+func TestDeadStackBanner_FrameContract(t *testing.T) {
+	pinANSIProfile(t)
+
+	for _, theme := range []string{"tokyo-night", "legacy"} {
+		for _, sz := range []struct{ w, h int }{
+			{120, 40}, {100, 24}, {40, 12}, {20, 8}, {10, 6}, {6, 6}, {2, 6}, {1, 6},
+		} {
+			name := fmt.Sprintf("%s_w%dh%d", theme, sz.w, sz.h)
+			t.Run(name, func(t *testing.T) {
+				withTestTheme(t, theme)
+				m := deadStackModel(t, sz.w, sz.h,
+					domain.ProcessStateCrashed, domain.ProcessStateBlocked)
+				assertFrameContract(t, m)
+
+				m.setViewMode(ViewModeRequests)
+				assertFrameContract(t, m)
+
+				if row, _, found := deadStackBannerRow(m); found {
+					assert.Equal(t, sz.w, ansi.StringWidth(row))
+				}
+			})
+		}
+	}
+}
+
+// TestDeadStackBanner_RowPosition pins where the row sits: after the process
+// panel, immediately above the panel's top border.
+func TestDeadStackBanner_RowPosition(t *testing.T) {
+	pinANSIProfile(t)
+	withTestTheme(t, "tokyo-night")
+
+	m := deadStackModel(t, 100, 24, domain.ProcessStateCrashed)
+	lines := strings.Split(m.View(), "\n")
+	_, idx, found := deadStackBannerRow(m)
+	require.True(t, found)
+
+	panelRowY, ok := m.processPanelRowY()
+	require.True(t, ok)
+	assert.Greater(t, idx, panelRowY, "banner sits below the process panel")
+	assert.Equal(t, m.chromeAbove()-1, idx, "banner is the last chrome row above the panel")
+	require.Less(t, idx+1, len(lines))
+	assert.True(t, strings.HasPrefix(ansi.Strip(lines[idx+1]), "╭"),
+		"the panel top border follows the banner, got %q", ansi.Strip(lines[idx+1]))
+}
+
+// TestDeadStackBanner_HitRectsUnaffected proves the banner does not corrupt
+// mouse targets: the process chips keep their row (the banner is BELOW them),
+// clicking one still solos, and a click on the first viewport row still lands
+// on log row 0 at the shifted origin.
+func TestDeadStackBanner_HitRectsUnaffected(t *testing.T) {
+	pinANSIProfile(t)
+	withTestTheme(t, "tokyo-night")
+
+	m := newTestModel()
+	m = clientUpdate(m, tea.WindowSizeMsg{Width: 120, Height: 24})
+	m = clientUpdate(m, LogEntryMsg(domain.LogEntry{Process: "p0", Line: "alpha"}))
+	m = clientUpdate(m, LogEntryMsg(domain.LogEntry{Process: "p0", Line: "beta"}))
+	m = clientUpdate(m, ProcessesMsg(deadStackProcsOf(
+		domain.ProcessStateRunning, domain.ProcessStateRunning)))
+	_ = m.View()
+	rowY, ok := m.processPanelRowY()
+	require.True(t, ok)
+	require.Len(t, m.mustHits().chips, 2)
+	chipsBefore := append([]processChipHit(nil), m.mustHits().chips...)
+
+	m = clientUpdate(m, ProcessesMsg(deadStackProcsOf(
+		domain.ProcessStateCrashed, domain.ProcessStateCrashed)))
+	require.True(t, m.showDeadStackBanner())
+	_ = m.View()
+
+	rowYAfter, ok := m.processPanelRowY()
+	require.True(t, ok)
+	assert.Equal(t, rowY, rowYAfter, "the banner is below the chips; their row cannot move")
+	assert.Equal(t, chipsBefore, m.mustHits().chips, "chip rects unchanged by the banner")
+
+	// The chip still solos on click.
+	m = clientUpdate(m, clickAt(2, rowYAfter))
+	assert.Equal(t, "p0", m.soloProcess)
+	m = clientUpdate(m, clickAt(2, rowYAfter))
+	assert.Empty(t, m.soloProcess)
+
+	// A click on the banner row itself must not be read as a log-pane click.
+	_, bannerIdx, found := deadStackBannerRow(m)
+	require.True(t, found)
+	_, oy := m.viewportOrigin()
+	require.Less(t, bannerIdx, oy)
+	before := m.logCursorSeq
+	m = clientUpdate(m, clickAt(5, bannerIdx))
+	assert.Equal(t, before, m.logCursorSeq, "banner row is not a log row")
+
+	// ...while the first real viewport row still is, at the shifted origin.
+	m = clientUpdate(m, clickAt(5, oy))
+	assert.NotEqual(t, before, m.logCursorSeq)
+}
+
+// TestDeadStackBanner_YieldsToTheLastContentRow pins the room check: on a frame
+// with no row to spare the banner stands down rather than overflowing the
+// frame, exactly as the requests header row does.
+func TestDeadStackBanner_YieldsToTheLastContentRow(t *testing.T) {
+	pinANSIProfile(t)
+	withTestTheme(t, "tokyo-night")
+
+	// Default chrome above is 3 (menu + panel + spacer) and 1 below, so h=5
+	// leaves exactly one content row: the banner must not take it.
+	tight := deadStackModel(t, 60, 5, domain.ProcessStateCrashed)
+	assert.False(t, tight.showDeadStackBanner())
+	assertFrameContract(t, tight)
+
+	roomy := deadStackModel(t, 60, 6, domain.ProcessStateCrashed)
+	assert.True(t, roomy.showDeadStackBanner())
+	assertFrameContract(t, roomy)
+}
+
+// TestDeadStackBanner_TextIsPureFunctionOfTheSnapshot keeps the predicate
+// itself covered directly, including the two states the CLI sibling
+// (internal/cli/dead_stack.go) also refuses to treat as failures.
+func TestDeadStackBanner_TextIsPureFunctionOfTheSnapshot(t *testing.T) {
+	assert.Empty(t, deadStackBannerText(nil))
+	assert.Empty(t, deadStackBannerText(deadStackProcsOf(domain.ProcessStateCompleted)))
+	assert.Empty(t, deadStackBannerText(deadStackProcsOf(domain.ProcessStateStopped)))
+	assert.False(t, deadStackProcs(deadStackProcsOf(domain.ProcessStateCompleted)),
+		"completed is a task's terminal SUCCESS, never a dead stack")
+	assert.True(t, deadStackProcs(deadStackProcsOf(domain.ProcessStateBlocked)))
+
+	// Exhaustive over the domain enum: a 9th state must be triaged here too.
+	for _, s := range domain.AllProcessStates() {
+		single := deadStackProcsOf(s)
+		assert.Equal(t, s.IsTerminalFailure(), deadStackProcs(single),
+			"single-process stack in state %s", s)
+	}
+}

--- a/internal/tui/dead_stack_test.go
+++ b/internal/tui/dead_stack_test.go
@@ -285,7 +285,17 @@ func TestDeadStackBanner_HitRectsUnaffected(t *testing.T) {
 	rowYAfter, ok := m.processPanelRowY()
 	require.True(t, ok)
 	assert.Equal(t, rowY, rowYAfter, "the banner is below the chips; their row cannot move")
-	assert.Equal(t, chipsBefore, m.mustHits().chips, "chip rects unchanged by the banner")
+	// Chip Y/H (and count) are unaffected by the banner, which is what this
+	// test actually pins. X/W now widen going running->crashed: stateLabel
+	// (issue #92 bug 1 / plan 028 C6) appends " (crashed)" to the chip text,
+	// so exact rect equality across that state change is no longer the right
+	// assertion — the earlier chips-before snapshot predates the label.
+	require.Len(t, m.mustHits().chips, len(chipsBefore))
+	for i, c := range m.mustHits().chips {
+		assert.Equal(t, chipsBefore[i].Rect.Y, c.Rect.Y, "chip %d row unchanged by the banner", i)
+		assert.Equal(t, chipsBefore[i].Rect.H, c.Rect.H, "chip %d height unchanged by the banner", i)
+	}
+	assert.Contains(t, ansi.Strip(m.processPanel()), "(crashed)")
 
 	// The chip still solos on click.
 	m = clientUpdate(m, clickAt(2, rowYAfter))

--- a/internal/tui/empty_chrome_test.go
+++ b/internal/tui/empty_chrome_test.go
@@ -108,6 +108,124 @@ func TestEmptyStates_FourCases(t *testing.T) {
 	})
 }
 
+// TestRequestsEmptyHint_ExplainsWhy pins the four answers the empty requests
+// pane can give (#92). The pre-C5 pane gave the last one unconditionally, so a
+// project with no proxy: block was told to wait for traffic that could never
+// arrive.
+func TestRequestsEmptyHint_ExplainsWhy(t *testing.T) {
+	pinANSIProfile(t)
+	withTestTheme(t, "tokyo-night")
+
+	// emptyRequestsHint renders the requests pane of a model built with the
+	// given proxy facts and returns its plain text.
+	emptyRequestsHint := func(t *testing.T, proxyConfigured, captureEnabled bool) string {
+		t.Helper()
+		opts := attachClientOptions()
+		opts.ProxyConfigured = proxyConfigured
+		opts.CaptureEnabled = captureEnabled
+		m := NewClientModel(&stubTUIClient{}, opts)
+		m = clientUpdate(m, tea.WindowSizeMsg{Width: 100, Height: 24})
+		m.setViewMode(ViewModeRequests)
+		return ansi.Strip(m.viewport.View())
+	}
+
+	t.Run("no proxy configured", func(t *testing.T) {
+		plain := emptyRequestsHint(t, false, false)
+		assert.Contains(t, plain, "No proxy running")
+		assert.Contains(t, plain, "prox.yaml")
+		assert.NotContains(t, plain, "No requests yet")
+		assert.NotContains(t, plain, "capture.enabled")
+	})
+
+	// The --no-proxy case: the file's proxy: block is enabled and capture with
+	// it, but the RUNTIME proxy is off, so the caller passes false/false and the
+	// pane must blame the proxy, not the capture setting.
+	t.Run("proxy disabled at runtime outranks capture", func(t *testing.T) {
+		plain := emptyRequestsHint(t, false, true)
+		assert.Contains(t, plain, "No proxy running")
+		assert.NotContains(t, plain, "capture is off")
+	})
+
+	// Capture being off does NOT stop rows arriving — both proxy paths still
+	// Upsert a metadata-only record (internal/proxy/proxy.go's brw branch). So
+	// this hint must still promise traffic, and only qualify what will land in
+	// it; claiming capture is why the list is empty would be false.
+	t.Run("capture disabled qualifies the promise instead of withdrawing it", func(t *testing.T) {
+		plain := emptyRequestsHint(t, true, false)
+		assert.Contains(t, plain, "No requests yet — capture is off, so rows will show metadata only")
+		assert.NotContains(t, plain, "traffic through the proxy appears here",
+			"the unqualified promise is for the capture-on case only")
+		assert.NotContains(t, plain, "No proxy running")
+	})
+
+	t.Run("proxy and capture on", func(t *testing.T) {
+		plain := emptyRequestsHint(t, true, true)
+		assert.Contains(t, plain, "No requests yet — traffic through the proxy appears here")
+	})
+
+	// An active filter is the user's own doing and outranks every hint above:
+	// the list is empty because they narrowed it, not because of the project's
+	// proxy configuration.
+	t.Run("active filter outranks both hints", func(t *testing.T) {
+		opts := attachClientOptions()
+		opts.ProxyConfigured = false
+		opts.CaptureEnabled = false
+		m := NewClientModel(&stubTUIClient{}, opts)
+		m = clientUpdate(m, tea.WindowSizeMsg{Width: 100, Height: 24})
+		m = clientUpdate(m, ProxyRequestMsg(proxy.RequestRecord{
+			ID: "r1", Method: "GET", URL: "/ok", StatusCode: 200,
+		}))
+		m.setViewMode(ViewModeRequests)
+		m.setRequestsFilterQuery("status:500")
+		m.updateViewport()
+		plain := ansi.Strip(m.viewport.View())
+		assert.Contains(t, plain, "No lines match status:500")
+		assert.NotContains(t, plain, "No proxy running")
+		assert.NotContains(t, plain, "capture is off")
+	})
+}
+
+// TestRequestDetail_CaptureDisabledNote pins the detail view's explanation for a
+// completed request with no headers and no bodies. formatRequestDetail renders
+// nothing at all for absent sections, so without the note the view is silently
+// bare — and the in-flight note must keep its own, unrelated explanation.
+func TestRequestDetail_CaptureDisabledNote(t *testing.T) {
+	pinANSIProfile(t)
+	withTestTheme(t, "tokyo-night")
+
+	const note = "Capture is disabled (proxy.capture.enabled: false) — no headers or bodies were recorded"
+
+	detail := func(captureEnabled, inFlight bool) string {
+		b := newTestBaseModel()
+		b.captureEnabled = captureEnabled
+		b.proxyConfigured = true
+		b.requestDetail = &RequestDetailData{
+			ID: "req-1", Timestamp: "t", Method: "GET", URL: "/x",
+			StatusCode: 200, InFlight: inFlight,
+		}
+		return ansi.Strip(strings.Join(b.formatRequestDetail(), "\n"))
+	}
+
+	t.Run("capture disabled", func(t *testing.T) {
+		out := detail(false, false)
+		assert.Contains(t, out, note)
+		assert.NotContains(t, out, "request in flight")
+	})
+
+	t.Run("capture enabled", func(t *testing.T) {
+		out := detail(true, false)
+		assert.NotContains(t, out, note)
+	})
+
+	// Both notes explain "no details here", so exactly one must fire. In flight
+	// wins: capture may well be on and the details simply not recorded yet.
+	t.Run("in flight wins over capture note", func(t *testing.T) {
+		out := detail(false, true)
+		assert.Contains(t, out, "(request in flight — details arrive on completion)")
+		assert.NotContains(t, out, note)
+	})
+}
+
 func TestDetailTitle_Style(t *testing.T) {
 	pinANSIProfile(t)
 	withTestTheme(t, "tokyo-night")

--- a/internal/tui/footer_test.go
+++ b/internal/tui/footer_test.go
@@ -110,6 +110,46 @@ func TestFooter_WidthDegradation(t *testing.T) {
 	}
 }
 
+// TestFooter_RequestDetailNoFollowOrCount pins issue #92 bug 2: the detail
+// view is not a scrolling list, so its footer must render the bare view tag
+// with no follow indicator and no N/M count — those describe the OTHER
+// views' lists. Logs and requests keep both, unchanged.
+func TestFooter_RequestDetailNoFollowOrCount(t *testing.T) {
+	m := newTestModel()
+	m = clientUpdate(m, tea.WindowSizeMsg{Width: 120, Height: 24})
+	m = clientUpdate(m, LogEntryMsg(domain.LogEntry{Process: "web", Line: "hello"}))
+	m = clientUpdate(m, ProxyRequestMsg(newArrival("req-001", "/x")))
+
+	t.Run("detail view", func(t *testing.T) {
+		m.viewMode = ViewModeRequestDetail
+		m.requestDetail = &RequestDetailData{ID: "req-001", Method: "GET", URL: "/x", StatusCode: 200}
+		m.updateViewport()
+		plain := ansi.Strip(m.statusBar(footerMsg{}))
+		assert.Contains(t, plain, "[Request Detail]")
+		assert.NotContains(t, plain, "[FOLLOW]")
+		assert.NotContains(t, plain, "[PAUSED]")
+		assert.NotContains(t, plain, "lines")
+		assert.NotContains(t, plain, "requests")
+	})
+
+	t.Run("logs view unchanged", func(t *testing.T) {
+		m.viewMode = ViewModeLogs
+		m.updateViewport()
+		plain := ansi.Strip(m.statusBar(footerMsg{}))
+		assert.Contains(t, plain, "[Logs]")
+		assert.Contains(t, plain, "[FOLLOW]")
+		assert.Contains(t, plain, "lines")
+	})
+
+	t.Run("requests view unchanged", func(t *testing.T) {
+		m.setViewMode(ViewModeRequests)
+		plain := ansi.Strip(m.statusBar(footerMsg{}))
+		assert.Contains(t, plain, "[Requests]")
+		assert.Contains(t, plain, "[FOLLOW]")
+		assert.Contains(t, plain, "requests")
+	})
+}
+
 func TestFooter_WideCharStatus(t *testing.T) {
 	for _, w := range []int{20, 40, 80, 120} {
 		t.Run(strconv.Itoa(w), func(t *testing.T) {

--- a/internal/tui/frame_contract_test.go
+++ b/internal/tui/frame_contract_test.go
@@ -133,3 +133,98 @@ func primedFrameModel(t *testing.T, w, h int, cfg Settings, mode ViewMode) Clien
 	}
 	return m
 }
+
+// TestFrameContract_DeadStackSweep re-runs the T5 sweep with the dead-stack
+// banner up (plan 028 C4).
+//
+// The banner is the first chrome row whose height changes on a DATA message
+// rather than on a WindowSizeMsg or a settings toggle, so it is the first thing
+// that can desync geometry from rendering mid-session -- the exact failure plan
+// 024 spent a batch fixing. The bespoke banner tests check its own behaviour;
+// this checks that the frame as a WHOLE still obeys the contract with the extra
+// row present, across every size, settings combo and view the baseline sweep
+// covers.
+//
+// It drives the banner up through the real ProcessesMsg path, not by setting
+// fields, because the relayout hook lives on that path: primed with a running
+// process and then given a crashed snapshot, this fails if that hook is ever
+// removed.
+func TestFrameContract_DeadStackSweep(t *testing.T) {
+	sizes := []struct{ w, h int }{
+		{80, 24},
+		{120, 40},
+		{40, 12},
+		{20, 8},
+		{10, 6},
+		{2, 6},
+		{1, 6},
+	}
+	settingsCombos := []Settings{
+		DefaultSettings(),
+		{MenuBar: true, ProcessPanel: false, Timestamps: true, Wrap: false},
+		{MenuBar: true, ProcessPanel: true, Timestamps: false, Wrap: true},
+		{MenuBar: false, ProcessPanel: false, Timestamps: false, Wrap: false},
+		{MenuBar: false, ProcessPanel: true, Timestamps: true, Wrap: true},
+	}
+	// Every dead-stack shape that must raise the banner, including the mixed
+	// and "nothing live, one failure" cases.
+	stacks := map[string][]domain.ProcessInfo{
+		"crashed": {
+			{Name: "web", State: domain.ProcessStateCrashed},
+			{Name: "api", State: domain.ProcessStateCrashed},
+		},
+		"blocked": {
+			{Name: "web", State: domain.ProcessStateBlocked, BlockedOn: []string{"db"}},
+		},
+		"mixed": {
+			{Name: "web", State: domain.ProcessStateCrashed},
+			{Name: "api", State: domain.ProcessStateBlocked, BlockedOn: []string{"db"}},
+			{Name: "seed", State: domain.ProcessStateCompleted},
+		},
+	}
+
+	for _, sz := range sizes {
+		for _, cfg := range settingsCombos {
+			// Same feasibility rule as the baseline sweep, plus the banner's
+			// own row -- derived from the production formula so a geometry
+			// change cannot silently desync this gate.
+			chrome := (&BaseModel{settings: cfg}).chromeHeight() + 1
+			if sz.h < chrome+1 {
+				continue
+			}
+			for name, procs := range stacks {
+				for _, mode := range []ViewMode{ViewModeLogs, ViewModeRequests, ViewModeRequestDetail} {
+					label := fmt.Sprintf("dead-%s-%s", name, viewSweepLabel(mode))
+					t.Run(frameSweepName(sz.w, sz.h, cfg, label), func(t *testing.T) {
+						m := primedFrameModel(t, sz.w, sz.h, cfg, mode)
+						require.False(t, m.showDeadStackBanner(),
+							"precondition: the primed model's stack is alive")
+
+						m = clientUpdate(m, ProcessesMsg(procs))
+						require.True(t, m.showDeadStackBanner(),
+							"the snapshot is a dead stack, so the banner must be up")
+						assertFrameContract(t, m)
+
+						// ...and giving the stack back must return the row.
+						m = clientUpdate(m, ProcessesMsg([]domain.ProcessInfo{
+							{Name: "web", State: domain.ProcessStateRunning},
+						}))
+						require.False(t, m.showDeadStackBanner())
+						assertFrameContract(t, m)
+					})
+				}
+			}
+		}
+	}
+}
+
+func viewSweepLabel(mode ViewMode) string {
+	switch mode {
+	case ViewModeRequests:
+		return "requests"
+	case ViewModeRequestDetail:
+		return "detail"
+	default:
+		return "logs"
+	}
+}

--- a/internal/tui/state_style_test.go
+++ b/internal/tui/state_style_test.go
@@ -1,11 +1,15 @@
 package tui
 
 import (
+	"strconv"
 	"testing"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/muesli/termenv"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/charliek/prox/internal/domain"
 )
@@ -58,24 +62,110 @@ func TestProcessStyle_GatedStates(t *testing.T) {
 	}
 }
 
-// TestGatedDetail pins the inline gated-launch annotation used by the process
-// panel (plan 013 D5).
-func TestGatedDetail(t *testing.T) {
+// TestStateLabel_GatedDetailPinned pins the two gated-launch annotation
+// strings (plan 013 D5's gatedDetail, now folded into stateLabel) byte-for-byte:
+// " (waiting on: X, Y)" and " (blocked on: X)" with targets in declaration
+// order. Nothing else in the package pins these strings now that gatedDetail
+// itself is gone, so this test is their only guard (issue #92 bug 1 / plan
+// 028 C6).
+func TestStateLabel_GatedDetailPinned(t *testing.T) {
 	tests := []struct {
 		name string
 		p    domain.ProcessInfo
 		want string
 	}{
-		{"running none", domain.ProcessInfo{State: domain.ProcessStateRunning}, ""},
-		{"waiting", domain.ProcessInfo{State: domain.ProcessStateWaiting, WaitingOn: []string{"postgres", "redis"}}, " (waiting on: postgres, redis)"},
-		{"blocked", domain.ProcessInfo{State: domain.ProcessStateBlocked, BlockedOn: []string{"restate-register"}}, " (blocked on: restate-register)"},
-		{"waiting no targets", domain.ProcessInfo{State: domain.ProcessStateWaiting}, ""},
+		{"waiting on targets", domain.ProcessInfo{State: domain.ProcessStateWaiting, WaitingOn: []string{"postgres", "redis"}}, " (waiting on: postgres, redis)"},
+		{"blocked on targets", domain.ProcessInfo{State: domain.ProcessStateBlocked, BlockedOn: []string{"restate-register"}}, " (blocked on: restate-register)"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := gatedDetail(tc.p); got != tc.want {
-				t.Errorf("gatedDetail = %q, want %q", got, tc.want)
+			if got := stateLabel(tc.p); got != tc.want {
+				t.Errorf("stateLabel = %q, want %q", got, tc.want)
 			}
+		})
+	}
+}
+
+// TestStateLabel_EnumExhaustive iterates domain.AllProcessStates() so a 9th
+// state added later fails this test until it is given a label (issue #92 bug
+// 1 pin table). running is the one state that must render nothing; every
+// other state must render a non-empty parenthesized word.
+func TestStateLabel_EnumExhaustive(t *testing.T) {
+	want := map[domain.ProcessState]string{
+		domain.ProcessStateRunning:   "",
+		domain.ProcessStateWaiting:   " (waiting)",
+		domain.ProcessStateBlocked:   " (blocked)",
+		domain.ProcessStateCrashed:   " (crashed)",
+		domain.ProcessStateCompleted: " (done)",
+		domain.ProcessStateStopped:   " (stopped)",
+		domain.ProcessStateStarting:  " (starting)",
+		domain.ProcessStateStopping:  " (stopping)",
+	}
+	states := domain.AllProcessStates()
+	require.Len(t, states, len(want), "a state was added/removed in domain — update this pin table")
+	for _, s := range states {
+		t.Run(string(s), func(t *testing.T) {
+			wantLabel, ok := want[s]
+			require.True(t, ok, "state %s has no pinned label — add one to this test AND to stateLabel", s)
+			got := stateLabel(domain.ProcessInfo{State: s})
+			assert.Equal(t, wantLabel, got)
+			if s == domain.ProcessStateRunning {
+				assert.Empty(t, got, "running must pay nothing")
+			} else {
+				assert.NotEmpty(t, got, "every non-running state must carry a colour-independent label")
+			}
+		})
+	}
+}
+
+// TestStateLabel_WaitingBlockedNoTargets pins the no-target forms of waiting
+// and blocked: these differ from running gatedDetail (which rendered "" here)
+// because a colour-independent reader still needs SOME word even without
+// named targets (issue #92 bug 1).
+func TestStateLabel_WaitingBlockedNoTargets(t *testing.T) {
+	assert.Equal(t, " (waiting)", stateLabel(domain.ProcessInfo{State: domain.ProcessStateWaiting}))
+	assert.Equal(t, " (blocked)", stateLabel(domain.ProcessInfo{State: domain.ProcessStateBlocked}))
+}
+
+// TestStateLabel_ColourIndependence is the actual point of issue #92 bug 1:
+// with ANSI stripped (piped output, TERM=dumb, screenshots, colour-blind
+// readers), a crashed process must still read differently from a running one.
+// Before this change, styles.Crashed's bold-red was the ONLY distinguishing
+// signal and healthDot renders nothing without a configured healthcheck, so
+// the two rows were byte-identical once stripped.
+func TestStateLabel_ColourIndependence(t *testing.T) {
+	pinANSIProfile(t)
+	withTestTheme(t, "tokyo-night")
+
+	b := newTestBaseModel()
+	b.viewMode = ViewModeLogs
+	b.processes = []domain.ProcessInfo{
+		{Name: "web", State: domain.ProcessStateRunning},
+		{Name: "worker", State: domain.ProcessStateCrashed},
+	}
+	plain := ansi.Strip(b.processPanel())
+	assert.Contains(t, plain, "1:web", "running carries no state label")
+	assert.NotContains(t, plain, "web (")
+	assert.Contains(t, plain, "2:worker (crashed)")
+}
+
+// TestStateLabel_FrameContractHolds re-runs the plan 023 T5 frame contract
+// (every rendered row exactly frame width) with state labels present,
+// including a width narrow enough that the panel's ansi.Cut truncates the
+// label mid-string (issue #92 bug 1 / plan 028 C6). The panel already handles
+// this for the gated-launch strings; this pins that the added label suffixes
+// don't reopen it.
+func TestStateLabel_FrameContractHolds(t *testing.T) {
+	for _, w := range []int{80, 40, 20} {
+		t.Run(strconv.Itoa(w), func(t *testing.T) {
+			m := newTestModel()
+			m.processes = []domain.ProcessInfo{
+				{Name: "web", State: domain.ProcessStateRunning},
+				{Name: "worker", State: domain.ProcessStateCrashed},
+				{Name: "db", State: domain.ProcessStateBlocked, BlockedOn: []string{"postgres", "redis"}},
+			}
+			m = clientUpdate(m, tea.WindowSizeMsg{Width: w, Height: 24})
+			assertFrameContract(t, m)
 		})
 	}
 }

--- a/test/integration/dead_stack_test.go
+++ b/test/integration/dead_stack_test.go
@@ -1,0 +1,168 @@
+package integration
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// This file covers the dead-stack exit end to end (plan 028 C3, #96).
+//
+// A foreground `prox up` used to wait forever on a shutdown trigger that only a
+// signal, POST /shutdown or a TUI quit ever closes. A typo in `cmd:` — the most
+// common first-run mistake there is — therefore left the user holding a
+// terminal that supervised nothing, silently, until they thought to press
+// Ctrl-C. The unit tests in internal/cli pin the DECISION (dead_stack_test.go);
+// these pin the WIRING against the real binary, including the two things that
+// most matter about a teardown rule: that it does NOT fire on a partial crash,
+// and that it does NOT exist in the detached daemon child.
+//
+// Everything here runs in plain (non-TUI) mode by construction: under `go test`
+// the child's stdout is a pipe, so TUI resolution degrades to plain log
+// streaming, which is the mode this feature belongs to. The TUI's own answer to
+// a dead stack — a persistent banner, and no auto-exit — is a separate commit.
+
+// deadStackBadCmd is a command that cannot be exec'd at all, so the supervisor
+// marks the process crashed the instant it tries to start it: a typo in `cmd:`,
+// reached deterministically and with no sleep for a slow runner to race.
+const deadStackBadCmd = "/no/such/binary-xyz"
+
+// deadStackSettleGrace is comfortably longer than the watcher's 500ms
+// confirmation window (internal/cli/process_settle.go), so "it had not exited"
+// means the rule did not fire rather than that it had not got round to it yet.
+const deadStackSettleGrace = 3 * time.Second
+
+// TestDeadStack_ForegroundUpExitsWhenEveryProcessIsDead is the #96 regression
+// test: the whole stack dies, so the session ends by itself, non-zero, saying
+// what died.
+//
+// It is written as WaitExit rather than a poll for a reason: against the
+// unfixed code `prox up` never exits at all, so this test hangs until the
+// budget kills it — which is exactly the user-visible bug, reproduced.
+func TestDeadStack_ForegroundUpExitsWhenEveryProcessIsDead(t *testing.T) {
+	startTest(t, defaultTestBudget)
+	skipShort(t)
+
+	binary := buildBinary(t)
+	f := newInlineFixture(t, `
+processes:
+  ghost:
+    cmd: "`+deadStackBadCmd+`"
+`)
+
+	run := f.Start(t, binary, "up", "--no-proxy", "-c", f.configPath)
+
+	if err := run.WaitExit(t, within(t, processExitTimeout)); err == nil {
+		t.Fatalf("`prox up` exited 0 with every process dead; output:\n%s", run.Output())
+	}
+	if code := run.ExitCode(t); code != 1 {
+		t.Fatalf("exit = %d, want 1; output:\n%s", code, run.Output())
+	}
+
+	out := run.Output()
+	for _, want := range []string{
+		"Crashed: ghost",                // named, in `prox status`'s own words
+		"prox logs ghost",               // where the reason is
+		"No processes are left running", // why the terminal came back
+		"1 process(es) crashed",         /* the same sentinel every other command returns */
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q; got:\n%s", want, out)
+		}
+	}
+}
+
+// TestDeadStack_PartialCrashKeepsRunning is the half that decides whether this
+// feature is safe to ship: one process of two dies and the other keeps serving,
+// so the session must NOT be torn down. Tearing a developer's whole stack down
+// because one process crashed would be a far worse bug than the one #96 fixes.
+//
+// It also pins the other end of the contract: an INTENTIONAL shutdown of a
+// session that contains a crashed process still exits 0, because the watcher
+// latches nothing when somebody else requested the shutdown.
+func TestDeadStack_PartialCrashKeepsRunning(t *testing.T) {
+	startTest(t, defaultTestBudget)
+	skipShort(t)
+
+	binary := buildBinary(t)
+	f := newInlineFixture(t, `
+processes:
+  ghost:
+    cmd: "`+deadStackBadCmd+`"
+  keeper:
+    cmd: "sleep 300"
+`)
+
+	run := f.Start(t, binary, "up", "--no-proxy", "-c", f.configPath)
+	waitForAPI(t, run.Addr(), within(t, apiReadyTimeout))
+
+	// Prove the interesting state really occurred — one crashed, one alive —
+	// so this cannot pass vacuously against a config where nothing failed.
+	waitForProcessState(t, run.Addr(), "ghost", "crashed", within(t, processStateTimeout))
+	waitForProcessState(t, run.Addr(), "keeper", "running", within(t, processStateTimeout))
+
+	if run.awaitExit(deadStackSettleGrace) {
+		t.Fatalf("`prox up` tore the session down over a PARTIAL crash; output:\n%s", run.Output())
+	}
+	// Still serving, not merely still resident.
+	waitForProcessState(t, run.Addr(), "keeper", "running", within(t, processStateTimeout))
+
+	// Now end it the way the user would. keeper stops cleanly and the crash was
+	// never this shutdown's doing, so the command exits 0.
+	if err := stopProx(t, run.Addr()); err != nil {
+		t.Fatalf("shutdown request failed: %v\noutput:\n%s", err, run.Output())
+	}
+	if err := run.WaitExit(t, within(t, processExitTimeout)); err != nil {
+		t.Fatalf("an intentional shutdown exited non-zero (%v); output:\n%s", err, run.Output())
+	}
+}
+
+// TestDeadStack_DetachedDaemonSurvivesAnAllCrashedConfig is the anti-regression
+// test for the gating rule.
+//
+// `--detach` short-circuits TUI resolution to plain mode, so the detached
+// daemon child runs the very same wait block a foreground `prox up` does. A
+// dead-stack watcher there would kill the daemon moments after `prox up -d`
+// printed "The daemon is still running; stop it with 'prox down'", taking the
+// API and the crash logs the user needs with it. `prox up -d` already reports
+// the crash at settle time and exits non-zero; the daemon staying up is the
+// contract.
+func TestDeadStack_DetachedDaemonSurvivesAnAllCrashedConfig(t *testing.T) {
+	startTest(t, defaultTestBudget)
+	skipShort(t)
+
+	binary := buildBinary(t)
+	f := newInlineFixture(t, `
+processes:
+  ghost:
+    cmd: "`+deadStackBadCmd+`"
+`)
+
+	// TryStartDetached, not StartDetached: a non-zero `up -d` is CORRECT here
+	// (the settle check reports the crash), and the handle it returns still owns
+	// the teardown of the daemon that is deliberately left running.
+	run, err := f.TryStartDetached(t, binary, "up", "-d", "--no-proxy", "-c", f.configPath)
+	if err == nil {
+		t.Fatalf("`prox up -d` exited 0 with a crashed process; output:\n%s", run.Output())
+	}
+	if out := run.Output(); !strings.Contains(out, "prox down") {
+		t.Errorf("`up -d` did not point at 'prox down'; got:\n%s", out)
+	}
+
+	// Well past the watcher's window: a daemon child that ran one would already
+	// have shut itself down.
+	time.Sleep(deadStackSettleGrace)
+
+	// The daemon is still there and still answering.
+	waitForAPI(t, run.Addr(), within(t, apiReadyTimeout))
+	statusOut, statusCode := f.Run(t, binary, "status", "-c", f.configPath)
+	if !strings.Contains(statusOut, "crashed") {
+		t.Errorf("`prox status` did not report the crashed process; exit=%d output:\n%s", statusCode, statusOut)
+	}
+
+	// And `prox down`, the remedy `up -d` advertised, has something to stop.
+	downOut, downCode := f.Run(t, binary, "down", "-c", f.configPath)
+	if downCode != 0 {
+		t.Fatalf("`prox down` exit = %d, want 0; output:\n%s", downCode, downOut)
+	}
+}

--- a/test/integration/up_test.go
+++ b/test/integration/up_test.go
@@ -546,11 +546,6 @@ func TestUpCommand_InstantCrashLogsAlwaysVisible(t *testing.T) {
 		// bug the old manual t.Cleanup workaround guarded against).
 		run := f.Start(t, binary, "up", "-c", f.configPath)
 
-		// Confirms the daemon itself came up; the process crash happens
-		// concurrently with (just after) supervisor start, so this does not run
-		// past the window we're testing.
-		waitForAPI(t, run.Addr(), within(t, apiReadyTimeout))
-
 		// Give the crashed process's log line a short, bounded window to reach
 		// the terminal. Bounded deliberately short: ghost is never restarted, so
 		// nothing will ever produce the line later -- if it isn't here within the
@@ -562,12 +557,14 @@ func TestUpCommand_InstantCrashLogsAlwaysVisible(t *testing.T) {
 			out = run.Output()
 		}
 
-		// Shut down before asserting, so a failed iteration doesn't leak the
-		// daemon (and its port) into the next one.
-		_ = stopProx(t, run.Addr())
-		if err := run.WaitExit(t, within(t, processExitTimeout)); err != nil {
-			t.Logf("iteration %d: prox up did not exit cleanly: %v", i, err)
-		}
+		// No shutdown request, and no readiness probe before it: since plan 028
+		// C3 (#96) this session ends BY ITSELF. `ghost` is the only process and
+		// it crashes, so the whole stack is dead and `prox up` tears it down and
+		// exits non-zero. Asking the API to shut down (or even polling it for
+		// readiness) now races the daemon's own exit and would fail this test for
+		// a reason that has nothing to do with log visibility.
+		_ = run.WaitExit(t, within(t, processExitTimeout))
+		out = run.Output()
 
 		if !strings.Contains(out, marker) || !strings.Contains(out, "ghost") {
 			t.Fatalf("iteration %d: crash reason missing from terminal output; wanted \"ghost\" + %q, got:\n%s", i, marker, out)

--- a/test/integration/warnings_test.go
+++ b/test/integration/warnings_test.go
@@ -1,0 +1,138 @@
+package integration
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// This file covers the session warning channel end to end (plan 028 A2): an
+// advisory raised where the user cannot see it — inside a `prox up -d` child,
+// whose stdout and stderr are .prox/prox.log — has to reach the terminal of the
+// person who typed the command.
+//
+// The unit tests in internal/cli pin the pieces (the sink, the two-line shape,
+// the parent's poll loop against a fake fetcher). These pin the WIRING against
+// the real binary, and above all the one thing no fake can prove: that the
+// completion latch really does cover the window between the parent's settle wait
+// and a producer that is still running.
+//
+// # HOW THE TIMING IS MADE REAL, AND THE ONE SYNTHETIC PART OF IT
+//
+// Plan 028's real asynchronous producer (the B2 DNS check) does not exist yet,
+// and no producer that does exist can be asked to finish at a chosen instant. So
+// the child is given one via PROX_TEST_STARTUP_WARNING (internal/cli/
+// warnings.go): a warning that lands after a stated delay. Everything else is
+// the production path — the real sink, the real GET /status, the real parent
+// poll loop, the real rendering.
+//
+// The delay is what makes the test non-vacuous. The parent normally exits at
+// (child ready) + a 500ms settle window; the warning does not exist until
+// warningProducerDelay after the child starts, which is well past that. A parent
+// that fetched status ONCE after settling — the implementation without the latch
+// — would print nothing here.
+// It must also stay BELOW internal/cli's warningProducerJoinTimeout (2s): past
+// that the child seals without ever collecting this warning and the test fails
+// outright rather than vacuously. Lowering that constant breaks this test, and
+// this comment is the pointer that saves the next person a bisect (CodeRabbit
+// review).
+const warningProducerDelay = 1200 * time.Millisecond
+
+// The advisory the hook produces. Deliberately distinctive so it cannot be
+// confused with any other line prox prints.
+const (
+	warningHookMessage = "the synthetic startup check reported a problem."
+	warningHookHint    = "Run 'prox doctor' (this is a test fixture)."
+)
+
+// warningHookEnv is the PROX_TEST_STARTUP_WARNING value: "<delay>|<code>|<message>|<hint>".
+func warningHookEnv(delay time.Duration) string {
+	return "PROX_TEST_STARTUP_WARNING=" + strings.Join([]string{
+		delay.String(), "test_startup_warning", warningHookMessage, warningHookHint,
+	}, "|")
+}
+
+const warningFixtureConfig = `
+processes:
+  web:
+    cmd: "sleep 300"
+`
+
+// TestWarnings_UpDetachSurfacesAWarningSealedAfterSettling is the flagship: a
+// warning that is not even produced until after `prox up -d` has finished
+// waiting for readiness and watching the processes settle still reaches the
+// launcher's terminal.
+//
+// It fails in exactly the way the feature would be broken: without the
+// warnings_sealed latch (or with a parent that reads status once instead of
+// polling it), the launcher exits before the warning exists and prints nothing.
+func TestWarnings_UpDetachSurfacesAWarningSealedAfterSettling(t *testing.T) {
+	startTest(t, defaultTestBudget)
+	skipShort(t)
+
+	binary := buildBinary(t)
+	f := newInlineFixture(t, warningFixtureConfig)
+
+	started := time.Now()
+	run := startDetachedIn(t, binary, f.dir, []startOpt{withEnv(warningHookEnv(warningProducerDelay))},
+		"up", "-d", "--no-proxy", "-c", f.configPath)
+	launcherTook := time.Since(started)
+
+	out := run.Output()
+	if !strings.Contains(out, "Warning: "+warningHookMessage) {
+		t.Fatalf("the launcher never printed the daemon-side warning; output:\n%s", out)
+	}
+	if !strings.Contains(out, "         "+warningHookHint) {
+		t.Errorf("the hint must ride along, indented under the message; output:\n%s", out)
+	}
+
+	// The headline still comes first: an advisory must not displace the outcome
+	// the user is waiting for.
+	headline := strings.Index(out, "prox started")
+	warning := strings.Index(out, "Warning: "+warningHookMessage)
+	if headline < 0 || headline > warning {
+		t.Errorf("expected the success headline before the warning; output:\n%s", out)
+	}
+
+	// The timing assertion is what keeps this test honest. The launcher cannot
+	// have printed that warning without waiting past the settle window for the
+	// latch, because the warning did not exist until then.
+	if launcherTook < warningProducerDelay {
+		t.Errorf("launcher exited in %s, sooner than the %s producer delay: the warning it printed "+
+			"cannot have come from the post-settle window this test exists to cover",
+			launcherTook, warningProducerDelay)
+	}
+
+	// The daemon is up and holds the warning for later readers too: `prox status`
+	// prints it, and — because an advisory is not a failure — still exits 0.
+	waitForAPI(t, run.Addr(), within(t, apiReadyTimeout))
+	statusOut, code := f.Run(t, binary, "status")
+	if code != 0 {
+		t.Errorf("`prox status` exit = %d, want 0: a warning must never change the exit code; output:\n%s",
+			code, statusOut)
+	}
+	if !strings.Contains(statusOut, "Warning: "+warningHookMessage) {
+		t.Errorf("`prox status` did not print the session warning; output:\n%s", statusOut)
+	}
+}
+
+// TestWarnings_ForegroundUpPrintsThemOnStderr is the plain-mode half: a
+// foreground session has no wire and no parent, so the warning has to appear on
+// the session's own output, in the same two-line shape.
+func TestWarnings_ForegroundUpPrintsThemOnStderr(t *testing.T) {
+	startTest(t, defaultTestBudget)
+	skipShort(t)
+
+	binary := buildBinary(t)
+	f := newInlineFixture(t, warningFixtureConfig)
+
+	// A short delay here: nothing is racing the render, this only has to prove
+	// the end-of-startup report happens at all.
+	run := f.StartWith(t, binary, []startOpt{withEnv(warningHookEnv(50 * time.Millisecond))},
+		"up", "--no-tui", "--no-proxy", "-c", f.configPath)
+
+	waitForRunOutputContains(t, run, "Warning: "+warningHookMessage, within(t, apiReadyTimeout))
+	if out := run.Output(); !strings.Contains(out, "         "+warningHookHint) {
+		t.Errorf("the hint must be printed under the message; output:\n%s", out)
+	}
+}


### PR DESCRIPTION
Plan 028 — the new-user experience. Three workstreams, landed in the order
**C → A → B**, one commit per unit of work, no commit mixing a wire-format
change with a TUI change.

> **Replaces #109**, which GitHub auto-closed when its base branch
> (`feature/plan-027-…`, PR #108) was merged and deleted — a stacked PR gets
> closed rather than retargeted. Same branch, same 11 commits, same green CI;
> only the base changed. #109's discussion is still worth reading.

Closes #92, closes #96, closes #97, closes #98, closes #107.

---

## Workstream C — first impression

Plan 026 made the TUI the default view for foreground `prox up`, so these stopped
being "what a coworker sees in `prox attach`" and became what every user sees.

**#96 — `prox up` never exited when every process was dead.** A typo in `cmd:`
left the terminal open, silent, until the user pressed Ctrl-C. Foreground plain
mode now ends the session and **exits non-zero** once every process is dead and
at least one ended `crashed`/`blocked`, printing the same summary `up -d`,
`start` and `restart` print. The **TUI deliberately does the opposite** — it does
not auto-exit, because the user is present and reading, and pulling the screen
away would take the crash output with it; it shows a persistent banner instead.
The **`-d` child is exempt**: `--detach` runs the same plain-mode block
internally, so an unguarded watcher would have killed the daemon moments after
`up -d` promised it was still running.

> **Breaking:** foreground `prox up` previously always exited `0`.

**#107 — health checks ran against dead pids.** The checker now stops the instant
the leader exits. The *placement* is the fix: `monitor` waits up to 5s for output
draining before committing the terminal state, so cancelling at the commit point
would have kept the user's check command executing for five more seconds. Sits on
the orphan-reaping path; the reaping suite (14 tests) passes unchanged and
unweakened.

**#92 — three remaining items.** The requests pane now says *why* it is empty
(no proxy running / capture off) instead of promising traffic that can never
arrive; the detail view explains a capture-disabled record; process state is
stated in words (`" (crashed)"`, `" (done)"`, `" (blocked on: db)"`) rather than
colour alone, which was invisible once ANSI is stripped and to colour-blind
readers — `crashed`/`blocked` and `stopped`/`completed` shared a colour. The
detail-view footer no longer shows `[FOLLOW] N/M lines`.

> The brief listed a fourth item — a missing logs empty state. **It already
> existed** (`internal/tui/base.go:1917`, plan 023 B6). The brief's grep was a
> false negative: the code checks the *filtered* slice. Dropped from scope.

## Workstream A — a designed daemon→client warning channel

`RegisterResponse` carried one field, so a daemon-side warning had no way to
reach the person who typed the command — and the shared daemon's own
stdout/stderr are `/dev/null`, so mkcert's warning was discarded outright.

`domain.Warning{code, message, hint}` is the one shape, used directly by both
`internal/proxyd` and `internal/api` (no per-package DTO, which is how wording
drifts). It is additive on the register response and on `GET /status`, which also
gained `warnings_sealed` — a completion latch, because an async producer can
still be running when the `up -d` parent takes its one status snapshot.

Warnings reach the user in all three modes: shared (register response),
standalone (raised in-process), detached (parent reads them back over the child's
API). They render through the existing preamble, so one call reaches the
terminal, the TUI's pinned preamble and the system log. **A warning never changes
an exit code.**

## Workstream B — the two consumers

**#97 — mkcert CA not in the trust store.** prox captures mkcert's output and
surfaces **mkcert's own sentence, verbatim**. It does not implement trust-store
detection — that is per-OS, per-OS-release and per-browser, and a second
implementation would be wrong in ways nobody notices. Because mkcert only speaks
when it generates, and a daemon restarted onto a new release starts with warm
certs, a bounded probe re-derives the verdict; without it the feature would
silently do nothing for most users. The probe never creates a CA.

**#98 — a registered hostname does not resolve.** One warning naming the
unresolvable hostnames, the actual configured domain, and the published guide.
Async, bounded, deterministic order, and it **only fires on a positive NXDOMAIN**.

---

## Verification

- **Gate on every one of the 11 commits:** `make lint && make test && make
  test-race && make build`, run bare. Docs commits also ran `zensical build
  --strict`.
- **Every regression guard was verified by reintroducing its bug** — 10 of them,
  including one that proves the *placement* of the #107 fix and not merely its
  presence. Details in the commit messages.
- **Real-PTY captures at 120×40** for the two criteria about what a user sees
  (the banner, and colour-independence with ANSI stripped).
- **Invariant sweep** over the whole diff for violations of the rules this plan
  introduces; three AST/enum guards enforce them mechanically.

### Honest coverage limits

- The mkcert warning was **never observed end-to-end against a genuinely
  untrusted CA** — the dev machine's CA is installed, and installing/removing a
  real CA to test it is not something to do to a machine. Covered by unit tests
  driving a fake mkcert on a scrubbed PATH with a temp CAROOT; the real binary's
  exact strings were read out of it rather than remembered.
- The DNS warning was **never observed against a real NXDOMAIN in a live
  session**; no test performs a real DNS lookup, deliberately.
- `up -d` warning surfacing uses a synthetic slow producer (env-gated, inert in
  release-pipeline builds), because no real producer can finish at a chosen
  instant.
- Run on macOS only; CI covers ubuntu + macos.

## Review

Plan reviewed by **Codex, GLM 5.2 and CodeRabbit** before implementation. Every
commit then got an external correctness review — codex for C1–C3, CodeRabbit from
C5 on (codex hit its usage limit mid-run; the cursor fallback produced no
output). **C4 got a self-review instead**, recorded in its commit message rather
than glossed — and that self-review is what found the frame-contract sweep gap.

Four review findings changed the design rather than the code, and all four are
the same bug this plan exists to remove — prox stating something untrue —
approached from different directions:

1. The **detached child would have killed its own daemon** (GLM, on the plan).
2. A warning **could never be withdrawn**, so a user who ran `mkcert -install`
   would keep being told their CA was untrusted (CodeRabbit).
3. **Every resolver error counted as "does not resolve"** — an offline laptop or
   sandboxed CI runner would be told its working setup was broken (CodeRabbit).
4. The **capture-disabled empty state blamed capture** for a list being empty,
   but capture-off still records metadata-only rows (CodeRabbit). This one was my
   own pinned wording.

Also fixed from review: a Ctrl-C landing between latching the dead-stack verdict
and triggering shutdown could make an intentional shutdown exit non-zero (now
arbitrated inside the coordinator's `sync.Once`); the marker matched mkcert's
*Java* note, which would have raised a false alarm on a machine whose browsers
work fine; and moving the trust check to every registration revealed that unit
tests would have started shelling out to the developer's real mkcert — now
prevented by an AST guard.

## Dependency / privacy / secret impact

None. No new dependencies, no new network calls except the DNS lookups described
above (localhost-resolver, bounded, best-effort) and mkcert subprocess
invocations that already existed. No secrets, no telemetry. Tests never touch the
real CAROOT or trust store.

## Accepted risks

- **The trust verdict is per daemon process.** Re-probing while the answer is bad
  makes the warning self-clearing, so the hint's promise holds; a settled *good*
  verdict is cached for the process, since a CA does not spontaneously become
  untrusted.
- **mkcert string matching** (#97 pinned this): if mkcert rewords its note, the
  warning stops appearing. The marker is the stable stem shared by its variants,
  pinned by a test.
- **`PROX_TEST_STARTUP_WARNING`** remains live in source-built binaries (`make
  build`, `go install`), since only the release pipeline sets the version ldflag.
  A build tag would have meant the suite tested a different binary from the one
  users run. Blast radius: a user exporting a variable in their own shell to
  print one line to their own terminal.

<details>
<summary>Plan 028 — design decisions (from <code>~/.claude/plans/prox/028-new-user-experience.md</code>)</summary>

The plan file lives outside the repo. Its pinned decisions, condensed:

**A-D1** One `domain.Warning` type used directly by both packages; additive on
the register response. The compatibility argument is ordinary additive JSON —
**not** the register version gate, because local `make build` binaries all report
`"dev"`, so that gate does not separate two different development builds.

**A-D3** The mkcert verdict is **CA-scoped, not per-domain**, and re-derived
rather than latched-forever, because the condition is one the user goes and
fixes.

**A-D5** `warnings_sealed` exists because the `up -d` parent's single status
fetch would otherwise race an async producer.

**B-D1** Capture mkcert's output and match the stem
`"the local CA is not installed in"`; carry mkcert's line verbatim. Never
reimplement trust-store detection. The Java store is excluded — it does not
affect browsers.

**B-D2** DNS: bounded, overlapped with startup, joined on `runUp`'s goroutine
(the preamble is single-goroutine by construction), deterministic order, warns
only on positive NXDOMAIN.

**C-D2** Dead stack := `len(procs) > 0 && nothing IsLive() && something
IsTerminalFailure()`. Both halves matter: a partial crash must not tear a session
down, and an all-`completed` task config or a deliberate API stop must not either.

**C-D3** Plain mode exits non-zero via a latched verdict (triggering the
coordinator alone cannot carry a *reason*); the watcher polls its confirmation
window rather than trusting further wakes, because the change bus is a
capacity-1 coalescing latch.

**C-D4** The TUI banner is computed from process snapshots the TUI already
streams — nothing new plumbed — and is the first chrome row whose height changes
on a *data* message, which is why the `ProcessesMsg` relayout hook is
load-bearing.

**C-D8** Words, not glyphs: the panel's only existing glyphs are the health dot's
`●`/`✗`, and a second `✗` for crashed a few columns away would be genuinely
ambiguous.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lht7YxhACcDzMHjpcyogyp


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added advisory warnings for untrusted HTTPS certificates and unresolved hostnames, with remediation hints.
  * `status` and startup commands now display session warnings without affecting exit codes.
  * Foreground sessions now exit unsuccessfully when all processes crash or become blocked; detached sessions remain available.
  * TUI now shows dead-stack banners, explicit process states, improved empty-state guidance, and capture-disabled explanations.

* **Bug Fixes**
  * Healthchecks stop immediately when processes terminate unexpectedly.
  * Improved warning lifecycle, deduplication, and clearing after issues are resolved.

* **Documentation**
  * Updated CLI, API, TUI, and local DNS guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->