### PR TITLE
TUI: live (incremental) `/` search — type to jump, Enter keeps, Esc cancels and restores (plan 030)

### DIFF
--- a/docs/reference/tui.md
+++ b/docs/reference/tui.md
@@ -58,7 +58,7 @@ Toggle the menu bar with `m`, the process panel with `p`. View preferences persi
 
 A single footer row carries everything that used to split across status and hint rows:
 
-- **Left:** typed status — mode prompts (`Search:` / `Filter:` while typing), committed search/filter/solo text, connection or restart messages, or the idle hint. Errors render as `✗ …` on the footer background.
+- **Left:** typed status — mode prompts (`Search:` / `Filter:` while typing — search applies live, jumping the cursor to matches on every keystroke), committed search/filter/solo text, connection or restart messages, or the idle hint. Errors render as `✗ …` on the footer background.
 - **Right:** `[Logs]` / `[Requests]` / `[Request Detail]`, `[FOLLOW]` / `[PAUSED]`, visible/total count, then two-tone key hints (`? help · m menu · / search · s filter · q stop`).
 
 The last hint is mode-aware: `q stop` under `prox up`, where quitting stops the processes, and `q quit` under `prox attach`, where it only detaches. The `?` help modal spells the same thing out in full.
@@ -159,7 +159,7 @@ Click a process chip in the panel (logs view) to solo that process — the same 
 | `p` | Toggle process panel |
 | `T` | Toggle timestamps in log lines |
 | `w` | Toggle soft-wrap in logs |
-| `Esc` | Clear filters/search/solo; back from detail |
+| `Esc` | Clear filters/search/solo; back from detail; while typing `/`, cancels the live search and restores the view to where `/` was pressed |
 | `q` | Quit (Normal mode) — under `prox up` this also stops the processes, under `prox attach` it only detaches; close help without quitting (Help mode); typed into search/filter bars while editing |
 | `ctrl+c` | Quit from any mode (including help and text entry), with the same stop-vs-detach meaning as `q` |
 
@@ -171,7 +171,7 @@ When the menu bar is visible:
 - Hover a sibling menu cell while a dropdown is open to slide the menu across the bar; hover dropdown rows to move the highlight.
 - With a menu open: `←`/`→`/`Tab` switch between menus; `↑`/`↓`/`j`/`k` navigate rows (separators skipped); the scroll wheel moves the highlight; `Enter`/`Space` activate; any other key closes the menu (except `?`, which closes the menu and opens help).
 - Long menus clamp to the frame with “… N more …” indicator rows; wheel scrolls the visible window.
-- Opening a menu by mouse while typing in a filter/search bar blurs the input first.
+- Opening a menu by mouse while typing in a filter/search bar blurs the input first — for the `/` bar this commits the live search (keeps what you typed), the same as `Enter`.
 
 Menu choices persist view toggles, theme, and (in Requests view) column visibility to `~/.prox/tui/config.toml` (`theme`, `[view]` keys: `process_panel`, `timestamps`, `wrap`, `menu_bar`, plus `[requests]` column booleans).
 
@@ -182,7 +182,7 @@ Menu choices persist view toggles, theme, and (in Requests view) column visibili
 | `1-9` | Solo process (toggle) |
 | `s` | Filter bar — query language, applied live |
 | `f` | Filter menu — process checks + log levels |
-| `/` | Search — jumps cursor to match (does not filter) |
+| `/` | Search — applied live as you type (does not filter); `Enter` keeps it, `Esc` cancels & restores; reopens seeded with the last committed search |
 | `n` / `N` | Next/previous search match |
 | `y` | Copy parked line (after click or `/` search cursor) |
 | `r` | Restart the soloed process |
@@ -234,7 +234,7 @@ Open the **View** menu (`v`) for a **Columns** checkbox section (Requests and Re
 | `G` / `End` | Cursor to bottom (resumes follow) |
 | `s` | Filter bar — query language |
 | `f` | Filter menu — status class + methods |
-| `/` | Search visible columns (navigate only) |
+| `/` | Search visible columns — applied live as you type (navigate only, not filter); `Enter` keeps it, `Esc` cancels & restores; reopens seeded with the last committed search |
 | `n` / `N` | Next/previous match |
 | `Enter` | Open detail for cursor row |
 | `y` | Copy full request ID |
@@ -279,7 +279,7 @@ Detail views live-update when the open request completes.
 
 ## Search vs. Filter
 
-- **`/`** navigates: jumps the cursor to matches without hiding rows/lines. Composes with an active `s` filter.
+- **`/`** navigates: applies live as you type, jumping the cursor to matches without hiding rows/lines. `Enter` keeps the result and exits the bar; `Esc` cancels and restores the view to where `/` was pressed. Composes with an active `s` filter. Reopening `/` seeds the bar with the view's last committed search.
 - **`s`** filters: hides non-matching entries using the query language above. Each view keeps its own filter across `Tab` switches.
 - The merged footer left side shows committed search as `/<query> (i/n)` (cursor on match *i* of *n*) or `/<query> (n matches)`, filter as `Filter: <query>`, or the idle hint. While typing, `Search:` / `Filter:` prompts take precedence.
 

--- a/docs/reference/tui.md
+++ b/docs/reference/tui.md
@@ -279,7 +279,7 @@ Detail views live-update when the open request completes.
 
 ## Search vs. Filter
 
-- **`/`** navigates: applies live as you type, jumping the cursor to matches without hiding rows/lines. `Enter` keeps the result and exits the bar; `Esc` cancels and restores the view to where `/` was pressed. Composes with an active `s` filter. Reopening `/` seeds the bar with the view's last committed search.
+- **`/`** navigates: applies live as you type, jumping the cursor to matches without hiding rows/lines. `Enter` keeps the result and exits the bar; `Esc` cancels — clearing the view's search, including a previously committed query the bar was seeded with, and restoring cursor, scroll, and follow to where `/` was pressed. Composes with an active `s` filter. Reopening `/` seeds the bar with the view's last committed search.
 - **`s`** filters: hides non-matching entries using the query language above. Each view keeps its own filter across `Tab` switches.
 - The merged footer left side shows committed search as `/<query> (i/n)` (cursor on match *i* of *n*) or `/<query> (n matches)`, filter as `Filter: <query>`, or the idle hint. While typing, `Search:` / `Filter:` prompts take precedence.
 

--- a/internal/tui/base.go
+++ b/internal/tui/base.go
@@ -1097,8 +1097,21 @@ func (b *BaseModel) sessionLogOriginIdx(entries []domain.LogEntry) int {
 // Callers MUST gate this on the input value actually changing: cursor-movement
 // keys (left/right/home/end) leave the term alone and must not re-run the scan
 // or re-seek (see handleSearchKey).
+//
+// The view is taken from the SESSION, not from b.viewMode, so the query this
+// writes and the origin restoreSearchOrigin puts back can never name different
+// views — Esc clearing one view's search while restoring the other's position
+// is the failure that makes structural. Nothing can switch views while the bar
+// is open today (tab is consumed as text, non-menu mouse is ignored, a menu
+// open commits the bar first); this stops that from being load-bearing. Without
+// an active session — a caller that set ModeSearch directly — there is no
+// press-time view to honor, so the live one stands.
 func (b *BaseModel) liveApplySearch(value string) {
-	if b.viewMode == ViewModeRequests {
+	view := b.viewMode
+	if b.searchSession.active {
+		view = b.searchSession.view
+	}
+	if view == ViewModeRequests {
 		b.requestSearchQuery = value
 		b.restoreSearchOrigin()
 		if value != "" {
@@ -1164,6 +1177,28 @@ func (b *BaseModel) sessionRequestOriginIdx(requests []proxy.RequestRecord) int 
 	return clampIndex(s.requestCursorIdx, n)
 }
 
+// cancelLiveSearch ends a `/` session DISCARDING it (Esc in the bar, plan 030
+// WS3): the ACTIVE view's query and cursor go away and the view returns to the
+// origin — scroll row, cursor row and follow as of the `/` press, with the same
+// eviction fallbacks every other restore uses (logs anchor gone → oldest
+// retained; requests record gone → nearest index; restored follow wins and
+// re-lands newest).
+//
+// It IS the empty-bar live preview, made permanent: running through
+// liveApplySearch("") is what keeps cancel and backspacing-to-nothing one
+// behavior rather than two that drift. Clearing the query before that path's
+// render also matters — the marker columns must be gone from the wrap math
+// before the spans the scroll restore reads are rebuilt.
+//
+// Scoped to the active view: the other view's search survives, mirroring the `s`
+// bar's Esc. Normal-mode Esc, which clears BOTH views, is untouched.
+func (b *BaseModel) cancelLiveSearch() {
+	b.liveApplySearch("")
+	b.mode = ModeNormal
+	b.textInput.Blur()
+	b.searchSession = searchSession{}
+}
+
 // commitLiveSearch ends a `/` session KEEPING the live-applied query, then exits
 // the bar. The re-apply is the true mirror of the `s` bar's Enter: idempotent
 // once every keystroke has gone through liveApplySearch, but it guarantees a
@@ -1177,14 +1212,17 @@ func (b *BaseModel) commitLiveSearch() {
 }
 
 // handleSearchKey handles keys in search mode. The `/` bar is LIVE (plan 030):
-// every keystroke that changes the term applies it and jumps the cursor,
-// Enter keeps the live result and exits, and Esc exits the bar.
+// every keystroke that changes the term applies it and jumps the cursor, Enter
+// keeps the live result and exits, and Esc cancels — clearing the active view's
+// search and putting the view back where `/` was pressed.
 func (b *BaseModel) handleSearchKey(msg tea.KeyMsg) (bool, tea.Cmd) {
 	switch msg.String() {
 	case "esc":
-		b.mode = ModeNormal
-		b.textInput.Blur()
-		b.searchSession = searchSession{}
+		// Cancel: the search is undone, not merely left as typed (WS3). A
+		// previously committed query for this view goes with it — accepted and
+		// user-pinned: with the bar seeded from that query, "keep the old
+		// search" is Enter.
+		b.cancelLiveSearch()
 		return true, nil
 
 	case "enter":

--- a/internal/tui/base.go
+++ b/internal/tui/base.go
@@ -149,6 +149,12 @@ type BaseModel struct {
 	// filteredEntries() at keypress time (D6-D8).
 	logSearchQuery string
 
+	// searchSession is the open `/` bar's origin — where the view sat when `/`
+	// was pressed — so every live keystroke seeks from there instead of from
+	// the previous keystroke's landing (plan 030 WS1). Zero value = no bar
+	// open; see searchSession and captureSearchSession.
+	searchSession searchSession
+
 	// logSeq is a session-local monotonic counter stamped onto each ingested
 	// LogEntry.DisplaySeq. The logs cursor is anchored by DisplaySeq, not index,
 	// so it rides the 1000-entry front-eviction ring without drifting (a bare
@@ -893,41 +899,308 @@ func (b *BaseModel) requestIsStale(req proxy.RequestRecord) bool {
 	return req.StaleAt(time.Now())
 }
 
-// handleSearchKey handles keys in search mode
+// searchSession is one open `/` bar: where the view sat when `/` was pressed
+// (plan 030 WS1). Live search is restore-then-seek — every keystroke puts the
+// view back here before scanning — so shrinking a term or fixing a typo finds
+// matches an earlier keystroke had already scrolled past, instead of the classic
+// broken-incsearch feel of seeking from the previous landing.
+//
+// Every anchor is an IDENTITY, never a raw index or viewport offset: entries and
+// records stream in and evict while the bar is open, so an offset captured at
+// press time decays into a different row mid-typing. Logs anchor by DisplaySeq
+// (the same idiom as logCursorSeq), requests by record ID with the index as the
+// eviction fallback. The zero value (active false) means no bar is open, and
+// every restore against it is a no-op.
+type searchSession struct {
+	active bool
+	// view is the view `/` was pressed in. The bar cannot change views (tab is
+	// consumed as text), so this is also the view every live apply writes to.
+	view ViewMode
+	// followMode as of the press. Restoring it takes PRECEDENCE over the
+	// positional anchors: a session that started under follow re-lands on
+	// newest, which is where follow would have dragged the view anyway.
+	followMode bool
+
+	// Logs origin. logCursorSeq is any cursor a PRIOR search had parked (0 when
+	// there was none); logAnchorSeq is the scroll anchor — the newest entry
+	// under follow, else the top visible row. Seq alone, with no paired index:
+	// an evicted logs anchor resolves to the oldest retained line, never to a
+	// remembered index (see sessionLogOriginIdx).
+	logCursorSeq int64
+	logAnchorSeq int64
+
+	// Requests origin: the cursor row's identity ("" / -1 on an empty list).
+	requestCursorID  string
+	requestCursorIdx int
+}
+
+// captureSearchSession records the active view's origin at the moment `/` is
+// pressed. It must run BEFORE anything the `/` handler does that could move the
+// view, since the origin is precisely the pre-search position.
+func (b *BaseModel) captureSearchSession() {
+	s := searchSession{active: true, view: b.viewMode, followMode: b.followMode}
+	switch b.viewMode {
+	case ViewModeRequests:
+		s.requestCursorID = b.cursorID
+		s.requestCursorIdx = b.cursorIdx
+	default:
+		entries := b.filteredEntries()
+		s.logCursorSeq = b.logCursorSeq
+		s.logAnchorSeq = b.logScrollAnchor(entries)
+	}
+	b.searchSession = s
+}
+
+// logScrollAnchor is the DisplaySeq of the entry the logs viewport is anchored
+// on: the newest entry under follow (the row follow keeps pinned — resolved AT
+// THE PRESS, not re-resolved later against whatever has streamed in since), else
+// the top visible row. Returns 0, the no-entry sentinel, for an empty list.
+func (b *BaseModel) logScrollAnchor(entries []domain.LogEntry) int64 {
+	n := len(entries)
+	if n == 0 {
+		return 0
+	}
+	idx := n - 1
+	if !b.followMode {
+		idx = b.entryIndexContainingRow(entries, b.viewport.YOffset)
+	}
+	return entries[idx].DisplaySeq
+}
+
+// restoreSearchOrigin puts cursor, scroll and follow state back to the open
+// session's origin. Live search calls it before every seek; the empty-bar path
+// calls it to preview a cleared search. It is deliberately standalone — the same
+// restore, with the same fallbacks, serves both.
+//
+// Restores are best-effort against a list that streamed and evicted while the
+// bar was open — the per-view helpers below carry the index fallbacks. A
+// restored followMode of true wins over the positional anchors. Without an open
+// session this is a no-op.
+func (b *BaseModel) restoreSearchOrigin() {
+	s := b.searchSession
+	if !s.active {
+		return
+	}
+	switch s.view {
+	case ViewModeRequests:
+		b.restoreRequestSearchOrigin(s)
+	default:
+		b.restoreLogSearchOrigin(s)
+	}
+}
+
+// restoreRequestSearchOrigin re-anchors the requests cursor on the session's
+// origin row — the same anchoring resolveRequestCursor does at render time, but
+// against the SESSION's identity rather than the live one. There is no scroll to
+// restore: updateViewport's ensure-visible clamp derives YOffset from the
+// cursor, so cursor identity plus follow fully determine the restored view.
+func (b *BaseModel) restoreRequestSearchOrigin(s searchSession) {
+	b.followMode = s.followMode
+	b.anchorRequestCursor(b.filteredProxyRequests(), s.requestCursorID, s.requestCursorIdx)
+}
+
+// restoreLogSearchOrigin re-anchors the logs cursor and scroll on the session's
+// origin. A session that began with no parked cursor restores to the no-cursor
+// sentinel, so an empty bar renders exactly like no search at all.
+func (b *BaseModel) restoreLogSearchOrigin(s searchSession) {
+	entries := b.filteredEntries()
+	b.followMode = s.followMode
+	if s.logCursorSeq != 0 {
+		// An evicted origin cursor lands on the oldest retained line — where the
+		// origin now sits relative to everything left — matching the scroll
+		// anchor's fallback rather than logIndexForSeq's mid-list clamp.
+		b.setLogCursor(entries, max(entryIndexOfSeq(entries, s.logCursorSeq), 0))
+	} else {
+		b.setLogCursor(nil, 0) // resets to the no-cursor sentinel
+	}
+	b.restoreLogSearchScroll()
+}
+
+// restoreLogSearchScroll re-applies the session's logs scroll anchor (follow
+// wins; else the anchor's row). It is split out of restoreLogSearchOrigin
+// because the offset is derived from logRowSpans, which every render rebuilds:
+// the ""↔non-empty query transition adds or removes the 2-column marker prefix
+// and so MOVES wrap points, leaving an offset computed against the previous
+// render's spans a few rows off. Paths that end with the query cleared re-apply
+// it after updateViewport, against fresh spans; paths that land a match need no
+// re-apply because ensureLogCursorVisible corrects them.
+func (b *BaseModel) restoreLogSearchScroll() {
+	s := b.searchSession
+	if !s.active {
+		return
+	}
+	if s.followMode {
+		b.viewport.GotoBottom()
+		return
+	}
+	b.viewport.SetYOffset(b.logOriginOffset(b.filteredEntries(), s.logAnchorSeq))
+}
+
+// logOriginOffset is the viewport row offset that restores the logs scroll
+// anchor stamped anchorSeq. Row spans are rebuilt by every render, so this
+// translates the anchor's DisplaySeq through the LAST render's spans: exact
+// while the bar sits over a settled view, and self-correcting on the next render
+// otherwise. An evicted anchor falls back to the oldest retained line.
+func (b *BaseModel) logOriginOffset(entries []domain.LogEntry, anchorSeq int64) int {
+	if len(entries) == 0 || anchorSeq == 0 {
+		return 0
+	}
+	idx := entryIndexOfSeq(entries, anchorSeq)
+	if idx < 0 {
+		return 0 // anchor evicted: oldest retained line
+	}
+	if sp, ok := b.logRowSpans[anchorSeq]; ok {
+		return sp.First
+	}
+	return idx // spans missing (no render yet): 1-entry==1-row
+}
+
+// sessionLogOriginIdx resolves the session's logs origin to an index in the
+// current filtered list: the cursor a prior search had parked, else the scroll
+// anchor. Both are press-time identities, so entries arriving while the bar is
+// open never move the origin — they only shift its index.
+//
+// An origin that is GONE resolves to 0, the oldest retained line, and so does an
+// origin that never existed (empty list at the press). Both say the same thing:
+// the ring evicts from the front and nothing arrives before the press, so every
+// line still retained is at-or-after the origin — starting anywhere else would
+// skip the true first match. This is deliberately NOT logIndexForSeq's clamped
+// last-known index, which for a front-evicted anchor points mid-list.
+func (b *BaseModel) sessionLogOriginIdx(entries []domain.LogEntry) int {
+	s := b.searchSession
+	if !s.active {
+		// No open bar: the ordinary cursor-derived origin, which is what n/N use.
+		return b.logSearchOriginIdx(entries)
+	}
+	seq := s.logCursorSeq
+	if seq == 0 {
+		seq = s.logAnchorSeq
+	}
+	if seq == 0 {
+		return 0 // nothing on screen at the press: everything arrived after it
+	}
+	if i := entryIndexOfSeq(entries, seq); i >= 0 {
+		return i
+	}
+	return 0 // origin evicted: it sat before the oldest line still retained
+}
+
+// liveApplySearch applies the `/` bar's current value to the ACTIVE view on
+// every keystroke (plan 030 WS1). It writes the committed query field, so every
+// existing consumer — inline highlight, row marker, selection band, the
+// follow-park guard, the footer indicator — works unmodified, and then
+// restore-then-seeks from the session origin.
+//
+// An empty value previews a cleared search: no query, no cursor, view back at
+// the origin — visually identical to never having searched.
+//
+// Callers MUST gate this on the input value actually changing: cursor-movement
+// keys (left/right/home/end) leave the term alone and must not re-run the scan
+// or re-seek (see handleSearchKey).
+func (b *BaseModel) liveApplySearch(value string) {
+	if b.viewMode == ViewModeRequests {
+		b.requestSearchQuery = value
+		b.restoreSearchOrigin()
+		if value != "" {
+			// Seek from the SESSION origin, not from the just-restored cursor:
+			// under follow the restore pins that cursor to the CURRENT newest
+			// row — right for the view — while the search must still start on
+			// the row `/` was pressed on, or records arriving mid-typing would
+			// flip the landing from keystroke to keystroke (D12).
+			requests := b.filteredProxyRequests()
+			b.seekRequestSearchMatchFrom(requests, b.sessionRequestOriginIdx(requests), 0)
+		}
+		b.updateViewport()
+		return
+	}
+	b.logSearchQuery = value
+	b.restoreSearchOrigin()
+	if value == "" {
+		// An empty bar leaves NO parked cursor behind: the marker is not
+		// rendered without a query anyway, but a lingering anchor would keep `y`
+		// copying a row nothing shows as selected. The session still holds the
+		// origin, so typing again re-anchors from it.
+		b.setLogCursor(nil, 0)
+		b.updateViewport()
+		// Dropping the query dropped the marker columns with it, so re-apply the
+		// scroll against the spans that render just rebuilt (see
+		// restoreLogSearchScroll).
+		b.restoreLogSearchScroll()
+		return
+	}
+	// Seek from the SESSION origin rather than seekLogSearchMatch's
+	// cursor-derived one: a session that started with no parked cursor restores
+	// none to seek from, and under follow the origin is the row that was newest
+	// AT THE PRESS, not whatever has streamed in since.
+	entries := b.filteredEntries()
+	b.seekLogSearchMatchFrom(entries, b.sessionLogOriginIdx(entries), 0)
+	b.updateViewport()
+	// One-shot scroll to the landed match (no-op on the no-cursor sentinel),
+	// mirroring the n/N handlers.
+	b.ensureLogCursorVisible()
+}
+
+// sessionRequestOriginIdx resolves the session's requests origin to an index in
+// the current filtered list: the press-time cursor RECORD, falling back to its
+// clamped index when that row is gone (trimmed or filtered out) and to the
+// oldest row when there was no cursor at all — an empty list at the press means
+// everything now on screen arrived after it. Falls back to the live cursor when
+// no bar is open.
+func (b *BaseModel) sessionRequestOriginIdx(requests []proxy.RequestRecord) int {
+	n := len(requests)
+	if n == 0 {
+		return 0
+	}
+	s := b.searchSession
+	if !s.active {
+		return clampIndex(b.cursorIdx, n)
+	}
+	if s.requestCursorID == "" {
+		return 0
+	}
+	if i := requestIndexOfID(requests, s.requestCursorID); i >= 0 {
+		return i
+	}
+	return clampIndex(s.requestCursorIdx, n)
+}
+
+// commitLiveSearch ends a `/` session KEEPING the live-applied query, then exits
+// the bar. The re-apply is the true mirror of the `s` bar's Enter: idempotent
+// once every keystroke has gone through liveApplySearch, but it guarantees a
+// value that reached the textinput without per-keystroke handling still commits
+// with its jump. Enter and a mouse menu-open (which blurs the bar) share it.
+func (b *BaseModel) commitLiveSearch() {
+	b.liveApplySearch(b.textInput.Value())
+	b.mode = ModeNormal
+	b.textInput.Blur()
+	b.searchSession = searchSession{}
+}
+
+// handleSearchKey handles keys in search mode. The `/` bar is LIVE (plan 030):
+// every keystroke that changes the term applies it and jumps the cursor,
+// Enter keeps the live result and exits, and Esc exits the bar.
 func (b *BaseModel) handleSearchKey(msg tea.KeyMsg) (bool, tea.Cmd) {
 	switch msg.String() {
 	case "esc":
 		b.mode = ModeNormal
 		b.textInput.Blur()
+		b.searchSession = searchSession{}
 		return true, nil
 
 	case "enter":
-		b.mode = ModeNormal
-		b.textInput.Blur()
-		if b.viewMode == ViewModeRequests {
-			// Requests view: `/` is navigation, not filtration. Commit the query
-			// to requestSearchQuery (`s` filter untouched) and jump the cursor
-			// to the first match at-or-after it (D12).
-			b.requestSearchQuery = b.textInput.Value()
-			b.jumpToRequestSearchMatch()
-			b.updateViewport()
-			return true, nil
-		}
-		// Logs view: `/` is navigation, not filtration (D6/D8) — it mirrors the
-		// requests view. Commit the query to logSearchQuery (`s` filter
-		// untouched) and jump the cursor to the first match at-or-after the
-		// current position, wrapping. The scroll-to-match is a one-shot here
-		// rather than wired into updateViewport, which also runs on streaming
-		// arrivals and free j/k scroll where re-scrolling would fight the reader.
-		b.logSearchQuery = b.textInput.Value()
-		b.seekLogSearchMatch(0)
-		b.updateViewport()
-		b.ensureLogCursorVisible()
+		// `/` is navigation, not filtration, in BOTH views (D6/D8/D12): the
+		// query lands in logSearchQuery / requestSearchQuery and the `s` filter
+		// is untouched. commitLiveSearch routes by view.
+		b.commitLiveSearch()
 		return true, nil
 	}
 
+	before := b.textInput.Value()
 	var cmd tea.Cmd
 	b.textInput, cmd = b.textInput.Update(msg)
+	if value := b.textInput.Value(); value != before {
+		b.liveApplySearch(value)
+	}
 	return true, cmd
 }
 
@@ -1263,6 +1536,10 @@ func (b *BaseModel) handleNavigationKey(msg tea.KeyMsg) (bool, tea.Cmd) {
 
 	case "/":
 		if b.viewMode != ViewModeRequestDetail {
+			// Capture the origin FIRST: the search is live from here on, and
+			// every keystroke restores to what the view looks like right now
+			// (plan 030 WS1).
+			b.captureSearchSession()
 			b.mode = ModeSearch
 			b.textInput.SetValue("")
 			b.textInput.Focus()
@@ -1477,17 +1754,6 @@ func requestDurationSearchText(req proxy.RequestRecord, stale bool) string {
 	}
 }
 
-// jumpToRequestSearchMatch moves the cursor to the first row matching
-// requestSearchQuery at-or-after the current cursor, wrapping (D12). "At-or-after"
-// is deliberate: a fresh search may already sit on the best match; n advances.
-// No-op when the query is empty or nothing matches (cursor unmoved). A match
-// disengages follow so the jump sticks (resolveRequestCursor would otherwise
-// re-pin to the newest row); it never RE-engages follow — a search jump is
-// positioning, not scrolling intent (D13).
-func (b *BaseModel) jumpToRequestSearchMatch() {
-	b.seekRequestSearchMatch(0)
-}
-
 // cycleRequestSearchMatch moves the cursor to the next (dir +1) or previous
 // (dir -1) matching row STRICTLY past the current cursor, wrapping (D13).
 func (b *BaseModel) cycleRequestSearchMatch(dir int) {
@@ -1495,22 +1761,39 @@ func (b *BaseModel) cycleRequestSearchMatch(dir int) {
 }
 
 // seekRequestSearchMatch scans the filtered list for a matching row and moves
-// the cursor to it. dir 0 = at-or-after the cursor (the `/`-commit jump,
-// includes the cursor's own row); dir +1/-1 = strictly next/previous (n/N).
-// Derived at keypress time — no match list is ever stored (D13).
+// the cursor to it, starting from the CURSOR (the n/N origin). dir 0 =
+// at-or-after the cursor, dir +1/-1 = strictly next/previous. Derived at
+// keypress time — no match list is ever stored (D13).
 func (b *BaseModel) seekRequestSearchMatch(dir int) {
 	if b.requestSearchQuery == "" {
 		return
 	}
 	requests := b.filteredProxyRequests()
+	if len(requests) == 0 {
+		return
+	}
+	b.seekRequestSearchMatchFrom(requests, b.cursorIdx, dir)
+}
+
+// seekRequestSearchMatchFrom is seekRequestSearchMatch's scan with an EXPLICIT
+// start index — live search (plan 030) seeks from the session origin, so a
+// second keystroke does not start where the first one landed.
+//
+// dir 0 is at-or-after start, wrapping, and includes start's own row: a fresh
+// search may already sit on the best match; n advances (D12). No-op when the
+// query is empty or nothing matches (cursor unmoved). A match disengages follow
+// so the jump sticks (resolveRequestCursor would otherwise re-pin to the newest
+// row); it never RE-engages follow — a search jump is positioning, not scrolling
+// intent (D13).
+func (b *BaseModel) seekRequestSearchMatchFrom(requests []proxy.RequestRecord, start, dir int) {
+	if b.requestSearchQuery == "" {
+		return
+	}
 	n := len(requests)
 	if n == 0 {
 		return
 	}
-	start := b.cursorIdx
-	if start < 0 {
-		start = 0
-	}
+	start = clampIndex(start, n)
 	if dir == 0 {
 		// At-or-after: offsets 0..n-1 forward, cursor row first.
 		for i := 0; i < n; i++ {
@@ -1582,11 +1865,21 @@ func (b *BaseModel) seekLogSearchMatch(dir int) {
 		return
 	}
 	entries := b.filteredEntries()
+	b.seekLogSearchMatchFrom(entries, b.logSearchOriginIdx(entries), dir)
+}
+
+// seekLogSearchMatchFrom is seekLogSearchMatch's scan with an EXPLICIT start
+// index. Live search (plan 030) seeks from the session origin rather than from
+// the parked cursor, so a second keystroke does not start where the first one
+// landed; the n/N path keeps the cursor-derived origin. It owns the empty-list
+// and empty-query guards for both paths, so start may be any int (it is clamped
+// here) and callers need not pre-check the slice.
+func (b *BaseModel) seekLogSearchMatchFrom(entries []domain.LogEntry, start, dir int) {
 	n := len(entries)
-	if n == 0 {
+	if b.logSearchQuery == "" || n == 0 {
 		return
 	}
-	start := b.logSearchOriginIdx(entries)
+	start = clampIndex(start, n)
 	if dir == 0 {
 		// At-or-after: offsets 0..n-1 forward, origin row first.
 		for i := 0; i < n; i++ {
@@ -1623,13 +1916,7 @@ func (b *BaseModel) seekLogSearchMatch(dir int) {
 func (b *BaseModel) logSearchOriginIdx(entries []domain.LogEntry) int {
 	n := len(entries)
 	if b.logCursorSeq != 0 {
-		for i, e := range entries {
-			if e.DisplaySeq == b.logCursorSeq {
-				return i
-			}
-		}
-		// Anchored line evicted: fall back to the clamped last-known index.
-		return clampIndex(b.logCursorIdx, n)
+		return logIndexForSeq(entries, b.logCursorSeq, b.logCursorIdx)
 	}
 	if b.followMode {
 		return n - 1
@@ -1658,6 +1945,36 @@ func (b *BaseModel) entryIndexContainingRow(entries []domain.LogEntry, row int) 
 		}
 	}
 	return clampIndex(row, n)
+}
+
+// logIndexForSeq resolves a DisplaySeq to its current index in entries — the
+// anchor surviving the eviction ring — and falls back to the clamped last-known
+// index when the line itself has been evicted. That fallback is bounded DRIFT,
+// not a position: it keeps the LIVE cursor in range (its only requirement) and
+// is wrong for a press-time anchor, which must resolve to the oldest retained
+// line instead (see sessionLogOriginIdx). An empty list yields 0, which every
+// caller feeds to setLogCursor, i.e. the no-cursor sentinel.
+func logIndexForSeq(entries []domain.LogEntry, seq int64, fallbackIdx int) int {
+	n := len(entries)
+	if n == 0 {
+		return 0
+	}
+	if i := entryIndexOfSeq(entries, seq); i >= 0 {
+		return i
+	}
+	return clampIndex(fallbackIdx, n)
+}
+
+// entryIndexOfSeq returns the index of the entry stamped with seq, or -1 when
+// that line is no longer retained. Callers that have a fallback index want
+// logIndexForSeq; this raw form is for the ones that must distinguish "evicted".
+func entryIndexOfSeq(entries []domain.LogEntry, seq int64) int {
+	for i, e := range entries {
+		if e.DisplaySeq == seq {
+			return i
+		}
+	}
+	return -1
 }
 
 // clampIndex clamps idx into [0, n-1] for a non-empty n (callers guard n > 0).
@@ -1726,14 +2043,8 @@ func (b *BaseModel) resolveLogCursor(entries []domain.LogEntry) {
 		b.setLogCursor(entries, len(entries)-1)
 		return
 	}
-	for i, e := range entries {
-		if e.DisplaySeq == b.logCursorSeq {
-			b.setLogCursor(entries, i)
-			return
-		}
-	}
-	// Anchored line evicted: clamp the last-known index and re-anchor.
-	b.setLogCursor(entries, b.logCursorIdx)
+	// Present: its current index; evicted: the clamped last-known index.
+	b.setLogCursor(entries, logIndexForSeq(entries, b.logCursorSeq, b.logCursorIdx))
 }
 
 // ensureLogCursorVisible scrolls the logs viewport the minimum amount needed to
@@ -1828,6 +2139,21 @@ func (b *BaseModel) setRequestCursor(requests []proxy.RequestRecord, idx int) {
 	b.cursorID = requests[idx].ID
 }
 
+// requestIndexOfID returns the index of the record carrying id, or -1 when that
+// row is no longer in the list (trimmed, or filtered out). "" is the no-cursor
+// sentinel — never a real ID — and reports -1 like any other absent row.
+func requestIndexOfID(requests []proxy.RequestRecord, id string) int {
+	if id == "" {
+		return -1
+	}
+	for i, req := range requests {
+		if req.ID == id {
+			return i
+		}
+	}
+	return -1
+}
+
 // resolveRequestCursor re-anchors the cursor against the current filtered list
 // at the render choke point, so every mutation source (upsert, append+trim,
 // live filter keystrokes, esc clear, follow toggles, view transitions) lands
@@ -1839,6 +2165,15 @@ func (b *BaseModel) setRequestCursor(requests []proxy.RequestRecord, idx int) {
 //     sits at that index (trim/filter removed the old row; empty→non-empty with
 //     follow off lands on row 0).
 func (b *BaseModel) resolveRequestCursor(requests []proxy.RequestRecord) {
+	b.anchorRequestCursor(requests, b.cursorID, b.cursorIdx)
+}
+
+// anchorRequestCursor is the cursor-anchoring rule itself, applied to an
+// (id, idx) pair: follow first, then the ID if that row is still present, then
+// the clamped last-known index. Shared by the render-time resolve (the live
+// cursor) and the `/` session restore (the press-time origin), which differ only
+// in whose identity they anchor on.
+func (b *BaseModel) anchorRequestCursor(requests []proxy.RequestRecord, id string, idx int) {
 	if len(requests) == 0 {
 		b.setRequestCursor(requests, 0) // resets to the no-cursor sentinel
 		return
@@ -1847,17 +2182,13 @@ func (b *BaseModel) resolveRequestCursor(requests []proxy.RequestRecord) {
 		b.setRequestCursor(requests, len(requests)-1)
 		return
 	}
-	if b.cursorID != "" { // "" is the no-cursor sentinel; never a real ID
-		for i, req := range requests {
-			if req.ID == b.cursorID {
-				b.setRequestCursor(requests, i)
-				return
-			}
-		}
+	if i := requestIndexOfID(requests, id); i >= 0 {
+		b.setRequestCursor(requests, i)
+		return
 	}
-	// Stale cursor (row filtered/trimmed away) or first anchor with follow off:
-	// clamp the last-known index and re-anchor to the row now there.
-	b.setRequestCursor(requests, b.cursorIdx)
+	// Row gone (filtered/trimmed away) or first anchor with follow off: clamp
+	// the last-known index and re-anchor to the row now there.
+	b.setRequestCursor(requests, idx)
 }
 
 // ensureCursorVisible scrolls the viewport the minimum amount needed to bring

--- a/internal/tui/base.go
+++ b/internal/tui/base.go
@@ -1316,6 +1316,15 @@ func (b *BaseModel) activeFilterRaw() string {
 	return b.logsFilter.RawQuery
 }
 
+// activeSearchQuery returns the active view's committed `/` term — what `/`
+// seeds its bar with (plan 030 WS4), mirroring activeFilterRaw for the `s` bar.
+func (b *BaseModel) activeSearchQuery() string {
+	if b.viewMode == ViewModeRequests || b.viewMode == ViewModeRequestDetail {
+		return b.requestSearchQuery
+	}
+	return b.logSearchQuery
+}
+
 // activeFilterParseErr returns the active view's ParseErr.
 func (b *BaseModel) activeFilterParseErr() error {
 	if b.viewMode == ViewModeRequests || b.viewMode == ViewModeRequestDetail {
@@ -1574,13 +1583,29 @@ func (b *BaseModel) handleNavigationKey(msg tea.KeyMsg) (bool, tea.Cmd) {
 
 	case "/":
 		if b.viewMode != ViewModeRequestDetail {
-			// Capture the origin FIRST: the search is live from here on, and
-			// every keystroke restores to what the view looks like right now
-			// (plan 030 WS1).
+			// ORDER IS LOAD-BEARING (plan 030 WS1/WS4): capture the origin, then
+			// seed, then apply. The search is live from here on and the seed
+			// applies ITSELF — an origin captured after that apply would be the
+			// seed's landing rather than the pre-search position, and every
+			// later keystroke would seek from there.
 			b.captureSearchSession()
 			b.mode = ModeSearch
-			b.textInput.SetValue("")
+			seed := b.activeSearchQuery()
+			b.textInput.SetValue(seed)
+			b.textInput.CursorEnd()
 			b.textInput.Focus()
+			if seed != "" {
+				// Reopening shows the seeded term's live state at once. The seek
+				// is at-or-after an origin that INCLUDES any cursor the term
+				// parked, so reopening over a match lands back on it and the view
+				// does not move. It can move when the prior search ended
+				// no-match: that cleared the cursor, so this seeks from the
+				// viewport instead and entries streamed in since may now match —
+				// accepted, and arguably what the user wants to see.
+				b.liveApplySearch(seed)
+			}
+			// An empty seed applies nothing at all: no render, no cursor touch —
+			// opening a fresh bar must be visually inert.
 		}
 		return true, nil
 

--- a/internal/tui/base_behavior_test.go
+++ b/internal/tui/base_behavior_test.go
@@ -2151,3 +2151,305 @@ func TestLiveSearch_EmptyInputRestoresOriginViewUnderWrap(t *testing.T) {
 		"the restored offset is the anchor's row in the CURRENT (marker-free) render")
 	assert.Equal(t, 20, m.viewport.YOffset)
 }
+
+// --- `/` bar Esc-cancel tests (plan 030 C2 / WS3) ---
+
+func TestLiveSearch_EscRestoresLogsOrigin(t *testing.T) {
+	lines := make([]string, 30)
+	for i := range lines {
+		lines[i] = fmt.Sprintf("row %02d", i)
+	}
+	lines[20] = "abc target"
+	m := newLogsModel(5, lines)
+	m = clientUpdate(m, keyRune('k')) // disengage follow
+	m.viewport.SetYOffset(2)          // origin: top visible row 2, no parked cursor
+
+	m = clientUpdate(m, keyRune('/'))
+	m = typeSearch(m, "abc")
+	require.Equal(t, 20, m.logCursorIdx)
+	require.NotEqual(t, 2, m.viewport.YOffset, "the live jump scrolled away from the origin")
+
+	m = clientUpdate(m, tea.KeyMsg{Type: tea.KeyEscape})
+	assert.Equal(t, ModeNormal, m.mode)
+	assert.Empty(t, m.logSearchQuery, "esc cancels the search, not just the edit")
+	assert.Equal(t, -1, m.logCursorIdx)
+	assert.Equal(t, int64(0), m.logCursorSeq)
+	assert.Equal(t, 2, m.viewport.YOffset, "the view is back where `/` was pressed")
+	assert.False(t, m.followMode, "follow as of the press")
+	assert.False(t, m.searchSession.active, "the session is cleared")
+	assert.NotContains(t, m.viewport.View(), "❯", "a cancelled search renders as if it never happened")
+}
+
+func TestLiveSearch_EscRestoresRequestsOrigin(t *testing.T) {
+	m := newSearchModel(20, liveSearchRequests())
+	m = clientUpdate(m, keyRune('g'))
+	m = clientUpdate(m, keyRune('j'))
+	require.Equal(t, "q1", m.cursorID, "origin: the q1 row, follow off")
+
+	m = clientUpdate(m, keyRune('/'))
+	m = typeSearch(m, "abc")
+	require.Equal(t, "q3", m.cursorID, "the live jump moved the cursor off the origin")
+
+	m = clientUpdate(m, tea.KeyMsg{Type: tea.KeyEscape})
+	assert.Equal(t, ModeNormal, m.mode)
+	assert.Empty(t, m.requestSearchQuery)
+	assert.Equal(t, "q1", m.cursorID, "the cursor is back on the origin row")
+	assert.False(t, m.followMode)
+	assert.False(t, m.searchSession.active)
+}
+
+func TestLiveSearch_EscScopedToActiveView(t *testing.T) {
+	// Esc cancels the ACTIVE view's search only — the `s` bar's Esc scoping.
+	// Clearing both views is normal-mode Esc's job, and it is untouched.
+	m := newLogsModel(20, []string{"alpha", "needle here", "gamma"})
+	m.proxyRequests = makeTestRequests(6)
+	m = clientUpdate(m, keyRune('g'))
+	m = commitSearch(m, "needle")
+	require.Equal(t, "needle", m.logSearchQuery)
+
+	m = clientUpdate(m, tea.KeyMsg{Type: tea.KeyTab})
+	require.Equal(t, ViewModeRequests, m.viewMode)
+	m = clientUpdate(m, keyRune('/'))
+	m = typeSearch(m, "path/003")
+	require.Equal(t, "req-003", m.cursorID)
+
+	m = clientUpdate(m, tea.KeyMsg{Type: tea.KeyEscape})
+	assert.Empty(t, m.requestSearchQuery, "the active view's search is cancelled")
+	assert.Equal(t, "needle", m.logSearchQuery, "the other view's committed search survives")
+}
+
+func TestLiveSearch_EscEvictedLogsOriginRestoresOldestRetained(t *testing.T) {
+	// Best-effort restore: the ring evicted the row the view was anchored on
+	// while the bar was open, so the closest truth left is the oldest line still
+	// retained.
+	m := newLogsModel(5, nil)
+	feed := func(line string) {
+		m.handleLogEntry(domain.LogEntry{Timestamp: time.Unix(0, 0), Process: "p", Line: line})
+	}
+	for i := 0; i < maxLogEntries; i++ {
+		if i == 400 {
+			feed("NEEDLE row")
+			continue
+		}
+		feed(fmt.Sprintf("log %04d", i))
+	}
+
+	m = clientUpdate(m, keyRune('k')) // disengage follow
+	m.viewport.SetYOffset(200)        // origin: entry 200, well into the list
+	m = clientUpdate(m, keyRune('/'))
+	originSeq := m.searchSession.logAnchorSeq
+	require.NotZero(t, originSeq)
+	m = typeSearch(m, "NEEDLE")
+	require.GreaterOrEqual(t, m.logCursorIdx, 0)
+
+	// The origin scrolls out of the ring while the bar is still open.
+	for i := 0; i < 300; i++ {
+		feed(fmt.Sprintf("flood %04d", i))
+	}
+	require.Equal(t, -1, entryIndexOfSeq(m.filteredEntries(), originSeq), "the origin anchor was evicted")
+
+	m = clientUpdate(m, tea.KeyMsg{Type: tea.KeyEscape})
+	assert.Empty(t, m.logSearchQuery)
+	assert.Equal(t, -1, m.logCursorIdx)
+	assert.Equal(t, 0, m.viewport.YOffset, "an evicted origin restores to the oldest retained line")
+	assert.False(t, m.followMode, "and not by silently re-engaging follow")
+}
+
+func TestLiveSearch_EscDroppedRequestsOriginFallsBackToNearestIndex(t *testing.T) {
+	reqs := []proxy.RequestRecord{
+		newArrival("r0", "/x0"),
+		newArrival("r1", "/x1"),
+		newArrival("r2", "/x2"),
+		newArrival("r3", "/x3"),
+		newArrival("r4", "/x4"),
+		newArrival("r5", "/hit-far"),
+	}
+	m := newSearchModel(20, reqs)
+	m = clientUpdate(m, keyRune('g'))
+	m = clientUpdate(m, keyRune('j'))
+	m = clientUpdate(m, keyRune('j'))
+	require.Equal(t, "r2", m.cursorID, "origin: the r2 row, follow off")
+
+	m = clientUpdate(m, keyRune('/'))
+	m = typeSearch(m, "hit")
+	require.Equal(t, "r5", m.cursorID, "the live jump moved the cursor off the origin")
+
+	// A reconnect sync rebuilds the list without the origin record.
+	m = clientUpdate(m, RequestsSyncMsg{Snapshot: []proxy.RequestRecord{
+		reqs[0], reqs[1], reqs[3], reqs[4], reqs[5],
+	}})
+	require.Equal(t, -1, requestIndexOfID(m.filteredProxyRequests(), "r2"), "the origin record is gone")
+
+	m = clientUpdate(m, tea.KeyMsg{Type: tea.KeyEscape})
+	assert.Empty(t, m.requestSearchQuery)
+	assert.Equal(t, "r3", m.cursorID, "a dropped origin record falls back to its index, now r3")
+	assert.False(t, m.followMode)
+}
+
+func TestLiveSearch_EscRestoresFollow(t *testing.T) {
+	// A live jump off the newest row disengages follow (it has to, or the pin to
+	// newest would undo the jump). Cancelling gives follow back, both views, and
+	// the view re-lands on newest — the restored follow WINS over the positional
+	// anchor.
+	m := newLogsModel(20, []string{"a", "hit mid", "c", "d"})
+	require.True(t, m.followMode)
+	m = clientUpdate(m, keyRune('/'))
+	m = typeSearch(m, "hit")
+	require.Equal(t, 1, m.logCursorIdx)
+	require.False(t, m.followMode, "the live jump landed off the newest row")
+
+	m = clientUpdate(m, tea.KeyMsg{Type: tea.KeyEscape})
+	assert.True(t, m.followMode, "esc restores follow as of the press")
+	assert.Equal(t, -1, m.logCursorIdx)
+	assert.True(t, m.viewport.AtBottom(), "restored follow re-lands on newest")
+
+	// And the cancelled search leaves no parked guard behind: arrivals follow
+	// again, exactly as they did before `/` was pressed.
+	m = clientUpdate(m, LogEntryMsg(domain.LogEntry{
+		Timestamp: time.Unix(9, 0), Process: "p", Line: "e newest",
+	}))
+	assert.True(t, m.followMode, "an arrival after a cancelled search still follows")
+
+	reqs := makeTestRequests(6)
+	reqs[2].URL = "/hit/mid"
+	m2 := newSearchModel(20, reqs)
+	require.True(t, m2.followMode)
+	m2 = clientUpdate(m2, keyRune('/'))
+	m2 = typeSearch(m2, "hit")
+	require.Equal(t, 2, m2.cursorIdx)
+	require.False(t, m2.followMode)
+
+	m2 = clientUpdate(m2, tea.KeyMsg{Type: tea.KeyEscape})
+	assert.True(t, m2.followMode)
+	assert.Equal(t, "req-005", m2.cursorID, "restored follow re-pins the cursor to newest")
+}
+
+func TestLiveSearch_EscClearsPreviouslyCommittedSearch(t *testing.T) {
+	// Accepted, user-pinned behavior (WS3): Esc cancels the SEARCH, not merely
+	// the edit, so a query committed by an earlier Enter goes with it. Once `/`
+	// seeds the bar with that query (C3), keeping it is what Enter is for.
+	m := newLogsModel(20, []string{"aaa", "needle", "bbb"})
+	m = clientUpdate(m, keyRune('g'))
+	m = commitSearch(m, "needle")
+	require.Equal(t, "needle", m.logSearchQuery)
+	require.Equal(t, 1, m.logCursorIdx)
+
+	m = clientUpdate(m, keyRune('/'))
+	m = clientUpdate(m, tea.KeyMsg{Type: tea.KeyEscape})
+	assert.Empty(t, m.logSearchQuery, "the previously committed query is cancelled too")
+	assert.Equal(t, -1, m.logCursorIdx)
+	assert.Equal(t, int64(0), m.logCursorSeq)
+	assert.NotContains(t, m.viewport.View(), "❯")
+}
+
+func TestLiveSearch_EscRestoresOriginViewUnderWrap(t *testing.T) {
+	// Sibling of TestLiveSearch_EmptyInputRestoresOriginViewUnderWrap: cancelling
+	// clears the query BEFORE the final render, so the scroll restore reads spans
+	// with the marker columns already gone.
+	lines := make([]string, 40)
+	for i := range lines {
+		lines[i] = strings.Repeat("x", 38)
+	}
+	lines[30] = "abc" + strings.Repeat("x", 35)
+	m := newLogsModelNarrow(60, 6, lines)
+	m.settings.Wrap = true
+	m.followMode = false
+	m.updateViewport()
+	m.viewport.SetYOffset(20)
+
+	m = clientUpdate(m, keyRune('/'))
+	anchorSeq := m.searchSession.logAnchorSeq
+	require.NotZero(t, anchorSeq)
+	m = typeSearch(m, "abc")
+	require.Equal(t, 30, m.logCursorIdx)
+	require.Equal(t, 40, m.logRowSpans[anchorSeq].First, "the marker prefix wrapped every entry onto two rows")
+
+	m = clientUpdate(m, tea.KeyMsg{Type: tea.KeyEscape})
+	require.Empty(t, m.logSearchQuery)
+	assert.Equal(t, m.logRowSpans[anchorSeq].First, m.viewport.YOffset,
+		"the restored offset is the anchor's row in the CURRENT (marker-free) render")
+	assert.Equal(t, 20, m.viewport.YOffset)
+}
+
+func TestLiveSearch_EscOnDrainedRequestsListLandsOnSentinel(t *testing.T) {
+	// Everything the origin could name is gone: a reconnect sync drained the list
+	// while the bar was open. The restore has no row to land on, so it must reach
+	// the no-cursor sentinel rather than clamping onto an index that no longer
+	// exists.
+	m := newSearchModel(5, makeTestRequests(30))
+	m = clientUpdate(m, keyRune('G')) // newest, follow on
+	m = clientUpdate(m, keyRune('k')) // origin: req-028, follow off
+	require.Equal(t, "req-028", m.cursorID)
+	require.Positive(t, m.viewport.YOffset, "the origin is scrolled well down the list")
+
+	m = clientUpdate(m, keyRune('/'))
+	m = typeSearch(m, "path/02")
+	require.NotEmpty(t, m.requestSearchQuery)
+
+	m = clientUpdate(m, RequestsSyncMsg{}) // empty snapshot: the list is drained
+	require.Empty(t, m.filteredProxyRequests())
+	require.Equal(t, 0, m.viewport.YOffset, "the drain itself already reset the view")
+
+	m = clientUpdate(m, tea.KeyMsg{Type: tea.KeyEscape})
+	assert.Equal(t, ModeNormal, m.mode)
+	assert.Empty(t, m.requestSearchQuery)
+	assert.Equal(t, -1, m.cursorIdx, "no-cursor sentinel")
+	assert.Empty(t, m.cursorID)
+	assert.Equal(t, 0, m.viewport.YOffset, "esc must not resurrect the pre-drain scroll position")
+	assert.False(t, m.searchSession.active)
+}
+
+func TestLiveSearch_LiveApplyRoutesByTheSessionView(t *testing.T) {
+	// Guards an INVARIANT, not a reachable state: nothing switches views while
+	// the bar is open today. The clear and the origin restore must name the same
+	// view, so liveApplySearch routes by the session's view rather than the live
+	// one — force them apart and the logs session still owns both halves.
+	m := newLogsModel(20, []string{"alpha", "needle here", "gamma"})
+	m = clientUpdate(m, keyRune('g'))
+	m = clientUpdate(m, keyRune('/'))
+	m = typeSearch(m, "needle")
+	require.Equal(t, 1, m.logCursorIdx)
+	m.proxyRequests = makeTestRequests(4)
+	m.requestSearchQuery = "committed"
+
+	m.viewMode = ViewModeRequests // only a test can do this mid-bar
+	m = clientUpdate(m, tea.KeyMsg{Type: tea.KeyEscape})
+
+	assert.Empty(t, m.logSearchQuery, "the SESSION's view is the one cancelled")
+	assert.Equal(t, -1, m.logCursorIdx, "and the one whose cursor is restored")
+	assert.Equal(t, "committed", m.requestSearchQuery, "the other view is left alone")
+}
+
+func TestLiveSearch_EscMatchesBackspaceToEmpty(t *testing.T) {
+	// Cancel IS the empty-bar preview made permanent (cancelLiveSearch runs
+	// through liveApplySearch("")), so backspacing a term away and then pressing
+	// Esc must land in exactly the state Esc alone would have reached — one
+	// behavior, not two that drift.
+	build := func() ClientModel {
+		lines := make([]string, 30)
+		for i := range lines {
+			lines[i] = fmt.Sprintf("row %02d", i)
+		}
+		lines[20] = "abc target"
+		m := newLogsModel(5, lines)
+		m = clientUpdate(m, keyRune('k')) // disengage follow
+		m.viewport.SetYOffset(2)
+		m = clientUpdate(m, keyRune('/'))
+		return typeSearch(m, "abc")
+	}
+
+	viaBackspace := clientUpdate(backspaceSearch(build(), 3), tea.KeyMsg{Type: tea.KeyEscape})
+	direct := clientUpdate(build(), tea.KeyMsg{Type: tea.KeyEscape})
+
+	assert.Equal(t, direct.logSearchQuery, viaBackspace.logSearchQuery)
+	assert.Equal(t, direct.logCursorIdx, viaBackspace.logCursorIdx)
+	assert.Equal(t, direct.logCursorSeq, viaBackspace.logCursorSeq)
+	assert.Equal(t, direct.followMode, viaBackspace.followMode)
+	assert.Equal(t, direct.viewport.YOffset, viaBackspace.viewport.YOffset)
+	assert.Equal(t, direct.mode, viaBackspace.mode)
+	assert.Equal(t, direct.searchSession, viaBackspace.searchSession)
+	// ...and that shared state is the origin, not merely equal to itself.
+	assert.Empty(t, direct.logSearchQuery)
+	assert.Equal(t, -1, direct.logCursorIdx)
+	assert.Equal(t, 2, direct.viewport.YOffset)
+}

--- a/internal/tui/base_behavior_test.go
+++ b/internal/tui/base_behavior_test.go
@@ -1698,3 +1698,456 @@ func finalRecordFor(id string) proxy.RequestRecord {
 		},
 	}
 }
+
+// --- Live (incremental) `/` search tests (plan 030 C1 / WS1-WS2) ---
+
+// typeSearch drives REAL per-rune keystrokes into an open `/` bar. The live path
+// runs off textinput value changes, so it must be exercised keystroke by
+// keystroke — commitSearch's SetValue deliberately bypasses it and only the
+// Enter re-apply saves it (plan 030 WS2).
+func typeSearch(m ClientModel, term string) ClientModel {
+	for _, r := range term {
+		m = clientUpdate(m, keyRune(r))
+	}
+	return m
+}
+
+// backspaceSearch is typeSearch's inverse: n real backspace keystrokes, the
+// keys that shrink a term back toward the origin.
+func backspaceSearch(m ClientModel, n int) ClientModel {
+	for i := 0; i < n; i++ {
+		m = clientUpdate(m, tea.KeyMsg{Type: tea.KeyBackspace})
+	}
+	return m
+}
+
+// liveSearchRequests builds requests whose URLs make prefix typing meaningful:
+// "a" and "ab" first match q1, "abc" only q3. IDs, method, status and duration
+// carry none of those letters, so a one-rune term can only match a URL.
+func liveSearchRequests() []proxy.RequestRecord {
+	base := time.Unix(0, 0)
+	urls := []string{"/zero", "/ab-hit", "/filler", "/abc-hit", "/end"}
+	reqs := make([]proxy.RequestRecord, len(urls))
+	for i, u := range urls {
+		reqs[i] = proxy.RequestRecord{
+			ID: fmt.Sprintf("q%d", i), Timestamp: base.Add(time.Duration(i) * time.Second),
+			Method: "GET", URL: u, StatusCode: 200, Duration: 5 * time.Millisecond,
+		}
+	}
+	return reqs
+}
+
+func TestLiveSearch_LogsSeeksFromOriginPerKeystroke(t *testing.T) {
+	m := newLogsModel(20, []string{"zero", "ab hit", "filler", "abc hit", "tail"})
+	m = clientUpdate(m, keyRune('g')) // top, follow off -> origin is row 0
+	m = clientUpdate(m, keyRune('/'))
+
+	// Each keystroke applies the term and jumps — no Enter involved.
+	m = typeSearch(m, "a")
+	assert.Equal(t, "a", m.logSearchQuery, "the keystroke writes the committed query field")
+	assert.Equal(t, "ab hit", logCursorLine(t, m))
+	m = typeSearch(m, "b")
+	assert.Equal(t, "ab hit", logCursorLine(t, m))
+	m = typeSearch(m, "c")
+	assert.Equal(t, "abc hit", logCursorLine(t, m), "a narrower term seeks on from the ORIGIN, not from row 1")
+
+	// Backspacing to a shorter term must find the match the previous landing had
+	// already passed — the whole point of restore-then-seek. Seeking from the
+	// cursor would strand it on "abc hit", which also contains "ab".
+	m = backspaceSearch(m, 1)
+	assert.Equal(t, "ab", m.logSearchQuery)
+	assert.Equal(t, "ab hit", logCursorLine(t, m), "backspace re-seeks from the origin")
+}
+
+func TestLiveSearch_RequestsSeeksFromOriginPerKeystroke(t *testing.T) {
+	m := newSearchModel(20, liveSearchRequests())
+	m = clientUpdate(m, keyRune('g')) // cursor q0, follow off -> origin is q0
+	require.Equal(t, "q0", m.cursorID)
+	m = clientUpdate(m, keyRune('/'))
+
+	m = typeSearch(m, "a")
+	assert.Equal(t, "a", m.requestSearchQuery)
+	assert.Equal(t, "q1", m.cursorID)
+	m = typeSearch(m, "b")
+	assert.Equal(t, "q1", m.cursorID)
+	m = typeSearch(m, "c")
+	assert.Equal(t, "q3", m.cursorID, "a narrower term seeks on from the ORIGIN row")
+
+	m = backspaceSearch(m, 1)
+	assert.Equal(t, "q1", m.cursorID, "backspace re-seeks from the origin")
+
+	// Emptying the bar previews a cleared search: no query, cursor back on the
+	// origin row, `s` filter never touched.
+	m = backspaceSearch(m, 2)
+	assert.Empty(t, m.requestSearchQuery)
+	assert.Equal(t, "q0", m.cursorID, "an empty bar leaves the cursor at the origin")
+	assert.Empty(t, m.requestsFilter.RawQuery)
+}
+
+func TestLiveSearch_EmptyInputRestoresOriginView(t *testing.T) {
+	lines := make([]string, 30)
+	for i := range lines {
+		lines[i] = fmt.Sprintf("row %02d", i)
+	}
+	lines[20] = "abc target"
+	m := newLogsModel(5, lines)
+	m = clientUpdate(m, keyRune('k')) // disengage follow
+	require.False(t, m.followMode)
+	m.viewport.SetYOffset(2) // origin: top visible row 2, no parked cursor
+
+	m = clientUpdate(m, keyRune('/'))
+	m = typeSearch(m, "abc")
+	require.Equal(t, 20, m.logCursorIdx)
+	require.NotEqual(t, 2, m.viewport.YOffset, "the live jump scrolled away from the origin")
+
+	// Backspace the term away: identical to no search at the origin.
+	m = backspaceSearch(m, 3)
+	assert.Empty(t, m.logSearchQuery)
+	assert.Equal(t, -1, m.logCursorIdx, "an empty bar leaves no cursor")
+	assert.Equal(t, int64(0), m.logCursorSeq)
+	assert.Equal(t, 2, m.viewport.YOffset, "the view is back at the origin scroll position")
+	assert.NotContains(t, m.viewport.View(), "❯", "no marker renders without a query")
+}
+
+func TestLiveSearch_NoMatchWhileTypingClearsCursorAtOrigin(t *testing.T) {
+	m := newLogsModel(20, []string{"alpha", "hit here", "gamma"})
+	m = clientUpdate(m, keyRune('g')) // origin: row 0, follow off
+	m = clientUpdate(m, keyRune('/'))
+	m = typeSearch(m, "hit")
+	require.Equal(t, "hit here", logCursorLine(t, m))
+
+	m = typeSearch(m, "z") // "hitz" matches nothing
+	assert.Equal(t, "hitz", m.logSearchQuery)
+	assert.Equal(t, -1, m.logCursorIdx, "a no-match keystroke clears the cursor")
+	assert.Equal(t, int64(0), m.logCursorSeq)
+	assert.Equal(t, 0, m.viewport.YOffset, "the view stays at the origin")
+
+	// A no-match keystroke must NOT disengage follow: only a jump that lands off
+	// the newest row does that, and there is no jump here (setLogCursor never
+	// touches followMode).
+	m2 := newLogsModel(20, []string{"a", "b", "c"})
+	require.True(t, m2.followMode)
+	m2 = clientUpdate(m2, keyRune('/'))
+	m2 = typeSearch(m2, "zzz")
+	assert.True(t, m2.followMode, "a no-match keystroke leaves follow engaged")
+	assert.Equal(t, -1, m2.logCursorIdx)
+}
+
+func TestLiveSearch_LogsArrivalsWhileBarOpen(t *testing.T) {
+	// The origin under follow is the row that was newest AT THE PRESS, not
+	// whatever has streamed in since: the at-or-after seek must find the ARRIVED
+	// match rather than wrapping around to the older one.
+	m := newLogsModel(20, []string{"a needle", "b", "c"})
+	require.True(t, m.followMode)
+	m = clientUpdate(m, keyRune('/'))
+
+	for i, line := range []string{"d needle", "e"} {
+		m = clientUpdate(m, LogEntryMsg(domain.LogEntry{
+			Timestamp: time.Unix(int64(10+i), 0),
+			Process:   "p",
+			Line:      line,
+		}))
+	}
+
+	m = typeSearch(m, "needle")
+	assert.Equal(t, "d needle", logCursorLine(t, m),
+		"the seek starts at the press-time newest row, so the arrival is the first match at-or-after it")
+}
+
+func TestLiveSearch_LogsEvictionWhileBarOpen(t *testing.T) {
+	// Sized like any logs model, but fed DIRECTLY (not through clientUpdate):
+	// this test needs ~1200 entries to push past the eviction ring, and a full
+	// re-render per line would dominate its runtime.
+	m := newLogsModel(5, nil)
+	feed := func(line string) {
+		m.handleLogEntry(domain.LogEntry{Timestamp: time.Unix(0, 0), Process: "p", Line: line})
+	}
+	for i := 0; i < 300; i++ {
+		feed(fmt.Sprintf("log %04d", i))
+	}
+	feed("NEEDLE row")
+	for i := 0; i < 300; i++ {
+		feed(fmt.Sprintf("log %04d", 300+i))
+	}
+
+	m = clientUpdate(m, keyRune('g')) // origin: oldest retained line, follow off
+	m = clientUpdate(m, keyRune('/'))
+	originSeq := m.searchSession.logAnchorSeq
+	require.NotZero(t, originSeq)
+
+	// Stream past the ring while the bar is open: the origin anchor is evicted
+	// outright, so the restore falls back to the oldest retained line.
+	for i := 0; i < 600; i++ {
+		feed(fmt.Sprintf("flood %04d", i))
+	}
+	require.Len(t, m.logEntries, maxLogEntries)
+	for _, e := range m.logEntries {
+		require.NotEqual(t, originSeq, e.DisplaySeq, "the origin anchor has been evicted")
+	}
+
+	m = typeSearch(m, "NEEDLE")
+	require.GreaterOrEqual(t, m.logCursorIdx, 0, "the search still lands with an evicted origin")
+	assert.Contains(t, logCursorLine(t, m), "NEEDLE")
+	sp, ok := m.logRowSpans[m.logCursorSeq]
+	require.True(t, ok)
+	assert.True(t, sp.Last >= m.viewport.YOffset && sp.First < m.viewport.YOffset+m.viewport.Height,
+		"the live jump scrolled the match into view")
+}
+
+func TestLiveSearch_LogsEvictedOriginSeeksFromOldestRetained(t *testing.T) {
+	// The ring evicts from the FRONT, so an evicted origin sat before every line
+	// still retained: the at-or-after scan has to start at the oldest retained
+	// line. Resuming from the origin's remembered INDEX would point mid-list and
+	// skip the true first match — which is why the session anchors carry no
+	// index at all (see sessionLogOriginIdx).
+	m := newLogsModel(5, nil)
+	feed := func(line string) {
+		m.handleLogEntry(domain.LogEntry{Timestamp: time.Unix(0, 0), Process: "p", Line: line})
+	}
+	for i := 0; i < maxLogEntries; i++ {
+		switch i {
+		case 400:
+			feed("NEEDLE early")
+		case 900:
+			feed("NEEDLE late")
+		default:
+			feed(fmt.Sprintf("log %04d", i))
+		}
+	}
+
+	m = clientUpdate(m, keyRune('k')) // disengage follow
+	m.viewport.SetYOffset(200)        // origin: entry 200, well into the list
+	m = clientUpdate(m, keyRune('/'))
+	originSeq := m.searchSession.logAnchorSeq
+	require.NotZero(t, originSeq)
+
+	// Flood past the origin while the bar is open: it is evicted, BOTH matches
+	// survive, and the origin's old index now points between them.
+	for i := 0; i < 300; i++ {
+		feed(fmt.Sprintf("flood %04d", i))
+	}
+	entries := m.filteredEntries()
+	require.Equal(t, -1, entryIndexOfSeq(entries, originSeq), "the origin anchor was evicted")
+	require.Contains(t, entries[100].Line, "NEEDLE early")
+	require.Contains(t, entries[600].Line, "NEEDLE late")
+
+	m = typeSearch(m, "NEEDLE")
+	assert.Equal(t, "NEEDLE early", logCursorLine(t, m),
+		"an evicted origin seeks from the oldest retained line, not from a stale index")
+}
+
+func TestLiveSearch_EmptyListAtPressSeeksFromFirstArrival(t *testing.T) {
+	// Nothing on screen when `/` was pressed, so every line retained now arrived
+	// AFTER the press: the at-or-after origin is the oldest of them. Degrading to
+	// the ordinary follow-mode origin (the newest row) would wrap and land on the
+	// LAST match instead of the first.
+	m := newLogsModel(20, nil)
+	require.True(t, m.followMode)
+	require.Empty(t, m.filteredEntries())
+
+	m = clientUpdate(m, keyRune('/'))
+	require.Zero(t, m.searchSession.logAnchorSeq, "an empty list has no anchor to capture")
+
+	for i, line := range []string{"first needle", "second needle"} {
+		m = clientUpdate(m, LogEntryMsg(domain.LogEntry{
+			Timestamp: time.Unix(int64(i), 0),
+			Process:   "p",
+			Line:      line,
+		}))
+	}
+
+	m = typeSearch(m, "needle")
+	assert.Equal(t, "first needle", logCursorLine(t, m),
+		"the origin is the oldest line that arrived after the press")
+}
+
+func TestLiveSearch_RequestsArrivalsWhileBarOpen(t *testing.T) {
+	// The requests origin is the cursor row's ID, so a rebuild that drops older
+	// rows (a reconnect sync) shifts every index without moving the origin.
+	reqs := []proxy.RequestRecord{
+		newArrival("r0", "/needle-old"),
+		newArrival("r1", "/x1"),
+		newArrival("r2", "/x2"),
+		newArrival("r3", "/needle-mid"),
+		newArrival("r4", "/x4"),
+	}
+	m := newSearchModel(20, reqs)
+	m = clientUpdate(m, keyRune('g'))
+	m = clientUpdate(m, keyRune('j'))
+	m = clientUpdate(m, keyRune('j'))
+	require.Equal(t, "r2", m.cursorID, "origin: the r2 row")
+	m = clientUpdate(m, keyRune('/'))
+
+	// A live arrival, then a sync rebuild that drops the two oldest rows: r2 is
+	// now index 0, and the old index 2 holds r4.
+	m = clientUpdate(m, ProxyRequestMsg(newArrival("r5", "/needle-new")))
+	m = clientUpdate(m, RequestsSyncMsg{Snapshot: []proxy.RequestRecord{
+		reqs[2], reqs[3], reqs[4], newArrival("r5", "/needle-new"),
+	}})
+	require.Equal(t, "r2", m.cursorID, "the ID-anchored cursor rode the rebuild")
+
+	m = typeSearch(m, "needle")
+	assert.Equal(t, "r3", m.cursorID,
+		"the seek starts at the origin RECORD (now index 0), not at its old index")
+}
+
+func TestLiveSearch_ComposesWithStringFilter(t *testing.T) {
+	m := newLogsModel(20, []string{
+		"keep needle-a", "drop needle-b", "keep plain", "keep needle-c", "drop needle-d",
+	})
+	m.setLogsFilterQuery("keep") // active `s` filter -> rows 0,2,3 survive
+	m.followMode = false
+	m.updateViewport()
+	m = clientUpdate(m, keyRune('g')) // origin: top of the FILTERED list
+
+	m = clientUpdate(m, keyRune('/'))
+	m = typeSearch(m, "needle")
+	assert.Equal(t, "keep needle-a", logCursorLine(t, m), "live search runs within the filtered set")
+	m = typeSearch(m, "-c")
+	assert.Equal(t, "keep needle-c", logCursorLine(t, m), "narrowing skips the filtered-out drop rows")
+	assert.Equal(t, "keep", m.logsFilter.RawQuery, "the `s` filter is untouched")
+	assert.Len(t, m.filteredEntries(), 3, "search never hides lines the filter kept")
+}
+
+func TestLiveSearch_EnterOnEmptyBarClearsCommittedSearch(t *testing.T) {
+	m := newLogsModel(20, []string{"aaa", "needle", "bbb"})
+	m = clientUpdate(m, keyRune('g'))
+	m = commitSearch(m, "needle")
+	require.Equal(t, "needle", m.logSearchQuery)
+	require.Equal(t, 1, m.logCursorIdx)
+
+	// Reopen and commit an empty bar: a committed CLEARED search.
+	m = clientUpdate(m, keyRune('/'))
+	m = clientUpdate(m, tea.KeyMsg{Type: tea.KeyEnter})
+	assert.Equal(t, ModeNormal, m.mode)
+	assert.Empty(t, m.logSearchQuery)
+	assert.Equal(t, -1, m.logCursorIdx)
+	assert.Equal(t, int64(0), m.logCursorSeq)
+	assert.False(t, m.searchSession.active, "the session is cleared on exit")
+	assert.NotContains(t, m.viewport.View(), "❯")
+}
+
+func TestLiveSearch_EnterKeepsLandingAndNextPrevCycleFromIt(t *testing.T) {
+	m := newLogsModel(20, []string{"needle a", "x", "needle b", "z"})
+	m = clientUpdate(m, keyRune('g'))
+	m = clientUpdate(m, keyRune('/'))
+	m = typeSearch(m, "needle")
+	require.Equal(t, 0, m.logCursorIdx)
+
+	m = clientUpdate(m, tea.KeyMsg{Type: tea.KeyEnter})
+	assert.Equal(t, ModeNormal, m.mode)
+	assert.Equal(t, "needle", m.logSearchQuery, "Enter keeps the live-applied query")
+	assert.Equal(t, 0, m.logCursorIdx, "and the live landing")
+	assert.False(t, m.searchSession.active)
+
+	m = clientUpdate(m, keyRune('n'))
+	assert.Equal(t, 2, m.logCursorIdx, "n cycles on from the live landing")
+	m = clientUpdate(m, keyRune('n'))
+	assert.Equal(t, 0, m.logCursorIdx, "n wraps")
+	m = clientUpdate(m, keyRune('N'))
+	assert.Equal(t, 2, m.logCursorIdx)
+}
+
+func TestLiveSearch_CursorMovementKeysDoNotReseek(t *testing.T) {
+	// Cursor-movement keys leave the term alone, so they must re-run neither the
+	// O(n) scan nor the restore — the live apply is gated on the value actually
+	// changing. Parking the search cursor somewhere a re-seek would move it away
+	// from is what makes the no-op observable.
+	m := newLogsModel(20, []string{"zero", "ab hit", "filler", "abc hit", "tail"})
+	m = clientUpdate(m, keyRune('g'))
+	m = clientUpdate(m, keyRune('/'))
+	m = typeSearch(m, "abc")
+	require.Equal(t, 3, m.logCursorIdx)
+	m.setLogCursor(m.filteredEntries(), 0)
+
+	for _, kt := range []tea.KeyType{tea.KeyLeft, tea.KeyRight, tea.KeyHome, tea.KeyEnd} {
+		m = clientUpdate(m, tea.KeyMsg{Type: kt})
+	}
+	assert.Equal(t, "abc", m.logSearchQuery, "movement keys are not text")
+	assert.Equal(t, 0, m.logCursorIdx, "movement keys must not re-seek")
+	assert.Equal(t, ModeSearch, m.mode)
+}
+
+func TestLiveSearch_MouseMenuOpenCommitsLiveQuery(t *testing.T) {
+	// Mouse-open blurs the bar; for `/` that is Enter-equivalent (plan 030 WS2):
+	// the live-applied query stands and the session is cleared.
+	m := newLogsModel(20, []string{"alpha", "needle here", "gamma"})
+	m = clientUpdate(m, keyRune('g'))
+	m = clientUpdate(m, keyRune('/'))
+	m = typeSearch(m, "needle")
+	require.Equal(t, 1, m.logCursorIdx)
+
+	_ = m.View() // record hit-rects for the menu bar
+	require.NotEmpty(t, m.mustHits().menuCells)
+	hit := m.mustHits().menuCells[0]
+	m = clientUpdate(m, tea.MouseMsg{
+		X:      hit.Rect.X,
+		Y:      hit.Rect.Y,
+		Action: tea.MouseActionPress,
+		Button: tea.MouseButtonLeft,
+	})
+
+	assert.Equal(t, ModeNormal, m.mode)
+	assert.True(t, m.menuOpen())
+	assert.Equal(t, "needle", m.logSearchQuery, "the live query stands after the blur")
+	assert.Equal(t, 1, m.logCursorIdx, "and so does its landing")
+	assert.False(t, m.searchSession.active, "the session is cleared")
+}
+
+func TestLiveSearch_RequestsFollowArrivalsSeekFromPressTimeNewest(t *testing.T) {
+	// Under follow the restore pins the CURSOR to the current newest row — right
+	// for the view, which is what follow means — but the seek must still start on
+	// the row `/` was pressed on. Seeking from the restored cursor would wrap
+	// past the arrival onto the older match, and flip the landing on every
+	// arrival mid-typing.
+	m := newSearchModel(20, []proxy.RequestRecord{
+		newArrival("r0", "/match-a"),
+		newArrival("r1", "/x1"),
+		newArrival("r2", "/x2"),
+	})
+	require.True(t, m.followMode)
+	require.Equal(t, "r2", m.cursorID, "follow pins the cursor to the press-time newest row")
+
+	m = clientUpdate(m, keyRune('/'))
+	m = clientUpdate(m, ProxyRequestMsg(newArrival("r3", "/match-b")))
+	m = clientUpdate(m, ProxyRequestMsg(newArrival("r4", "/x4")))
+	require.Equal(t, "r4", m.cursorID, "follow moved the live cursor to the newest arrival")
+
+	m = typeSearch(m, "match")
+	assert.Equal(t, "r3", m.cursorID,
+		"the seek starts at the press-time newest row, so the arrival is the first match at-or-after it")
+	assert.False(t, m.followMode, "the jump landed off the newest row")
+}
+
+func TestLiveSearch_EmptyInputRestoresOriginViewUnderWrap(t *testing.T) {
+	// With wrap on, the 2-column marker prefix a non-empty query adds MOVES wrap
+	// points — these lines are sized to flip from one display row to two — so the
+	// row spans the restore translates its anchor through are stale the moment
+	// the query changes. Emptying the bar must land on the anchor's row in the
+	// render the user actually sees, not in the marker-era one.
+	lines := make([]string, 40)
+	for i := range lines {
+		lines[i] = strings.Repeat("x", 38)
+	}
+	lines[30] = "abc" + strings.Repeat("x", 35)
+	m := newLogsModelNarrow(60, 6, lines)
+	m.settings.Wrap = true
+	m.followMode = false
+	m.updateViewport()
+	m.viewport.SetYOffset(20)
+
+	m = clientUpdate(m, keyRune('/'))
+	anchorSeq := m.searchSession.logAnchorSeq
+	require.NotZero(t, anchorSeq)
+	require.Equal(t, 20, m.logRowSpans[anchorSeq].First, "one row per entry while no query is set")
+
+	m = typeSearch(m, "abc")
+	require.Equal(t, 30, m.logCursorIdx, "the live jump moved the view off the origin")
+	require.Equal(t, 40, m.logRowSpans[anchorSeq].First, "the marker prefix wrapped every entry onto two rows")
+
+	m = backspaceSearch(m, 3)
+	require.Empty(t, m.logSearchQuery)
+	assert.Equal(t, m.logRowSpans[anchorSeq].First, m.viewport.YOffset,
+		"the restored offset is the anchor's row in the CURRENT (marker-free) render")
+	assert.Equal(t, 20, m.viewport.YOffset)
+}

--- a/internal/tui/base_behavior_test.go
+++ b/internal/tui/base_behavior_test.go
@@ -2016,8 +2016,11 @@ func TestLiveSearch_EnterOnEmptyBarClearsCommittedSearch(t *testing.T) {
 	require.Equal(t, "needle", m.logSearchQuery)
 	require.Equal(t, 1, m.logCursorIdx)
 
-	// Reopen and commit an empty bar: a committed CLEARED search.
+	// Reopen (the bar comes up seeded — plan 030 WS4), clear it, and commit the
+	// empty bar: a committed CLEARED search.
 	m = clientUpdate(m, keyRune('/'))
+	require.Equal(t, "needle", m.textInput.Value(), "the reopened bar carries the previous term")
+	m = backspaceSearch(m, len("needle"))
 	m = clientUpdate(m, tea.KeyMsg{Type: tea.KeyEnter})
 	assert.Equal(t, ModeNormal, m.mode)
 	assert.Empty(t, m.logSearchQuery)
@@ -2452,4 +2455,203 @@ func TestLiveSearch_EscMatchesBackspaceToEmpty(t *testing.T) {
 	assert.Empty(t, direct.logSearchQuery)
 	assert.Equal(t, -1, direct.logCursorIdx)
 	assert.Equal(t, 2, direct.viewport.YOffset)
+}
+
+// --- `/` seeds the previous term (plan 030 C3 / WS4) ---
+
+func TestLiveSearch_SlashSeedsPreviousTerm(t *testing.T) {
+	m := newLogsModel(20, []string{"aaa", "needle here", "bbb"})
+	m = clientUpdate(m, keyRune('g'))
+	m = commitSearch(m, "needle")
+	require.Equal(t, "needle", m.logSearchQuery)
+
+	// Leave the input cursor mid-term before reopening: SetValue only re-homes it
+	// when it sat at 0 or past the end, so this is what makes CursorEnd load-bearing.
+	m = clientUpdate(m, keyRune('/'))
+	m = clientUpdate(m, tea.KeyMsg{Type: tea.KeyLeft})
+	m = clientUpdate(m, tea.KeyMsg{Type: tea.KeyLeft})
+	require.Equal(t, len("needle")-2, m.textInput.Position())
+	m = clientUpdate(m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	m = clientUpdate(m, keyRune('/'))
+	assert.Equal(t, ModeSearch, m.mode)
+	assert.Equal(t, "needle", m.textInput.Value(), "the bar reopens seeded with the committed term")
+	assert.Equal(t, len("needle"), m.textInput.Position(), "cursor at the end, ready to extend")
+
+	// So typing EXTENDS the previous term rather than starting a fresh one.
+	m = typeSearch(m, "!")
+	assert.Equal(t, "needle!", m.logSearchQuery)
+
+	// With nothing committed there is nothing to seed: a first search opens empty.
+	fresh := newLogsModel(20, []string{"x"})
+	fresh = clientUpdate(fresh, keyRune('/'))
+	assert.Empty(t, fresh.textInput.Value())
+	assert.Equal(t, -1, fresh.logCursorIdx, "an empty seed applies nothing at all")
+}
+
+func TestLiveSearch_ReopenOverParkedMatchDoesNotMoveView(t *testing.T) {
+	// The seed applies itself, and its at-or-after seek starts from an origin
+	// that INCLUDES the cursor the term already parked — so it lands back on that
+	// same row and reopening the bar is visually inert.
+	lines := make([]string, 30)
+	for i := range lines {
+		lines[i] = fmt.Sprintf("row %02d", i)
+	}
+	lines[20] = "abc target"
+	m := newLogsModel(5, lines)
+	m = clientUpdate(m, keyRune('k')) // disengage follow
+	m.viewport.SetYOffset(2)
+	m = commitSearch(m, "abc")
+	require.Equal(t, 20, m.logCursorIdx)
+	seq, yOffset, follow := m.logCursorSeq, m.viewport.YOffset, m.followMode
+
+	m = clientUpdate(m, keyRune('/'))
+	assert.Equal(t, "abc", m.textInput.Value())
+	assert.Equal(t, 20, m.logCursorIdx, "the parked cursor stays put")
+	assert.Equal(t, seq, m.logCursorSeq)
+	assert.Equal(t, yOffset, m.viewport.YOffset, "and the scroll position with it")
+	assert.Equal(t, follow, m.followMode)
+
+	reqs := makeTestRequests(20)
+	reqs[7].URL = "/hit/here"
+	m2 := newSearchModel(5, reqs)
+	m2 = clientUpdate(m2, keyRune('g'))
+	m2 = commitSearch(m2, "hit")
+	require.Equal(t, "req-007", m2.cursorID)
+	yOffset2 := m2.viewport.YOffset
+
+	m2 = clientUpdate(m2, keyRune('/'))
+	assert.Equal(t, "hit", m2.textInput.Value())
+	assert.Equal(t, "req-007", m2.cursorID, "the requests cursor stays on its match")
+	assert.Equal(t, yOffset2, m2.viewport.YOffset)
+}
+
+func TestLiveSearch_ReopenAfterNoMatchMayJump(t *testing.T) {
+	// Accepted qualifier (WS4): a search that ended with NO match cleared its
+	// cursor, so the seed's apply seeks from the viewport origin instead — and
+	// entries that streamed in since may now match. Reopening therefore CAN move
+	// the view, which is arguably what the user wants to see.
+	m := newLogsModel(20, []string{"aaa", "bbb", "ccc"})
+	m = clientUpdate(m, keyRune('g'))
+	m = commitSearch(m, "zzz")
+	require.Equal(t, -1, m.logCursorIdx, "no match: no cursor")
+
+	m = clientUpdate(m, LogEntryMsg(domain.LogEntry{
+		Timestamp: time.Unix(9, 0), Process: "p", Line: "zzz now here",
+	}))
+	require.Equal(t, -1, m.logCursorIdx, "the committed no-match search still has no cursor")
+
+	m = clientUpdate(m, keyRune('/'))
+	assert.Equal(t, "zzz", m.textInput.Value())
+	assert.Equal(t, "zzz now here", logCursorLine(t, m), "the seed's apply lands on the arrival")
+}
+
+func TestLiveSearch_SeedApplyDoesNotDestroyTheOrigin(t *testing.T) {
+	// The pinned order (capture → seed → apply). The seed's own seek MOVES the
+	// view here, so an origin captured after it would be the seed's landing and
+	// Esc would "restore" to the very position the reopen introduced. The origin
+	// must be the pre-seed position — where `/` was actually pressed.
+	lines := make([]string, 30)
+	for i := range lines {
+		lines[i] = fmt.Sprintf("row %02d", i)
+	}
+	m := newLogsModel(5, lines)
+	m = clientUpdate(m, keyRune('k')) // disengage follow
+	m.viewport.SetYOffset(2)
+	m = commitSearch(m, "zzz")
+	require.Equal(t, -1, m.logCursorIdx, "no match: no cursor to seek from later")
+	require.Equal(t, 2, m.viewport.YOffset)
+
+	m = clientUpdate(m, LogEntryMsg(domain.LogEntry{
+		Timestamp: time.Unix(99, 0), Process: "p", Line: "zzz arrived",
+	}))
+	require.Equal(t, 2, m.viewport.YOffset, "the arrival did not move a parked search")
+
+	m = clientUpdate(m, keyRune('/'))
+	require.Equal(t, "zzz arrived", logCursorLine(t, m), "the seed's apply jumped to the arrival")
+	require.NotEqual(t, 2, m.viewport.YOffset, "...and scrolled the view to it")
+
+	m = clientUpdate(m, tea.KeyMsg{Type: tea.KeyEscape})
+	assert.Equal(t, 2, m.viewport.YOffset, "esc restores the PRE-seed position")
+	assert.Empty(t, m.logSearchQuery)
+	assert.Equal(t, -1, m.logCursorIdx)
+}
+
+func TestLiveSearch_SeedThenEscClearsEverything(t *testing.T) {
+	// Composes with C2: Esc cancels the search the bar was SEEDED with, exactly
+	// as it cancels one typed from scratch, and restores the position as of this
+	// `/` press — not the position from before the original search.
+	lines := make([]string, 30)
+	for i := range lines {
+		lines[i] = fmt.Sprintf("row %02d", i)
+	}
+	lines[20] = "abc target"
+	m := newLogsModel(5, lines)
+	m = clientUpdate(m, keyRune('k'))
+	m.viewport.SetYOffset(2)
+	m = commitSearch(m, "abc")
+	require.Equal(t, 20, m.logCursorIdx)
+	pressOffset := m.viewport.YOffset
+	require.NotEqual(t, 2, pressOffset)
+
+	m = clientUpdate(m, keyRune('/'))
+	require.Equal(t, "abc", m.textInput.Value())
+	m = clientUpdate(m, tea.KeyMsg{Type: tea.KeyEscape})
+
+	assert.Empty(t, m.logSearchQuery, "the seeded query does not survive the cancel")
+	assert.Equal(t, -1, m.logCursorIdx)
+	assert.Equal(t, int64(0), m.logCursorSeq)
+	assert.Equal(t, pressOffset, m.viewport.YOffset, "restored to where THIS `/` was pressed")
+	assert.NotContains(t, m.viewport.View(), "❯")
+}
+
+func TestLiveSearch_SeedThenEnterRoundTrips(t *testing.T) {
+	// Reopen-and-commit with no edit is a no-op: same query, same landing, same
+	// scroll. Enter's re-apply runs over the seeded value, and restore-then-seek
+	// from an origin that already sits on the match returns it unchanged.
+	lines := make([]string, 30)
+	for i := range lines {
+		lines[i] = fmt.Sprintf("row %02d", i)
+	}
+	lines[20] = "abc target"
+	m := newLogsModel(5, lines)
+	m = clientUpdate(m, keyRune('k'))
+	m.viewport.SetYOffset(2)
+	m = commitSearch(m, "abc")
+	query, seq, yOffset, follow := m.logSearchQuery, m.logCursorSeq, m.viewport.YOffset, m.followMode
+
+	m = clientUpdate(m, keyRune('/'))
+	m = clientUpdate(m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	assert.Equal(t, ModeNormal, m.mode)
+	assert.Equal(t, query, m.logSearchQuery)
+	assert.Equal(t, seq, m.logCursorSeq)
+	assert.Equal(t, 20, m.logCursorIdx)
+	assert.Equal(t, yOffset, m.viewport.YOffset)
+	assert.Equal(t, follow, m.followMode)
+	assert.False(t, m.searchSession.active)
+}
+
+func TestLiveSearch_SeedsPerView(t *testing.T) {
+	// Each view seeds from its OWN committed term, like the `s` bar seeds from
+	// the active view's RawQuery.
+	m := newLogsModel(20, []string{"alpha one", "beta two", "gamma"})
+	m.proxyRequests = makeTestRequests(6)
+	m = clientUpdate(m, keyRune('g'))
+	m = commitSearch(m, "alpha")
+	require.Equal(t, "alpha", m.logSearchQuery)
+
+	m = clientUpdate(m, tea.KeyMsg{Type: tea.KeyTab})
+	require.Equal(t, ViewModeRequests, m.viewMode)
+	m = commitSearch(m, "path/004")
+	require.Equal(t, "path/004", m.requestSearchQuery)
+
+	m = clientUpdate(m, keyRune('/'))
+	assert.Equal(t, "path/004", m.textInput.Value(), "the requests bar seeds the requests term")
+	m = clientUpdate(m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	m = clientUpdate(m, tea.KeyMsg{Type: tea.KeyTab})
+	require.Equal(t, ViewModeLogs, m.viewMode)
+	m = clientUpdate(m, keyRune('/'))
+	assert.Equal(t, "alpha", m.textInput.Value(), "the logs bar seeds the logs term")
 }

--- a/internal/tui/frame_contract_test.go
+++ b/internal/tui/frame_contract_test.go
@@ -228,3 +228,93 @@ func viewSweepLabel(mode ViewMode) string {
 		return "logs"
 	}
 }
+
+// TestFrameContract_LiveSearchStates covers the state combination plan 030
+// introduced and nothing before it could reach: ModeSearch (the typing bar in
+// the footer) with the view's committed query ALREADY non-empty, so the logs
+// pane carries the 2-column marker gutter, a ❯ cursor row and inline highlight
+// runs WHILE the input is focused. Every row of a prox frame is exactly
+// terminal-width wide, so a single mis-counted row or over-wide footer wraps,
+// scrolls the terminal, and (because the renderer only repaints changed rows)
+// never heals — the failure mode the plan-030 PTY smoke went looking for.
+//
+// TestFrameContract_Sweep does not reach here: it drives views, settings, help
+// and menus, but never a text-input mode. Wrap is included because the marker
+// gutter is the one thing that genuinely moves wrap points, and the sizes go
+// narrow because the footer carries the fixed-width search input next to the
+// status bands.
+func TestFrameContract_LiveSearchStates(t *testing.T) {
+	sizes := []struct{ w, h int }{{120, 35}, {80, 24}, {40, 12}, {20, 8}}
+	for _, sz := range sizes {
+		for _, wrap := range []bool{false, true} {
+			cfg := DefaultSettings()
+			cfg.Wrap = wrap
+			name := fmt.Sprintf("w%dh%d_wrap%t", sz.w, sz.h, wrap)
+
+			t.Run("logs_"+name, func(t *testing.T) {
+				m := primedFrameModel(t, sz.w, sz.h, cfg, ViewModeLogs)
+				for i := 0; i < 30; i++ {
+					m = clientUpdate(m, LogEntryMsg(domain.LogEntry{
+						Process: "web", Line: fmt.Sprintf("line %02d hello world", i),
+					}))
+				}
+
+				// (a) bar open with a live query parked on a match (the smoke's F3).
+				m = clientUpdate(m, keyRune('/'))
+				m = typeSearch(m, "hello")
+				require.Equal(t, ModeSearch, m.mode)
+				require.NotEmpty(t, m.logSearchQuery, "the new combo: typing bar AND committed query")
+				require.GreaterOrEqual(t, m.logCursorIdx, 0, "a match is parked, so the ❯ gutter is rendered")
+				assertFrameContract(t, m)
+
+				// (b) the same, after entries arrive while the bar is open.
+				for i := 0; i < 5; i++ {
+					m = clientUpdate(m, LogEntryMsg(domain.LogEntry{
+						Process: "web", Line: fmt.Sprintf("arrival %02d hello", i),
+					}))
+				}
+				assertFrameContract(t, m)
+
+				// (c) after Esc cancels back to the origin (the smoke's F4).
+				m = clientUpdate(m, tea.KeyMsg{Type: tea.KeyEscape})
+				require.Equal(t, ModeNormal, m.mode)
+				require.Empty(t, m.logSearchQuery)
+				assertFrameContract(t, m)
+
+				// (d) committed query, then reopened seeded (the smoke's F5/F6).
+				m = commitSearch(m, "hello")
+				require.Equal(t, "hello", m.logSearchQuery)
+				assertFrameContract(t, m)
+				m = clientUpdate(m, keyRune('/'))
+				require.Equal(t, "hello", m.textInput.Value(), "reopened seeded")
+				assertFrameContract(t, m)
+			})
+
+			t.Run("requests_"+name, func(t *testing.T) {
+				m := primedFrameModel(t, sz.w, sz.h, cfg, ViewModeRequests)
+				for i := 0; i < 20; i++ {
+					m = clientUpdate(m, ProxyRequestMsg(newArrival(
+						fmt.Sprintf("req-%03d", i), fmt.Sprintf("/hello/%02d", i))))
+				}
+
+				m = clientUpdate(m, keyRune('/'))
+				m = typeSearch(m, "hello")
+				require.Equal(t, ModeSearch, m.mode)
+				require.NotEmpty(t, m.requestSearchQuery)
+				assertFrameContract(t, m)
+
+				m = clientUpdate(m, ProxyRequestMsg(newArrival("req-late", "/hello/late")))
+				assertFrameContract(t, m)
+
+				m = clientUpdate(m, tea.KeyMsg{Type: tea.KeyEscape})
+				require.Empty(t, m.requestSearchQuery)
+				assertFrameContract(t, m)
+
+				m = commitSearch(m, "hello")
+				assertFrameContract(t, m)
+				m = clientUpdate(m, keyRune('/'))
+				assertFrameContract(t, m)
+			})
+		}
+	}
+}

--- a/internal/tui/help_content.go
+++ b/internal/tui/help_content.go
@@ -71,9 +71,9 @@ func (b *BaseModel) logsHelpSections() []helpSection {
 				{key: "s", desc: "Filter bar (query language, live)"},
 				{key: "", desc: "e.g. proc:api level:error -health"},
 				{key: "f", desc: "Filter menu (process + level checks)"},
-				{key: "/", desc: "Search — jump cursor to match (does not hide lines)"},
+				{key: "/", desc: "Search (live) — cursor jumps as you type (does not hide lines)"},
 				{key: "n/N", desc: "Next/previous search match"},
-				{key: "Esc", desc: "Clear filters, search, and solo"},
+				{key: "Esc", desc: "Clear filters, search, and solo (while typing: cancel & restore)"},
 			},
 		},
 		{
@@ -139,9 +139,9 @@ func (b *BaseModel) requestsHelpSections() []helpSection {
 				{key: "s", desc: "Filter bar (query language, live)"},
 				{key: "", desc: "e.g. method:GET status:5xx host:api url:/orders"},
 				{key: "f", desc: "Filter menu (status class, methods)"},
-				{key: "/", desc: "Search visible columns (navigate, not filter)"},
+				{key: "/", desc: "Search visible columns (live, navigate — not filter)"},
 				{key: "n/N", desc: "Next/previous search match"},
-				{key: "Esc", desc: "Back from detail, or clear filters/search"},
+				{key: "Esc", desc: "Back from detail, clear filters/search, or cancel while typing"},
 			},
 		},
 		{

--- a/internal/tui/help_content.go
+++ b/internal/tui/help_content.go
@@ -141,7 +141,7 @@ func (b *BaseModel) requestsHelpSections() []helpSection {
 				{key: "f", desc: "Filter menu (status class, methods)"},
 				{key: "/", desc: "Search visible columns (live, navigate — not filter)"},
 				{key: "n/N", desc: "Next/previous search match"},
-				{key: "Esc", desc: "Back from detail, clear filters/search, or cancel while typing"},
+				{key: "Esc", desc: "Back from detail, clear filters/search (typing: cancel & restore)"},
 			},
 		},
 		{

--- a/internal/tui/menu_mouse.go
+++ b/internal/tui/menu_mouse.go
@@ -39,9 +39,14 @@ func (b *BaseModel) handleMenuMouse(msg tea.MouseMsg) (bool, tea.Cmd) {
 	hits := b.mustHits()
 
 	// Mouse-open while a textinput mode is active: blur → ModeNormal first (Codex #4).
+	// For the live `/` bar the blur is Enter-equivalent (plan 030 WS2): the
+	// live-applied query stands and the session is cleared — the same contract
+	// the `s` bar already has here, its query likewise already live-applied.
 	blurTextMode := func() {
 		switch b.mode {
-		case ModeSearch, ModeStringFilter:
+		case ModeSearch:
+			b.commitLiveSearch()
+		case ModeStringFilter:
 			b.mode = ModeNormal
 			b.textInput.Blur()
 		}


### PR DESCRIPTION
## TUI: live (incremental) `/` search

Typing in the `/` search bar now applies **per keystroke** in both the logs and requests views: the cursor jumps to matches as you type, **Enter keeps** the search and exits the bar, **Esc cancels** — clearing the active view's search and restoring the view (cursor, scroll, follow) to where it was when `/` was pressed. `/` also **reopens seeded** with the view's last committed term. Search remains navigation (never hides lines) and still composes with the `s` filter; the `s` bar — which was already live — is untouched, so the two bars now share one interaction model.

### How it works

- A **search session** captures the origin at `/`-press time using identity anchors (logs: DisplaySeq; requests: record ID — never raw indices or viewport offsets, which streaming arrivals invalidate) plus `followMode`.
- Every value-changing keystroke is **restore-then-seek**: put the view back at the origin, then seek at-or-after it — so shrinking `err`→`er` or fixing a typo re-finds earlier matches instead of stranding the cursor at a previous landing. Cursor-movement keys are gated out (no O(n) re-scan).
- Enter re-applies once then exits (mirroring the `s` bar); a mouse menu-open while typing commits the same way. `n`/`N` stay cursor-relative.
- Esc routes through the same code path as backspacing the bar to empty, so cancel and empty-preview cannot drift apart. Eviction fallbacks: logs anchor evicted → oldest retained; requests record dropped → nearest index; restored `followMode == true` wins and re-lands newest. Normal-mode Esc is unchanged.

### Commits (each gated on `make lint && make test && make test-race && make build`)

1. **C1** — session + live apply + Enter semantics, both views (16 tests)
2. **C2** — Esc cancel + origin restore (11 tests)
3. **C3** — `/` seeds the previous term, pinned capture→seed→apply order (7 tests)
4. **C4** — help modal + `docs/reference/tui.md` (docs build `--strict` green)
5. **C5** — frame-contract coverage for text-input modes (a real gap: no render test had ever entered a text-input mode)

### Review

Panel plan review (GLM 5.3 + CodeRabbit; Codex and Cursor were usage-limited) reshaped the design before implementation: Enter-as-re-apply (keeps the `SetValue`+Enter test-helper path sound), restore-then-seek pinned as one shared helper, value-change gating as default, press-time origin capture, follow-restore precedence.

Per-commit external correctness reviews (CodeRabbit) found and fixed before commit:
- **C1 (major):** requests view under follow seeked from the *current* newest instead of the press-time origin; fixed via `sessionRequestOriginIdx` + `seekRequestSearchMatchFrom`.
- **C1 (major):** an evicted session anchor fell back to its stale press-time index instead of the oldest retained line.
- **C1 (minor ×2):** scroll restore read the previous render's wrap spans; empty-list-at-press under follow degraded the origin to current newest.
- **C2 (minor ×2, hardened):** query-clear and origin-restore now provably route by the same view; coverage for drained-list Esc and backspace-to-empty ≡ Esc.
- **C3:** no findings.

All findings carry mutation-verified regression tests.

### Verification beyond unit tests

A manual PTY smoke drove the real `prox up` TUI (120×35) through the full journey: live jump to an old line while logs stream, Esc restoring follow, committed match info `/BETA (1/1)`, seeded reopen with byte-identical content rows (view does not move), clean `q` exit. The first run reported a "stale rows" render regression that root-caused to a **harness bug** (per-read UTF-8 decode splitting glyphs), not a product bug — verified by replaying the captured raw bytes through an incremental decoder and a byte-level frame audit; the durable outcome is C5's coverage.

### Accepted behavior changes / risks

- Esc-in-bar now clears a previously committed search for that view (user-pinned; the term is seeded in the bar, so "keep it" is Enter).
- Reopening after a *no-match* search may jump if streamed entries now match (accepted, pinned by test).
- The `[FOLLOW]` badge can turn off while a live preview parks off-newest; Esc restores it. A no-match keystroke does not disengage follow.
- Logs content shifts 2 columns when the query transitions empty↔non-empty — same as commit-time today, just earlier.
- Per-keystroke cost is the same O(n) class as the already-live `s` filter bar.

No dependency, privacy, or secret impact. Deliberately out of scope: live match counter (offered, declined), search in the request detail view.

<details>
<summary>Plan 030 — full text</summary>

```
# Plan 030 — TUI live (incremental) `/` search

- **Status:** panel-reviewed, ready to implement
- **Panel record:** Codex unavailable (usage limit until Aug 22); Cursor
  failed twice with empty output (known flaky mode). Effective panel: GLM
  5.3 + CodeRabbit, no contradictions. Incorporated: Enter re-applies (not
  pure exit) to keep the `commitSearch` helper path sound; the seek-origin
  mechanism pinned as restore-then-seek via one shared helper; value-change
  gating made the default; origin captured at press time; requests restore
  drops the raw viewport offset; follow-restore precedence stated for both
  views; menu-blur AC; several test-list additions; docs `:174` clause;
  logs width-shift pinned as accepted.
- **Date:** 2026-08-17
- **Repo:** prox (single-repo scope)
- **Branch / PR:** `feature/plan-030-live-search` → one PR
- **User decisions pinned up front:** Esc restores the pre-search position
  (vim-incsearch-style cancel); `/` seeds the bar with the previous committed
  term; NO live match counter (offered, declined).

## 1. Problem / motivation

The TUI's `/` search is type-then-commit: nothing happens while the term is
typed; only Enter applies the query and jumps the cursor. The user wants
incremental search: the view updates on the fly with each keystroke, Enter
sticks the search, Esc cancels it entirely. The `s` filter bar already
behaves exactly this way (live per keystroke, Enter keeps, Esc-in-bar
clears), so today's `/` is the inconsistent one.

## 2. Current state (verified this session)

- `/` keypress (`internal/tui/base.go:1264-1270`): sets `ModeSearch`, clears
  the textinput (`SetValue("")`), focuses it. No seeding from the previous
  committed query.
- While typing (`handleSearchKey`, `base.go:896-932`): only `esc`/`enter`
  are special-cased; every other key just updates the textinput. The
  committed query fields are untouched until Enter — no live application.
- Enter (`base.go:904-926`): commits `requestSearchQuery` (requests view) or
  `logSearchQuery` (logs view), then jumps: requests via
  `jumpToRequestSearchMatch()` → `seekRequestSearchMatch(0)` (at-or-after,
  wrapping, `base.go:1501-1534`); logs via `seekLogSearchMatch(0)` +
  `ensureLogCursorVisible()` (one-shot scroll).
- Esc in the bar (`base.go:899-902`): exits the mode, discards the
  in-progress text, **keeps** any previously committed query.
- Esc in normal mode (`base.go:1323-1341`): clears both views' searches,
  both `s` filters, solo, and the logs cursor anchor. (Unchanged by this
  plan.)
- Search is navigation, not filtration (D6/D8/D12 comments,
  `base.go:138-150`): it never hides lines; it composes with the `s` filter.
  Matching is case-insensitive substring — logs over `entry.Line`
  (`logMatchesSearch`, `base.go:1571-1573`), requests over visible columns +
  URL (`requestMatchesSearch`, `base.go:1437-1461`).
- Committed-query consumers that come along for free once the fields are
  written live: substring highlight (`styleLogContent`, `base.go:2653-2668`),
  row marker gating and 2-col width budget (`base.go:1985-2007`, `:2607`),
  selection band (`selection.go:14-34`), follow-park guard (`searchParked`,
  `base.go:645`), footer match info (`base.go:2848-2870`).
- Follow-mode: `landSearchJump`/`landLogSearchJump` disengage `followMode`
  only when the jump lands off the newest row (`base.go:1536-1546`).
- Logs cursor is DisplaySeq-anchored (`logCursorSeq`/`logCursorIdx`,
  `base.go:159-168`) because entries stream and evict; the requests cursor
  is `cursorIdx` with records that shift on arrivals.
- The in-bar input renders in the footer left band
  (`"Search: " + textInput.View()`, `base.go:2929-2936`). Key routing:
  `tea.KeyMsg` returns early (`client.go:356-357`), so the outer
  `textInput.Update` (`client.go:525-529`) only carries cursor-blink ticks —
  no double keystroke application.
- Mouse menu-open while a text mode is active blurs the input and drops to
  `ModeNormal` (`menu_mouse.go:41-46`).
- Precedent for the live pattern: `handleStringFilterKey`
  (`base.go:937-960`) live-applies on every keystroke, Enter keeps + exits,
  Esc-in-bar clears the active view's filter. Per-keystroke reparse +
  full re-render over the 5000-entry retention window is already the shipped
  cost of the `s` bar.
- Help text pins semantics at `internal/tui/help_content.go:74,76,142,144`;
  docs at `docs/reference/tui.md:61-62,107,162,183-187` (and the requests
  key table below it).
- Test coverage is unit-level via `ClientModel.Update`
  (`base_behavior_test.go` — ~20 search tests incl. `commitSearch` helper at
  `:1076-1084`; `filterquery_test.go` for the `s` bar; `copy_test.go:268`
  pins that copy keys are swallowed as text in these modes). No PTY/e2e test
  drives `/`.

## 3. Design decisions (PINNED)

### WS1 — Search session + live apply

On `/`, capture a **search session** (new small struct on `BaseModel`)
recording the origin **at press time**: for logs, the anchor needed to
restore the exact scroll position (DisplaySeq-based, following the existing
`logCursorSeq`/`logSearchOriginIdx` anchoring idiom — NOT a raw viewport
offset, which streaming arrivals invalidate), any already-parked search
cursor seq, and `followMode`; for requests, the cursor row's request
identity (record ID, index as fallback) and `followMode` — NO raw viewport
offset (`updateViewport`'s ensure-visible clamp derives `YOffset` from the
cursor anyway, so cursor identity + follow determine the restored view;
CodeRabbit #3). Under follow with no cursor, the logs origin is the newest
seq **as of the press** (not re-resolved newest later) — it composes with
the eviction fallback (GLM).

**Seek mechanism (PINNED — CodeRabbit #2 / GLM #3):** the existing seek
entry points start from the CURRENT cursor (`seekRequestSearchMatch` from
`cursorIdx`, `base.go:1510`; `seekLogSearchMatch` via `logSearchOriginIdx`,
which prefers the parked `logCursorSeq`, `base.go:1589,1623-1641`), so
naive re-calls would seek from the previous live landing. Instead, one
shared `restoreSearchOrigin()` helper puts cursor/scroll state back to the
session origin, and every live apply is **restore-then-seek**. The same
helper serves the empty-value path and WS3's Esc — one implementation, one
set of eviction fallbacks.

Every non-esc/non-enter keystroke: update the textinput, then
`liveApplySearch(value)` — which is **gated on the value actually
changing** (cursor-movement keys like left/right/home/end re-render nothing
and re-run no O(n) scan; GLM #4 / CodeRabbit #7, default not fallback):
- write the ACTIVE view's committed field (`requestSearchQuery` /
  `logSearchQuery`) — all existing render consumers then work unmodified;
- non-empty value: `restoreSearchOrigin()` then seek at-or-after (wrapping)
  — so shrinking `err`→`er` or correcting a typo re-seeks from where the
  user started, never strands the cursor downstream; then
  `updateViewport()` (+ `ensureLogCursorVisible()` on logs);
- empty value: identical visuals to "no search" — clear the live query and
  cursor state and `restoreSearchOrigin()` (live preview of a cleared
  search), sharing that helper's eviction fallbacks.

The footer is intentionally unchanged while typing: the bar occupies the
left band (`"Search: " + textInput.View()`), so no live match info renders
— consistent with the declined match counter (CodeRabbit #11). Accepted
visual: the logs content width reserves 2 marker columns whenever
`logSearchQuery != ""` (`base.go:2607`), so lines shift horizontally once
per session at the empty↔non-empty transition — exactly what committing a
search does today, just earlier (GLM #2, view corrected to logs).

No-match while typing: cursor state cleared (existing no-match behavior,
`TestLogsSearch_NoMatchAfterPriorMatchClearsCursor` idiom), view stays at
origin. Follow-mode may transiently disengage during live jumps
(`landSearchJump` semantics unchanged); WS3 restores it on Esc, Enter keeps
the landing state — matching today's committed behavior.

*Alternative considered:* seek-from-current-cursor per keystroke (simpler,
no session struct) — rejected: backspacing can never return to earlier
matches, the classic broken-incsearch feel.

### WS2 — Enter = keep and exit

Enter runs `liveApplySearch(textInput.Value())` one final time, then exits
the bar (`ModeNormal`, blur) and clears the session. This is the TRUE
mirror of the `s` bar's Enter, which re-applies before exiting
(`base.go:948`) — idempotent when the live state already matches, but it
guarantees any value that reached the textinput without passing through
per-keystroke handling still commits with its jump (CodeRabbit #1). Pinned
consequence: the `commitSearch` test helper (`base_behavior_test.go:
1080-1084`, `SetValue` + Enter, used by ~20 tests) keeps working unchanged
via this re-apply; it is NOT rewritten to per-rune keystrokes. Enter on an
empty bar = committed cleared search. `n`/`N` after Enter cycle from the
live landing exactly as today (`base.go:1282-1304`).

Mouse menu-open while typing (menu blur path, `menu_mouse.go:41-46`) is
treated as Enter-equivalent: the live-applied query stands, session
cleared — same contract the `s` bar already has under that path.

### WS3 — Esc = cancel: clear active view's search AND restore origin

Esc in the bar: exit the mode, clear the ACTIVE view's search query and
cursor state, and `restoreSearchOrigin()` (the same shared helper as WS1's
empty-value path) — scroll position, cursor row, and `followMode` as of
the `/` press. Scoped to the active view (the other view's search
survives), matching the `s` bar's Esc scoping. Fallbacks, both views:
- logs: origin anchor evicted → fall back to the oldest retained line
  (best-effort restore);
- requests: origin record gone → nearest index;
- **follow precedence (both views, CodeRabbit #4):** restored
  `followMode == true` wins over the positional anchor — the view re-lands
  on newest (logs: `GotoBottom` semantics, `base.go:646-651`; requests:
  pin-to-newest), and the anchor is ignored.

Normal-mode Esc (`base.go:1323-1341`) is unchanged.

*Behavior change accepted (user-pinned):* today Esc-in-bar preserves a
previously committed search; now it clears it. With WS4 seeding, the old
term is in the bar anyway, so "keep the old search" is Enter.

### WS4 — `/` seeds the previous term

`/` seeds the textinput with the ACTIVE view's committed query
(`SetValue(...)`, `CursorEnd()`, `Focus()`), like the `s` bar seeds from
`activeFilterRaw()` (`base.go:1272-1280`). **Order is pinned (GLM #1):
capture session origin → seed → live-apply** — the origin must exist
before the seed's own seek runs, or that seek destroys it. When a parked
cursor sits on a match, the at-or-after seek from an origin that includes
that cursor means reopening the bar does not move the view. Qualifier
(CodeRabbit #5): if the prior search ended no-match, the cursor anchor was
cleared (`base.go:1599-1603`), so the seed's live-apply seeks from the
viewport-derived origin and MAY jump if streamed entries now match —
accepted, arguably desirable, and pinned by a C3 test.

### WS5 — Help + docs text

- `help_content.go:74` → "Search — live; jumps cursor as you type";
  `:76` (logs Esc) and `:144` (requests Esc) gain the in-bar cancel
  meaning; `:142` similarly updated. Bar-specific hints stay accurate:
  Enter keeps, Esc cancels.
- `docs/reference/tui.md`: footer description (`:61-62`), `Esc` row
  (`:162`), logs/requests key tables (`:183-187` and the requests table),
  the menu-blur line (`:174` — blur now commits the live search, WS2), and
  any prose describing type-then-Enter search.

## 4. Deviations / non-goals

- No live match counter in the footer (offered; user declined).
- No change to `s` filter behavior, `n`/`N`, normal-mode Esc, match
  predicates, highlight styling, or the navigate-not-filter contract.
- No regex/smart-case search; substring semantics unchanged.
- No PTY/e2e test harness work beyond the manual verification smoke.

## 5. Work breakdown (gated commits)

Gate for every commit: `make lint && make test && make test-race && make
build` (bare, no piping). C4 adds `uv run --locked zensical build --strict`.

- **C1 (opus — most subtle):** search session struct + restore-then-seek
  live apply (value-change-gated) + Enter re-apply semantics (WS1+WS2),
  both views. `commitSearch` helper kept as-is (Enter re-apply covers it).
  Update tests that assumed nothing-applies-until-Enter; add: per-keystroke
  jump seeks from origin; backspace re-seeks from origin; empty-input live
  state; no-match during typing (and: no-match under follow does NOT
  disengage follow — `setLogCursor(nil, 0)` never touches `followMode`);
  live state survives streaming arrival/eviction while the bar is open
  (logs AND requests — arrivals shift indices under the ID-anchored
  origin); live search composes with an active `s` filter; Enter on empty
  bar = cleared committed search; `n`/`N` after live+Enter cycle from the
  live landing; cursor-movement keys don't re-seek; menu-open blur commits.
  Intermediate quirk accepted until C2: Esc-in-bar leaves the live query
  standing (≈ Enter). C1 adds NO Esc-path tests — C2 owns them (avoids
  churn; CodeRabbit #10).
- **C2 (opus):** Esc cancel + shared origin restore (WS3), both views,
  incl. follow-mode restore precedence and eviction fallbacks. Tests: Esc
  restores scroll/cursor/follow (both views); Esc scoped to active view;
  Esc after arrivals evicted the origin (logs) / dropped the record
  (requests); Esc after live jump disengaged follow restores it; restored
  follow=true re-lands newest over the anchor.
- **C3 (sonnet):** seed previous term (WS4), capture→seed→apply order.
  Tests: seed value + cursor at end; reopen-over-parked-match doesn't move
  the view; reopen-after-no-match may jump (pins the accepted qualifier);
  seed then Esc clears (interaction with WS3).
- **C4 (sonnet):** help modal + docs (WS5). Full gate + docs build.

## 6. File map (indicative)

- `internal/tui/base.go` — session struct + fields, `/` entry,
  `handleSearchKey`, live-apply helper, restore helper
- `internal/tui/menu_mouse.go` — blur path session cleanup (if needed)
- `internal/tui/base_behavior_test.go` — updated + new tests
- `internal/tui/copy_test.go`, `framefill_test.go` — only if helper
  signatures (`commitSearch`) shift
- `internal/tui/help_content.go`, `docs/reference/tui.md`

## 7. Acceptance criteria

1. Typing in the `/` bar updates highlight and cursor per keystroke in both
   views, always seeking at-or-after the position where `/` was pressed —
   the origin captured at press time (under follow: the then-newest row).
2. Backspacing to a shorter or empty term re-seeks from origin; an empty
   bar renders identically to no-search with the view at origin.
3. Enter exits the bar with the committed state identical to the last live
   preview (via the final re-apply); `n`/`N` then cycle matches exactly as
   today. Opening a menu by mouse while typing commits the same way.
4. Esc exits the bar, clears the active view's search (query, highlight,
   cursor), and restores pre-`/` scroll, cursor, and follow state — robust
   to arrivals/eviction during typing in both views (logs: anchor evicted →
   oldest retained; requests: record gone → nearest index; restored
   follow=true re-lands newest in either view).
5. `/` reopens seeded with the previous committed term (cursor at end) and
   does not move the view when a parked match is active.
6. Help modal and `docs/reference/tui.md` describe live search, Enter
   keeps, Esc cancels; docs build green under `--strict`.
7. Invariants hold: search never hides lines, composes with the `s` filter,
   normal-mode Esc unchanged, copy keys still swallowed while typing,
   `ctrl+c`/`q` semantics unchanged.

## 8. Verification plan

Primary: the unit suite (`ClientModel.Update`-driven), which is the
repo's established layer for search behavior — C1–C3 extend it as above.
Beyond that, one manual PTY smoke: drive `prox up` in a PTY, send
`/`, then a term one keystroke at a time, capture frames showing the live
jump, then Esc showing restore, then a re-`/` showing the seed; artifacts
into `~/.claude/plans/prox/030-tui-live-search/`. Mind the repo's
integration-suite hazards (shared daemon, pinned port 15555) — run the
smoke against a scratch project dir.

## 9. Risks / open items

- **Per-keystroke seek + render cost** — same O(n) class as the live `s`
  bar over ≤5000 entries; value-change gating (now the WS1 default) already
  removes the no-op re-seeks; `perf_bench_test.go` is the tripwire.
- **Streaming while the bar is open** is the subtle surface: origin
  anchoring must be seq-based and live re-seeks must tolerate eviction
  mid-typing — in BOTH views. C1/C2 carry dedicated tests; this is why
  they're opus.
- **Follow disengage during typing** is visible when a live jump lands
  off-newest (the `[FOLLOW]` badge turns off while previewing). Accepted:
  it reflects reality, and Esc restores it. Note the narrower truth (GLM):
  a NO-MATCH keystroke does not disengage follow — `setLogCursor(nil, 0)`
  never touches `followMode` — so the badge only reacts to actual jumps.
- **PR body must carry the plan's substance** (plan file is never
  committed, per CLAUDE.md) — the Phase-6 PR includes the plan text in a
  collapsible details block.

## § Verified

Beyond the automated tests (46+ new/updated unit tests across C1–C3, all
mutation-verified against the specific bugs they pin, plus the C5 frame-
contract sweep), a **PTY smoke of the real TUI** was run twice (120x35,
Python pty driver + pyte emulator; artifacts F1–F7 `.txt`/`.ans`,
`drive.py`, and `rerun-fixed-harness/` in
`~/.claude/plans/prox/030-tui-live-search/`): live per-keystroke jump to
an old match while lines stream (F3, exactly one ❯ marker), Esc restoring
follow (F4), commit + parked match info `/BETA (1/1)` (F5), reopen seeded
with the term and byte-identical content rows — the view does not move
(F6), Esc clear (F7), clean `q` exit.

The first smoke run reported a "permanent stale rows" rendering
regression; root-causing proved it was a **harness bug** (per-read
`bytes.decode` splitting multi-byte glyphs → U+FFFD overflow → emulator
scroll), not a product bug — verified four ways, including replaying the
captured raw bytes through a correct incremental decoder and a byte-level
audit showing every flush is exactly 35 full-width rows. The harness was
fixed and the re-run is clean. The lasting product outcome: the frame-
contract tests had never covered text-input modes; `TestFrameContract_
LiveSearchStates` (C5) closes that gap.

Known-unexercised beyond this: no automated PTY/e2e test drives `/` in
CI (unchanged from before this plan — coverage stays unit-level by
design); the smoke was manual, its artifacts retained.

## 10. Implementation log

- **C1 external review (CodeRabbit; codex usage-limited to 8/22, cursor
  usage-limited to 8/23):** 4 findings, all fixed before commit —
  (1, major) requests view under follow seeked from the CURRENT newest
  instead of the press-time origin (restore's follow pin discarded the
  captured record ID); fixed by mirroring the logs split: view restore may
  pin to newest, but the seek starts from `sessionRequestOriginIdx` via a
  new `seekRequestSearchMatchFrom`. (2, major) an evicted SESSION anchor
  fell back to its stale press-time index (mid-list) instead of oldest
  retained — session paths now resolve via `entryIndexOfSeq` with 0 on
  eviction; the clamp idiom stays only on live-cursor paths. (3, minor)
  empty-value scroll restore used the previous render's wrap spans (2-char
  marker prefix changes wrap points); scroll restore now applies after
  `updateViewport` rebuilds spans. (4, minor) empty-list-at-press under
  follow degraded the origin to current newest; an active session with both
  seqs 0 now seeks from index 0. Tests added for all four (the review
  proved the original test set couldn't catch 1 or 2).
- Future work (explicitly out): live match counter (declined, could revisit),
  incremental-search for the requests **detail** view (search is blocked
  there today, unchanged).

```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lht7YxhACcDzMHjpcyogyp


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live search for logs and requests, updating results with each keystroke.
  * Search now moves the cursor to matches and supports filtered results, live updates, and backspace re-seeking.
  * Press **Enter** to commit a search, or **Esc** to cancel and restore the previous view.
  * Reopening search restores the last committed query.
  * Opening a menu while searching commits the current query.

* **Documentation**
  * Updated help text and TUI documentation to describe live search behavior and controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->